### PR TITLE
ci: add build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Test
+        run: dotnet test --no-build --verbosity normal


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow that builds and runs tests on Linux, Windows, and macOS
- Uses .NET 10 SDK with `fail-fast: false` to surface platform-specific issues

## Test plan
- [x] All 3 platform jobs pass (ubuntu, windows, macos)
- [x] All 193 tests pass on each platform