### PR TITLE
Fix Enter key drill-down on General tab references

### DIFF
--- a/src/Dotsider/Views/GeneralView.cs
+++ b/src/Dotsider/Views/GeneralView.cs
@@ -77,6 +77,24 @@ public static class GeneralView
                     .Compact()
                     .Empty(e => e.Text("  No assembly references"))
                     .FillHeight()
+                    .WithInputBindings(bindings =>
+                    {
+                        bindings.Key(Hex1bKey.Enter).Action(_ =>
+                        {
+                            var focusedName = state.GeneralFocusedDep as string
+                                ?? analyzer.AssemblyRefs.FirstOrDefault()?.Name;
+                            if (focusedName is not null)
+                            {
+                                var resolvedPath = AssemblyAnalyzer.ResolveAssemblyPath(
+                                    state.Analyzer.FilePath, focusedName);
+                                if (resolvedPath is not null)
+                                {
+                                    state.PushAssembly(resolvedPath);
+                                    state.App.Invalidate();
+                                }
+                            }
+                        }, "Drill into reference");
+                    })
             ).Title($" Assembly References ({analyzer.AssemblyRefs.Count}) ").Fill()
         ])
         .WithInputBindings(bindings =>

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -206,6 +206,28 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
     }
 
     [Fact(Timeout = 10_000)]
+    public async Task General_EnterOnReference_DrillsIntoAssembly()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.HelloWorldDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var runTask = app.RunAsync(cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            // Tab to focus the dependency table, then Enter to drill into the first ref
+            .Key(Hex1bKey.Tab)
+            .Key(Hex1bKey.Enter)
+            // After drill-down, the title bar should no longer show "HelloWorld.dll"
+            .WaitUntil(s => !s.ContainsText("HelloWorld.dll"), TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 10_000)]
     public async Task QuitKey_ExitsApp()
     {
         var (terminal, app) = CreateDotsiderApp(samples.HelloWorldDll);


### PR DESCRIPTION
## Summary
- Pressing Enter on an assembly reference in the General tab now drills into that assembly
- Adds a scoped Enter key binding on the table widget itself, working around Hex1b's `TableNode` not binding Enter to `OnRowActivated`
- Falls back to the first assembly ref when no row has been explicitly navigated to

## Root cause
Hex1b's `TableNode.ConfigureDefaultBindings()` has no Enter key binding, so the `OnRowActivated` callback was never invoked from the keyboard.

## Test plan
- [x] Regression test: Tab into table, press Enter, verify drill-down occurs
- [x] Interactive test: Enter drills down, Backspace navigates back
- [x] Full test suite passes

Fixes #2