### PR TITLE
Fix global size format toggle

### DIFF
--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -47,7 +47,7 @@ public sealed class DotsiderApp
                 bar.Section(_state.Analyzer.Architecture).Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(200, 180, 100))),
                 bar.Separator(" | "),
-                bar.Section(DotsiderState.FormatSize(_state.Analyzer.FileSize)).Theme(t => t
+                bar.Section(_state.FormatSizeToggleable(_state.Analyzer.FileSize)).Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(200, 180, 100)))
             ]),
 
@@ -97,6 +97,11 @@ public sealed class DotsiderApp
             }
 
             // Global keybindings matching binsider
+            bindings.Key(Hex1bKey.S).Global().Action(_ =>
+            {
+                _state.HumanReadableSizes = !_state.HumanReadableSizes;
+                _state.App.Invalidate();
+            }, "Toggle size format");
             bindings.Key(Hex1bKey.Q).Global().Action(ctx => ctx.RequestStop(), "Quit");
             bindings.Ctrl().Key(Hex1bKey.C).Global().OverridesCapture()
                 .Action(ctx => ctx.RequestStop(), "Quit");
@@ -137,7 +142,9 @@ public sealed class DotsiderApp
                     hints.Add(s.Section("Enter: Launch"));
             }
 
-            hints.Add(s.Section("s: Sizes"));
+            // Show size toggle hint only on tabs that display sizes
+            if (_state.CurrentTab is 0 or 1 or 6) // General, PE/Metadata, Size Map
+                hints.Add(s.Section(_state.HumanReadableSizes ? "s: Sizes (dec)" : "s: Sizes (hex)"));
             hints.Add(s.Spacer());
             hints.Add(s.Section("q: Quit"));
             return hints;

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -271,7 +271,7 @@ public sealed class DotsiderState : IDisposable
     }
 
     /// <summary>
-    /// Formats a file size in bytes to a human-readable string.
+    /// Formats a file size in bytes to a human-readable string (always human-readable).
     /// </summary>
     /// <param name="bytes">The size in bytes.</param>
     /// <returns>A formatted string like "1.5 KB" or "3.2 MB".</returns>
@@ -282,6 +282,13 @@ public sealed class DotsiderState : IDisposable
         < 1024 * 1024 * 1024 => $"{bytes / (1024.0 * 1024):F1} MB",
         _ => $"{bytes / (1024.0 * 1024 * 1024):F1} GB"
     };
+
+    /// <summary>
+    /// Formats a size respecting the current <see cref="HumanReadableSizes"/> toggle.
+    /// Returns human-readable (e.g. "1.5 KB") or hex (e.g. "0x600").
+    /// </summary>
+    public string FormatSizeToggleable(long bytes) =>
+        HumanReadableSizes ? FormatSize(bytes) : $"0x{bytes:X}";
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/Dotsider/Views/GeneralView.cs
+++ b/src/Dotsider/Views/GeneralView.cs
@@ -35,7 +35,7 @@ public static class GeneralView
                     InfoLine(info, "Culture", analyzer.Culture ?? "neutral"),
                     InfoLine(info, "Public Key Token", analyzer.PublicKeyToken ?? "(none)"),
                     info.Text(""),
-                    InfoLine(info, "File Size", DotsiderState.FormatSize(analyzer.FileSize)),
+                    InfoLine(info, "File Size", state.FormatSizeToggleable(analyzer.FileSize)),
                     InfoLine(info, "Architecture", analyzer.Architecture),
                     InfoLine(info, "Last Modified", analyzer.LastModified.ToString("yyyy-MM-dd HH:mm:ss UTC")),
                     InfoLine(info, "Created", analyzer.CreatedTime.ToString("yyyy-MM-dd HH:mm:ss UTC")),

--- a/src/Dotsider/Views/PeMetadataView.cs
+++ b/src/Dotsider/Views/PeMetadataView.cs
@@ -133,11 +133,6 @@ public static class PeMetadataView
             })
             .WithInputBindings(bindings =>
             {
-                bindings.Key(Hex1bKey.S).Action(_ =>
-                {
-                    state.HumanReadableSizes = !state.HumanReadableSizes;
-                    state.App.Invalidate();
-                }, "Toggle size format");
                 bindings.Key(Hex1bKey.OemQuestion).Action(_ =>
                 {
                     state.PeSearchActive = !state.PeSearchActive;
@@ -426,12 +421,8 @@ public static class PeMetadataView
             .Compact().FillHeight();
     }
 
-    private static string FormatSize(int size, DotsiderState state)
-    {
-        return state.HumanReadableSizes
-            ? DotsiderState.FormatSize(size)
-            : $"0x{size:X}";
-    }
+    private static string FormatSize(int size, DotsiderState state) =>
+        state.FormatSizeToggleable(size);
 
     private static IReadOnlyList<T> ApplySearch<T>(
         IReadOnlyList<T> items, string? query, Func<T, string> toSearchable)

--- a/src/Dotsider/Views/SizeTreemapView.cs
+++ b/src/Dotsider/Views/SizeTreemapView.cs
@@ -37,7 +37,7 @@ public static class SizeTreemapView
             {
                 var parts = new List<Hex1bWidget>();
                 parts.Add(row.Text($" {BuildBreadcrumb(state)} "));
-                parts.Add(row.Text($"| Total: {DotsiderState.FormatSize(currentLevel.Size)}").Fill());
+                parts.Add(row.Text($"| Total: {state.FormatSizeToggleable(currentLevel.Size)}").Fill());
                 return parts.ToArray();
             }).FixedHeight(1),
 
@@ -133,7 +133,7 @@ public static class SizeTreemapView
 
                 if (cellH > 1)
                 {
-                    var sizeLabel = DotsiderState.FormatSize(rect.Node.Size);
+                    var sizeLabel = state.FormatSizeToggleable(rect.Node.Size);
                     if (sizeLabel.Length <= cellW - 2)
                         surface.WriteText(x1 + 1, y1 + 1, sizeLabel, Hex1bColor.Black, color);
                 }
@@ -142,7 +142,7 @@ public static class SizeTreemapView
             // Mouse hover detection
             if (mouseX >= x1 && mouseX < x2 && mouseY >= y1 && mouseY < y2)
             {
-                state.TreemapHoveredItem = $" {rect.Node.FullPath}: {DotsiderState.FormatSize(rect.Node.Size)} ({rect.Node.Children.Count} children)";
+                state.TreemapHoveredItem = $" {rect.Node.FullPath}: {state.FormatSizeToggleable(rect.Node.Size)} ({rect.Node.Children.Count} children)";
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #4

- `s` keybinding moved from PE/Metadata-local to app-global so it works from any tab
- New `FormatSizeToggleable()` instance method on `DotsiderState` respects the toggle
- General tab file size, Size Map (breadcrumb, cell labels, hover), and title bar all now respond to the toggle
- Hint bar only shows `s: Sizes` on tabs with toggleable sizes (General, PE/Metadata, Size Map) and indicates current mode `(dec)`/`(hex)`

## Test plan

- [x] Build succeeds with 0 warnings
- [x] All 194 tests pass
- [x] Manual: press `s` on General tab — file size toggles between human-readable and hex
- [x] Manual: press `s` on PE/Metadata tab — all size fields toggle
- [x] Manual: press `s` on Size Map tab — breadcrumb total and cell labels toggle
- [x] Manual: verify title bar file size also toggles
- [x] Manual: verify hint bar does NOT show `s: Sizes` on Strings, Hex Dump, IL Inspector, Dep Graph, Dynamic tabs