### PR TITLE
Add dotnet tool packaging and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  pack-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Pack
+        run: dotnet pack src/Dotsider/Dotsider.csproj -c Release -o ./nupkg
+
+      - name: Push to NuGet
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+  build-binaries:
+    strategy:
+      matrix:
+        include:
+          - rid: win-x64
+            os: windows-latest
+            artifact: dotsider-win-x64
+          - rid: linux-x64
+            os: ubuntu-latest
+            artifact: dotsider-linux-x64
+          - rid: osx-arm64
+            os: macos-latest
+            artifact: dotsider-osx-arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish
+        run: dotnet publish src/Dotsider/Dotsider.csproj -c Release -r ${{ matrix.rid }} --self-contained -p:PublishSingleFile=true -o ./publish
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ./publish/dotsider*
+
+  create-release:
+    needs: [pack-and-publish, build-binaries]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: Package binaries
+        run: |
+          cd artifacts
+          chmod +x dotsider-linux-x64/dotsider
+          chmod +x dotsider-osx-arm64/dotsider
+          tar -czf dotsider-linux-x64.tar.gz -C dotsider-linux-x64 .
+          tar -czf dotsider-osx-arm64.tar.gz -C dotsider-osx-arm64 .
+          cd dotsider-win-x64 && zip -r ../dotsider-win-x64.zip . && cd ..
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --latest \
+            artifacts/dotsider-win-x64.zip \
+            artifacts/dotsider-linux-x64.tar.gz \
+            artifacts/dotsider-osx-arm64.tar.gz

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ dotsider HelloWorld.dll
 
 [![dotsider demo](https://asciinema.org/a/bPs2Bop54ust8e3C.svg)](https://asciinema.org/a/bPs2Bop54ust8e3C)
 
+## Installation
+
+### dotnet tool (recommended)
+
+```
+dotnet tool install -g dotsider
+```
+
+### Download binary
+
+Grab a standalone binary from [Releases](https://github.com/willibrandon/dotsider/releases).
+
 ## What it does
 
 dotsider opens any .NET DLL or EXE and lets you explore it across 8 tabs:

--- a/src/Dotsider/Dotsider.csproj
+++ b/src/Dotsider/Dotsider.csproj
@@ -10,8 +10,26 @@
     <AssemblyName>dotsider</AssemblyName>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>dotsider</ToolCommandName>
+    <PackageId>dotsider</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>willibrandon</Authors>
+    <Description>A TUI for analyzing .NET assemblies — structure, metadata, IL, strings, dependencies, and more.</Description>
+    <PackageTags>dotnet;assembly;tui;il;metadata;pe;disassembler;nuget</PackageTags>
+    <PackageProjectUrl>https://github.com/willibrandon/dotsider</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/willibrandon/dotsider</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Hex1b" Version="*" />
+    <None Include="../../README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Hex1b" Version="0.103.0" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.*" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.*" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Package dotsider as a dotnet global tool (`dotnet tool install -g dotsider`)
- Add tag-triggered release workflow: NuGet push + self-contained binaries for win-x64, linux-x64, osx-arm64
- Pin Hex1b from wildcard `*` to `0.103.0`
- Add Installation section to README

## Test plan
- [x] `dotnet build` succeeds with 0 warnings
- [x] `dotnet pack -c Release` produces valid .nupkg with correct metadata
- [x] `dotnet tool install -g --add-source ./nupkg dotsider` installs and runs
- [x] All 194 tests pass

Fixes #6