### PR TITLE
Fix garbled rendering on Windows dotnet tool

### DIFF
--- a/src/Dotsider/Program.cs
+++ b/src/Dotsider/Program.cs
@@ -1,5 +1,8 @@
+using System.Text;
 using Dotsider;
 using Hex1b;
+
+Console.OutputEncoding = Encoding.UTF8;
 
 // Parse CLI arguments
 string? filePath = null;


### PR DESCRIPTION
## Summary
- Set `Console.OutputEncoding = Encoding.UTF8` at startup before Hex1b renders anything
- The dotnet tool shim on Windows inherits the system code page (437/1252) which mangles UTF-8 box-drawing characters

## Test plan
- [x] Install from this branch on Windows: `dotnet tool install -g --add-source ./nupkg dotsider`
- [x] Run `dotsider <assembly.dll>` in PowerShell 7 — verify no garbled characters
- [x] Verify macOS still works

Fixes #8