### PR TITLE
Add arrow key navigation for sub-tabs

### DIFF
--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -236,6 +236,19 @@ public sealed class DotsiderApp
     private void SelectTab(int tabIndex)
     {
         if (_state.CurrentTab == tabIndex) return;
+
+        // If the current tab has an in-progress search edit, finalize it before
+        // switching away. Otherwise the editing state persists without a focused
+        // TextBox, which blocks the Hex1bKey.None "/" binding on return.
+        var previousSearch = _state.Search[_state.CurrentTab];
+        if (previousSearch.IsActive && !previousSearch.IsConfirmed)
+        {
+            if (string.IsNullOrEmpty(previousSearch.Query))
+                previousSearch.Dismiss();
+            else
+                previousSearch.Confirm();
+        }
+
         var previousTab = _state.CurrentTab;
         _state.CurrentTab = tabIndex;
         if (previousTab != TabId.IlInspector && tabIndex == TabId.IlInspector)

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -331,9 +331,9 @@ public sealed class DotsiderState : IDisposable
     {
         var entries = StringsSourceTab switch
         {
-            0 => CachedUserStrings ??= StringExtractor.ExtractUserStrings(),
-            1 => CachedMetadataStrings ??= StringExtractor.ExtractMetadataStrings(),
-            2 => GetCachedRawStrings(),
+            StringsSubTabId.UserStrings => CachedUserStrings ??= StringExtractor.ExtractUserStrings(),
+            StringsSubTabId.Metadata => CachedMetadataStrings ??= StringExtractor.ExtractMetadataStrings(),
+            StringsSubTabId.RawBinary => GetCachedRawStrings(),
             _ => []
         };
 

--- a/src/Dotsider/DynamicSubTabId.cs
+++ b/src/Dotsider/DynamicSubTabId.cs
@@ -1,0 +1,22 @@
+namespace Dotsider;
+
+/// <summary>
+/// Sub-tab index constants for the Dynamic Analysis tab.
+/// </summary>
+public static class DynamicSubTabId
+{
+    /// <summary>Events sub-tab.</summary>
+    public const int Events = 0;
+
+    /// <summary>Counters sub-tab.</summary>
+    public const int Counters = 1;
+
+    /// <summary>Output sub-tab.</summary>
+    public const int Output = 2;
+
+    /// <summary>Summary sub-tab.</summary>
+    public const int Summary = 3;
+
+    /// <summary>Total number of Dynamic Analysis sub-tabs.</summary>
+    public const int Count = 4;
+}

--- a/src/Dotsider/PeSubTabId.cs
+++ b/src/Dotsider/PeSubTabId.cs
@@ -1,0 +1,31 @@
+namespace Dotsider;
+
+/// <summary>
+/// Sub-tab index constants for the PE/Metadata tab.
+/// </summary>
+public static class PeSubTabId
+{
+    /// <summary>Sections sub-tab.</summary>
+    public const int Sections = 0;
+
+    /// <summary>TypeDef sub-tab.</summary>
+    public const int TypeDef = 1;
+
+    /// <summary>MethodDef sub-tab.</summary>
+    public const int MethodDef = 2;
+
+    /// <summary>TypeRef sub-tab.</summary>
+    public const int TypeRef = 3;
+
+    /// <summary>MemberRef sub-tab.</summary>
+    public const int MemberRef = 4;
+
+    /// <summary>Attributes sub-tab.</summary>
+    public const int Attributes = 5;
+
+    /// <summary>Resources sub-tab.</summary>
+    public const int Resources = 6;
+
+    /// <summary>Total number of PE/Metadata sub-tabs.</summary>
+    public const int Count = 7;
+}

--- a/src/Dotsider/StringsSubTabId.cs
+++ b/src/Dotsider/StringsSubTabId.cs
@@ -1,0 +1,19 @@
+namespace Dotsider;
+
+/// <summary>
+/// Sub-tab index constants for the Strings tab.
+/// </summary>
+public static class StringsSubTabId
+{
+    /// <summary>User Strings (#US) sub-tab.</summary>
+    public const int UserStrings = 0;
+
+    /// <summary>Metadata (#Strings) sub-tab.</summary>
+    public const int Metadata = 1;
+
+    /// <summary>Raw Binary sub-tab.</summary>
+    public const int RawBinary = 2;
+
+    /// <summary>Total number of Strings sub-tabs.</summary>
+    public const int Count = 3;
+}

--- a/src/Dotsider/Views/DynamicAnalysisView.cs
+++ b/src/Dotsider/Views/DynamicAnalysisView.cs
@@ -129,7 +129,7 @@ public static class DynamicAnalysisView
     {
         var search = state.Search[TabId.Dynamic];
         // Search bar hidden on Counters (1) and Summary (3) sub-tabs
-        var showSearch = state.DynamicSubTab is 0 or 2;
+        var showSearch = state.DynamicSubTab is DynamicSubTabId.Events or DynamicSubTabId.Output;
 
         // Set up match navigation
         state.NavigateNextMatch = null;
@@ -150,13 +150,13 @@ public static class DynamicAnalysisView
             widgets.Add(outer.TabPanel(tp =>
             [
                 tp.Tab("Events", t => [BuildEventsSubTab(t, state, tracer)])
-                    .Selected(state.DynamicSubTab == 0),
+                    .Selected(state.DynamicSubTab == DynamicSubTabId.Events),
                 tp.Tab("Counters", t => [BuildCountersSubTab(t, state, tracer)])
-                    .Selected(state.DynamicSubTab == 1),
+                    .Selected(state.DynamicSubTab == DynamicSubTabId.Counters),
                 tp.Tab("Output", t => [BuildOutputSubTab(t, state, tracer)])
-                    .Selected(state.DynamicSubTab == 2),
+                    .Selected(state.DynamicSubTab == DynamicSubTabId.Output),
                 tp.Tab("Summary", t => [BuildSummarySubTab(t, state, tracer)])
-                    .Selected(state.DynamicSubTab == 3)
+                    .Selected(state.DynamicSubTab == DynamicSubTabId.Summary)
             ])
             .OnSelectionChanged(e =>
             {
@@ -170,24 +170,29 @@ public static class DynamicAnalysisView
         })
         .WithInputBindings(bindings =>
         {
-            // Left/Right arrows to switch sub-tabs
-            bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
-            {
-                if (state.DynamicSubTab > 0)
-                {
-                    state.DynamicSubTab--;
-                    state.App.Invalidate();
-                }
-            }, "Previous sub-tab");
+            var isSearchEditing = search.IsActive && !search.IsConfirmed;
 
-            bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
+            // Left/Right arrows to switch sub-tabs (suppressed during search editing)
+            if (!isSearchEditing)
             {
-                if (state.DynamicSubTab < 3)
+                bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
                 {
-                    state.DynamicSubTab++;
-                    state.App.Invalidate();
-                }
-            }, "Next sub-tab");
+                    if (state.DynamicSubTab > 0)
+                    {
+                        state.DynamicSubTab--;
+                        state.App.Invalidate();
+                    }
+                }, "Previous sub-tab");
+
+                bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
+                {
+                    if (state.DynamicSubTab < DynamicSubTabId.Count - 1)
+                    {
+                        state.DynamicSubTab++;
+                        state.App.Invalidate();
+                    }
+                }, "Next sub-tab");
+            }
 
             // Ctrl+K to stop the traced process
             bindings.Ctrl().Key(Hex1bKey.K).Global().Action(_ =>
@@ -196,8 +201,9 @@ public static class DynamicAnalysisView
                 state.App.Invalidate();
             }, "Stop traced process");
 
-            // Enter to re-run after exit
-            if (tracer.ProcessState is TraceProcessState.Exited or TraceProcessState.Error)
+            // Enter to re-run after exit (suppressed during search editing to avoid
+            // conflicting with DotsiderApp's global "Confirm search" Enter binding)
+            if (!isSearchEditing && tracer.ProcessState is TraceProcessState.Exited or TraceProcessState.Error)
             {
                 bindings.Key(Hex1bKey.Enter).Global().Action(_ =>
                 {

--- a/src/Dotsider/Views/PeMetadataView.cs
+++ b/src/Dotsider/Views/PeMetadataView.cs
@@ -107,19 +107,19 @@ public static class PeMetadataView
                 widgets.Add(outer.TabPanel(tp =>
                 [
                     tp.Tab("Sections", t => [BuildSectionsTable(t, state)])
-                        .Selected(state.PeSubTab == 0),
+                        .Selected(state.PeSubTab == PeSubTabId.Sections),
                     tp.Tab("TypeDef", t => [BuildTypeDefsTable(t, state)])
-                        .Selected(state.PeSubTab == 1),
+                        .Selected(state.PeSubTab == PeSubTabId.TypeDef),
                     tp.Tab("MethodDef", t => [BuildMethodDefsTable(t, state)])
-                        .Selected(state.PeSubTab == 2),
+                        .Selected(state.PeSubTab == PeSubTabId.MethodDef),
                     tp.Tab("TypeRef", t => [BuildTypeRefsTable(t, state)])
-                        .Selected(state.PeSubTab == 3),
+                        .Selected(state.PeSubTab == PeSubTabId.TypeRef),
                     tp.Tab("MemberRef", t => [BuildMemberRefsTable(t, state)])
-                        .Selected(state.PeSubTab == 4),
+                        .Selected(state.PeSubTab == PeSubTabId.MemberRef),
                     tp.Tab("Attributes", t => [BuildAttributesTable(t, state)])
-                        .Selected(state.PeSubTab == 5),
+                        .Selected(state.PeSubTab == PeSubTabId.Attributes),
                     tp.Tab("Resources", t => [BuildResourcesTable(t, state)])
-                        .Selected(state.PeSubTab == 6)
+                        .Selected(state.PeSubTab == PeSubTabId.Resources)
                 ])
                 .OnSelectionChanged(e =>
                 {
@@ -135,27 +135,32 @@ public static class PeMetadataView
             })
             .WithInputBindings(bindings =>
             {
-                bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
-                {
-                    if (state.PeSubTab > 0)
-                    {
-                        state.PeSubTab--;
-                        search.Reset();
-                        state.PeFocusedKey = null;
-                        state.App.Invalidate();
-                    }
-                }, "Previous sub-tab");
+                var isSearchEditing = search.IsActive && !search.IsConfirmed;
 
-                bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
+                if (!isSearchEditing)
                 {
-                    if (state.PeSubTab < 6)
+                    bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
                     {
-                        state.PeSubTab++;
-                        search.Reset();
-                        state.PeFocusedKey = null;
-                        state.App.Invalidate();
-                    }
-                }, "Next sub-tab");
+                        if (state.PeSubTab > 0)
+                        {
+                            state.PeSubTab--;
+                            search.Reset();
+                            state.PeFocusedKey = null;
+                            state.App.Invalidate();
+                        }
+                    }, "Previous sub-tab");
+
+                    bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
+                    {
+                        if (state.PeSubTab < PeSubTabId.Count - 1)
+                        {
+                            state.PeSubTab++;
+                            search.Reset();
+                            state.PeFocusedKey = null;
+                            state.App.Invalidate();
+                        }
+                    }, "Next sub-tab");
+                }
 
                 bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
                 {

--- a/src/Dotsider/Views/StringsView.cs
+++ b/src/Dotsider/Views/StringsView.cs
@@ -62,11 +62,11 @@ public static class StringsView
 
                 // Sub-tab selector for string sources
                 widgets.Add(outer.TabPanel(tp =>
-                [
-                    tp.Tab(SourceTabs[0], t => [t.Text("")]),
-                    tp.Tab(SourceTabs[1], t => [t.Text("")]),
-                    tp.Tab(SourceTabs[2], t => [t.Text("")])
-                ])
+                    SourceTabs.Select((name, i) =>
+                        tp.Tab(name, t => [t.Text("")])
+                            .Selected(state.StringsSourceTab == i)
+                    ).ToArray()
+                )
                 .Compact()
                 .OnSelectionChanged(e =>
                 {
@@ -107,7 +107,7 @@ public static class StringsView
 
                 // Status line
                 var statusParts = new List<string> { $"{activeStrings.Count} strings" };
-                if (state.StringsSourceTab == 2)
+                if (state.StringsSourceTab == StringsSubTabId.RawBinary)
                 {
                     statusParts.Add($"Min length: {state.StringsMinLength}");
                 }
@@ -117,6 +117,34 @@ public static class StringsView
             })
             .WithInputBindings(bindings =>
             {
+                var isSearchEditing = search.IsActive && !search.IsConfirmed;
+
+                // Left/Right arrows to switch sub-tabs (suppressed during search editing)
+                if (!isSearchEditing)
+                {
+                    bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
+                    {
+                        if (state.StringsSourceTab > 0)
+                        {
+                            state.StringsSourceTab--;
+                            search.Reset();
+                            state.StringsFocusedKey = null;
+                            state.App.Invalidate();
+                        }
+                    }, "Previous sub-tab");
+
+                    bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
+                    {
+                        if (state.StringsSourceTab < StringsSubTabId.Count - 1)
+                        {
+                            state.StringsSourceTab++;
+                            search.Reset();
+                            state.StringsFocusedKey = null;
+                            state.App.Invalidate();
+                        }
+                    }, "Next sub-tab");
+                }
+
                 bindings.Key(Hex1bKey.OemPlus).Action(_ =>
                 {
                     state.StringsMinLength++;

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -206,6 +206,38 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
         await runTask.ContinueWith(_ => { });
     }
 
+    [Fact(Timeout = 15_000)]
+    public async Task Tab8_SearchAfterProcessExit_NoGlobalBindingConflict()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.HelloWorldDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var runTask = app.RunAsync(cts.Token);
+
+        // Navigate to Dynamic tab and launch the process
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D8)
+            .WaitUntil(s => s.ContainsText("EventPipe") || s.ContainsText("Launch"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.Enter) // Launch process
+            .WaitUntil(s => s.ContainsText("Exited") || s.ContainsText("Exit code"), TimeSpan.FromSeconds(8))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Process has exited — activating search must not crash with
+        // "Global binding conflict: Enter is already registered"
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.OemQuestion) // '/' — activate search
+            .WaitUntil(_ => _state!.Search[TabId.Dynamic].IsActive, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.True(_state!.Search[TabId.Dynamic].IsActive);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
     [Fact(Timeout = 10_000)]
     public async Task General_EnterOnReference_DrillsIntoAssembly()
     {
@@ -289,6 +321,100 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
             .Ctrl().Key(Hex1bKey.C)
             .Build()
             .ApplyAsync(terminal, cts.Token);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 10_000)]
+    public async Task Tab4_ArrowKeysCycleSubTabs()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var runTask = app.RunAsync(cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D4) // Tab 4 — Strings
+            .WaitUntil(s => s.ContainsText("User Strings"), TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Verify starting state
+        Assert.Equal(0, _state!.StringsSourceTab);
+
+        // Right arrow → sub-tab 1
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state.StringsSourceTab == 1, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(1, _state.StringsSourceTab);
+
+        // Right arrow → sub-tab 2
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state.StringsSourceTab == 2, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(2, _state.StringsSourceTab);
+
+        // Left arrow → back to sub-tab 1
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.LeftArrow)
+            .WaitUntil(_ => _state.StringsSourceTab == 1, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(1, _state.StringsSourceTab);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 10_000)]
+    public async Task Tab4_ArrowKeysDuringSearchEditing_DoNotSwitchSubTab()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var runTask = app.RunAsync(cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D4) // Tab 4 — Strings
+            .WaitUntil(s => s.ContainsText("User Strings"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.OemQuestion) // '/' — activate search
+            .WaitUntil(_ => _state!.Search[TabId.Strings].IsActive, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(0, _state!.StringsSourceTab);
+
+        // Arrow keys during search editing should NOT switch sub-tabs
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .Key(Hex1bKey.RightArrow)
+            .Key(Hex1bKey.LeftArrow)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(0, _state.StringsSourceTab);
+        Assert.True(_state.Search[TabId.Strings].IsActive);
+
+        // Dismiss search, then arrows should work again
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => !_state.Search[TabId.Strings].IsActive, TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state.StringsSourceTab == 1, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(1, _state.StringsSourceTab);
 
         await runTask.ContinueWith(_ => { });
     }


### PR DESCRIPTION
## Summary
- Add left/right arrow key bindings to cycle Strings sub-tabs, matching PE/Metadata and Dynamic tab behavior
- Add `.Selected()` to Strings TabPanel so programmatic tab changes are reflected visually
- Guard arrow key bindings during search editing across all three sub-tab views
- Finalize in-progress search edits on tab switch so `/` works when returning
- Replace magic numbers with named sub-tab ID constants (`PeSubTabId`, `StringsSubTabId`, `DynamicSubTabId`)

Fixes #16