### PR TITLE
Dynamic tab highlighting, filter keys, and focus fixes

### DIFF
--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -117,11 +117,15 @@ public sealed class DotsiderApp
                     }, $"Tab {tabIndex + 1}");
                 }
 
-                bindings.Key(Hex1bKey.S).Global().Action(_ =>
+                // Suppress size toggle on Dynamic Events sub-tab where S is used for Socket filter
+                if (!(_state.CurrentTab == TabId.Dynamic && _state.DynamicSubTab == DynamicSubTabId.Events))
                 {
-                    _state.HumanReadableSizes = !_state.HumanReadableSizes;
-                    _state.App.Invalidate();
-                }, "Toggle size format");
+                    bindings.Key(Hex1bKey.S).Global().Action(_ =>
+                    {
+                        _state.HumanReadableSizes = !_state.HumanReadableSizes;
+                        _state.App.Invalidate();
+                    }, "Toggle size format");
+                }
                 bindings.Key(Hex1bKey.Q).Global().Action(ctx => ctx.RequestStop(), "Quit");
             }
 
@@ -252,7 +256,10 @@ public sealed class DotsiderApp
         var previousTab = _state.CurrentTab;
         _state.CurrentTab = tabIndex;
         if (previousTab != TabId.IlInspector && tabIndex == TabId.IlInspector)
+        {
             _state.IlRestoreDisassemblyScroll = true;
+            _state.IlNeedsTreeFocus = true;
+        }
     }
 
     private Hex1bWidget BuildHintsBar(WidgetContext<VStackWidget> ctx)

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -113,6 +113,9 @@ public sealed class DotsiderState : IDisposable
     /// </summary>
     public bool IlRestoreDisassemblyScroll { get; set; }
 
+    /// <summary>Whether the IL Inspector tree needs focus after a tab switch.</summary>
+    public bool IlNeedsTreeFocus { get; set; }
+
     // --- Strings Tab State ---
 
     /// <summary>The minimum string length filter for raw strings.</summary>

--- a/src/Dotsider/Views/DynamicAnalysisView.cs
+++ b/src/Dotsider/Views/DynamicAnalysisView.cs
@@ -23,6 +23,7 @@ public static class DynamicAnalysisView
     private static readonly Hex1bColor Blue = Hex1bColor.FromRgb(80, 140, 220);
     private static readonly Hex1bColor DimGray = Hex1bColor.FromRgb(100, 100, 120);
     private static readonly Hex1bColor Teal = Hex1bColor.FromRgb(0, 200, 180);
+    private static readonly Hex1bColor LabelColor = Hex1bColor.FromRgb(100, 130, 160);
 
     private static readonly Dictionary<TraceEventCategory, Hex1bColor> CategoryColors = new()
     {
@@ -91,13 +92,15 @@ public static class DynamicAnalysisView
         return ctx.VStack(outer =>
         [
             outer.Text(""),
-            outer.Text($"  Assembly:    {state.Analyzer.FileName}"),
-            outer.Text($"  Entry Point: 0x{state.Analyzer.ClrHeader!.EntryPointToken:X8}"),
-            outer.Text($"  Args:        {argsDisplay}"),
+            IdleLine(outer, "Assembly:   ", state.Analyzer.FileName),
+            IdleLine(outer, "Entry Point:", $"0x{state.Analyzer.ClrHeader!.EntryPointToken:X8}"),
+            IdleLine(outer, "Args:       ", argsDisplay),
             outer.Text(""),
-            outer.Text("  Press Enter to launch with EventPipe tracing."),
+            outer.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, Teal),
+                outer.Text("  Press Enter to launch with EventPipe tracing.")),
             outer.Text(""),
-            outer.Text("  Providers:"),
+            outer.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, LabelColor),
+                outer.Text("  Providers:")),
             outer.Text("    CLR Runtime — GC, JIT, Exceptions, Loader, Threading"),
             outer.Text("    System.Runtime — Performance Counters (1s interval)"),
             outer.Text("    System.Net.Http, System.Net.Sockets")
@@ -111,6 +114,8 @@ public static class DynamicAnalysisView
                     state.Tracer = new RuntimeTracer(
                         state.Analyzer.FilePath, state.DynamicArguments, state.App);
                     state.Tracer.Start();
+                    state.App.RequestFocus(node =>
+                        node.GetType().Name.StartsWith("TableNode"));
                     state.App.Invalidate();
                 }
             }, "Launch process");
@@ -214,6 +219,8 @@ public static class DynamicAnalysisView
                     state.DynamicEventsFocusedKey = null;
                     state.DynamicOutputFocusedKey = null;
                     state.DynamicCategoryFilter = null;
+                    state.App.RequestFocus(node =>
+                        node.GetType().Name.StartsWith("TableNode"));
                     state.App.Invalidate();
                 }, "Re-run process");
             }
@@ -280,7 +287,7 @@ public static class DynamicAnalysisView
 
         var filterText = state.DynamicCategoryFilter is { } f
             ? $" | Filter: {f} (Esc to clear)"
-            : " | g/j/e/l/h to filter";
+            : " | g/j/e/l/t/h/s to filter";
 
         return ctx.VStack(inner =>
         [
@@ -324,6 +331,8 @@ public static class DynamicAnalysisView
             bindings.Key(Hex1bKey.E).Action(_ => SetFilter(state, TraceEventCategory.Exception), "Filter Exceptions");
             bindings.Key(Hex1bKey.L).Action(_ => SetFilter(state, TraceEventCategory.Loader), "Filter Loader");
             bindings.Key(Hex1bKey.H).Action(_ => SetFilter(state, TraceEventCategory.Http), "Filter HTTP");
+            bindings.Key(Hex1bKey.T).Action(_ => SetFilter(state, TraceEventCategory.Threading), "Filter Threading");
+            bindings.Key(Hex1bKey.S).Action(_ => SetFilter(state, TraceEventCategory.Socket), "Filter Socket");
             bindings.Key(Hex1bKey.Escape).Action(_ =>
             {
                 if (search.IsActive)
@@ -370,8 +379,8 @@ public static class DynamicAnalysisView
             inner.Border(
                 inner.VStack(v =>
                 [
-                    v.Text($"  Working Set:  {counters.WorkingSetMb:F1} MB"),
-                    v.Text($"  GC Heap Size: {counters.GcHeapSizeMb:F1} MB")
+                    CounterLine(v, "  Working Set:  ", $"{counters.WorkingSetMb:F1} MB"),
+                    CounterLine(v, "  GC Heap Size: ", $"{counters.GcHeapSizeMb:F1} MB")
                 ])
             ).Title(" Memory ").FixedHeight(4),
 
@@ -379,9 +388,9 @@ public static class DynamicAnalysisView
             inner.Border(
                 inner.HStack(row =>
                 [
-                    row.Text($"  Gen 0: {counters.Gen0Collections}"),
-                    row.Text($"    Gen 1: {counters.Gen1Collections}"),
-                    row.Text($"    Gen 2: {counters.Gen2Collections}").Fill()
+                    CounterLine(row, "  Gen 0: ", $"{counters.Gen0Collections}"),
+                    CounterLine(row, "    Gen 1: ", $"{counters.Gen1Collections}"),
+                    CounterLine(row, "    Gen 2: ", $"{counters.Gen2Collections}").Fill()
                 ])
             ).Title(" GC Collections ").FixedHeight(3),
 
@@ -389,10 +398,10 @@ public static class DynamicAnalysisView
             inner.Border(
                 inner.HStack(row =>
                 [
-                    row.Text($"  Threads: {counters.ThreadPoolThreadCount}"),
-                    row.Text($"    Queue: {counters.ThreadPoolQueueLength}"),
-                    row.Text($"    Exceptions: {counters.ExceptionCount}"),
-                    row.Text($"    Timers: {counters.ActiveTimerCount}").Fill()
+                    CounterLine(row, "  Threads: ", $"{counters.ThreadPoolThreadCount}"),
+                    CounterLine(row, "    Queue: ", $"{counters.ThreadPoolQueueLength}"),
+                    CounterLine(row, "    Exceptions: ", $"{counters.ExceptionCount}"),
+                    CounterLine(row, "    Timers: ", $"{counters.ActiveTimerCount}").Fill()
                 ])
             ).Title(" Threading ").FixedHeight(3),
 
@@ -492,12 +501,35 @@ public static class DynamicAnalysisView
         ]).Fill();
     }
 
+    private static Hex1bWidget IdleLine<T>(WidgetContext<T> ctx, string label, string value)
+        where T : Hex1bWidget
+    {
+        return ctx.HStack(row =>
+        [
+            row.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, LabelColor),
+                row.Text($"  {label}")).FixedWidth(16),
+            row.Text(value).Fill()
+        ]).FixedHeight(1);
+    }
+
+    private static Hex1bWidget CounterLine<T>(WidgetContext<T> ctx, string label, string value)
+        where T : Hex1bWidget
+    {
+        return ctx.HStack(row =>
+        [
+            row.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, LabelColor),
+                row.Text(label)),
+            row.Text(value)
+        ]);
+    }
+
     private static Hex1bWidget InfoLine<T>(WidgetContext<T> ctx, string label, string value)
         where T : Hex1bWidget
     {
         return ctx.HStack(row =>
         [
-            row.Text($"  {label}:").FixedWidth(22),
+            row.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, LabelColor),
+                row.Text($"  {label}:")).FixedWidth(22),
             row.Text($" {value}").Fill()
         ]).FixedHeight(1);
     }

--- a/src/Dotsider/Views/IlInspectorView.cs
+++ b/src/Dotsider/Views/IlInspectorView.cs
@@ -24,6 +24,13 @@ public static class IlInspectorView
         var search = state.Search[TabId.IlInspector];
         ScheduleDisassemblyScrollRestore(state);
 
+        // Focus the tree after scroll restore completes (second render)
+        if (state.IlNeedsTreeFocus && !state.IlRestoreDisassemblyScroll)
+        {
+            state.IlNeedsTreeFocus = false;
+            state.App.RequestFocus(node => node is TreeNode);
+        }
+
         // Set up match navigation
         state.NavigateNextMatch = null;
         state.NavigatePrevMatch = null;

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -1,3 +1,4 @@
+using Dotsider.Analysis.Models;
 using Hex1b;
 using Hex1b.Input;
 using Hex1b.Nodes;
@@ -419,6 +420,41 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
             .ApplyAsync(terminal, cts.Token);
 
         Assert.Equal(1, _state.StringsSourceTab);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task Tab8_Events_SKey_FiltersSocket_NotToggleSize()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.HelloWorldDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var runTask = app.RunAsync(cts.Token);
+
+        // Navigate to Dynamic tab, launch the process, wait for exit
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D8)
+            .WaitUntil(s => s.ContainsText("EventPipe") || s.ContainsText("Launch"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(s => s.ContainsText("Exited") || s.ContainsText("Exit code"), TimeSpan.FromSeconds(8))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Record initial size toggle state
+        var sizesBefore = _state!.HumanReadableSizes;
+
+        // Press S on the Events sub-tab — should set Socket filter, not toggle sizes
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.S)
+            .WaitUntil(_ => _state.DynamicCategoryFilter == TraceEventCategory.Socket, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(TraceEventCategory.Socket, _state.DynamicCategoryFilter);
+        Assert.Equal(sizesBefore, _state.HumanReadableSizes);
 
         await runTask.ContinueWith(_ => { });
     }


### PR DESCRIPTION
## Summary
- Dim labels on idle view, counters, and summary sub-tabs for visual hierarchy
- Add `T` (Threading) and `S` (Socket) category filter key bindings on Events sub-tab
- Suppress global `S` size-toggle when on Dynamic Events sub-tab to avoid conflict
- Focus table on process launch/re-run so filter keys work without mouse click
- Fix IL Inspector tree focus after mouse-click tab switch (two-phase approach)

## Test plan
- [x] New test `Tab8_Events_SKey_FiltersSocket_NotToggleSize` asserts S key precedence
- [x] Full suite passes (253 tests)

Fixes #18