### PR TITLE
Fix hex save file locking on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Options:
 | `Ctrl+T` | Any | Toggle text/hex search mode |
 | `Ctrl+S` | Normal | Save edited bytes (only when modified) |
 
+In insert mode, type two hex digits (0-9, a-f) to overwrite one byte. The first digit sets the high nibble; the second commits the edit. Saving validates the PE image before writing — invalid edits are rejected.
+
 Diff mode adds `f` to cycle filters (All / Added / Removed / Changed).
 
 ## How it works

--- a/src/Dotsider/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider/Analysis/AssemblyAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Dotsider.Analysis;
 /// </summary>
 public sealed class AssemblyAnalyzer : IDisposable
 {
-    private readonly FileStream _stream;
+    private readonly Stream _stream;
     private readonly PEReader _peReader;
     private readonly MetadataReader? _metadataReader;
     private readonly byte[] _rawBytes;
@@ -48,6 +48,35 @@ public sealed class AssemblyAnalyzer : IDisposable
         IsReadOnly = fileInfo.IsReadOnly;
 
         _stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        _peReader = new PEReader(_stream);
+
+        if (_peReader.HasMetadata)
+        {
+            _metadataReader = _peReader.GetMetadataReader();
+            ReadAssemblyIdentity();
+            ReadTargetFramework();
+        }
+
+        ReadPeHeaders();
+        ReadClrHeader();
+    }
+
+    /// <summary>
+    /// Creates an analyzer from raw bytes in memory. Used as a last-resort
+    /// fallback when disk I/O is unavailable after a save operation.
+    /// </summary>
+    internal AssemblyAnalyzer(byte[] bytes, string filePath)
+    {
+        FilePath = filePath;
+        FileName = Path.GetFileName(filePath);
+
+        _rawBytes = bytes;
+        FileSize = bytes.Length;
+
+        LastModified = DateTime.UtcNow;
+        CreatedTime = DateTime.UtcNow;
+
+        _stream = new MemoryStream(bytes, writable: false);
         _peReader = new PEReader(_stream);
 
         if (_peReader.HasMetadata)

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -389,61 +389,74 @@ public sealed class DotsiderApp
         var filePath = state.Analyzer.FilePath;
         var tempPath = filePath + ".tmp";
 
+        // Phase 1: write and validate. state.Analyzer is still live here,
+        // so any exception is safe — just report and return.
+        byte[] newBytes;
         try
         {
-            var newBytes = state.HexEditorState.Document.GetBytes().ToArray();
+            newBytes = state.HexEditorState.Document.GetBytes().ToArray();
             File.WriteAllBytes(tempPath, newBytes);
-
-            // Build replacement from temp BEFORE disposing old analyzer.
-            // This validates the image AND gives us a ready fallback.
-            AssemblyAnalyzer newAnalyzer;
-            try
-            {
-                newAnalyzer = new AssemblyAnalyzer(tempPath);
-            }
-            catch (Exception ex)
-            {
-                try { File.Delete(tempPath); } catch { }
-                state.HexNotification = $"Cannot save: invalid image — {ex.Message}";
-                return;
-            }
-
-            // Replacement ready — dispose old analyzer to release file lock
-            state.Analyzer.Dispose();
-
-            try
-            {
-                File.Move(tempPath, filePath, overwrite: true);
-            }
-            catch (Exception moveEx)
-            {
-                // Move failed — commit the temp analyzer directly
-                CommitAnalyzer(state, newAnalyzer);
-                state.HexNotification = $"Save failed, working from {tempPath}: {moveEx.Message}";
-                return;
-            }
-
-            // Move succeeded — reopen from original path for correct FilePath.
-            // Keep newAnalyzer as fallback (its FD survived the rename).
-            try
-            {
-                var finalAnalyzer = new AssemblyAnalyzer(filePath);
-                newAnalyzer.Dispose();
-                CommitAnalyzer(state, finalAnalyzer);
-            }
-            catch
-            {
-                CommitAnalyzer(state, newAnalyzer);
-            }
-
-            var fileName = Path.GetFileName(filePath);
-            var size = new FileInfo(filePath).Length;
-            state.HexNotification = $"\"{fileName}\" {size}B written";
         }
         catch (Exception ex)
         {
             state.HexNotification = $"Save failed: {ex.Message}";
+            return;
         }
+
+        try
+        {
+            using var validator = new AssemblyAnalyzer(tempPath);
+        }
+        catch (Exception ex)
+        {
+            try { File.Delete(tempPath); } catch { }
+            state.HexNotification = $"Cannot save: invalid image — {ex.Message}";
+            return;
+        }
+
+        // Phase 2: replace analyzer. After Dispose(), every path must
+        // commit a live replacement before returning — no exceptions
+        // may propagate without first restoring state.Analyzer.
+        state.Analyzer.Dispose();
+
+        // Move temp → original. If move fails, the file is still at tempPath.
+        string savedPath;
+        try { File.Move(tempPath, filePath, overwrite: true); savedPath = filePath; }
+        catch { savedPath = tempPath; }
+
+        // Try reopening from the saved path, then alt path, then recovery.
+        string[] candidates =
+        [
+            savedPath,
+            savedPath == filePath ? tempPath : filePath,
+            filePath + ".recovery"
+        ];
+
+        foreach (var path in candidates)
+        {
+            try
+            {
+                // Recovery path needs the bytes written first
+                if (path.EndsWith(".recovery") && !File.Exists(path))
+                    File.WriteAllBytes(path, newBytes);
+
+                CommitAnalyzer(state, new AssemblyAnalyzer(path));
+                savedPath = path;
+
+                var fileName = Path.GetFileName(savedPath);
+                var size = new FileInfo(savedPath).Length;
+                state.HexNotification = savedPath == filePath
+                    ? $"\"{fileName}\" {size}B written"
+                    : $"Saved to {fileName} (could not overwrite original)";
+                return;
+            }
+            catch { /* try next candidate */ }
+        }
+
+        // All disk candidates exhausted. Fall back to in-memory analyzer
+        // constructed from the validated bytes — no filesystem I/O required.
+        CommitAnalyzer(state, new AssemblyAnalyzer(newBytes, filePath));
+        state.HexNotification = "Saved (working from memory — file may be locked)";
     }
 
     /// <summary>

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -375,6 +375,60 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
         await runTask.ContinueWith(_ => { });
     }
 
+    [Fact(Timeout = 15_000)]
+    public async Task Tab5_CtrlS_SavesWithCorrectFileName()
+    {
+        // Work on a disposable copy so we don't modify the shared fixture assembly
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dotsider-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var tempDll = Path.Combine(tempDir, "HelloWorld.dll");
+        File.Copy(samples.HelloWorldDll, tempDll);
+
+        try
+        {
+            var (terminal, app) = CreateDotsiderApp(tempDll);
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+            var runTask = app.RunAsync(cts.Token);
+
+            await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+                .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+                .Key(Hex1bKey.D5)
+                .WaitUntil(s => s.ContainsText("i: Edit"), TimeSpan.FromSeconds(3))
+                // Enter insert mode, skip past MZ header into DOS stub padding,
+                // then type two nibbles to complete a byte edit without breaking PE
+                .Key(Hex1bKey.I)
+                .WaitUntil(s => s.ContainsText("INSERT"), TimeSpan.FromSeconds(3))
+                .Key(Hex1bKey.RightArrow).Key(Hex1bKey.RightArrow)
+                .Key(Hex1bKey.RightArrow).Key(Hex1bKey.RightArrow)
+                .Key(Hex1bKey.F)
+                .Key(Hex1bKey.F)
+                .WaitUntil(_ => _state!.HexIsDirty, TimeSpan.FromSeconds(3))
+                // Return to normal mode, then save
+                .Key(Hex1bKey.Escape)
+                .WaitUntil(s => s.ContainsText("i: Edit"), TimeSpan.FromSeconds(3))
+                .Ctrl().Key(Hex1bKey.S)
+                .WaitUntil(_ => _state!.HexNotification != null, TimeSpan.FromSeconds(3))
+                .Ctrl().Key(Hex1bKey.C)
+                .Build()
+                .ApplyAsync(terminal, cts.Token);
+
+            // FilePath must be the original, not the .tmp fallback
+            Assert.Equal(tempDll, _state!.Analyzer.FilePath);
+            Assert.DoesNotContain(".tmp", _state.Analyzer.FileName);
+            Assert.Contains("written", _state.HexNotification);
+            Assert.Contains("HelloWorld.dll", _state.HexNotification);
+            // No temp file should remain
+            Assert.False(File.Exists(tempDll + ".tmp"));
+
+            await runTask.ContinueWith(_ => { });
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
     [Fact(Timeout = 10_000)]
     public async Task Tab6_ShowsDepGraph()
     {


### PR DESCRIPTION
## Summary
- Dispose the validation analyzer before `File.Move` so the temp file handle doesn't block the rename on Windows
- Split save into two phases: pre-dispose (safe to throw) and post-dispose (must always restore a live analyzer)
- Add in-memory `AssemblyAnalyzer(byte[], string)` fallback so `state.Analyzer` is never left disposed
- Add save integration test covering the full edit → save → verify flow
- Document nibble editing behavior in README

## Test plan
- [x] Verified on Windows — save completes, correct filename in title bar
- [x] New `Tab5_CtrlS_SavesWithCorrectFileName` test
- [x] All 263 tests pass

Fixes #22