### PR TITLE
fix(nupkg): add Enter key binding to open DLLs and fix InfoBar contrast

### DIFF
--- a/src/Dotsider/NuGetApp.cs
+++ b/src/Dotsider/NuGetApp.cs
@@ -12,7 +12,7 @@ namespace Dotsider;
 public sealed class NuGetApp
 {
     private readonly NuGetState _state;
-
+    
     /// <summary>
     /// Creates a new NuGet application with the specified state.
     /// </summary>
@@ -36,13 +36,13 @@ public sealed class NuGetApp
                     .Set(GlobalTheme.BackgroundColor, Hex1bColor.FromRgb(160, 100, 200))),
                 bar.Separator(" "),
                 bar.Section(_state.Package.FileName).Theme(t => t
-                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(180, 180, 200))),
+                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(80, 80, 100))),
                 bar.Spacer(),
                 bar.Section(_state.IsBrowsingPackage ? "Package Browser" : "DLL Inspector").Theme(t => t
-                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(200, 180, 100))),
+                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(130, 110, 30))),
                 bar.Separator(" | "),
                 bar.Section($"{_state.Package.DllFiles.Count} DLLs").Theme(t => t
-                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(200, 180, 100)))
+                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(130, 110, 30)))
             ]),
 
             // Main content: browser or inspector
@@ -62,6 +62,33 @@ public sealed class NuGetApp
         ])
         .WithInputBindings(bindings =>
         {
+            if (_state.IsBrowsingPackage)
+            {
+                bindings.Key(Hex1bKey.Enter).Action(_ =>
+                {
+                    var focusedKey = _state.FileTreeFocusedKey as string;
+                    var entry = focusedKey is not null
+                        ? _state.Package.DllFiles.FirstOrDefault(d => d.FullPath == focusedKey)
+                        : _state.Package.DllFiles.FirstOrDefault();
+
+                    if (entry is null) return;
+
+                    try
+                    {
+                        var analyzer = _state.Package.OpenDll(entry);
+                        _state.SelectedDllState?.Dispose();
+                        _state.SelectedDllState = new DotsiderState(_state.App, analyzer);
+                        _state.SelectedDllEntry = entry;
+                        _state.IsBrowsingPackage = false;
+                        _state.App.Invalidate();
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"Failed to open DLL: {ex.Message}");
+                    }
+                }, "Open DLL");
+            }
+
             bindings.Key(Hex1bKey.Backspace).Action(_ =>
             {
                 if (!_state.IsBrowsingPackage)

--- a/tests/Dotsider.Tests/NuGetModeViewTests.cs
+++ b/tests/Dotsider.Tests/NuGetModeViewTests.cs
@@ -89,6 +89,31 @@ public class NuGetModeViewTests(SampleAssemblyFixture samples) : IDisposable
         Assert.Equal(runTask, completed);
     }
 
+    [Fact(Timeout = 10_000)]
+    public async Task Enter_OnDllRow_OpensDllInspector()
+    {
+        var (terminal, app) = CreateNuGetApp();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var runTask = app.RunAsync(cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(5))
+            // Focus the DLL row and press Enter
+            .Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => !_state!.IsBrowsingPackage, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.False(_state!.IsBrowsingPackage);
+        Assert.NotNull(_state.SelectedDllState);
+        Assert.NotNull(_state.SelectedDllEntry);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
     public void Dispose()
     {
         _state?.Dispose();


### PR DESCRIPTION
## Summary
- Add explicit Enter key binding in NuGet browser to open focused DLL — `OnRowActivated` never fired because the table lacked keyboard focus in the VStack layout
- Fix WCAG AA color contrast for all InfoBar sections (filename, mode label, DLL count) on inverted background
- Add regression test `Enter_OnDllRow_OpensDllInspector`

## Test plan
- [x] `Enter_OnDllRow_OpensDllInspector` passes
- [x] Manual: open a .nupkg, press Enter on a DLL row — inspector opens
- [x] Manual: verify InfoBar text is readable on the title bar

Fixes: #24