### PR TITLE
fix(diff): WCAG colors, search, arrow nav, and highlighting parity

### DIFF
--- a/src/Dotsider/DiffApp.cs
+++ b/src/Dotsider/DiffApp.cs
@@ -43,17 +43,17 @@ public sealed class DiffApp
                     .Set(GlobalTheme.BackgroundColor, Hex1bColor.FromRgb(200, 200, 80))),
                 bar.Separator(" "),
                 bar.Section(_state.Left.FileName).Theme(t => t
-                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(180, 180, 200))),
+                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(80, 80, 100))),
                 bar.Section(" <> "),
                 bar.Section(_state.Right.FileName).Theme(t => t
-                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(180, 180, 200))),
+                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(80, 80, 100))),
                 bar.Spacer(),
                 bar.Section($"+{summary.TypesAdded + summary.MethodsAdded}").Theme(t => t
-                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(80, 200, 120))),
+                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(20, 100, 50))),
                 bar.Section($" -{summary.TypesRemoved + summary.MethodsRemoved}").Theme(t => t
-                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(200, 80, 80))),
+                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(140, 30, 30))),
                 bar.Section($" ~{summary.TypesChanged + summary.MethodsChanged}").Theme(t => t
-                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(200, 200, 80)))
+                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(130, 110, 30)))
             ]),
 
             // Filter indicator
@@ -110,6 +110,27 @@ public sealed class DiffApp
                 }
 
                 bindings.Key(Hex1bKey.Q).Global().Action(ctx => ctx.RequestStop(), "Quit");
+
+                // Left/Right arrows to cycle tabs
+                bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
+                {
+                    if (_state.CurrentTab > 0)
+                    {
+                        _state.CurrentTab--;
+                        _state.DiffFocusedKey = null;
+                        _state.App.Invalidate();
+                    }
+                }, "Previous tab");
+
+                bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
+                {
+                    if (_state.CurrentTab < 3)
+                    {
+                        _state.CurrentTab++;
+                        _state.DiffFocusedKey = null;
+                        _state.App.Invalidate();
+                    }
+                }, "Next tab");
             }
 
             bindings.Key(Hex1bKey.F).Action(_ =>
@@ -127,10 +148,10 @@ public sealed class DiffApp
                     _state.App.RequestFocus(node => node is TextBoxNode);
                 _state.App.Invalidate();
             };
-            bindings.Key(Hex1bKey.OemQuestion).Global().Action(_ => searchToggle(), "Search");
+            bindings.Key(Hex1bKey.OemQuestion).Global().OverridesCapture().Action(_ => searchToggle(), "Search");
             if (!isSearchEditing)
             {
-                bindings.Key(Hex1bKey.None).Global().Action(_ => searchToggle(), "Search");
+                bindings.Key(Hex1bKey.None).Global().OverridesCapture().Action(_ => searchToggle(), "Search");
             }
             if (isSearchEditing)
             {
@@ -169,7 +190,7 @@ public sealed class DiffApp
         return ctx.InfoBar(s =>
         {
             var hints = new List<IInfoBarChild>();
-            hints.Add(s.Section("1-4: Tabs"));
+            hints.Add(s.Section("1-4/←→: Tabs"));
             hints.Add(s.Section("f: Filter"));
 
             var currentSearch = _state.Search[_state.CurrentTab];

--- a/src/Dotsider/NuGetApp.cs
+++ b/src/Dotsider/NuGetApp.cs
@@ -52,24 +52,79 @@ public sealed class NuGetApp
 
             // Hints bar
             outer.InfoBar(s =>
-            [
-                s.Section(_state.IsBrowsingPackage ? "Enter: Open DLL" : "1-5: Tabs"),
-                s.Separator(" | "),
-                s.Section("Backspace: Back"),
-                s.Spacer(),
-                s.Section("q: Quit")
-            ]).WithDefaultSeparator(" | ")
+            {
+                var hints = new List<IInfoBarChild>();
+                hints.Add(s.Section(_state.IsBrowsingPackage ? "Enter: Open DLL" : "1-5: Tabs"));
+                hints.Add(s.Section("Backspace: Back"));
+                if (_state.IsBrowsingPackage)
+                {
+                    if (_state.BrowserSearch.IsActive)
+                        hints.Add(s.Section("Esc: Clear"));
+                    hints.Add(s.Section("/: Search"));
+                }
+                hints.Add(s.Spacer());
+                hints.Add(s.Section("q: Quit"));
+                return hints;
+            }).WithDefaultSeparator(" | ")
         ])
         .WithInputBindings(bindings =>
         {
+            var browserSearch = _state.BrowserSearch;
+            var isSearchEditing = browserSearch.IsActive && !browserSearch.IsConfirmed;
+
             if (_state.IsBrowsingPackage)
             {
+                // Search toggle (same dual-binding strategy as DotsiderApp/DiffApp)
+                Action searchToggle = () =>
+                {
+                    browserSearch.ActivateOrCycle();
+                    if (browserSearch.IsActive && !browserSearch.IsConfirmed)
+                        _state.App.RequestFocus(node => node is TextBoxNode);
+                    _state.App.Invalidate();
+                };
+                bindings.Key(Hex1bKey.OemQuestion).Global().OverridesCapture().Action(_ => searchToggle(), "Search");
+                if (!isSearchEditing)
+                {
+                    bindings.Key(Hex1bKey.None).Global().OverridesCapture().Action(_ => searchToggle(), "Search");
+                }
+                if (isSearchEditing)
+                {
+                    bindings.Key(Hex1bKey.Enter).Global().OverridesCapture().Action(_ =>
+                    {
+                        if (!string.IsNullOrEmpty(browserSearch.Query))
+                        {
+                            browserSearch.Confirm();
+                            _state.App.Invalidate();
+                        }
+                    }, "Confirm search");
+                }
+
+                bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
+                {
+                    if (browserSearch.IsActive)
+                    {
+                        browserSearch.Dismiss();
+                        _state.App.Invalidate();
+                    }
+                }, "Esc");
+
                 bindings.Key(Hex1bKey.Enter).Action(_ =>
                 {
+                    // Filter against search query so Enter cannot open a hidden DLL
+                    var visibleDlls = (IReadOnlyList<Analysis.Models.NuGetFileEntry>)_state.Package.DllFiles;
+                    var q = browserSearch.Query;
+                    if (!string.IsNullOrEmpty(q))
+                    {
+                        visibleDlls = visibleDlls.Where(d =>
+                            d.Name.Contains(q, StringComparison.OrdinalIgnoreCase) ||
+                            d.Directory.Contains(q, StringComparison.OrdinalIgnoreCase))
+                            .ToList();
+                    }
+
                     var focusedKey = _state.FileTreeFocusedKey as string;
                     var entry = focusedKey is not null
-                        ? _state.Package.DllFiles.FirstOrDefault(d => d.FullPath == focusedKey)
-                        : _state.Package.DllFiles.FirstOrDefault();
+                        ? visibleDlls.FirstOrDefault(d => d.FullPath == focusedKey)
+                        : visibleDlls.FirstOrDefault();
 
                     if (entry is null) return;
 
@@ -115,7 +170,8 @@ public sealed class NuGetApp
                 }
             }
 
-            bindings.Key(Hex1bKey.Q).Global().Action(ctx => ctx.RequestStop(), "Quit");
+            if (!isSearchEditing)
+                bindings.Key(Hex1bKey.Q).Global().Action(ctx => ctx.RequestStop(), "Quit");
             bindings.Ctrl().Key(Hex1bKey.C).Global().OverridesCapture()
                 .Action(ctx => ctx.RequestStop(), "Quit");
         });

--- a/src/Dotsider/NuGetState.cs
+++ b/src/Dotsider/NuGetState.cs
@@ -38,6 +38,9 @@ public sealed class NuGetState : IDisposable
     /// <summary>Whether the user is viewing the package file list (true) or a DLL inspector (false).</summary>
     public bool IsBrowsingPackage { get; set; } = true;
 
+    /// <summary>Search state for the package browser view.</summary>
+    public SearchState BrowserSearch { get; } = new();
+
     /// <summary>The currently selected tab index in the DLL inspector.</summary>
     public int CurrentTab { get; set; }
 

--- a/src/Dotsider/Views/DiffMethodsView.cs
+++ b/src/Dotsider/Views/DiffMethodsView.cs
@@ -72,11 +72,12 @@ public static class DiffMethodsView
                     return
                     [
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(prefix))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(method.DeclaringType))),
-                        r.Cell(c => !string.IsNullOrEmpty(query)
-                            ? c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, HighlightHelper.MatchBgColor), c.Text(method.Name))
-                            : c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(method.Name))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(method.Signature))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
+                            HighlightHelper.HighlightCell(c, method.DeclaringType, query, !string.IsNullOrEmpty(query)))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
+                            HighlightHelper.HighlightCell(c, method.Name, query, !string.IsNullOrEmpty(query)))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
+                            HighlightHelper.HighlightCell(c, method.Signature, query, !string.IsNullOrEmpty(query)))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(entry.ChangeDescription ?? "")))
                     ];
                 })
@@ -90,7 +91,7 @@ public static class DiffMethodsView
         })
         .WithInputBindings(bindings =>
         {
-            bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
+            bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
             {
                 if (search.IsActive)
                 {

--- a/src/Dotsider/Views/DiffRefsView.cs
+++ b/src/Dotsider/Views/DiffRefsView.cs
@@ -74,9 +74,8 @@ public static class DiffRefsView
                     return
                     [
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(prefix))),
-                        r.Cell(c => !string.IsNullOrEmpty(query)
-                            ? c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, HighlightHelper.MatchBgColor), c.Text(name))
-                            : c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(name))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
+                            HighlightHelper.HighlightCell(c, name, query, !string.IsNullOrEmpty(query)))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(leftVer))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(rightVer))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(entry.ChangeDescription ?? "")))
@@ -92,7 +91,7 @@ public static class DiffRefsView
         })
         .WithInputBindings(bindings =>
         {
-            bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
+            bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
             {
                 if (search.IsActive)
                 {

--- a/src/Dotsider/Views/DiffSummaryView.cs
+++ b/src/Dotsider/Views/DiffSummaryView.cs
@@ -1,4 +1,5 @@
 using Hex1b;
+using Hex1b.Input;
 using Hex1b.Layout;
 using Hex1b.Theming;
 using Hex1b.Widgets;
@@ -22,23 +23,34 @@ public static class DiffSummaryView
     /// <returns>The root widget for the Summary tab.</returns>
     public static Hex1bWidget Build(WidgetContext<VStackWidget> ctx, DiffState state)
     {
+        var search = state.Search[0]; // Summary = tab 0
+        var query = search.Query;
         var summary = state.DiffResult.MetadataSummary;
 
+        // Set up match navigation (not applicable for static view)
+        state.NavigateNextMatch = null;
+        state.NavigatePrevMatch = null;
+
         return ctx.VStack(outer =>
-        [
+        {
+            var widgets = new List<Hex1bWidget>();
+
+            // Search bar
+            SearchBarHelper.AddSearchBar(widgets, outer, search, state.App);
+
             // Side-by-side assembly info
-            outer.HSplitter(
+            widgets.Add(outer.HSplitter(
                 left =>
                 [
                     left.Border(
                         left.VStack(info =>
                         [
-                            DiffInfoLine(info, "Name", state.Left.AssemblyName ?? ""),
-                            DiffInfoLine(info, "Version", state.Left.AssemblyVersion ?? ""),
-                            DiffInfoLine(info, "Size", DotsiderState.FormatSize(state.Left.FileSize)),
-                            DiffInfoLine(info, "Types", state.Left.TypeDefs.Count.ToString()),
-                            DiffInfoLine(info, "Methods", state.Left.MethodDefs.Count.ToString()),
-                            DiffInfoLine(info, "References", state.Left.AssemblyRefs.Count.ToString())
+                            DiffInfoLine(info, "Name", state.Left.AssemblyName ?? "", query),
+                            DiffInfoLine(info, "Version", state.Left.AssemblyVersion ?? "", query),
+                            DiffInfoLine(info, "Size", DotsiderState.FormatSize(state.Left.FileSize), query),
+                            DiffInfoLine(info, "Types", state.Left.TypeDefs.Count.ToString(), query),
+                            DiffInfoLine(info, "Methods", state.Left.MethodDefs.Count.ToString(), query),
+                            DiffInfoLine(info, "References", state.Left.AssemblyRefs.Count.ToString(), query)
                         ])
                     ).Title($" {state.Left.FileName} (Left) ").Fill()
                 ],
@@ -47,19 +59,19 @@ public static class DiffSummaryView
                     right.Border(
                         right.VStack(info =>
                         [
-                            DiffInfoLine(info, "Name", state.Right.AssemblyName ?? ""),
-                            DiffInfoLine(info, "Version", state.Right.AssemblyVersion ?? ""),
-                            DiffInfoLine(info, "Size", DotsiderState.FormatSize(state.Right.FileSize)),
-                            DiffInfoLine(info, "Types", state.Right.TypeDefs.Count.ToString()),
-                            DiffInfoLine(info, "Methods", state.Right.MethodDefs.Count.ToString()),
-                            DiffInfoLine(info, "References", state.Right.AssemblyRefs.Count.ToString())
+                            DiffInfoLine(info, "Name", state.Right.AssemblyName ?? "", query),
+                            DiffInfoLine(info, "Version", state.Right.AssemblyVersion ?? "", query),
+                            DiffInfoLine(info, "Size", DotsiderState.FormatSize(state.Right.FileSize), query),
+                            DiffInfoLine(info, "Types", state.Right.TypeDefs.Count.ToString(), query),
+                            DiffInfoLine(info, "Methods", state.Right.MethodDefs.Count.ToString(), query),
+                            DiffInfoLine(info, "References", state.Right.AssemblyRefs.Count.ToString(), query)
                         ])
                     ).Title($" {state.Right.FileName} (Right) ").Fill()
                 ],
-                leftWidth: 50).FixedHeight(9),
+                leftWidth: 50).FixedHeight(9));
 
             // Change statistics
-            outer.Border(
+            widgets.Add(outer.Border(
                 outer.VStack(stats =>
                 [
                     stats.HStack(h =>
@@ -86,16 +98,30 @@ public static class DiffSummaryView
                     stats.Text(""),
                     stats.Text($"  Size delta: {(summary.SizeDelta >= 0 ? "+" : "")}{DotsiderState.FormatSize(Math.Abs(summary.SizeDelta))}")
                 ])
-            ).Title(" Change Summary ").Fill()
-        ]).Fill();
+            ).Title(" Change Summary ").Fill());
+
+            return widgets.ToArray();
+        })
+        .WithInputBindings(bindings =>
+        {
+            bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
+            {
+                if (search.IsActive)
+                {
+                    search.Dismiss();
+                    state.App.Invalidate();
+                }
+            }, "Esc");
+        })
+        .Fill();
     }
 
-    private static Hex1bWidget DiffInfoLine<T>(WidgetContext<T> ctx, string label, string value) where T : Hex1bWidget
+    private static Hex1bWidget DiffInfoLine<T>(WidgetContext<T> ctx, string label, string value, string? query) where T : Hex1bWidget
     {
         return ctx.HStack(row =>
         [
             row.Text($"  {label}: ").FixedWidth(16),
-            row.Text(value)
+            HighlightHelper.HighlightText(row, value, query)
         ]).FixedHeight(1);
     }
 }

--- a/src/Dotsider/Views/DiffTypesView.cs
+++ b/src/Dotsider/Views/DiffTypesView.cs
@@ -70,9 +70,8 @@ public static class DiffTypesView
                     return
                     [
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(prefix))),
-                        r.Cell(c => !string.IsNullOrEmpty(query)
-                            ? c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, HighlightHelper.MatchBgColor), c.Text(type.FullName))
-                            : c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(type.FullName))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
+                            HighlightHelper.HighlightCell(c, type.FullName, query, !string.IsNullOrEmpty(query)))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(type.BaseType ?? ""))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(type.MethodCount.ToString()))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(type.FieldCount.ToString()))),
@@ -89,7 +88,7 @@ public static class DiffTypesView
         })
         .WithInputBindings(bindings =>
         {
-            bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
+            bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
             {
                 if (search.IsActive)
                 {

--- a/src/Dotsider/Views/NuGetBrowserView.cs
+++ b/src/Dotsider/Views/NuGetBrowserView.cs
@@ -20,27 +20,45 @@ public static class NuGetBrowserView
     public static Hex1bWidget Build(WidgetContext<VStackWidget> ctx, NuGetState state)
     {
         var pkg = state.Package;
+        var search = state.BrowserSearch;
+        var query = search.Query;
+
+        // Filter DLL list by search query
+        var dlls = (IReadOnlyList<NuGetFileEntry>)pkg.DllFiles;
+        if (!string.IsNullOrEmpty(query))
+        {
+            dlls = dlls.Where(d =>
+                d.Name.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                d.Directory.Contains(query, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            search.SetMatchCount(dlls.Count);
+        }
 
         return ctx.VStack(outer =>
-        [
+        {
+            var widgets = new List<Hex1bWidget>();
+
             // Package metadata
-            outer.Border(
+            widgets.Add(outer.Border(
                 outer.VStack(info =>
                 [
-                    InfoLine(info, "Package ID", pkg.PackageId ?? "(unknown)"),
-                    InfoLine(info, "Version", pkg.PackageVersion ?? "(unknown)"),
-                    InfoLine(info, "Authors", pkg.Authors ?? "(unknown)"),
-                    InfoLine(info, "Description", pkg.Description ?? "(none)"),
+                    InfoLine(info, "Package ID", pkg.PackageId ?? "(unknown)", query),
+                    InfoLine(info, "Version", pkg.PackageVersion ?? "(unknown)", query),
+                    InfoLine(info, "Authors", pkg.Authors ?? "(unknown)", query),
+                    InfoLine(info, "Description", pkg.Description ?? "(none)", query),
                     info.Text(""),
-                    InfoLine(info, "Total Files", pkg.Files.Count.ToString()),
-                    InfoLine(info, "DLL Files", pkg.DllFiles.Count.ToString()),
-                    InfoLine(info, "Total Size", DotsiderState.FormatSize(pkg.Files.Sum(f => f.UncompressedSize)))
+                    InfoLine(info, "Total Files", pkg.Files.Count.ToString(), query),
+                    InfoLine(info, "DLL Files", pkg.DllFiles.Count.ToString(), query),
+                    InfoLine(info, "Total Size", DotsiderState.FormatSize(pkg.Files.Sum(f => f.UncompressedSize)), query)
                 ])
-            ).Title(" Package Info "),
+            ).Title(" Package Info "));
+
+            // Search bar
+            SearchBarHelper.AddSearchBar(widgets, outer, search, state.App);
 
             // DLL selector table
-            outer.Border(
-                outer.Table(pkg.DllFiles)
+            widgets.Add(outer.Border(
+                outer.Table(dlls)
                     .RowKey(r => r.FullPath)
                     .Header(h =>
                     [
@@ -50,8 +68,8 @@ public static class NuGetBrowserView
                     ])
                     .Row((r, entry, rowState) =>
                     [
-                        r.Cell(entry.Name),
-                        r.Cell(entry.Directory),
+                        r.Cell(c => HighlightHelper.HighlightCell(c, entry.Name, query, !string.IsNullOrEmpty(query))),
+                        r.Cell(c => HighlightHelper.HighlightCell(c, entry.Directory, query, !string.IsNullOrEmpty(query))),
                         r.Cell(DotsiderState.FormatSize(entry.UncompressedSize))
                     ])
                     .Focus(state.FileTreeFocusedKey)
@@ -75,16 +93,18 @@ public static class NuGetBrowserView
                     .Compact()
                     .Empty(e => e.Text("  No DLL files in package"))
                     .FillHeight()
-            ).Title($" DLL Files ({pkg.DllFiles.Count}) — Enter to inspect ").Fill()
-        ]).Fill();
+            ).Title($" DLL Files ({pkg.DllFiles.Count}) — Enter to inspect ").Fill());
+
+            return widgets.ToArray();
+        }).Fill();
     }
 
-    private static Hex1bWidget InfoLine<T>(WidgetContext<T> ctx, string label, string value) where T : Hex1bWidget
+    private static Hex1bWidget InfoLine<T>(WidgetContext<T> ctx, string label, string value, string? query) where T : Hex1bWidget
     {
         return ctx.HStack(row =>
         [
             row.Text($"  {label}: ").FixedWidth(18),
-            row.Text(value)
+            HighlightHelper.HighlightText(row, value, query)
         ]).FixedHeight(1);
     }
 }

--- a/tests/Dotsider.Tests/DiffModeViewTests.cs
+++ b/tests/Dotsider.Tests/DiffModeViewTests.cs
@@ -93,6 +93,80 @@ public class DiffModeViewTests(SampleAssemblyFixture samples) : IDisposable
         Assert.Equal(runTask, completed);
     }
 
+    [Fact(Timeout = 10_000)]
+    public async Task ArrowKeys_CycleTabs()
+    {
+        var (terminal, app) = CreateDiffApp();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var runTask = app.RunAsync(cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Summary") || s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(5))
+            // Start on tab 0 (Summary), arrow right to Types (tab 1)
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.CurrentTab == 1, TimeSpan.FromSeconds(2))
+            // Arrow right again to Methods (tab 2)
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.CurrentTab == 2, TimeSpan.FromSeconds(2))
+            // Arrow left back to Types (tab 1)
+            .Key(Hex1bKey.LeftArrow)
+            .WaitUntil(_ => _state!.CurrentTab == 1, TimeSpan.FromSeconds(2))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(1, _state!.CurrentTab);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 10_000)]
+    public async Task Search_ActivatesAndFilters()
+    {
+        var (terminal, app) = CreateDiffApp();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var runTask = app.RunAsync(cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Summary") || s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(5))
+            // Switch to Types tab, then activate search
+            .Key(Hex1bKey.D2)
+            .WaitUntil(_ => _state!.CurrentTab == 1, TimeSpan.FromSeconds(2))
+            .Key(Hex1bKey.OemQuestion)
+            .WaitUntil(_ => _state!.Search[1].IsActive, TimeSpan.FromSeconds(2))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.True(_state!.Search[1].IsActive);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 10_000)]
+    public async Task LeftArrow_DoesNotGoBelowZero()
+    {
+        var (terminal, app) = CreateDiffApp();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var runTask = app.RunAsync(cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Summary") || s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(5))
+            // On tab 0, press left twice — should stay at 0
+            .Key(Hex1bKey.LeftArrow)
+            .Key(Hex1bKey.LeftArrow)
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(0, _state!.CurrentTab);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
     public void Dispose()
     {
         _state?.Dispose();

--- a/tests/Dotsider.Tests/NuGetModeViewTests.cs
+++ b/tests/Dotsider.Tests/NuGetModeViewTests.cs
@@ -114,6 +114,31 @@ public class NuGetModeViewTests(SampleAssemblyFixture samples) : IDisposable
         await runTask.ContinueWith(_ => { });
     }
 
+    [Fact(Timeout = 10_000)]
+    public async Task Search_ActivatesAndDismisses()
+    {
+        var (terminal, app) = CreateNuGetApp();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var runTask = app.RunAsync(cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("RichLibrary") || s.ContainsText("DLL"), TimeSpan.FromSeconds(5))
+            // Activate search
+            .Key(Hex1bKey.OemQuestion)
+            .WaitUntil(_ => _state!.BrowserSearch.IsActive, TimeSpan.FromSeconds(2))
+            // Dismiss with Esc
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => !_state!.BrowserSearch.IsActive, TimeSpan.FromSeconds(2))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.False(_state!.BrowserSearch.IsActive);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
     public void Dispose()
     {
         _state?.Dispose();


### PR DESCRIPTION
## Summary
- Fix WCAG AA color contrast for all diff InfoBar text (assembly names, +/-/~ stats)
- Fix `/` search not activating (missing `.OverridesCapture()` on key bindings)
- Add left/right arrow key tab navigation for diff tabs
- Replace broken `MatchBgColor` foreground with proper `HighlightHelper.HighlightCell()` inline substring highlighting in Types/Methods/Refs tables
- Add search with highlighting to DiffSummaryView and NuGet package browser
- Make Esc `.Global()` on all diff view search dismiss bindings so it works after confirm
- Prevent Enter from opening hidden DLLs in filtered NuGet search results

## Test plan
- [x] `ArrowKeys_CycleTabs` — right/right/left navigates tabs correctly
- [x] `Search_ActivatesAndFilters` — `/` activates search on Types tab
- [x] `LeftArrow_DoesNotGoBelowZero` — left arrow on tab 0 stays at 0
- [x] `Search_ActivatesAndDismisses` — `/` then Esc in NuGet browser
- [x] Full suite: 268/268 pass

Fixes: #26