### PR TITLE
fix(il-inspector): replace reflection with anchor-based scroll restore

### DIFF
--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -308,7 +308,7 @@ public sealed class DotsiderApp
         _state.CurrentTab = tabIndex;
         if (previousTab != TabId.IlInspector && tabIndex == TabId.IlInspector)
         {
-            _state.IlRestoreDisassemblyScroll = true;
+            _state.IlScrollRestoreFrames = 2;
             _state.IlNeedsTreeFocus = true;
         }
     }

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -106,11 +106,14 @@ public sealed class DotsiderState : IDisposable
     /// <summary>The current vertical scroll offset in the IL disassembly pane.</summary>
     public int IlDisassemblyScrollOffset { get; set; }
 
+    /// <summary>The viewport height of the IL disassembly scroll panel (saved from OnScroll).</summary>
+    public int IlDisassemblyViewportSize { get; set; }
+
     /// <summary>
-    /// Indicates that IL disassembly scroll should be restored on next scroll callback
-    /// after returning to the IL tab.
+    /// Scroll restore frame counter. 2 = focus the interactable anchor,
+    /// 1 = let EnsureFocusedVisible adjust offset during layout, 0 = done.
     /// </summary>
-    public bool IlRestoreDisassemblyScroll { get; set; }
+    public int IlScrollRestoreFrames { get; set; }
 
     /// <summary>Whether the IL Inspector tree needs focus after a tab switch.</summary>
     public bool IlNeedsTreeFocus { get; set; }
@@ -300,7 +303,8 @@ public sealed class DotsiderState : IDisposable
         IlSelectedMethod = null;
         IlTreeExpansionState.Clear();
         IlDisassemblyScrollOffset = 0;
-        IlRestoreDisassemblyScroll = false;
+        IlDisassemblyViewportSize = 0;
+        IlScrollRestoreFrames = 0;
         StringsSourceTab = 0;
         StringsFocusedKey = null;
         StringsDetailContent = null;

--- a/src/Dotsider/Views/IlInspectorView.cs
+++ b/src/Dotsider/Views/IlInspectorView.cs
@@ -3,7 +3,6 @@ using Hex1b;
 using Hex1b.Input;
 using Hex1b.Nodes;
 using Hex1b.Widgets;
-using System.Reflection;
 
 namespace Dotsider.Views;
 
@@ -22,10 +21,35 @@ public static class IlInspectorView
     public static Hex1bWidget Build(WidgetContext<VStackWidget> ctx, DotsiderState state)
     {
         var search = state.Search[TabId.IlInspector];
-        ScheduleDisassemblyScrollRestore(state);
 
-        // Focus the tree after scroll restore completes (second render)
-        if (state.IlNeedsTreeFocus && !state.IlRestoreDisassemblyScroll)
+        // Scroll restore state machine:
+        //   2 → focus the interactable anchor and capture viewport size, decrement to 1
+        //   1 → EnsureFocusedVisible adjusts Offset during layout, decrement to 0
+        //   0 → done
+        var scrollRestorePhase = state.IlScrollRestoreFrames;
+        if (state.IlScrollRestoreFrames > 0)
+            state.IlScrollRestoreFrames--;
+
+        if (scrollRestorePhase == 2)
+        {
+            // The predicate visits ScrollPanelNode before its children (InteractableNode),
+            // so we capture ViewportSize as a side effect. OnScroll never fires for this
+            // panel because EnsureFocusedVisible bypasses SetOffset/ScrollAction.
+            state.App.RequestFocus(node =>
+            {
+                if (node is ScrollPanelNode sp)
+                    state.IlDisassemblyViewportSize = sp.ViewportSize;
+                return node is InteractableNode;
+            });
+        }
+        else if (scrollRestorePhase == 1)
+        {
+            // Force another frame so tree focus runs after scroll is restored
+            state.App.Invalidate();
+        }
+
+        // Focus the tree after scroll restore completes
+        if (state.IlNeedsTreeFocus && scrollRestorePhase == 0)
         {
             state.IlNeedsTreeFocus = false;
             state.App.RequestFocus(node => node is TreeNode);
@@ -59,26 +83,22 @@ public static class IlInspectorView
                         {
                             var searchQuery = state.Search[TabId.IlInspector].Query;
                             var disassembly = state.IlDisassembler.FormatDisassembly(method);
-                            return disassembly.Split('\n')
-                                .Select(line => string.IsNullOrEmpty(searchQuery)
-                                    ? scroll.Text(IlColorizer.ColorizeLine(line))
-                                    : HighlightHelper.HighlightText(scroll, line, searchQuery))
-                                .ToArray();
+                            var lines = disassembly.Split('\n');
+
+                            return BuildDisassemblyWidgets(
+                                scroll, lines, searchQuery, scrollRestorePhase, state);
                         }
 
                         return [scroll.Text("  Select a method to view IL disassembly")];
                     })
                     .OnScroll(e =>
                     {
-                        if (state.IlRestoreDisassemblyScroll
-                            && TrySetScrollOffset(e.Node, state.IlDisassemblyScrollOffset, e.Context))
-                        {
-                            state.IlRestoreDisassemblyScroll = false;
-                            state.IlDisassemblyScrollOffset = e.Node.Offset;
-                            return;
-                        }
-
-                        state.IlDisassemblyScrollOffset = e.Offset;
+                        // Don't overwrite the saved offset during scroll restore —
+                        // the scroll panel starts at 0 when recreated after a tab switch,
+                        // and clobbering the saved value would defeat the anchor mechanism.
+                        if (state.IlScrollRestoreFrames <= 0)
+                            state.IlDisassemblyScrollOffset = e.Offset;
+                        state.IlDisassemblyViewportSize = e.ViewportSize;
                     })
                     .FillHeight()
                 ],
@@ -101,7 +121,7 @@ public static class IlInspectorView
             {
                 if (state.IlSelectedMethod is null) return;
                 state.IlDisassemblyScrollOffset += 20;
-                state.IlRestoreDisassemblyScroll = true;
+                state.IlScrollRestoreFrames = 2;
                 state.App.Invalidate();
             }, "Page Down");
 
@@ -109,11 +129,77 @@ public static class IlInspectorView
             {
                 if (state.IlSelectedMethod is null) return;
                 state.IlDisassemblyScrollOffset = Math.Max(0, state.IlDisassemblyScrollOffset - 20);
-                state.IlRestoreDisassemblyScroll = true;
+                state.IlScrollRestoreFrames = 2;
                 state.App.Invalidate();
             }, "Page Up");
         })
         .FillWidth().FillHeight();
+    }
+
+    /// <summary>
+    /// Builds the disassembly line widgets, optionally wrapping a viewport-sized
+    /// span in an Interactable anchor for scroll position restoration.
+    /// </summary>
+    private static Hex1bWidget[] BuildDisassemblyWidgets<T>(
+        WidgetContext<T> ctx,
+        string[] lines,
+        string? searchQuery,
+        int scrollRestorePhase,
+        DotsiderState state) where T : Hex1bWidget
+    {
+        // When not restoring scroll, just build plain text widgets
+        if (scrollRestorePhase <= 0)
+        {
+            return lines
+                .Select(line => MakeLineWidget(ctx, line, searchQuery))
+                .ToArray();
+        }
+
+        // Calculate the anchor span: a viewport-sized range starting at the target offset.
+        // When EnsureFocusedVisible sees a focused child spanning [target..target+viewport],
+        // it adjusts Offset to exactly `target` regardless of scroll direction.
+        // Use a minimum of 1 so the anchor is still created even if OnScroll hasn't
+        // fired yet to populate the viewport size (e.g. first PageDown after selecting a method).
+        var viewportSize = Math.Max(state.IlDisassemblyViewportSize, 1);
+        var anchorStart = Math.Clamp(state.IlDisassemblyScrollOffset, 0, Math.Max(0, lines.Length - 1));
+        var anchorEnd = Math.Min(anchorStart + viewportSize, lines.Length);
+
+        if (anchorEnd <= anchorStart)
+        {
+            return lines
+                .Select(line => MakeLineWidget(ctx, line, searchQuery))
+                .ToArray();
+        }
+
+        var widgets = new Hex1bWidget[lines.Length - (anchorEnd - anchorStart) + 1];
+        var wi = 0;
+
+        // Lines before anchor
+        for (var i = 0; i < anchorStart; i++)
+            widgets[wi++] = MakeLineWidget(ctx, lines[i], searchQuery);
+
+        // Anchor: wrap viewport-sized span in Interactable for EnsureFocusedVisible
+        widgets[wi++] = ctx.Interactable(ic =>
+        {
+            var anchorWidgets = new Hex1bWidget[anchorEnd - anchorStart];
+            for (var j = 0; j < anchorWidgets.Length; j++)
+                anchorWidgets[j] = MakeLineWidget(ic, lines[anchorStart + j], searchQuery);
+            return anchorWidgets;
+        });
+
+        // Lines after anchor
+        for (var i = anchorEnd; i < lines.Length; i++)
+            widgets[wi++] = MakeLineWidget(ctx, lines[i], searchQuery);
+
+        return widgets;
+    }
+
+    private static Hex1bWidget MakeLineWidget<T>(
+        WidgetContext<T> ctx, string line, string? searchQuery) where T : Hex1bWidget
+    {
+        return string.IsNullOrEmpty(searchQuery)
+            ? ctx.Text(IlColorizer.ColorizeLine(line))
+            : HighlightHelper.HighlightText(ctx, line, searchQuery);
     }
 
     private static IEnumerable<TreeItemWidget> BuildMethodTree(TreeContext t, DotsiderState state)
@@ -189,7 +275,7 @@ public static class IlInspectorView
                     {
                         state.IlSelectedMethod = m;
                         state.IlDisassemblyScrollOffset = 0;
-                        state.IlRestoreDisassemblyScroll = false;
+                        state.IlScrollRestoreFrames = 0;
                         state.App.Invalidate();
                     }
 
@@ -207,56 +293,4 @@ public static class IlInspectorView
 
     private static bool GetTreeExpansionState(DotsiderState state, string key, bool defaultExpanded) =>
         state.IlTreeExpansionState.TryGetValue(key, out var expanded) ? expanded : defaultExpanded;
-
-    private static void ScheduleDisassemblyScrollRestore(DotsiderState state)
-    {
-        if (!state.IlRestoreDisassemblyScroll) return;
-
-        // RequestFocus is processed post-reconciliation, so this sees the newly built
-        // IL scroll panel node after tab activation.
-        state.App.RequestFocus(node =>
-        {
-            if (!state.IlRestoreDisassemblyScroll) return false;
-            if (node is not ScrollPanelNode scroll || scroll.Orientation != ScrollOrientation.Vertical)
-                return false;
-
-            if (!TrySetScrollOffset(scroll, state.IlDisassemblyScrollOffset, null))
-                return false;
-
-            state.IlRestoreDisassemblyScroll = false;
-            state.IlDisassemblyScrollOffset = scroll.Offset;
-            state.App.Invalidate();
-            return false;
-        });
-    }
-
-    private static bool TrySetScrollOffset(ScrollPanelNode node, int requestedOffset, InputBindingActionContext? context)
-    {
-        var targetOffset = Math.Clamp(requestedOffset, 0, node.MaxOffset);
-        if (targetOffset == node.Offset) return true;
-
-        if (context is not null)
-        {
-            var setOffset = typeof(ScrollPanelNode).GetMethod(
-                "SetOffset",
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                binder: null,
-                types: [typeof(int), typeof(InputBindingActionContext)],
-                modifiers: null);
-            if (setOffset is not null)
-            {
-                setOffset.Invoke(node, [targetOffset, context]);
-                return true;
-            }
-        }
-
-        var offsetProperty = typeof(ScrollPanelNode).GetProperty(
-            "Offset",
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-        var setter = offsetProperty?.SetMethod;
-        if (setter is null) return false;
-
-        setter.Invoke(node, [targetOffset]);
-        return true;
-    }
 }

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -757,6 +757,78 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
         await runTask.ContinueWith(_ => { });
     }
 
+    [Fact(Timeout = 20_000)]
+    public async Task Tab3_ScrollPositionPreservedAcrossTabSwitch()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(18));
+        var runTask = app.RunAsync(cts.Token);
+
+        // Navigate to IL Inspector and select ToTitleCase (139 bytes of IL, overflows viewport)
+        var builder = new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D3)
+            .WaitUntil(s => s.ContainsText("Select a method"), TimeSpan.FromSeconds(3));
+
+        // Navigate tree to StringHelpers > ToTitleCase
+        for (var i = 0; i < 15; i++)
+            builder = builder.Key(Hex1bKey.DownArrow);
+
+        await builder
+            .Key(Hex1bKey.RightArrow) // Expand StringHelpers
+            .WaitUntil(s => s.ContainsText("ToTitleCase"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.Enter) // Select ToTitleCase
+            .WaitUntil(s => s.ContainsText("IL_0000"), TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Scroll down via PageDown — exercises the full keyboard scroll path
+        // without seeding IlDisassemblyViewportSize.
+        // Verify rendered output actually scrolled past IL_0000.
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.PageDown)
+            .WaitUntil(_ => _state!.IlDisassemblyScrollOffset > 0, TimeSpan.FromSeconds(3))
+            .WaitUntil(s => !s.ContainsText("IL_0000"), TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        var savedOffset = _state!.IlDisassemblyScrollOffset;
+        var savedMethod = _state.IlSelectedMethod;
+        Assert.True(savedOffset > 0, "Scroll offset should be non-zero after PageDown");
+
+        // Switch to tab 1 (General)
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.D1)
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // State must survive while on another tab
+        Assert.Equal(savedOffset, _state.IlDisassemblyScrollOffset);
+        Assert.Equal(savedMethod, _state.IlSelectedMethod);
+
+        // Switch back to tab 3 — triggers scroll restore state machine.
+        // Verify the rendered disassembly is restored past IL_0000 (not reset to top).
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.D3)
+            .WaitUntil(s => s.ContainsText("IL_"), TimeSpan.FromSeconds(5))
+            .WaitUntil(_ => _state.IlScrollRestoreFrames == 0, TimeSpan.FromSeconds(3))
+            .WaitUntil(s => !s.ContainsText("IL_0000"), TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Scroll offset must be preserved after restore completes
+        Assert.Equal(savedOffset, _state.IlDisassemblyScrollOffset);
+        Assert.Equal(savedMethod, _state.IlSelectedMethod);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
     [Fact(Timeout = 10_000)]
     public async Task QuitKey_ExitsApp()
     {


### PR DESCRIPTION
## Summary

- Remove `System.Reflection` usage (`GetMethod`, `BindingFlags`, `Invoke`) from `IlInspectorView.TrySetScrollOffset` that set `ScrollPanelNode.Offset` via its private setter
- Replace with a 3-frame state machine that wraps a viewport-sized span in an `InteractableWidget`, then uses `EnsureFocusedVisible` during layout to scroll to the target offset
- Capture `ScrollPanelNode.ViewportSize` via the `RequestFocus` predicate since `OnScroll` never fires for this panel (`EnsureFocusedVisible` bypasses `SetOffset`/`ScrollAction`)
- Guard the `OnScroll` handler during restore frames to prevent the recreated scroll panel's initial `Offset=0` from clobbering the saved offset
- Add integration test that verifies both rendered scroll position and state are preserved across a tab switch round-trip

## Test plan

- [x] All 275 tests pass (274 existing + 1 new)
- [x] `Tab3_ScrollPositionPreservedAcrossTabSwitch` verifies rendered output scrolls past `IL_0000` after PageDown, and stays scrolled after switching to tab 1 and back
- [x] No `System.Reflection` imports remain in `IlInspectorView.cs`
- [x] Manual: open a large assembly, select a method with long IL, PageDown, switch tabs, switch back — disassembly should stay scrolled

Fixes #33