### PR TITLE
fix(views): add keyboard nav to dep graph and fix treemap interactions

### DIFF
--- a/src/Dotsider/DiffApp.cs
+++ b/src/Dotsider/DiffApp.cs
@@ -12,15 +12,13 @@ namespace Dotsider;
 /// <summary>
 /// Root application class for diff mode. Compares two assemblies side-by-side.
 /// </summary>
-public sealed class DiffApp
+/// <remarks>
+/// Creates a new diff application with the specified state.
+/// </remarks>
+/// <param name="state">The diff state holding both analyzers and the diff result.</param>
+public sealed class DiffApp(DiffState state)
 {
-    private readonly DiffState _state;
-
-    /// <summary>
-    /// Creates a new diff application with the specified state.
-    /// </summary>
-    /// <param name="state">The diff state holding both analyzers and the diff result.</param>
-    public DiffApp(DiffState state) => _state = state;
+    private readonly DiffState _state = state;
 
     /// <summary>
     /// Builds the root widget tree for the diff view.
@@ -140,14 +138,15 @@ public sealed class DiffApp
             }, "Cycle filter");
 
             // Global search toggle (same dual-binding strategy as DotsiderApp)
-            Action searchToggle = () =>
+            void searchToggle()
             {
                 _state.Search[_state.CurrentTab].ActivateOrCycle();
                 var s = _state.Search[_state.CurrentTab];
                 if (s.IsActive && !s.IsConfirmed)
                     _state.App.RequestFocus(node => node is TextBoxNode);
                 _state.App.Invalidate();
-            };
+            }
+
             bindings.Key(Hex1bKey.OemQuestion).Global().OverridesCapture().Action(_ => searchToggle(), "Search");
             if (!isSearchEditing)
             {
@@ -185,13 +184,14 @@ public sealed class DiffApp
         });
     }
 
-    private Hex1bWidget BuildHintsBar(WidgetContext<VStackWidget> ctx)
-    {
-        return ctx.InfoBar(s =>
+    private InfoBarWidget BuildHintsBar(WidgetContext<VStackWidget> ctx) =>
+        ctx.InfoBar(s =>
         {
-            var hints = new List<IInfoBarChild>();
-            hints.Add(s.Section("1-4/←→: Tabs"));
-            hints.Add(s.Section("f: Filter"));
+            var hints = new List<IInfoBarChild>
+            {
+                s.Section("1-4/←→: Tabs"),
+                s.Section("f: Filter")
+            };
 
             var currentSearch = _state.Search[_state.CurrentTab];
             if (currentSearch.IsActive)
@@ -202,8 +202,7 @@ public sealed class DiffApp
             hints.Add(s.Section("q: Quit"));
             return hints;
         }).WithDefaultSeparator(" | ");
-    }
 
-    private static int CountChanges<T>(IReadOnlyList<DiffEntry<T>> diffs)
-        => diffs.Count(d => d.Kind != DiffKind.Unchanged);
+    private static int CountChanges<T>(IReadOnlyList<DiffEntry<T>> diffs) =>
+        diffs.Count(d => d.Kind != DiffKind.Unchanged);
 }

--- a/src/Dotsider/DiffFilterMode.cs
+++ b/src/Dotsider/DiffFilterMode.cs
@@ -1,0 +1,19 @@
+namespace Dotsider;
+
+/// <summary>
+/// Specifies which diff entries to display.
+/// </summary>
+public enum DiffFilterMode
+{
+    /// <summary>Show all diff entries (added, removed, and changed).</summary>
+    All,
+
+    /// <summary>Show only entries present in the new assembly but not the old.</summary>
+    AddedOnly,
+
+    /// <summary>Show only entries present in the old assembly but not the new.</summary>
+    RemovedOnly,
+
+    /// <summary>Show only entries that exist in both assemblies but differ.</summary>
+    ChangedOnly
+}

--- a/src/Dotsider/DiffState.cs
+++ b/src/Dotsider/DiffState.cs
@@ -60,8 +60,3 @@ public sealed class DiffState : IDisposable
         Right.Dispose();
     }
 }
-
-/// <summary>
-/// Specifies which diff entries to display.
-/// </summary>
-public enum DiffFilterMode { All, AddedOnly, RemovedOnly, ChangedOnly }

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -39,7 +39,7 @@ public sealed class DotsiderApp
         {
             _initialFocusRequested = true;
             _state.App.RequestFocus(node =>
-                node is EditorNode or TreeNode
+                node is EditorNode or TreeNode or InteractableNode
                 || node.GetType().Name.StartsWith("TableNode"));
         }
         return ctx.VStack(outer =>
@@ -86,6 +86,9 @@ public sealed class DotsiderApp
             .OnSelectionChanged(e =>
             {
                 SelectTab(e.SelectedIndex);
+                _state.App.RequestFocus(node =>
+                    node is EditorNode or TreeNode or InteractableNode
+                    || node.GetType().Name.StartsWith("TableNode"));
                 _state.App.Invalidate();
             })
             .Full()
@@ -113,7 +116,7 @@ public sealed class DotsiderApp
                         SelectTab(tabIndex);
                         // Move focus from tab bar into content so arrow keys work immediately
                         _state.App.RequestFocus(node =>
-                            node is EditorNode or TreeNode
+                            node is EditorNode or TreeNode or InteractableNode
                             || node.GetType().Name.StartsWith("TableNode"));
                         _state.App.Invalidate();
                     }, $"Tab {tabIndex + 1}");
@@ -168,6 +171,10 @@ public sealed class DotsiderApp
                         if (_state.CurrentTab == TabId.HexDump)
                             Views.HexDumpView.ExecuteSearch(_state);
                         currentSearch.Confirm();
+                        // Restore focus from the search TextBox back to the content area
+                        _state.App.RequestFocus(node =>
+                            node is EditorNode or TreeNode or InteractableNode
+                            || node.GetType().Name.StartsWith("TableNode"));
                         _state.App.Invalidate();
                     }
                 }, "Confirm search");
@@ -346,8 +353,10 @@ public sealed class DotsiderApp
                     hints.Add(s.Section(hexHints));
                 }
             }
+            else if (_state.CurrentTab == 5)
+                hints.Add(s.Section("←→: Select"));
             else if (_state.CurrentTab == 6)
-                hints.Add(s.Section("Backspace: Up"));
+                hints.Add(s.Section("Enter: Drill | ←→: Select | Backspace: Up"));
             else if (_state.CurrentTab == 7)
             {
                 if (_state.Tracer?.ProcessState == Analysis.Models.TraceProcessState.Running)

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -155,6 +155,9 @@ public sealed class DotsiderState : IDisposable
     /// <summary>Stable match index for dependency graph search navigation.</summary>
     public int GraphMatchIndex { get; set; } = -1;
 
+    /// <summary>Keyboard-selected node index in the dependency graph, or -1 for none.</summary>
+    public int GraphSelectedIndex { get; set; } = -1;
+
     // --- Size Treemap Tab State ---
 
     /// <summary>Cached size tree for treemap visualization.</summary>
@@ -169,8 +172,14 @@ public sealed class DotsiderState : IDisposable
     /// <summary>The hovered item description in the treemap.</summary>
     public string? TreemapHoveredItem { get; set; }
 
+    /// <summary>The hovered SizeNode in the treemap, used for click/Enter drill-down.</summary>
+    public SizeNode? TreemapHoveredNode { get; set; }
+
     /// <summary>Stable match index for treemap search navigation.</summary>
     public int TreemapMatchIndex { get; set; } = -1;
+
+    /// <summary>Keyboard-selected child index in the treemap, or -1 for none.</summary>
+    public int TreemapSelectedIndex { get; set; } = -1;
 
     // --- Hex Dump Tab State ---
 
@@ -314,11 +323,14 @@ public sealed class DotsiderState : IDisposable
         CachedGraph = null;
         GraphSelectedNode = null;
         GraphMatchIndex = -1;
+        GraphSelectedIndex = -1;
         CachedSizeTree = null;
         TreemapCurrentLevel = null;
         TreemapBreadcrumb.Clear();
         TreemapHoveredItem = null;
+        TreemapHoveredNode = null;
         TreemapMatchIndex = -1;
+        TreemapSelectedIndex = -1;
         HexMatchOffsets = [];
         HexCurrentMatchIndex = -1;
         HexMatchPatternLength = 0;

--- a/src/Dotsider/Views/DependencyGraphView.cs
+++ b/src/Dotsider/Views/DependencyGraphView.cs
@@ -18,6 +18,7 @@ public static class DependencyGraphView
     private static readonly Hex1bColor RefColor = Hex1bColor.FromRgb(100, 130, 180);
     private static readonly Hex1bColor EdgeColor = Hex1bColor.FromRgb(80, 80, 100);
     private static readonly Hex1bColor HighlightColor = Hex1bColor.FromRgb(255, 220, 100);
+    private static readonly Hex1bColor SelectionBorder = Hex1bColor.FromRgb(255, 255, 255);
 
     /// <summary>
     /// Builds the Dependency Graph view widget tree.
@@ -51,25 +52,26 @@ public static class DependencyGraphView
         state.NavigateNextMatch = matchingNodes.Count > 0 ? () =>
         {
             state.GraphMatchIndex = (state.GraphMatchIndex + 1) % matchingNodes.Count;
-            var node = nodes[matchingNodes[state.GraphMatchIndex]];
-            var version = node.Version is not null ? $" v{node.Version}" : "";
-            state.GraphSelectedNode = $"{node.Name}{version}";
         } : null;
         state.NavigatePrevMatch = matchingNodes.Count > 0 ? () =>
         {
             state.GraphMatchIndex = state.GraphMatchIndex <= 0
                 ? matchingNodes.Count - 1 : state.GraphMatchIndex - 1;
-            var node = nodes[matchingNodes[state.GraphMatchIndex]];
-            var version = node.Version is not null ? $" v{node.Version}" : "";
-            state.GraphSelectedNode = $"{node.Name}{version}";
         } : null;
 
         return ctx.VStack(outer =>
         {
             var widgets = new List<Hex1bWidget>();
 
-            // Display: hover info takes priority, then navigated match, then default
+            // Display: hover > keyboard selection > search match > default
             var displayNode = state.GraphSelectedNode;
+            if (displayNode is null && state.GraphSelectedIndex >= 0
+                && state.GraphSelectedIndex < nodes.Count)
+            {
+                var node = nodes[state.GraphSelectedIndex];
+                var version = node.Version is not null ? $" v{node.Version}" : "";
+                displayNode = $"{node.Name}{version}";
+            }
             if (displayNode is null && state.GraphMatchIndex >= 0
                 && state.GraphMatchIndex < matchingNodes.Count)
             {
@@ -89,12 +91,36 @@ public static class DependencyGraphView
             // Search bar
             SearchBarHelper.AddSearchBar(widgets, outer, search, state.App);
 
-            widgets.Add(outer.Surface(s =>
-            [
-                s.Layer(surface => DrawGraph(surface, nodes, edges, state, s.MouseX, s.MouseY, query))
-            ]).Fill());
+            // Graph surface wrapped in Interactable for keyboard/click support
+            widgets.Add(outer.Interactable(ic =>
+                ic.Surface(s =>
+                [
+                    s.Layer(surface => DrawGraph(surface, nodes, edges, state, s.MouseX, s.MouseY, query))
+                ]).Fill()
+            ).WithInputBindings(bindings =>
+            {
+                bindings.Key(Hex1bKey.RightArrow).Action(_ =>
+                {
+                    if (nodes.Count > 0)
+                    {
+                        state.GraphSelectedIndex = (state.GraphSelectedIndex + 1) % nodes.Count;
+                        state.App.Invalidate();
+                    }
+                }, "Next node");
 
-            return widgets.ToArray();
+                bindings.Key(Hex1bKey.LeftArrow).Action(_ =>
+                {
+                    if (nodes.Count > 0)
+                    {
+                        state.GraphSelectedIndex = state.GraphSelectedIndex <= 0
+                            ? nodes.Count - 1
+                            : state.GraphSelectedIndex - 1;
+                        state.App.Invalidate();
+                    }
+                }, "Previous node");
+            }).Fill());
+
+            return [.. widgets];
         })
         .WithInputBindings(bindings =>
         {
@@ -118,6 +144,7 @@ public static class DependencyGraphView
         if (w < 10 || h < 5) return;
 
         var hasQuery = !string.IsNullOrEmpty(query);
+        var selectedIndex = state.GraphSelectedIndex;
 
         // Draw edges first (underneath nodes)
         foreach (var edge in edges)
@@ -153,8 +180,9 @@ public static class DependencyGraphView
 
         // Draw nodes on top
         state.GraphSelectedNode = null;
-        foreach (var node in nodes)
+        for (var i = 0; i < nodes.Count; i++)
         {
+            var node = nodes[i];
             var cx = (int)(node.X * (w - 1));
             var cy = (int)(node.Y * (h - 1));
             var label = node.Name;
@@ -167,6 +195,7 @@ public static class DependencyGraphView
             if (y0 + 3 > h) y0 = h - 3;
 
             var isMatch = hasQuery && node.Name.Contains(query!, StringComparison.OrdinalIgnoreCase);
+            var isSelected = i == selectedIndex;
             var bg = isMatch ? (node.IsRoot ? RootColor : RefColor)
                 : hasQuery ? HighlightHelper.DimColor
                 : node.IsRoot ? RootColor : RefColor;
@@ -180,18 +209,20 @@ public static class DependencyGraphView
                 state.GraphSelectedNode = $"{node.Name}{version}";
             }
 
+            var borderColor = isSelected ? SelectionBorder : bg;
+
             // Draw box
-            surface.WriteChar(x0, y0, '┌', bg);
-            surface.WriteChar(x0 + boxW - 1, y0, '┐', bg);
-            surface.WriteChar(x0, y0 + 2, '└', bg);
-            surface.WriteChar(x0 + boxW - 1, y0 + 2, '┘', bg);
+            surface.WriteChar(x0, y0, '┌', borderColor);
+            surface.WriteChar(x0 + boxW - 1, y0, '┐', borderColor);
+            surface.WriteChar(x0, y0 + 2, '└', borderColor);
+            surface.WriteChar(x0 + boxW - 1, y0 + 2, '┘', borderColor);
             for (var x = x0 + 1; x < x0 + boxW - 1; x++)
             {
-                surface.WriteChar(x, y0, '─', bg);
-                surface.WriteChar(x, y0 + 2, '─', bg);
+                surface.WriteChar(x, y0, '─', borderColor);
+                surface.WriteChar(x, y0 + 2, '─', borderColor);
             }
-            surface.WriteChar(x0, y0 + 1, '│', bg);
-            surface.WriteChar(x0 + boxW - 1, y0 + 1, '│', bg);
+            surface.WriteChar(x0, y0 + 1, '│', borderColor);
+            surface.WriteChar(x0 + boxW - 1, y0 + 1, '│', borderColor);
 
             // Fill interior and write label
             for (var x = x0 + 1; x < x0 + boxW - 1; x++)

--- a/src/Dotsider/Views/SizeTreemapView.cs
+++ b/src/Dotsider/Views/SizeTreemapView.cs
@@ -59,73 +59,150 @@ public static class SizeTreemapView
         {
             state.TreemapMatchIndex = state.TreemapMatchIndex < 0
                 ? 0 : (state.TreemapMatchIndex + 1) % matchingItems.Count;
-            var child = currentLevel.Children[matchingItems[state.TreemapMatchIndex]];
-            state.TreemapHoveredItem = $" {child.FullPath}: {state.FormatSizeToggleable(child.Size)} ({child.Children.Count} children)";
         } : null;
         state.NavigatePrevMatch = matchingItems.Count > 0 ? () =>
         {
             state.TreemapMatchIndex = state.TreemapMatchIndex <= 0
                 ? matchingItems.Count - 1 : state.TreemapMatchIndex - 1;
-            var child = currentLevel.Children[matchingItems[state.TreemapMatchIndex]];
-            state.TreemapHoveredItem = $" {child.FullPath}: {state.FormatSizeToggleable(child.Size)} ({child.Children.Count} children)";
         } : null;
 
         return ctx.VStack(outer =>
         {
-            var widgets = new List<Hex1bWidget>();
-
-            // Breadcrumb
-            widgets.Add(outer.HStack(row =>
+            var widgets = new List<Hex1bWidget>
             {
-                var parts = new List<Hex1bWidget>();
-                parts.Add(row.Text($" {BuildBreadcrumb(state)} "));
-                parts.Add(row.Text($"| Total: {state.FormatSizeToggleable(currentLevel.Size)}").Fill());
-                return parts.ToArray();
-            }).FixedHeight(1));
+                // Breadcrumb
+                outer.HStack(row =>
+                {
+                    var parts = new List<Hex1bWidget>();
+                    parts.Add(row.Text($" {BuildBreadcrumb(state)} "));
+                    parts.Add(row.Text($"| Total: {state.FormatSizeToggleable(currentLevel.Size)}").Fill());
+                    return parts.ToArray();
+                }).FixedHeight(1)
+            };
 
             // Search bar
             SearchBarHelper.AddSearchBar(widgets, outer, search, state.App);
 
-            // Treemap surface
-            widgets.Add(outer.Surface(s =>
-            [
-                s.Layer(surface =>
-                {
-                    if (currentLevel.Children.Count == 0)
+            // Treemap surface wrapped in Interactable for click/Enter/arrow/Backspace support
+            widgets.Add(outer.Interactable(ic =>
+                ic.Surface(s =>
+                [
+                    s.Layer(surface =>
                     {
-                        surface.WriteText(2, 1, "No code size data available", Hex1bColor.FromRgb(140, 140, 160));
-                        return;
-                    }
-                    var rects = TreemapLayout.Layout(
-                        currentLevel.Children, 0, 0, surface.Width, surface.Height);
-                    state.TreemapHoveredItem = null;
-                    DrawTreemap(surface, rects, state, s.MouseX, s.MouseY, query);
-                })
-            ]).Fill());
+                        if (currentLevel.Children.Count == 0)
+                        {
+                            surface.WriteText(2, 1, "No code size data available", Hex1bColor.FromRgb(140, 140, 160));
+                            return;
+                        }
+                        var rects = TreemapLayout.Layout(
+                            currentLevel.Children, 0, 0, surface.Width, surface.Height);
+                        state.TreemapHoveredItem = null;
+                        state.TreemapHoveredNode = null;
+                        DrawTreemap(surface, rects, state, s.MouseX, s.MouseY, query);
+                    })
+                ]).Fill()
+            ).OnClick(e =>
+            {
+                SizeNode? drillTarget = null;
 
-            // Detail bar: hover takes priority, then navigated match, then default
+                if (e.Context.MouseX >= 0)
+                {
+                    // Mouse click: compute target from click coordinates
+                    var relX = e.Context.MouseX - e.Node.Bounds.X;
+                    var relY = e.Context.MouseY - e.Node.Bounds.Y;
+                    var rects = TreemapLayout.Layout(
+                        currentLevel.Children, 0, 0, e.Node.Bounds.Width, e.Node.Bounds.Height);
+                    foreach (var rect in rects)
+                    {
+                        if (relX >= (int)rect.X && relX < (int)(rect.X + rect.Width) &&
+                            relY >= (int)rect.Y && relY < (int)(rect.Y + rect.Height))
+                        {
+                            drillTarget = rect.Node;
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    // Keyboard (Enter/Space): prefer search match over stale selection
+                    if (state.TreemapMatchIndex >= 0 && state.TreemapMatchIndex < matchingItems.Count)
+                        drillTarget = currentLevel.Children[matchingItems[state.TreemapMatchIndex]];
+                    else if (state.TreemapSelectedIndex >= 0 && state.TreemapSelectedIndex < currentLevel.Children.Count)
+                        drillTarget = currentLevel.Children[state.TreemapSelectedIndex];
+                }
+
+                if (drillTarget is { Children.Count: > 0 })
+                {
+                    state.TreemapBreadcrumb.Push(currentLevel);
+                    state.TreemapCurrentLevel = drillTarget;
+                    state.TreemapSelectedIndex = -1;
+                    state.TreemapMatchIndex = -1;
+                    state.TreemapHoveredNode = null;
+                    state.App.Invalidate();
+                }
+            }).WithInputBindings(bindings =>
+            {
+                bindings.Key(Hex1bKey.Backspace).Action(_ =>
+                {
+                    if (state.TreemapBreadcrumb.Count > 0)
+                    {
+                        state.TreemapCurrentLevel = state.TreemapBreadcrumb.Pop();
+                        state.TreemapSelectedIndex = -1;
+                        state.App.Invalidate();
+                    }
+                }, "Go up");
+
+                bindings.Mouse(MouseButton.Right).Action(_ =>
+                {
+                    if (state.TreemapBreadcrumb.Count > 0)
+                    {
+                        state.TreemapCurrentLevel = state.TreemapBreadcrumb.Pop();
+                        state.TreemapSelectedIndex = -1;
+                        state.App.Invalidate();
+                    }
+                }, "Go up");
+
+                bindings.Key(Hex1bKey.RightArrow).Action(_ =>
+                {
+                    if (currentLevel.Children.Count > 0)
+                    {
+                        state.TreemapSelectedIndex = (state.TreemapSelectedIndex + 1) % currentLevel.Children.Count;
+                        state.App.Invalidate();
+                    }
+                }, "Next item");
+
+                bindings.Key(Hex1bKey.LeftArrow).Action(_ =>
+                {
+                    if (currentLevel.Children.Count > 0)
+                    {
+                        state.TreemapSelectedIndex = state.TreemapSelectedIndex <= 0
+                            ? currentLevel.Children.Count - 1
+                            : state.TreemapSelectedIndex - 1;
+                        state.App.Invalidate();
+                    }
+                }, "Previous item");
+            }).Fill());
+
+            // Detail bar: hover > selected > search match > default hint
             var detailText = state.TreemapHoveredItem;
+            if (detailText is null && state.TreemapSelectedIndex >= 0
+                && state.TreemapSelectedIndex < currentLevel.Children.Count)
+            {
+                var child = currentLevel.Children[state.TreemapSelectedIndex];
+                detailText = $" {child.FullPath}: {state.FormatSizeToggleable(child.Size)} ({child.Children.Count} children)";
+            }
             if (detailText is null && state.TreemapMatchIndex >= 0
                 && state.TreemapMatchIndex < matchingItems.Count)
             {
                 var child = currentLevel.Children[matchingItems[state.TreemapMatchIndex]];
                 detailText = $" {child.FullPath}: {state.FormatSizeToggleable(child.Size)} ({child.Children.Count} children)";
             }
-            widgets.Add(outer.Text(detailText ?? " Click to drill down | Backspace to go up").FixedHeight(1));
+            widgets.Add(outer.Text(detailText ?? "").FixedHeight(1));
 
             return widgets.ToArray();
         })
         .WithInputBindings(bindings =>
         {
-            bindings.Key(Hex1bKey.Backspace).Action(_ =>
-            {
-                if (state.TreemapBreadcrumb.Count > 0)
-                {
-                    state.TreemapCurrentLevel = state.TreemapBreadcrumb.Pop();
-                    state.App.Invalidate();
-                }
-            }, "Go up");
-
             bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
             {
                 if (search.IsActive)
@@ -150,15 +227,19 @@ public static class SizeTreemapView
         return string.Join(" > ", parts);
     }
 
+    private static readonly Hex1bColor SelectionBorder = Hex1bColor.FromRgb(255, 255, 255);
+
     private static void DrawTreemap(Surface surface, IReadOnlyList<TreemapRect> rects,
         DotsiderState state, int mouseX, int mouseY, string? query)
     {
         var hasQuery = !string.IsNullOrEmpty(query);
+        var selectedIndex = state.TreemapSelectedIndex;
 
         for (var i = 0; i < rects.Count; i++)
         {
             var rect = rects[i];
             var isMatch = hasQuery && rect.Node.Name.Contains(query!, StringComparison.OrdinalIgnoreCase);
+            var isSelected = i == selectedIndex;
             var color = isMatch ? Palette[i % Palette.Length]
                 : hasQuery ? HighlightHelper.DimColor
                 : Palette[i % Palette.Length];
@@ -175,11 +256,13 @@ public static class SizeTreemapView
                 for (var x = x1; x < x2 && x < surface.Width; x++)
                     surface.WriteChar(x, y, ' ', color, color);
 
-            // Draw border (darker shade)
-            var borderColor = Hex1bColor.FromRgb(
-                (byte)(color.R * 40 / 100),
-                (byte)(color.G * 40 / 100),
-                (byte)(color.B * 40 / 100));
+            // Draw border: bright white for selected, dark shade for normal
+            var borderColor = isSelected
+                ? SelectionBorder
+                : Hex1bColor.FromRgb(
+                    (byte)(color.R * 40 / 100),
+                    (byte)(color.G * 40 / 100),
+                    (byte)(color.B * 40 / 100));
 
             for (var x = x1; x < x2 && x < surface.Width; x++)
             {
@@ -188,6 +271,19 @@ public static class SizeTreemapView
             for (var y = y1; y < y2 && y < surface.Height; y++)
             {
                 if (x1 < surface.Width) surface.WriteChar(x1, y, '▕', borderColor, color);
+            }
+
+            // Selected items also get right and bottom borders
+            if (isSelected)
+            {
+                for (var x = x1; x < x2 && x < surface.Width; x++)
+                {
+                    if (y2 - 1 < surface.Height) surface.WriteChar(x, y2 - 1, '▔', borderColor, color);
+                }
+                for (var y = y1; y < y2 && y < surface.Height; y++)
+                {
+                    if (x2 - 1 < surface.Width) surface.WriteChar(x2 - 1, y, '▏', borderColor, color);
+                }
             }
 
             // Write label if fits
@@ -211,6 +307,7 @@ public static class SizeTreemapView
             if (mouseX >= x1 && mouseX < x2 && mouseY >= y1 && mouseY < y2)
             {
                 state.TreemapHoveredItem = $" {rect.Node.FullPath}: {state.FormatSizeToggleable(rect.Node.Size)} ({rect.Node.Children.Count} children)";
+                state.TreemapHoveredNode = rect.Node;
             }
         }
     }

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -14,7 +14,7 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
     private Hex1bApp? _hex1bApp;
     private DotsiderState? _state;
 
-    private (Hex1bTerminal terminal, Hex1bApp app) CreateDotsiderApp(string dllPath)
+    private (Hex1bTerminal terminal, Hex1bApp app) CreateDotsiderApp(string dllPath, int? initialTab = null)
     {
         _workload = new Hex1bAppWorkloadAdapter();
         _terminal = Hex1bTerminal.CreateBuilder()
@@ -26,7 +26,12 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
         _hex1bApp = new Hex1bApp(
             ctx =>
             {
-                _state ??= new DotsiderState(_hex1bApp!, dllPath);
+                if (_state is null)
+                {
+                    _state = new DotsiderState(_hex1bApp!, dllPath);
+                    if (initialTab.HasValue)
+                        _state.CurrentTab = initialTab.Value;
+                }
                 dotsiderApp ??= new DotsiderApp(_state);
                 return Task.FromResult<Hex1bWidget>(dotsiderApp.Build(ctx));
             },
@@ -463,6 +468,535 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
             .Ctrl().Key(Hex1bKey.C)
             .Build()
             .ApplyAsync(terminal, cts.Token);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 10_000)]
+    public async Task Tab6_ShowsNodeAndEdgeCounts()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var runTask = app.RunAsync(cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D6)
+            .WaitUntil(s => s.ContainsText("Nodes:") && s.ContainsText("Edges:"), TimeSpan.FromSeconds(5))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.NotNull(_state!.CachedGraph);
+        Assert.True(_state.CachedGraph.Value.Nodes.Count > 0);
+        Assert.True(_state.CachedGraph.Value.Edges.Count > 0);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task Tab6_SearchShowsMatchCount()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var runTask = app.RunAsync(cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D6)
+            .WaitUntil(s => s.ContainsText("Nodes:"), TimeSpan.FromSeconds(5))
+            .Key(Hex1bKey.OemQuestion) // '/' — activate search
+            .WaitUntil(_ => _state!.Search[TabId.DepGraph].IsActive, TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.S).Key(Hex1bKey.Y).Key(Hex1bKey.S) // "sys"
+            .Key(Hex1bKey.Enter) // Confirm
+            .WaitUntil(_ => _state!.Search[TabId.DepGraph].IsConfirmed, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.True(_state!.Search[TabId.DepGraph].MatchCount > 0,
+            "Search for 'sys' should match System.* dependencies");
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task Tab6_MatchNavigation_CyclesGraphSelectedNode()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var runTask = app.RunAsync(cts.Token);
+
+        // Navigate to dep graph and search for "sys"
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D6)
+            .WaitUntil(s => s.ContainsText("Nodes:"), TimeSpan.FromSeconds(5))
+            .Key(Hex1bKey.OemQuestion)
+            .WaitUntil(_ => _state!.Search[TabId.DepGraph].IsActive, TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.S).Key(Hex1bKey.Y).Key(Hex1bKey.S)
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.Search[TabId.DepGraph].IsConfirmed, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Press 'n' to navigate to first match
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.N)
+            .WaitUntil(_ => _state!.GraphMatchIndex >= 0, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        var firstIndex = _state!.GraphMatchIndex;
+        Assert.True(firstIndex >= 0);
+
+        // Press 'n' again — should advance to next match
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.N)
+            .WaitUntil(_ => _state.GraphMatchIndex != firstIndex
+                            || _state.Search[TabId.DepGraph].MatchCount == 1,
+                TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        if (_state.Search[TabId.DepGraph].MatchCount > 1)
+            Assert.NotEqual(firstIndex, _state.GraphMatchIndex);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task Tab6_ArrowKeys_WorkAfterSearchConfirm()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var runTask = app.RunAsync(cts.Token);
+
+        // Navigate to dep graph, search for "sys", confirm
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D6)
+            .WaitUntil(s => s.ContainsText("Nodes:"), TimeSpan.FromSeconds(5))
+            .Key(Hex1bKey.OemQuestion)
+            .WaitUntil(_ => _state!.Search[TabId.DepGraph].IsActive, TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.S).Key(Hex1bKey.Y).Key(Hex1bKey.S)
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.Search[TabId.DepGraph].IsConfirmed, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Arrow keys should work immediately — focus restored to Interactable
+        Assert.Equal(-1, _state!.GraphSelectedIndex);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.GraphSelectedIndex == 0, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(0, _state.GraphSelectedIndex);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task Tab7_ArrowKeys_WorkAfterSearchConfirm()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var runTask = app.RunAsync(cts.Token);
+
+        // Navigate to Size Map, search for "rich", confirm
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D7)
+            .WaitUntil(s => s.ContainsText("Total:"), TimeSpan.FromSeconds(5))
+            .Key(Hex1bKey.OemQuestion)
+            .WaitUntil(_ => _state!.Search[TabId.SizeMap].IsActive, TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.R).Key(Hex1bKey.I).Key(Hex1bKey.C).Key(Hex1bKey.H)
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.Search[TabId.SizeMap].IsConfirmed, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Arrow keys should work immediately — focus restored to Interactable
+        Assert.Equal(-1, _state!.TreemapSelectedIndex);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.TreemapSelectedIndex == 0, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(0, _state.TreemapSelectedIndex);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task Tab6_StartupFocus_ArrowKeysWorkWithoutTabSwitch()
+    {
+        // Start directly on Dep Graph tab — tests the initial focus predicate
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll, initialTab: TabId.DepGraph);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var runTask = app.RunAsync(cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Nodes:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(-1, _state!.GraphSelectedIndex);
+
+        // Arrow keys should work immediately without switching tabs first
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.GraphSelectedIndex == 0, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(0, _state.GraphSelectedIndex);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task Tab7_StartupFocus_ArrowKeysWorkWithoutTabSwitch()
+    {
+        // Start directly on Size Map tab — tests the initial focus predicate
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll, initialTab: TabId.SizeMap);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var runTask = app.RunAsync(cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Total:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(-1, _state!.TreemapSelectedIndex);
+
+        // Arrow keys should work immediately without switching tabs first
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.TreemapSelectedIndex == 0, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(0, _state.TreemapSelectedIndex);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task Tab6_ArrowKeys_CycleSelectedIndex()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var runTask = app.RunAsync(cts.Token);
+
+        // Navigate to dep graph tab
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D6)
+            .WaitUntil(s => s.ContainsText("Nodes:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(-1, _state!.GraphSelectedIndex);
+
+        // Press Right to select first node
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.GraphSelectedIndex == 0, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(0, _state.GraphSelectedIndex);
+
+        // Press Right again — should advance
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state.GraphSelectedIndex == 1, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(1, _state.GraphSelectedIndex);
+
+        // Press Left — should go back
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.LeftArrow)
+            .WaitUntil(_ => _state.GraphSelectedIndex == 0, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(0, _state.GraphSelectedIndex);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task Tab7_ArrowKeys_CycleSelectedIndex()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var runTask = app.RunAsync(cts.Token);
+
+        // Navigate to Size Map tab
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D7)
+            .WaitUntil(s => s.ContainsText("Total:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(-1, _state!.TreemapSelectedIndex);
+
+        // Press Right to select first item
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.TreemapSelectedIndex == 0, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(0, _state.TreemapSelectedIndex);
+
+        // Press Right again — should advance
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state.TreemapSelectedIndex == 1, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(1, _state.TreemapSelectedIndex);
+
+        // Press Left — should go back
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.LeftArrow)
+            .WaitUntil(_ => _state.TreemapSelectedIndex == 0, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(0, _state.TreemapSelectedIndex);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 10_000)]
+    public async Task Tab7_ShowsBreadcrumbAndTotalSize()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var runTask = app.RunAsync(cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D7)
+            .WaitUntil(s => s.ContainsText("RichLibrary") && s.ContainsText("Total:"),
+                TimeSpan.FromSeconds(5))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.NotNull(_state!.CachedSizeTree);
+        Assert.True(_state.CachedSizeTree.Size > 0);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task Tab7_Backspace_PopsBreadcrumb()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var runTask = app.RunAsync(cts.Token);
+
+        // Navigate to tab 7, let treemap render
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D7)
+            .WaitUntil(s => s.ContainsText("RichLibrary") && s.ContainsText("Total:"),
+                TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Programmatically drill down into first child namespace
+        var root = _state!.CachedSizeTree!;
+        var firstChild = root.Children[0];
+        _state.TreemapBreadcrumb.Push(root);
+        _state.TreemapCurrentLevel = firstChild;
+        _hex1bApp!.Invalidate();
+
+        // Wait for breadcrumb to show the drill-down path (root > child)
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.ContainsText(firstChild.Name), TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Single(_state.TreemapBreadcrumb);
+
+        // Press Backspace to go up
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Backspace)
+            .WaitUntil(_ => _state.TreemapBreadcrumb.Count == 0, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Empty(_state.TreemapBreadcrumb);
+        Assert.Equal(root, _state.TreemapCurrentLevel);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task Tab7_SearchMatchNavigation_UpdatesHoveredItem()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var runTask = app.RunAsync(cts.Token);
+
+        // Navigate to tab 7 and search for a namespace
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D7)
+            .WaitUntil(s => s.ContainsText("Total:"), TimeSpan.FromSeconds(5))
+            .Key(Hex1bKey.OemQuestion) // '/' — activate search
+            .WaitUntil(_ => _state!.Search[TabId.SizeMap].IsActive, TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.R).Key(Hex1bKey.I).Key(Hex1bKey.C).Key(Hex1bKey.H) // "rich"
+            .Key(Hex1bKey.Enter) // Confirm
+            .WaitUntil(_ => _state!.Search[TabId.SizeMap].IsConfirmed, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.True(_state!.Search[TabId.SizeMap].MatchCount > 0,
+            "Search for 'rich' should match RichLibrary namespace");
+
+        // Press 'n' to navigate to first match
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.N)
+            .WaitUntil(_ => _state.TreemapMatchIndex >= 0, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.True(_state.TreemapMatchIndex >= 0);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task Tab7_Enter_PrefersSearchMatchOverStaleSelection()
+    {
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var runTask = app.RunAsync(cts.Token);
+
+        // Navigate to Size Map, select first item with arrow key
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(3))
+            .Key(Hex1bKey.D7)
+            .WaitUntil(s => s.ContainsText("Total:"), TimeSpan.FromSeconds(5))
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.TreemapSelectedIndex == 0, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        var currentLevel = _state!.TreemapCurrentLevel ?? _state.CachedSizeTree!;
+        Assert.Equal(0, _state.TreemapSelectedIndex);
+
+        // Find a drillable child at index != 0 whose name differs from child 0
+        var child0Name = currentLevel.Children[0].Name;
+        string? searchTerm = null;
+        for (var i = 1; i < currentLevel.Children.Count; i++)
+        {
+            var child = currentLevel.Children[i];
+            if (child.Children.Count == 0) continue;
+            // Use enough of the name to get a unique-ish match, but not child 0
+            var candidate = child.Name.Length > 3 ? child.Name[..4] : child.Name;
+            if (!child0Name.Contains(candidate, StringComparison.OrdinalIgnoreCase))
+            {
+                searchTerm = candidate.ToLowerInvariant();
+                break;
+            }
+        }
+
+        if (searchTerm is null)
+        {
+            // No suitable child found — skip
+            await new Hex1bTerminalInputSequenceBuilder()
+                .Ctrl().Key(Hex1bKey.C)
+                .Build()
+                .ApplyAsync(terminal, cts.Token);
+            await runTask.ContinueWith(_ => { });
+            return;
+        }
+
+        // Search for the non-zero child, confirm, navigate to match
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.OemQuestion)
+            .WaitUntil(_ => _state.Search[TabId.SizeMap].IsActive, TimeSpan.FromSeconds(3))
+            .Type(searchTerm)
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state.Search[TabId.SizeMap].IsConfirmed, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        if (_state.Search[TabId.SizeMap].MatchCount == 0)
+        {
+            await new Hex1bTerminalInputSequenceBuilder()
+                .Ctrl().Key(Hex1bKey.C)
+                .Build()
+                .ApplyAsync(terminal, cts.Token);
+            await runTask.ContinueWith(_ => { });
+            return;
+        }
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.N)
+            .WaitUntil(_ => _state.TreemapMatchIndex >= 0, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Stale selection is still 0, but search match points elsewhere
+        Assert.Equal(0, _state.TreemapSelectedIndex);
+        Assert.True(_state.TreemapMatchIndex >= 0);
+
+        // Press Enter — should drill into search match, not stale selection at index 0
+        var previousLevel = _state.TreemapCurrentLevel;
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state.TreemapCurrentLevel != previousLevel
+                            || _state.TreemapBreadcrumb.Count > 0, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Verify we drilled into the search match (name contains query), not child 0
+        if (_state.TreemapCurrentLevel != previousLevel)
+        {
+            Assert.Contains(searchTerm, _state.TreemapCurrentLevel!.Name,
+                StringComparison.OrdinalIgnoreCase);
+        }
 
         await runTask.ContinueWith(_ => { });
     }


### PR DESCRIPTION
## Summary
- Wrap dep graph and treemap `Surface` widgets in `Interactable` so they receive focus and keyboard input — `SurfaceNode` isn't focusable, so clicks and local key bindings were silently dropped
- Add `InteractableNode` to all focus predicates (initial render, tab switch, search confirm) so keyboard controls work immediately on every entry path
- Dep graph: arrow keys cycle through nodes with a white selection border and node info in the header bar
- Treemap: Enter now prefers the active search match over a stale arrow-key selection, fixing n → Enter inconsistency
- Remove dead `TreemapHoveredItem` assignments from nav closures (wiped by next render frame before display logic reads them)
- Add hints bar entries for dep graph (`←→: Select`) and treemap tabs
- Extract `DiffFilterMode` enum with XML docs, refactor `DiffApp` to primary constructor

## Tests added (7 new, 288 total)
- `Tab6_StartupFocus_ArrowKeysWorkWithoutTabSwitch` — launch directly on tab 6, arrow keys work without switching tabs first
- `Tab7_StartupFocus_ArrowKeysWorkWithoutTabSwitch` — same for tab 7
- `Tab6_ArrowKeys_WorkAfterSearchConfirm` — Right/Left arrow responds after `/sys` + Enter
- `Tab7_ArrowKeys_WorkAfterSearchConfirm` — same for treemap
- `Tab6_ArrowKeys_CycleSelectedIndex` — Right advances, Left goes back
- `Tab7_ArrowKeys_CycleSelectedIndex` — same for treemap
- `Tab7_Enter_PrefersSearchMatchOverStaleSelection` — stale selection at index 0, search matches a different child, Enter drills into the match

## Test plan
- [x] 288/288 tests pass
- [x] Verified dep graph arrow keys and search confirm focus via hex1b terminal emulator
- [x] Verified treemap click, Enter, Backspace, right-click, and arrow keys via hex1b terminal emulator

Fixes #29