### PR TITLE
Add BenchmarkDotNet project for core analyzers

### DIFF
--- a/Dotsider.slnx
+++ b/Dotsider.slnx
@@ -14,4 +14,8 @@
   <Folder Name="/tests/">
     <Project Path="tests/Dotsider.Tests/Dotsider.Tests.csproj" />
   </Folder>
+
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/Dotsider.Benchmarks/Dotsider.Benchmarks.csproj" />
+  </Folder>
 </Solution>

--- a/benchmarks/Dotsider.Benchmarks/AssemblyAnalyzerBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/AssemblyAnalyzerBenchmarks.cs
@@ -1,0 +1,84 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Dotsider.Analysis;
+
+namespace Dotsider.Benchmarks;
+
+/// <summary>
+/// Benchmarks for <see cref="AssemblyAnalyzer"/> construction against BCL assemblies
+/// of varying sizes.
+/// </summary>
+[MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+public class AssemblyAnalyzerBenchmarks
+{
+    private string _coreLibPath = null!;
+    private string _xmlPath = null!;
+    private AssemblyAnalyzer? _lastAnalyzer;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        _coreLibPath = Path.Combine(runtimeDir, "System.Private.CoreLib.dll");
+        _xmlPath = Path.Combine(runtimeDir, "System.Private.Xml.dll");
+
+        if (!File.Exists(_coreLibPath))
+            throw new FileNotFoundException($"BCL assembly not found: {_coreLibPath}");
+        if (!File.Exists(_xmlPath))
+            throw new FileNotFoundException($"BCL assembly not found: {_xmlPath}");
+    }
+
+    // IterationCleanup with no explicit InvocationCount/UnrollFactor
+    // gives 1 invocation per iteration. Do not add those attributes to
+    // Construction benchmarks without switching to a list-based cleanup.
+    [IterationCleanup]
+    public void CleanupConstruction()
+    {
+        _lastAnalyzer?.Dispose();
+        _lastAnalyzer = null;
+    }
+
+    [Benchmark(Description = "CoreLib (~16MB)")]
+    [BenchmarkCategory("Construction")]
+    public AssemblyAnalyzer ConstructCoreLib()
+        => _lastAnalyzer = new AssemblyAnalyzer(_coreLibPath);
+
+    [Benchmark(Description = "Xml (~8MB)")]
+    [BenchmarkCategory("Construction")]
+    public AssemblyAnalyzer ConstructXml()
+        => _lastAnalyzer = new AssemblyAnalyzer(_xmlPath);
+
+    [Benchmark(Description = "CoreLib TypeDefs")]
+    [BenchmarkCategory("TypeDefs")]
+    public int EnumerateTypeDefsCoreLib()
+    {
+        using var analyzer = new AssemblyAnalyzer(_coreLibPath);
+        return analyzer.TypeDefs.Count;
+    }
+
+    [Benchmark(Description = "Xml TypeDefs")]
+    [BenchmarkCategory("TypeDefs")]
+    public int EnumerateTypeDefsXml()
+    {
+        using var analyzer = new AssemblyAnalyzer(_xmlPath);
+        return analyzer.TypeDefs.Count;
+    }
+
+    [Benchmark(Description = "CoreLib MethodDefs")]
+    [BenchmarkCategory("MethodDefs")]
+    public int EnumerateMethodDefsCoreLib()
+    {
+        using var analyzer = new AssemblyAnalyzer(_coreLibPath);
+        return analyzer.MethodDefs.Count;
+    }
+
+    [Benchmark(Description = "Xml MethodDefs")]
+    [BenchmarkCategory("MethodDefs")]
+    public int EnumerateMethodDefsXml()
+    {
+        using var analyzer = new AssemblyAnalyzer(_xmlPath);
+        return analyzer.MethodDefs.Count;
+    }
+}

--- a/benchmarks/Dotsider.Benchmarks/Dotsider.Benchmarks.csproj
+++ b/benchmarks/Dotsider.Benchmarks/Dotsider.Benchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>14</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Dotsider/Dotsider.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Dotsider.Benchmarks/HexSearchBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/HexSearchBenchmarks.cs
@@ -1,0 +1,62 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Dotsider.Views;
+
+namespace Dotsider.Benchmarks;
+
+/// <summary>
+/// Benchmarks for <see cref="HexDumpView.FindBytePattern"/> against BCL assemblies.
+/// The 8ms adaptive threshold (HexDumpView line 44) governs whether hex search runs
+/// live-as-you-type or waits for confirmation. These benchmarks establish baselines
+/// against real assemblies to validate that threshold.
+/// </summary>
+[MemoryDiagnoser]
+public class HexSearchBenchmarks
+{
+    private byte[] _coreLibBytes = null!;
+    private byte[] _xmlBytes = null!;
+    private byte[] _shortPattern = null!;
+    private byte[] _longPattern = null!;
+    private byte[] _noMatchPattern = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        _coreLibBytes = File.ReadAllBytes(Path.Combine(runtimeDir, "System.Private.CoreLib.dll"));
+        _xmlBytes = File.ReadAllBytes(Path.Combine(runtimeDir, "System.Private.Xml.dll"));
+
+        // Short pattern: "MZ" header — guaranteed to exist at offset 0
+        _shortPattern = "MZ"u8.ToArray();
+
+        // Longer pattern: search for "System.Runtime" — common metadata string
+        _longPattern = System.Text.Encoding.ASCII.GetBytes("System.Runtime");
+
+        // No-match pattern: unlikely byte sequence that forces a full scan
+        _noMatchPattern = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE];
+    }
+
+    [Benchmark(Description = "CoreLib short pattern (2B)")]
+    public List<long> CoreLib_ShortPattern()
+        => HexDumpView.FindBytePattern(_coreLibBytes, _shortPattern);
+
+    [Benchmark(Description = "CoreLib long pattern (14B)")]
+    public List<long> CoreLib_LongPattern()
+        => HexDumpView.FindBytePattern(_coreLibBytes, _longPattern);
+
+    [Benchmark(Description = "CoreLib no-match (full scan)")]
+    public List<long> CoreLib_NoMatch()
+        => HexDumpView.FindBytePattern(_coreLibBytes, _noMatchPattern);
+
+    [Benchmark(Description = "Xml short pattern (2B)")]
+    public List<long> Xml_ShortPattern()
+        => HexDumpView.FindBytePattern(_xmlBytes, _shortPattern);
+
+    [Benchmark(Description = "Xml long pattern (14B)")]
+    public List<long> Xml_LongPattern()
+        => HexDumpView.FindBytePattern(_xmlBytes, _longPattern);
+
+    [Benchmark(Description = "Xml no-match (full scan)")]
+    public List<long> Xml_NoMatch()
+        => HexDumpView.FindBytePattern(_xmlBytes, _noMatchPattern);
+}

--- a/benchmarks/Dotsider.Benchmarks/HexSearchThresholdBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/HexSearchThresholdBenchmarks.cs
@@ -1,0 +1,36 @@
+using BenchmarkDotNet.Attributes;
+using Dotsider.Views;
+
+namespace Dotsider.Benchmarks;
+
+/// <summary>
+/// Parameterized benchmark that tests <see cref="HexDumpView.FindBytePattern"/>
+/// against synthetic byte arrays of varying sizes to pinpoint where the 8ms
+/// adaptive search threshold (HexDumpView line 44) is crossed. The no-match
+/// pattern forces a complete scan — the worst-case path that determines whether
+/// live search degrades.
+/// </summary>
+[MemoryDiagnoser]
+public class HexSearchThresholdBenchmarks
+{
+    private byte[] _data = null!;
+    private byte[] _pattern = null!;
+
+    // Cluster around the expected 8ms crossover, with low/high anchors for slope.
+    [Params(4, 8, 9, 10, 11, 12, 16)]
+    public int SizeMB { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _data = new byte[SizeMB * 1024 * 1024];
+        Random.Shared.NextBytes(_data);
+
+        // No-match pattern: forces full scan (worst case for threshold)
+        _pattern = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE];
+    }
+
+    [Benchmark(Description = "FindBytePattern (no match, full scan)")]
+    public List<long> FullScan()
+        => HexDumpView.FindBytePattern(_data, _pattern);
+}

--- a/benchmarks/Dotsider.Benchmarks/IlDisassemblerBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/IlDisassemblerBenchmarks.cs
@@ -1,0 +1,100 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Dotsider.Analysis;
+
+namespace Dotsider.Benchmarks;
+
+/// <summary>
+/// Benchmarks for <see cref="IlDisassembler"/> disassembly of all methods
+/// in large BCL assemblies. Some methods in CoreLib contain tokens that
+/// reference forward-declared runtime types, causing BadImageFormatException
+/// during operand resolution — these are caught and skipped, matching the
+/// real app's behavior.
+/// </summary>
+[MemoryDiagnoser]
+public class IlDisassemblerBenchmarks
+{
+    private AssemblyAnalyzer _coreLibAnalyzer = null!;
+    private AssemblyAnalyzer _xmlAnalyzer = null!;
+    private IlDisassembler _coreLibDisasm = null!;
+    private IlDisassembler _xmlDisasm = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        _coreLibAnalyzer = new AssemblyAnalyzer(Path.Combine(runtimeDir, "System.Private.CoreLib.dll"));
+        _xmlAnalyzer = new AssemblyAnalyzer(Path.Combine(runtimeDir, "System.Private.Xml.dll"));
+        _coreLibDisasm = new IlDisassembler(_coreLibAnalyzer);
+        _xmlDisasm = new IlDisassembler(_xmlAnalyzer);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _coreLibAnalyzer.Dispose();
+        _xmlAnalyzer.Dispose();
+    }
+
+    [Benchmark(Description = "CoreLib DisassembleAll")]
+    public int CoreLib_DisassembleAll()
+    {
+        var count = 0;
+        foreach (var method in _coreLibAnalyzer.MethodDefs)
+        {
+            try
+            {
+                var instructions = _coreLibDisasm.Disassemble(method);
+                count += instructions.Count;
+            }
+            catch (BadImageFormatException) { }
+        }
+        return count;
+    }
+
+    [Benchmark(Description = "Xml DisassembleAll")]
+    public int Xml_DisassembleAll()
+    {
+        var count = 0;
+        foreach (var method in _xmlAnalyzer.MethodDefs)
+        {
+            try
+            {
+                var instructions = _xmlDisasm.Disassemble(method);
+                count += instructions.Count;
+            }
+            catch (BadImageFormatException) { }
+        }
+        return count;
+    }
+
+    [Benchmark(Description = "CoreLib FormatAll")]
+    public int CoreLib_FormatAll()
+    {
+        var totalLen = 0;
+        foreach (var method in _coreLibAnalyzer.MethodDefs)
+        {
+            try
+            {
+                totalLen += _coreLibDisasm.FormatDisassembly(method).Length;
+            }
+            catch (BadImageFormatException) { }
+        }
+        return totalLen;
+    }
+
+    [Benchmark(Description = "Xml FormatAll")]
+    public int Xml_FormatAll()
+    {
+        var totalLen = 0;
+        foreach (var method in _xmlAnalyzer.MethodDefs)
+        {
+            try
+            {
+                totalLen += _xmlDisasm.FormatDisassembly(method).Length;
+            }
+            catch (BadImageFormatException) { }
+        }
+        return totalLen;
+    }
+}

--- a/benchmarks/Dotsider.Benchmarks/Program.cs
+++ b/benchmarks/Dotsider.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/benchmarks/Dotsider.Benchmarks/SizeAnalyzerBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/SizeAnalyzerBenchmarks.cs
@@ -1,0 +1,44 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Dotsider.Analysis;
+using Dotsider.Analysis.Models;
+
+namespace Dotsider.Benchmarks;
+
+/// <summary>
+/// Benchmarks for <see cref="SizeAnalyzer.BuildSizeTree"/> which traverses
+/// every type and method to build the treemap hierarchy.
+/// </summary>
+[MemoryDiagnoser]
+public class SizeAnalyzerBenchmarks
+{
+    private AssemblyAnalyzer _coreLibAnalyzer = null!;
+    private AssemblyAnalyzer _xmlAnalyzer = null!;
+    private IlDisassembler _coreLibDisasm = null!;
+    private IlDisassembler _xmlDisasm = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        _coreLibAnalyzer = new AssemblyAnalyzer(Path.Combine(runtimeDir, "System.Private.CoreLib.dll"));
+        _xmlAnalyzer = new AssemblyAnalyzer(Path.Combine(runtimeDir, "System.Private.Xml.dll"));
+        _coreLibDisasm = new IlDisassembler(_coreLibAnalyzer);
+        _xmlDisasm = new IlDisassembler(_xmlAnalyzer);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _coreLibAnalyzer.Dispose();
+        _xmlAnalyzer.Dispose();
+    }
+
+    [Benchmark(Description = "CoreLib BuildSizeTree")]
+    public SizeNode CoreLib_BuildSizeTree()
+        => SizeAnalyzer.BuildSizeTree(_coreLibAnalyzer, _coreLibDisasm);
+
+    [Benchmark(Description = "Xml BuildSizeTree")]
+    public SizeNode Xml_BuildSizeTree()
+        => SizeAnalyzer.BuildSizeTree(_xmlAnalyzer, _xmlDisasm);
+}

--- a/benchmarks/Dotsider.Benchmarks/StringExtractorBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/StringExtractorBenchmarks.cs
@@ -1,0 +1,55 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Dotsider.Analysis;
+using Dotsider.Analysis.Models;
+
+namespace Dotsider.Benchmarks;
+
+/// <summary>
+/// Benchmarks for <see cref="StringExtractor"/> extraction methods against BCL assemblies.
+/// </summary>
+[MemoryDiagnoser]
+public class StringExtractorBenchmarks
+{
+    private AssemblyAnalyzer _coreLibAnalyzer = null!;
+    private AssemblyAnalyzer _xmlAnalyzer = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        _coreLibAnalyzer = new AssemblyAnalyzer(Path.Combine(runtimeDir, "System.Private.CoreLib.dll"));
+        _xmlAnalyzer = new AssemblyAnalyzer(Path.Combine(runtimeDir, "System.Private.Xml.dll"));
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _coreLibAnalyzer.Dispose();
+        _xmlAnalyzer.Dispose();
+    }
+
+    [Benchmark(Description = "CoreLib UserStrings")]
+    public IReadOnlyList<StringEntry> CoreLib_UserStrings()
+        => new StringExtractor(_coreLibAnalyzer).ExtractUserStrings();
+
+    [Benchmark(Description = "CoreLib MetadataStrings")]
+    public IReadOnlyList<StringEntry> CoreLib_MetadataStrings()
+        => new StringExtractor(_coreLibAnalyzer).ExtractMetadataStrings();
+
+    [Benchmark(Description = "CoreLib RawStrings")]
+    public IReadOnlyList<StringEntry> CoreLib_RawStrings()
+        => new StringExtractor(_coreLibAnalyzer).ExtractRawStrings();
+
+    [Benchmark(Description = "Xml UserStrings")]
+    public IReadOnlyList<StringEntry> Xml_UserStrings()
+        => new StringExtractor(_xmlAnalyzer).ExtractUserStrings();
+
+    [Benchmark(Description = "Xml MetadataStrings")]
+    public IReadOnlyList<StringEntry> Xml_MetadataStrings()
+        => new StringExtractor(_xmlAnalyzer).ExtractMetadataStrings();
+
+    [Benchmark(Description = "Xml RawStrings")]
+    public IReadOnlyList<StringEntry> Xml_RawStrings()
+        => new StringExtractor(_xmlAnalyzer).ExtractRawStrings();
+}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,114 @@
+# Dotsider Benchmarks
+
+BenchmarkDotNet project measuring performance of core analyzers against large BCL assemblies.
+
+## Running
+
+Run all benchmarks:
+
+```sh
+dotnet run --project benchmarks/Dotsider.Benchmarks -c Release
+```
+
+Run a specific benchmark class:
+
+```sh
+dotnet run --project benchmarks/Dotsider.Benchmarks -c Release -- --filter '*HexSearchBenchmarks*'
+```
+
+Run the parameterized hex search threshold test:
+
+```sh
+dotnet run --project benchmarks/Dotsider.Benchmarks -c Release -- --filter '*HexSearchThresholdBenchmarks*'
+```
+
+List all available benchmarks:
+
+```sh
+dotnet run --project benchmarks/Dotsider.Benchmarks -c Release -- --list flat
+```
+
+## Benchmark Classes
+
+| Class | What it measures |
+|---|---|
+| `AssemblyAnalyzerBenchmarks` | Constructor and metadata table enumeration (TypeDefs, MethodDefs) |
+| `HexSearchBenchmarks` | `FindBytePattern` with short, long, and no-match patterns against real assemblies |
+| `HexSearchThresholdBenchmarks` | Parameterized sweep (4–16MB) to pinpoint the 8ms adaptive search crossover |
+| `StringExtractorBenchmarks` | UserStrings, MetadataStrings, and RawStrings extraction |
+| `SizeAnalyzerBenchmarks` | `BuildSizeTree` full traversal |
+| `IlDisassemblerBenchmarks` | Disassemble and format all methods |
+
+## Test Assemblies
+
+Benchmarks use BCL assemblies from the running .NET runtime directory:
+
+- **System.Private.CoreLib.dll** (~16MB) — largest BCL assembly, stress tests all analyzers
+- **System.Private.Xml.dll** (~8MB) — mid-size assembly near the hex search threshold
+
+## Baseline Results
+
+### macOS — Apple M4 Pro, .NET 10.0.2
+
+#### AssemblyAnalyzer
+
+| Benchmark | Mean | Allocated |
+|---|---|---|
+| CoreLib Construction | 1.35 ms | 16.29 MB |
+| Xml Construction | 0.66 ms | 8.60 MB |
+| CoreLib TypeDefs | 2.13 ms | 17.31 MB |
+| Xml TypeDefs | 1.19 ms | 9.25 MB |
+| CoreLib MethodDefs | 23.5 ms | 47.04 MB |
+| Xml MethodDefs | 9.13 ms | 18.14 MB |
+
+#### Hex Search (FindBytePattern)
+
+| Benchmark | Mean | Allocated |
+|---|---|---|
+| CoreLib short pattern (2B) | 11.7 ms | 1,156 B |
+| CoreLib long pattern (14B) | 13.1 ms | 33 KB |
+| CoreLib no-match (full scan) | 13.1 ms | — |
+| Xml short pattern (2B) | 6.2 ms | 614 B |
+| Xml long pattern (14B) | 7.0 ms | 182 B |
+| Xml no-match (full scan) | 7.0 ms | — |
+
+#### Hex Search Threshold (8ms crossover)
+
+| SizeMB | Mean |
+|---|---|
+| 4 | 3.28 ms |
+| 8 | 6.51 ms |
+| 9 | 7.33 ms |
+| **10** | **8.14 ms** |
+| 11 | 8.97 ms |
+| 12 | 9.88 ms |
+| 16 | 13.03 ms |
+
+The 8ms adaptive threshold (`HexDumpView` line 44) crosses at ~10MB on this machine. Scaling is linear at ~0.82 ms/MB.
+
+#### StringExtractor
+
+| Benchmark | Mean | Allocated |
+|---|---|---|
+| CoreLib UserStrings | 0.05 ms | 42 KB |
+| CoreLib MetadataStrings | 1.73 ms | 2,875 KB |
+| CoreLib RawStrings | 27.3 ms | 7,430 KB |
+| Xml UserStrings | 0.07 ms | 375 KB |
+| Xml MetadataStrings | 1.03 ms | 1,519 KB |
+| Xml RawStrings | 15.0 ms | 3,962 KB |
+
+#### SizeAnalyzer
+
+| Benchmark | Mean | Allocated |
+|---|---|---|
+| CoreLib BuildSizeTree | 11.1 ms | 28.49 MB |
+| Xml BuildSizeTree | 3.32 ms | 10.03 MB |
+
+#### IlDisassembler
+
+| Benchmark | Mean | Allocated |
+|---|---|---|
+| CoreLib DisassembleAll | 42.1 ms | 134.18 MB |
+| Xml DisassembleAll | 38.7 ms | 129.75 MB |
+| CoreLib FormatAll | 79.4 ms | 285.24 MB |
+| Xml FormatAll | 69.3 ms | 254.36 MB |


### PR DESCRIPTION
## Summary

- Add `benchmarks/Dotsider.Benchmarks` BenchmarkDotNet project targeting core analyzers against System.Private.CoreLib (~16MB) and System.Private.Xml (~8MB)
- Benchmark `AssemblyAnalyzer` construction, `StringExtractor` (all 3 extraction modes), `SizeAnalyzer.BuildSizeTree`, `IlDisassembler` (disassemble + format), and `HexDumpView.FindBytePattern`
- Parameterized hex search threshold sweep (4–16MB) pinpoints the 8ms adaptive search crossover at ~10MB on Apple M4 Pro
- README with run instructions and baseline results

## Baseline highlights (Apple M4 Pro, .NET 10.0.2)

| Metric | CoreLib (16MB) | Xml (8.6MB) |
|---|---|---|
| Analyzer construction | 1.35 ms | 0.66 ms |
| Hex search (no-match) | 13.0 ms | 7.0 ms |
| BuildSizeTree | 11.1 ms | 3.3 ms |
| DisassembleAll | 42 ms | 39 ms |
| FormatAll | 79 ms | 69 ms |

8ms hex search threshold crosses at **~10MB** (~0.82 ms/MB linear scaling).

## Test plan

- [x] `dotnet build` succeeds for full solution
- [x] All 297 existing tests pass
- [x] All 5 benchmark classes run to completion in Release mode
- [x] Parameterized threshold benchmark produces consistent linear scaling

Fixes: #34