### PR TITLE
Guard PushAssembly against crashes, cap nav depth, track skipped strings

### DIFF
--- a/src/Dotsider/Analysis/StringExtractor.cs
+++ b/src/Dotsider/Analysis/StringExtractor.cs
@@ -23,6 +23,12 @@ public sealed class StringExtractor
         _analyzer = analyzer;
     }
 
+    /// <summary>Number of malformed entries skipped during the last <see cref="ExtractUserStrings"/> call.</summary>
+    public int SkippedUserStringCount { get; private set; }
+
+    /// <summary>Number of malformed entries skipped during the last <see cref="ExtractMetadataStrings"/> call.</summary>
+    public int SkippedMetadataStringCount { get; private set; }
+
     /// <summary>
     /// Extracts all user string literals from the #US metadata heap.
     /// These are the string constants used in IL code via <c>ldstr</c>.
@@ -33,6 +39,7 @@ public sealed class StringExtractor
         var reader = _analyzer.GetMetadataReader();
         if (reader is null) return [];
 
+        SkippedUserStringCount = 0;
         var results = new List<StringEntry>();
         var handle = MetadataTokens.UserStringHandle(1);
 
@@ -49,7 +56,7 @@ public sealed class StringExtractor
             }
             catch
             {
-                // Skip malformed entries
+                SkippedUserStringCount++;
             }
 
             handle = reader.GetNextHandle(handle);
@@ -68,6 +75,7 @@ public sealed class StringExtractor
         var reader = _analyzer.GetMetadataReader();
         if (reader is null) return [];
 
+        SkippedMetadataStringCount = 0;
         var results = new List<StringEntry>();
         var handle = MetadataTokens.StringHandle(1);
 
@@ -84,7 +92,7 @@ public sealed class StringExtractor
             }
             catch
             {
-                // Skip malformed entries
+                SkippedMetadataStringCount++;
             }
 
             handle = reader.GetNextHandle(handle);
@@ -120,6 +128,7 @@ public sealed class StringExtractor
                 {
                     results.Add(new StringEntry(startOffset, sb.ToString(), StringSource.RawBinary));
                 }
+                
                 sb.Clear();
                 startOffset = -1;
             }

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -375,6 +375,14 @@ public sealed class DotsiderApp(DotsiderState state)
 
             hints.Add(s.Spacer());
 
+            // General tab: navigation error (right side)
+            if (_state.CurrentTab == 0 && !string.IsNullOrEmpty(_state.NavigationError))
+            {
+                hints.Add(s.Section(_state.NavigationError).Theme(t => t
+                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(200, 80, 60))));
+                hints.Add(s.Separator(" "));
+            }
+
             // Hex tab: vim-style save notification (right side)
             if (_state.CurrentTab == 4 && !string.IsNullOrEmpty(_state.HexNotification))
             {

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -68,10 +68,16 @@ public sealed class DotsiderState : IDisposable
     /// <summary>Navigation stack of assembly paths for drill-down.</summary>
     public Stack<AssemblyAnalyzer> NavigationStack { get; } = new();
 
+    /// <summary>Maximum navigation depth for assembly drill-down.</summary>
+    public const int MaxNavigationDepth = 10;
+
+    /// <summary>Error message from the last failed navigation attempt, or null.</summary>
+    public string? NavigationError { get; set; }
+
     // --- Search State (shared across all tabs) ---
 
     /// <summary>Per-tab search state, indexed by <see cref="TabId"/> constants.</summary>
-    public SearchState[] Search { get; } = Enumerable.Range(0, 8).Select(_ => new SearchState()).ToArray();
+    public SearchState[] Search { get; } = [.. Enumerable.Range(0, 8).Select(_ => new SearchState())];
 
     /// <summary>Delegate to navigate to the next search match in the current view.</summary>
     public Action? NavigateNextMatch { get; set; }
@@ -268,11 +274,30 @@ public sealed class DotsiderState : IDisposable
 
     /// <summary>
     /// Pushes a new assembly onto the navigation stack and makes it the active analyzer.
+    /// Returns false if the assembly could not be loaded or the depth limit is reached.
     /// </summary>
-    public void PushAssembly(string filePath)
+    public bool PushAssembly(string filePath)
     {
+        if (NavigationStack.Count >= MaxNavigationDepth)
+        {
+            NavigationError = $"Navigation depth limit reached ({MaxNavigationDepth})";
+            return false;
+        }
+
+        AssemblyAnalyzer newAnalyzer;
+        try
+        {
+            newAnalyzer = new AssemblyAnalyzer(filePath);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or FileNotFoundException or IOException or UnauthorizedAccessException)
+        {
+            NavigationError = $"Cannot open assembly: {ex.Message}";
+            return false;
+        }
+
+        NavigationError = null;
         NavigationStack.Push(Analyzer);
-        Analyzer = new AssemblyAnalyzer(filePath);
+        Analyzer = newAnalyzer;
         IlDisassembler = new IlDisassembler(Analyzer);
         StringExtractor = new StringExtractor(Analyzer);
         var hexDoc = new HexRowDocument(new Hex1bDocument(Analyzer.RawBytes.ToArray()));
@@ -280,6 +305,7 @@ public sealed class DotsiderState : IDisposable
         HexEditorState = new EditorState(hexDoc) { IsReadOnly = true };
         HexCleanVersion = hexDoc.Version;
         ResetViewState();
+        return true;
     }
 
     /// <summary>
@@ -288,6 +314,7 @@ public sealed class DotsiderState : IDisposable
     public bool PopAssembly()
     {
         if (NavigationStack.Count == 0) return false;
+        NavigationError = null;
         Analyzer.Dispose();
         Analyzer = NavigationStack.Pop();
         IlDisassembler = new IlDisassembler(Analyzer);
@@ -370,9 +397,7 @@ public sealed class DotsiderState : IDisposable
         var query = Search[TabId.Strings].Query;
         if (!string.IsNullOrEmpty(query))
         {
-            entries = entries
-                .Where(e => e.Value.Contains(query, StringComparison.OrdinalIgnoreCase))
-                .ToList();
+            entries = [.. entries.Where(e => e.Value.Contains(query, StringComparison.OrdinalIgnoreCase))];
         }
 
         return entries;
@@ -414,6 +439,7 @@ public sealed class DotsiderState : IDisposable
             CachedRawStrings = StringExtractor.ExtractRawStrings(StringsMinLength);
             CachedRawStringsMinLength = StringsMinLength;
         }
+        
         return CachedRawStrings;
     }
 }

--- a/src/Dotsider/NuGetApp.cs
+++ b/src/Dotsider/NuGetApp.cs
@@ -60,6 +60,15 @@ public sealed class NuGetApp(NuGetState state)
                     hints.Add(s.Section("/: Search"));
                 }
                 hints.Add(s.Spacer());
+
+                // Navigation error in DLL inspector (right side)
+                if (!_state.IsBrowsingPackage && _state.SelectedDllState is { NavigationError: { } navError })
+                {
+                    hints.Add(s.Section(navError).Theme(t => t
+                        .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(200, 80, 60))));
+                    hints.Add(s.Separator(" "));
+                }
+
                 hints.Add(s.Section("q: Quit"));
                 return hints;
             }).WithDefaultSeparator(" | ")

--- a/src/Dotsider/Views/StringsView.cs
+++ b/src/Dotsider/Views/StringsView.cs
@@ -58,10 +58,9 @@ public static class StringsView
             // Layer 0: Main content
             z.VStack(outer =>
             {
-                var widgets = new List<Hex1bWidget>();
-
-                // Sub-tab selector for string sources
-                widgets.Add(outer.TabPanel(tp =>
+                var widgets = new List<Hex1bWidget> {
+                    // Sub-tab selector for string sources
+                outer.TabPanel(tp =>
                     SourceTabs.Select((name, i) =>
                         tp.Tab(name, t => [t.Text("")])
                             .Selected(state.StringsSourceTab == i)
@@ -75,7 +74,7 @@ public static class StringsView
                     state.StringsFocusedKey = null;
                     state.App.Invalidate();
                 })
-                .FixedHeight(1));
+                .FixedHeight(1) };
 
                 // Search bar (shared helper)
                 SearchBarHelper.AddSearchBar(widgets, outer, search, state.App);
@@ -111,9 +110,22 @@ public static class StringsView
                 {
                     statusParts.Add($"Min length: {state.StringsMinLength}");
                 }
+
+                var skipped = state.StringsSourceTab switch
+                {
+                    StringsSubTabId.UserStrings => state.StringExtractor.SkippedUserStringCount,
+                    StringsSubTabId.Metadata => state.StringExtractor.SkippedMetadataStringCount,
+                    _ => 0
+                };
+                
+                if (skipped > 0)
+                {
+                    statusParts.Add($"{skipped} malformed skipped");
+                }
+
                 widgets.Add(outer.Text($" {string.Join(" | ", statusParts)}").FixedHeight(1));
 
-                return widgets.ToArray();
+                return [.. widgets];
             })
             .WithInputBindings(bindings =>
             {
@@ -218,7 +230,8 @@ public static class StringsView
         ]).Fill();
     }
 
-    private static string RowKey(Analysis.Models.StringEntry e) => $"{e.Offset}:{e.Source}";
+    private static string RowKey(Analysis.Models.StringEntry e) =>
+        $"{e.Offset}:{e.Source}";
 
     private static int FindFocusedIndex(IReadOnlyList<Analysis.Models.StringEntry> entries, object? focusedKey)
     {
@@ -228,6 +241,7 @@ public static class StringsView
             if (RowKey(entries[i]) == key)
                 return i;
         }
+        
         return -1;
     }
 }

--- a/tests/Dotsider.Tests/DotsiderStateTests.cs
+++ b/tests/Dotsider.Tests/DotsiderStateTests.cs
@@ -92,7 +92,7 @@ public class DotsiderStateTests(SampleAssemblyFixture samples) : IDisposable
         var app = CreateApp();
         using var state = new DotsiderState(app, samples.HelloWorldDll);
         Assert.Equal("HelloWorld.dll", state.Analyzer.FileName);
-        state.PushAssembly(samples.RichLibraryDll);
+        Assert.True(state.PushAssembly(samples.RichLibraryDll));
         Assert.Equal("RichLibrary.dll", state.Analyzer.FileName);
         Assert.Single(state.NavigationStack);
     }
@@ -102,10 +102,86 @@ public class DotsiderStateTests(SampleAssemblyFixture samples) : IDisposable
     {
         var app = CreateApp();
         using var state = new DotsiderState(app, samples.HelloWorldDll);
-        state.PushAssembly(samples.RichLibraryDll);
+        Assert.True(state.PushAssembly(samples.RichLibraryDll));
         Assert.True(state.PopAssembly());
         Assert.Equal("HelloWorld.dll", state.Analyzer.FileName);
         Assert.Empty(state.NavigationStack);
+    }
+
+    [Fact(Timeout = 5_000)]
+    public void PushAssembly_InvalidPath_ReturnsFalseAndSetsError()
+    {
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.HelloWorldDll);
+        Assert.False(state.PushAssembly("/nonexistent/fake.dll"));
+        Assert.Equal("HelloWorld.dll", state.Analyzer.FileName);
+        Assert.Empty(state.NavigationStack);
+        Assert.NotNull(state.NavigationError);
+    }
+
+    [Fact(Timeout = 5_000)]
+    public void PushAssembly_DepthLimit_ReturnsFalseAtMax()
+    {
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.HelloWorldDll);
+        // Push to the limit (alternating two assemblies)
+        for (var i = 0; i < DotsiderState.MaxNavigationDepth; i++)
+        {
+            var path = i % 2 == 0 ? samples.RichLibraryDll : samples.EmptyLibDll;
+            Assert.True(state.PushAssembly(path), $"Push {i + 1} should succeed");
+        }
+        // Next push should fail
+        Assert.False(state.PushAssembly(samples.ComplexAppDll));
+        Assert.Contains("depth limit", state.NavigationError);
+    }
+
+    [Fact(Timeout = 5_000)]
+    public void PushAssembly_SuccessClearsError()
+    {
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.HelloWorldDll);
+        // Trigger an error first
+        state.PushAssembly("/nonexistent/fake.dll");
+        Assert.NotNull(state.NavigationError);
+        // Successful push clears it
+        Assert.True(state.PushAssembly(samples.RichLibraryDll));
+        Assert.Null(state.NavigationError);
+    }
+
+    [Fact(Timeout = 5_000)]
+    public void PopAssembly_ClearsNavigationError()
+    {
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.HelloWorldDll);
+        Assert.True(state.PushAssembly(samples.RichLibraryDll));
+        // Set an error, then pop
+        state.PushAssembly("/nonexistent/fake.dll");
+        Assert.NotNull(state.NavigationError);
+        Assert.True(state.PopAssembly());
+        Assert.Null(state.NavigationError);
+    }
+
+    [Fact(Timeout = 5_000)]
+    public void PushAssembly_BadImage_ReturnsFalseAndPreservesState()
+    {
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.HelloWorldDll);
+        Assert.False(state.PushAssembly(samples.NonDotNetBinaryPath));
+        Assert.Equal("HelloWorld.dll", state.Analyzer.FileName);
+        Assert.Empty(state.NavigationStack);
+        Assert.Contains("Cannot open assembly", state.NavigationError);
+    }
+
+    [Fact(Timeout = 5_000)]
+    public void PushAssembly_UnauthorizedAccess_ReturnsFalse()
+    {
+        // File.ReadAllBytes on a directory throws UnauthorizedAccessException on all platforms
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.HelloWorldDll);
+        Assert.False(state.PushAssembly(Path.GetTempPath()));
+        Assert.Equal("HelloWorld.dll", state.Analyzer.FileName);
+        Assert.Empty(state.NavigationStack);
+        Assert.NotNull(state.NavigationError);
     }
 
     [Fact(Timeout = 5_000)]

--- a/tests/Dotsider.Tests/NuGetModeViewTests.cs
+++ b/tests/Dotsider.Tests/NuGetModeViewTests.cs
@@ -139,6 +139,49 @@ public class NuGetModeViewTests(SampleAssemblyFixture samples) : IDisposable
         await runTask.ContinueWith(_ => { });
     }
 
+    [Fact(Timeout = 10_000)]
+    public async Task DllInspector_DepthLimit_ShowsErrorInHintsBar()
+    {
+        var (terminal, app) = CreateNuGetApp();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var runTask = app.RunAsync(cts.Token);
+        var depthLimitHit = false;
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(5))
+            // Enter DLL inspector
+            .Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => !_state!.IsBrowsingPackage, TimeSpan.FromSeconds(3))
+            // Push assemblies to hit the depth limit, then verify the error renders
+            .WaitUntil(s =>
+            {
+                if (!depthLimitHit)
+                {
+                    var dllState = _state!.SelectedDllState!;
+                    for (var i = 0; i < DotsiderState.MaxNavigationDepth; i++)
+                    {
+                        var path = i % 2 == 0 ? samples.RichLibraryDll : samples.EmptyLibDll;
+                        dllState.PushAssembly(path);
+                    }
+                    // This push should fail with depth limit
+                    dllState.PushAssembly(samples.ComplexAppDll);
+                    _state.App.Invalidate();
+                    depthLimitHit = true;
+                }
+
+                return s.ContainsText("depth limit");
+            }, TimeSpan.FromSeconds(3))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Contains("depth limit", _state!.SelectedDllState!.NavigationError);
+
+        await runTask.ContinueWith(_ => { });
+    }
+
     public void Dispose()
     {
         _state?.Dispose();

--- a/tests/Dotsider.Tests/StringExtractorTests.cs
+++ b/tests/Dotsider.Tests/StringExtractorTests.cs
@@ -142,4 +142,15 @@ public class StringExtractorTests(SampleAssemblyFixture samples)
         var metaStrings = extractor.ExtractMetadataStrings();
         Assert.All(metaStrings, s => Assert.True(s.Offset >= 0));
     }
+
+    [Fact(Timeout = 5_000)]
+    public void SkippedCounts_ZeroForValidAssembly()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var extractor = new StringExtractor(a);
+        extractor.ExtractUserStrings();
+        Assert.Equal(0, extractor.SkippedUserStringCount);
+        extractor.ExtractMetadataStrings();
+        Assert.Equal(0, extractor.SkippedMetadataStringCount);
+    }
 }


### PR DESCRIPTION
## Summary

- **PushAssembly crash guard**: creates the new `AssemblyAnalyzer` before mutating state so failures are a clean no-op. Catches `BadImageFormatException`, `FileNotFoundException`, `IOException`, and `UnauthorizedAccessException`. Returns `bool` instead of `void`.
- **Navigation depth cap**: `MaxNavigationDepth = 10`. Refuses to push beyond the limit and sets `NavigationError`.
- **StringExtractor skip tracking**: `SkippedUserStringCount` and `SkippedMetadataStringCount` replace bare `catch {}` blocks. The Strings tab status line shows the count when > 0.
- **NavigationError hints bar**: error text renders in both `DotsiderApp` and `NuGetApp` hints bars (red text, right-aligned).

## Test plan

- [x] `PushAssembly_InvalidPath_ReturnsFalseAndSetsError`
- [x] `PushAssembly_BadImage_ReturnsFalseAndPreservesState`
- [x] `PushAssembly_UnauthorizedAccess_ReturnsFalse` (cross-platform via directory path)
- [x] `PushAssembly_DepthLimit_ReturnsFalseAtMax`
- [x] `PushAssembly_SuccessClearsError`
- [x] `PopAssembly_ClearsNavigationError`
- [x] `SkippedCounts_ZeroForValidAssembly`
- [x] `DllInspector_DepthLimit_ShowsErrorInHintsBar` (full workflow in NuGet mode)
- [x] All 305 tests pass

Fixes #43