### PR TITLE
Add Scoop bucket for Windows distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,15 +424,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Update manifest with new version and checksums
+      - name: Update manifests with new version and checksums
         run: |
           cd scoop-bucket
           VERSION="${{ steps.version.outputs.version }}"
 
           python3 << 'EOF'
-          import json, sys
+          import json
 
           version = "${{ steps.version.outputs.version }}"
+
+          # Update dotsider manifest
           sha_win_x64 = "${{ needs.create-release.outputs.sha256_win_x64 }}"
           sha_win_arm64 = "${{ needs.create-release.outputs.sha256_win_arm64 }}"
 
@@ -448,18 +450,38 @@ jobs:
           with open('bucket/dotsider.json', 'w') as f:
               json.dump(manifest, f, indent=4)
               f.write('\n')
+
+          # Update dotsider-mcp manifest
+          sha_mcp_win_x64 = "${{ needs.create-release.outputs.sha256_mcp_win_x64 }}"
+          sha_mcp_win_arm64 = "${{ needs.create-release.outputs.sha256_mcp_win_arm64 }}"
+
+          with open('bucket/dotsider-mcp.json', 'r') as f:
+              manifest = json.load(f)
+
+          manifest['version'] = version
+          manifest['architecture']['64bit']['url'] = f'https://github.com/willibrandon/dotsider/releases/download/v{version}/dotsider-mcp-win-x64.zip'
+          manifest['architecture']['64bit']['hash'] = sha_mcp_win_x64
+          manifest['architecture']['arm64']['url'] = f'https://github.com/willibrandon/dotsider/releases/download/v{version}/dotsider-mcp-win-arm64.zip'
+          manifest['architecture']['arm64']['hash'] = sha_mcp_win_arm64
+
+          with open('bucket/dotsider-mcp.json', 'w') as f:
+              json.dump(manifest, f, indent=4)
+              f.write('\n')
           EOF
 
           echo "Updated bucket/dotsider.json:"
           cat bucket/dotsider.json
+          echo ""
+          echo "Updated bucket/dotsider-mcp.json:"
+          cat bucket/dotsider-mcp.json
 
       - name: Commit and push changes
         run: |
           cd scoop-bucket
           VERSION="${{ steps.version.outputs.version }}"
 
-          git add bucket/dotsider.json
-          git diff --staged --quiet || git commit -m "Update dotsider to $VERSION"
+          git add bucket/dotsider.json bucket/dotsider-mcp.json
+          git diff --staged --quiet || git commit -m "Update dotsider and dotsider-mcp to $VERSION"
           git push origin main
 
   update-winget:

--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ dotnet tool install -g Dotsider.Mcp
 brew install willibrandon/tap/dotsider-mcp
 ```
 
+#### Scoop (Windows)
+
+```
+scoop install dotsider-mcp
+```
+
 #### WinGet (Windows)
 
 ```


### PR DESCRIPTION
## Summary

- Create `willibrandon/scoop-bucket` repo with `bucket/dotsider.json` manifest pointing at win-x64 and win-arm64 zip artifacts from GitHub Releases
- Add `update-scoop` job to the release workflow that updates the manifest version and SHA256 hashes on each stable release
- Add Scoop install instructions to README

## Install

```powershell
scoop bucket add dotsider https://github.com/willibrandon/scoop-bucket
scoop install dotsider
```

## Test plan

- [x] Verified `scoop bucket add` succeeds
- [x] Verified `scoop search dotsider` finds the package
- [x] Verified `scoop install dotsider` downloads, hash-checks, and shims correctly
- [x] Verified `dotsider --help` works after install
- [x] Verified `scoop uninstall dotsider` cleans up cleanly

Fixes #50