### PR TITLE
feat: add detail popup syntax highlighting and fix theme application

### DIFF
--- a/src/Dotsider/Dotsider.csproj
+++ b/src/Dotsider/Dotsider.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hex1b" Version="0.118.0" />
+    <PackageReference Include="Hex1b" Version="0.122.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.5" />
   </ItemGroup>
 

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -37,6 +37,7 @@ public sealed class DotsiderApp(DotsiderState state)
         if (!_initialFocusRequested)
         {
             _initialFocusRequested = true;
+            SeedFocusedRowIfNeeded();
             RequestContentFocus();
         }
 

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -79,6 +79,9 @@ public sealed class DotsiderState : IDisposable
     /// <summary>Navigation stack of assembly paths for drill-down.</summary>
     public Stack<AssemblyAnalyzer> NavigationStack { get; } = new();
 
+    /// <summary>Saved focused dep keys matching the navigation stack for restore on back.</summary>
+    private readonly Stack<object?> _focusedDepStack = new();
+
     /// <summary>Maximum navigation depth for assembly drill-down.</summary>
     public const int MaxNavigationDepth = 10;
 
@@ -461,6 +464,7 @@ public sealed class DotsiderState : IDisposable
         }
 
         NavigationError = null;
+        _focusedDepStack.Push(GeneralFocusedDep);
         NavigationStack.Push(Analyzer);
         Analyzer = newAnalyzer;
         IlDisassembler = new IlDisassembler(Analyzer);
@@ -488,7 +492,9 @@ public sealed class DotsiderState : IDisposable
         HexRowDoc = hexDoc;
         HexEditorState = new EditorState(hexDoc) { IsReadOnly = true };
         HexCleanVersion = hexDoc.Version;
+        var savedFocus = _focusedDepStack.Count > 0 ? _focusedDepStack.Pop() : null;
         ResetViewState();
+        GeneralFocusedDep = savedFocus;
         return true;
     }
 
@@ -498,7 +504,7 @@ public sealed class DotsiderState : IDisposable
         NavigateNextMatch = null;
         NavigatePrevMatch = null;
         CrossViewBackTarget = null;
-        GeneralFocusedDep = null;
+        GeneralFocusedDep = Analyzer.AssemblyRefs.Count > 0 ? Analyzer.AssemblyRefs[0].Name : null;
         PeSubTab = 0;
         PeFocusedKey = null;
         PeDetailContent = null;

--- a/src/Dotsider/HighlightHelper.cs
+++ b/src/Dotsider/HighlightHelper.cs
@@ -20,16 +20,23 @@ public static class HighlightHelper
 
     private static readonly string MatchBgAnsi = MatchBgColor.ToBackgroundAnsi();
     private static readonly string BlackFgAnsi = Hex1bColor.Black.ToForegroundAnsi();
-    private const string AnsiReset = "\x1b[0m";
 
     /// <summary>
     /// Wraps each case-insensitive match of <paramref name="query"/> in <paramref name="text"/>
     /// with ANSI background (yellow) + foreground (black) codes, returning an ANSI-annotated string.
+    /// After each match, restores <paramref name="restoreFg"/> and <paramref name="restoreBg"/>
+    /// so the caller's active styling (e.g. focused-row colors) is preserved.
     /// </summary>
-    public static string HighlightSubstring(string text, string? query)
+    public static string HighlightSubstring(string text, string? query,
+        Hex1bColor? restoreFg = null, Hex1bColor? restoreBg = null)
     {
         if (string.IsNullOrEmpty(query) || string.IsNullOrEmpty(text))
             return text;
+
+        // Build the restore sequence from the caller's colors, falling back to
+        // default fg/bg resets when no explicit color is provided.
+        var restoreAnsi = (restoreFg?.ToForegroundAnsi() ?? "\x1b[39m")
+                        + (restoreBg?.ToBackgroundAnsi() ?? "\x1b[49m");
 
         var sb = new StringBuilder(text.Length + 32);
         var pos = 0;
@@ -49,7 +56,7 @@ public static class HighlightHelper
             sb.Append(MatchBgAnsi);
             sb.Append(BlackFgAnsi);
             sb.Append(text, idx, query.Length);
-            sb.Append(AnsiReset);
+            sb.Append(restoreAnsi);
 
             pos = idx + query.Length;
         }
@@ -61,12 +68,15 @@ public static class HighlightHelper
     /// Creates a table cell with optional inline match highlighting.
     /// When a query is active and the row matches, matching substrings render
     /// with yellow background + black foreground via embedded ANSI codes.
+    /// After each match, <paramref name="restoreFg"/> and <paramref name="restoreBg"/>
+    /// are re-applied so focused-row or cell-specific styling is preserved.
     /// </summary>
     public static Hex1bWidget HighlightCell<T>(
-        WidgetContext<T> ctx, string text, string? query, bool isMatch) where T : Hex1bWidget
+        WidgetContext<T> ctx, string text, string? query, bool isMatch,
+        Hex1bColor? restoreFg = null, Hex1bColor? restoreBg = null) where T : Hex1bWidget
     {
         if (!string.IsNullOrEmpty(query) && isMatch)
-            return ctx.Text(HighlightSubstring(text, query));
+            return ctx.Text(HighlightSubstring(text, query, restoreFg, restoreBg));
 
         return ctx.Text(text);
     }
@@ -76,10 +86,11 @@ public static class HighlightHelper
     /// For use in non-table contexts such as the IL Inspector disassembly.
     /// </summary>
     public static Hex1bWidget HighlightText<T>(
-        WidgetContext<T> ctx, string text, string? query) where T : Hex1bWidget
+        WidgetContext<T> ctx, string text, string? query,
+        Hex1bColor? restoreFg = null, Hex1bColor? restoreBg = null) where T : Hex1bWidget
     {
         if (!string.IsNullOrEmpty(query))
-            return ctx.Text(HighlightSubstring(text, query));
+            return ctx.Text(HighlightSubstring(text, query, restoreFg, restoreBg));
 
         return ctx.Text(text);
     }

--- a/src/Dotsider/Program.cs
+++ b/src/Dotsider/Program.cs
@@ -6,6 +6,7 @@ using Dotsider.Commands;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
+using Hex1b.Diagnostics;
 
 Console.OutputEncoding = Encoding.UTF8;
 
@@ -142,25 +143,51 @@ diffCommand.SetAction(async (parseResult, ct) =>
         new ConsolePresentationAdapter(enableMouse: true),
         TimeSpan.FromMilliseconds(escTimeoutMs));
 
-    await using var diffTerminal = Hex1bTerminal.CreateBuilder()
-        .WithPresentation(diffEscAdapter)
-        .WithMouse()
-        .WithHex1bApp((app, options) =>
-        {
-            options.Theme = DotsiderTheme.Create();
-
-            var diffState = new DiffState(app, left.FullName, right.FullName);
-            capturedDiffState = diffState;
-            var diffApp = new DiffApp(diffState);
-            return ctx => diffApp.Build(ctx);
-        })
-        .WithDiagnostics(appName: "dotsider-diff", forceEnable: true)
-        .Build();
-
+    var diffWorkload = new Hex1bAppWorkloadAdapter(diffEscAdapter.Capabilities);
+    var diffTerminalOptions = new Hex1bTerminalOptions
+    {
+        PresentationAdapter = diffEscAdapter,
+        WorkloadAdapter = diffWorkload
+    };
+    diffTerminalOptions.PresentationFilters.Add(new McpDiagnosticsPresentationFilter("dotsider-diff"));
+    await using var diffTerminal = new Hex1bTerminal(diffTerminalOptions);
     diffEscAdapter.Terminal = diffTerminal;
 
+    var diffAppOptions = new Hex1bAppOptions
+    {
+        WorkloadAdapter = diffWorkload,
+        Theme = DotsiderTheme.Create(),
+        EnableMouse = true
+    };
+
+    DiffApp? diffApp = null;
+    Hex1bApp? diffHex1bApp = null;
+
+    diffHex1bApp = new Hex1bApp(ctx =>
+    {
+        if (capturedDiffState is null)
+        {
+            var diffState = new DiffState(diffHex1bApp!, left.FullName, right.FullName);
+            capturedDiffState = diffState;
+            diffApp = new DiffApp(diffState);
+        }
+        return diffApp!.Build(ctx);
+    }, diffAppOptions);
+
     diagnosticsListener.StartListening();
-    await diffTerminal.RunAsync(ct);
+
+    // OSC 12: set terminal cursor color to teal (0,200,180) to match the theme accent
+    Console.Write("\x1b]12;rgb:00/c8/b4\x1b\\");
+
+    try
+    {
+        await diffHex1bApp.RunAsync(ct);
+    }
+    finally
+    {
+        diffHex1bApp.Dispose();
+    }
+
     return 0;
 });
 
@@ -226,25 +253,47 @@ static async Task<int> RunTui(string[] args, string filePath)
             new ConsolePresentationAdapter(enableMouse: true),
             TimeSpan.FromMilliseconds(parsed.EscapeTimeoutMs));
 
-        await using var nugetTerminal = Hex1bTerminal.CreateBuilder()
-            .WithPresentation(nugetEscAdapter)
-            .WithMouse()
-            .WithHex1bApp((app, options) =>
-            {
-                options.Theme = DotsiderTheme.Create();
-
-                var nugetState = new NuGetState(app, filePath);
-                capturedNugetState = nugetState;
-                var nugetApp = new NuGetApp(nugetState);
-                return ctx => nugetApp.Build(ctx);
-            })
-            .WithDiagnostics(appName: "dotsider-nuget", forceEnable: true)
-            .Build();
-
+        var nugetWorkload = new Hex1bAppWorkloadAdapter(nugetEscAdapter.Capabilities);
+        var nugetTerminalOptions = new Hex1bTerminalOptions
+        {
+            PresentationAdapter = nugetEscAdapter,
+            WorkloadAdapter = nugetWorkload
+        };
+        nugetTerminalOptions.PresentationFilters.Add(new McpDiagnosticsPresentationFilter("dotsider-nuget"));
+        await using var nugetTerminal = new Hex1bTerminal(nugetTerminalOptions);
         nugetEscAdapter.Terminal = nugetTerminal;
 
+        var nugetAppOptions = new Hex1bAppOptions
+        {
+            WorkloadAdapter = nugetWorkload,
+            Theme = DotsiderTheme.Create(),
+            EnableMouse = true
+        };
+
+        NuGetApp? nugetApp = null;
+        Hex1bApp? nugetHex1bApp = null;
+
+        nugetHex1bApp = new Hex1bApp(ctx =>
+        {
+            capturedNugetState ??= new NuGetState(nugetHex1bApp!, filePath);
+            nugetApp ??= new NuGetApp(capturedNugetState);
+            return nugetApp.Build(ctx);
+        }, nugetAppOptions);
+
         nugetListener.StartListening();
-        await nugetTerminal.RunAsync();
+
+        // OSC 12: set terminal cursor color to teal (0,200,180) to match the theme accent
+        Console.Write("\x1b]12;rgb:00/c8/b4\x1b\\");
+
+        try
+        {
+            await nugetHex1bApp.RunAsync();
+        }
+        finally
+        {
+            nugetHex1bApp.Dispose();
+        }
+
         return 0;
     }
 
@@ -259,30 +308,52 @@ static async Task<int> RunTui(string[] args, string filePath)
         new ConsolePresentationAdapter(enableMouse: true),
         TimeSpan.FromMilliseconds(parsed.EscapeTimeoutMs));
 
-    await using var terminal = Hex1bTerminal.CreateBuilder()
-        .WithPresentation(escAdapter)
-        .WithMouse()
-        .WithHex1bApp((app, options) =>
-        {
-            options.Theme = DotsiderTheme.Create();
+    var workload = new Hex1bAppWorkloadAdapter(escAdapter.Capabilities);
 
-            var state = new DotsiderState(app, filePath, pendingMutations)
-            {
-                CurrentTab = initialTab,
-                StringsMinLength = minStringLength
-            };
-            capturedState = state;
 
-            var dotsiderApp = new DotsiderApp(state);
-            return ctx => dotsiderApp.Build(ctx);
-        })
-        .WithDiagnostics(appName: "dotsider", forceEnable: true)
-        .Build();
-
+    var terminalOptions = new Hex1bTerminalOptions
+    {
+        PresentationAdapter = escAdapter,
+        WorkloadAdapter = workload
+    };
+    terminalOptions.PresentationFilters.Add(new McpDiagnosticsPresentationFilter("dotsider"));
+    await using var terminal = new Hex1bTerminal(terminalOptions);
     escAdapter.Terminal = terminal;
 
-    diagnosticsListener.StartListening();
+    var appOptions = new Hex1bAppOptions
+    {
+        WorkloadAdapter = workload,
+        Theme = DotsiderTheme.Create(),
+        EnableMouse = true
+    };
 
-    await terminal.RunAsync();
+    DotsiderApp? dotsiderApp = null;
+    Hex1bApp? hex1bApp = null;
+
+    hex1bApp = new Hex1bApp(ctx =>
+    {
+        capturedState ??= new DotsiderState(hex1bApp!, filePath, pendingMutations)
+        {
+            CurrentTab = initialTab,
+            StringsMinLength = minStringLength
+        };
+        dotsiderApp ??= new DotsiderApp(capturedState);
+        return dotsiderApp.Build(ctx);
+    }, appOptions);
+
+    diagnosticsListener.StartListening();
+    
+    // OSC 12: set terminal cursor color to teal (0,200,180) to match the theme accent
+    Console.Write("\x1b]12;rgb:00/c8/b4\x1b\\");
+
+    try
+    {
+        await hex1bApp.RunAsync();
+    }
+    finally
+    {
+        hex1bApp.Dispose();
+    }
+
     return 0;
 }

--- a/src/Dotsider/Views/DiffMethodsView.cs
+++ b/src/Dotsider/Views/DiffMethodsView.cs
@@ -73,11 +73,11 @@ public static class DiffMethodsView
                     [
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(prefix))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
-                            HighlightHelper.HighlightCell(c, method.DeclaringType, query, !string.IsNullOrEmpty(query)))),
+                            HighlightHelper.HighlightCell(c, method.DeclaringType, query, !string.IsNullOrEmpty(query), color))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
-                            HighlightHelper.HighlightCell(c, method.Name, query, !string.IsNullOrEmpty(query)))),
+                            HighlightHelper.HighlightCell(c, method.Name, query, !string.IsNullOrEmpty(query), color))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
-                            HighlightHelper.HighlightCell(c, method.Signature, query, !string.IsNullOrEmpty(query)))),
+                            HighlightHelper.HighlightCell(c, method.Signature, query, !string.IsNullOrEmpty(query), color))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(entry.ChangeDescription ?? "")))
                     ];
                 })

--- a/src/Dotsider/Views/DiffRefsView.cs
+++ b/src/Dotsider/Views/DiffRefsView.cs
@@ -75,7 +75,7 @@ public static class DiffRefsView
                     [
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(prefix))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
-                            HighlightHelper.HighlightCell(c, name, query, !string.IsNullOrEmpty(query)))),
+                            HighlightHelper.HighlightCell(c, name, query, !string.IsNullOrEmpty(query), color))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(leftVer))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(rightVer))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(entry.ChangeDescription ?? "")))

--- a/src/Dotsider/Views/DiffTypesView.cs
+++ b/src/Dotsider/Views/DiffTypesView.cs
@@ -71,7 +71,7 @@ public static class DiffTypesView
                     [
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(prefix))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
-                            HighlightHelper.HighlightCell(c, type.FullName, query, !string.IsNullOrEmpty(query)))),
+                            HighlightHelper.HighlightCell(c, type.FullName, query, !string.IsNullOrEmpty(query), color))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(type.BaseType ?? ""))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(type.MethodCount.ToString()))),
                         r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(type.FieldCount.ToString()))),

--- a/src/Dotsider/Views/DynamicAnalysisView.cs
+++ b/src/Dotsider/Views/DynamicAnalysisView.cs
@@ -317,7 +317,7 @@ public static class DynamicAnalysisView
                     h.Cell("Event").Width(SizeHint.Fixed(22)),
                     h.Cell("Detail").Width(SizeHint.Fill)
                 ])
-                .Row((r, evt, _) =>
+                .Row((r, evt, rs) =>
                 [
                     r.Cell(evt.Timestamp.ToString(@"mm\:ss\.fff")),
                     r.Cell(c => c.ThemePanel(
@@ -325,9 +325,11 @@ public static class DynamicAnalysisView
                             CategoryColors.GetValueOrDefault(evt.Category, Hex1bColor.White)),
                         c.Text(evt.Category.ToString()))),
                     r.Cell(c => HighlightHelper.HighlightCell(c, evt.EventName, query,
-                        !string.IsNullOrEmpty(query))),
+                        !string.IsNullOrEmpty(query),
+                        rs.IsFocused ? Hex1bColor.Black : null, rs.IsFocused ? Teal : null)),
                     r.Cell(c => HighlightHelper.HighlightCell(c, evt.Detail, query,
-                        !string.IsNullOrEmpty(query)))
+                        !string.IsNullOrEmpty(query),
+                        rs.IsFocused ? Hex1bColor.Black : null, rs.IsFocused ? Teal : null))
                 ])
                 .Focus(state.DynamicEventsFocusedKey)
                 .OnFocusChanged(key =>
@@ -480,7 +482,7 @@ public static class DynamicAnalysisView
                 h.Cell("Src").Width(SizeHint.Fixed(6)),
                 h.Cell("Output").Width(SizeHint.Fill)
             ])
-            .Row((r, line, _) =>
+            .Row((r, line, rs) =>
             [
                 r.Cell(line.Timestamp.ToString(@"mm\:ss\.fff")),
                 r.Cell(c => line.IsStdErr
@@ -489,7 +491,8 @@ public static class DynamicAnalysisView
                 r.Cell(c => line.IsStdErr
                     ? c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, Red), c.Text(line.Text))
                     : HighlightHelper.HighlightCell(c, line.Text, query,
-                        !string.IsNullOrEmpty(query)))
+                        !string.IsNullOrEmpty(query),
+                        rs.IsFocused ? Hex1bColor.Black : null, rs.IsFocused ? Teal : null))
             ])
             .Focus(state.DynamicOutputFocusedKey)
             .OnFocusChanged(key => state.DynamicOutputFocusedKey = key)

--- a/src/Dotsider/Views/GeneralView.cs
+++ b/src/Dotsider/Views/GeneralView.cs
@@ -103,13 +103,14 @@ public static class GeneralView
                         h.Cell("Culture").Width(SizeHint.Fixed(10)),
                         h.Cell("Public Key Token").Width(SizeHint.Fixed(20))
                     ])
-                    .Row((r, asmRef, rowState) =>
+                    .Row((r, asmRef, rs) =>
                     [
-                        r.Cell(c => HighlightHelper.HighlightCell(c, asmRef.Name, query,
-                            !string.IsNullOrEmpty(query))),
-                        r.Cell(asmRef.Version),
-                        r.Cell(asmRef.Culture),
-                        r.Cell(asmRef.PublicKeyToken ?? "")
+                        r.Cell(c => FocusStyle(c, HighlightHelper.HighlightCell(c, asmRef.Name, query,
+                            !string.IsNullOrEmpty(query),
+                            rs.IsFocused ? FocusFg : null, rs.IsFocused ? FocusBg : null), rs.IsFocused)),
+                        r.Cell(c => FocusStyle(c, c.Text(asmRef.Version), rs.IsFocused)),
+                        r.Cell(c => FocusStyle(c, c.Text(asmRef.Culture), rs.IsFocused)),
+                        r.Cell(c => FocusStyle(c, c.Text(asmRef.PublicKeyToken ?? ""), rs.IsFocused))
                     ])
                     .Focus(state.GeneralFocusedDep)
                     .OnFocusChanged(key => state.GeneralFocusedDep = key)
@@ -180,6 +181,15 @@ public static class GeneralView
         }
         return -1;
     }
+
+    private static readonly Hex1bColor FocusFg = Hex1bColor.Black;
+    private static readonly Hex1bColor FocusBg = Hex1bColor.FromRgb(0, 200, 180);
+
+    private static Hex1bWidget FocusStyle<T>(WidgetContext<T> c, Hex1bWidget child, bool isFocused)
+        where T : Hex1bWidget =>
+        isFocused ? c.ThemePanel(t => t
+            .Set(GlobalTheme.ForegroundColor, FocusFg)
+            .Set(GlobalTheme.BackgroundColor, FocusBg), child) : child;
 
     private static HStackWidget InfoLine<T>(WidgetContext<T> ctx, string label, string value) where T : Hex1bWidget
     {

--- a/src/Dotsider/Views/NuGetBrowserView.cs
+++ b/src/Dotsider/Views/NuGetBrowserView.cs
@@ -1,6 +1,7 @@
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
 using Hex1b.Layout;
+using Hex1b.Theming;
 using Hex1b.Widgets;
 
 namespace Dotsider.Views;
@@ -67,8 +68,10 @@ public static class NuGetBrowserView
                     ])
                     .Row((r, entry, rowState) =>
                     [
-                        r.Cell(c => HighlightHelper.HighlightCell(c, entry.Name, query, !string.IsNullOrEmpty(query))),
-                        r.Cell(c => HighlightHelper.HighlightCell(c, entry.Directory, query, !string.IsNullOrEmpty(query))),
+                        r.Cell(c => HighlightHelper.HighlightCell(c, entry.Name, query, !string.IsNullOrEmpty(query),
+                            rowState.IsFocused ? Hex1bColor.Black : null, rowState.IsFocused ? Hex1bColor.FromRgb(0, 200, 180) : null)),
+                        r.Cell(c => HighlightHelper.HighlightCell(c, entry.Directory, query, !string.IsNullOrEmpty(query),
+                            rowState.IsFocused ? Hex1bColor.Black : null, rowState.IsFocused ? Hex1bColor.FromRgb(0, 200, 180) : null)),
                         r.Cell(DotsiderState.FormatSize(entry.UncompressedSize))
                     ])
                     .Focus(state.FileTreeFocusedKey)

--- a/src/Dotsider/Views/PeMetadataView.cs
+++ b/src/Dotsider/Views/PeMetadataView.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
 using Hex1b.Input;
@@ -15,6 +16,8 @@ public static class PeMetadataView
 {
     private static readonly Hex1bColor LabelColor = Hex1bColor.FromRgb(100, 130, 160);
     private static readonly Hex1bColor AddressColor = Hex1bColor.FromRgb(100, 100, 130);
+    private static readonly string AddressAnsi = AddressColor.ToForegroundAnsi();
+    private const string AnsiReset = "\x1b[0m";
 
     /// <summary>
     /// Builds the PE/Metadata view widget tree.
@@ -141,7 +144,7 @@ public static class PeMetadataView
                 SearchBarHelper.AddSearchBar(widgets, outer, search, state.App);
 
                 // Bottom section: Metadata tables in sub-tabs
-                widgets.Add(outer.TabPanel(tp =>
+                Hex1bWidget metadataTabs = outer.TabPanel(tp =>
                 [
                     tp.Tab("Sections", t => [BuildSectionsTable(t, state)])
                         .Selected(state.PeSubTab == PeSubTabId.Sections),
@@ -167,7 +170,19 @@ public static class PeMetadataView
                     state.App.Invalidate();
                 })
                 .Compact()
-                .Fill());
+                .Fill();
+
+                // Suppress the teal selected-tab highlight when the detail popup
+                // is open so it doesn't bleed through the transparent backdrop.
+                if (state.PeDetailContent is not null)
+                {
+                    metadataTabs = outer.ThemePanel(t => t
+                        .Set(TabBarTheme.SelectedForegroundColor, Hex1bColor.FromRgb(140, 140, 160))
+                        .Set(TabBarTheme.SelectedBackgroundColor, Hex1bColor.Default),
+                        metadataTabs);
+                }
+
+                widgets.Add(metadataTabs);
 
                 return [.. widgets];
             })
@@ -250,7 +265,7 @@ public static class PeMetadataView
                     z.Border(
                         z.VStack(dlg =>
                             [.. state.PeDetailContent.Split('\n')
-                                .Select(line => dlg.Text($"  {line}"))]
+                                .Select(line => DetailLine(dlg, line))]
                         )
                     ).Title(" Detail ").FixedWidth(60).FixedHeight(12)
                 ).OnClickAway(() =>
@@ -281,14 +296,14 @@ public static class PeMetadataView
                 h.Cell("Raw Size").Width(SizeHint.Fixed(14)),
                 h.Cell("Characteristics").Width(SizeHint.Fill)
             ])
-            .Row((r, s, _) =>
+            .Row((r, s, rs) =>
             [
-                r.Cell(c => HighlightHelper.HighlightCell(c, s.Name, query, true)),
-                r.Cell(c => HexCell(c, $"0x{s.VirtualAddress:X8}")),
-                r.Cell(FormatSize(s.VirtualSize, state)),
-                r.Cell(c => HexCell(c, $"0x{s.RawDataOffset:X8}")),
-                r.Cell(FormatSize(s.RawDataSize, state)),
-                r.Cell(c => HighlightHelper.HighlightCell(c, s.Characteristics.ToString(), query, true))
+                r.Cell(c => FocusHighlightCell(c,s.Name, query, true, rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{s.VirtualAddress:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, c.Text(FormatSize(s.VirtualSize, state)), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{s.RawDataOffset:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, c.Text(FormatSize(s.RawDataSize, state)), rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,s.Characteristics.ToString(), query, true, rs.IsFocused))
             ])
             .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
@@ -324,14 +339,14 @@ public static class PeMetadataView
                 h.Cell("Methods").Width(SizeHint.Fixed(8)),
                 h.Cell("Fields").Width(SizeHint.Fixed(8))
             ])
-            .Row((r, t, _) =>
+            .Row((r, t, rs) =>
             [
-                r.Cell(c => HexCell(c, $"0x{t.Token:X8}")),
-                r.Cell(c => HighlightHelper.HighlightCell(c, t.FullName, query, true)),
-                r.Cell(c => HighlightHelper.HighlightCell(c, t.BaseType ?? "", query, true)),
-                r.Cell(c => HighlightHelper.HighlightCell(c, t.Attributes.ToString(), query, true)),
-                r.Cell(t.MethodCount.ToString()),
-                r.Cell(t.FieldCount.ToString())
+                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{t.Token:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,t.FullName, query, true, rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,t.BaseType ?? "", query, true, rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,t.Attributes.ToString(), query, true, rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, c.Text(t.MethodCount.ToString()), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, c.Text(t.FieldCount.ToString()), rs.IsFocused))
             ])
             .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
@@ -367,14 +382,14 @@ public static class PeMetadataView
                 h.Cell("Attributes").Width(SizeHint.Fixed(20)),
                 h.Cell("RVA").Width(SizeHint.Fixed(12))
             ])
-            .Row((r, m, _) =>
+            .Row((r, m, rs) =>
             [
-                r.Cell(c => HexCell(c, $"0x{m.Token:X8}")),
-                r.Cell(c => HighlightHelper.HighlightCell(c, m.DeclaringType, query, true)),
-                r.Cell(c => HighlightHelper.HighlightCell(c, m.Name, query, true)),
-                r.Cell(c => HighlightHelper.HighlightCell(c, m.Signature, query, true)),
-                r.Cell(m.Attributes.ToString()),
-                r.Cell(c => m.Rva == 0 ? c.Text("") : HexCell(c, $"0x{m.Rva:X8}"))
+                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{m.Token:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,m.DeclaringType, query, true, rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,m.Name, query, true, rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,m.Signature, query, true, rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, c.Text(m.Attributes.ToString()), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, m.Rva == 0 ? c.Text("") : HexCell(c, $"0x{m.Rva:X8}"), rs.IsFocused))
             ])
             .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
@@ -407,11 +422,11 @@ public static class PeMetadataView
                 h.Cell("Full Name").Width(SizeHint.Fill),
                 h.Cell("Resolution Scope").Width(SizeHint.Fixed(30))
             ])
-            .Row((r, t, _) =>
+            .Row((r, t, rs) =>
             [
-                r.Cell(c => HexCell(c, $"0x{t.Token:X8}")),
-                r.Cell(c => HighlightHelper.HighlightCell(c, t.FullName, query, true)),
-                r.Cell(c => HighlightHelper.HighlightCell(c, t.ResolutionScope, query, true))
+                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{t.Token:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,t.FullName, query, true, rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,t.ResolutionScope, query, true, rs.IsFocused))
             ])
             .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
@@ -443,11 +458,11 @@ public static class PeMetadataView
                 h.Cell("Declaring Type").Width(SizeHint.Fill),
                 h.Cell("Name").Width(SizeHint.Fixed(25))
             ])
-            .Row((r, m, _) =>
+            .Row((r, m, rs) =>
             [
-                r.Cell(c => HexCell(c, $"0x{m.Token:X8}")),
-                r.Cell(c => HighlightHelper.HighlightCell(c, m.DeclaringType, query, true)),
-                r.Cell(c => HighlightHelper.HighlightCell(c, m.Name, query, true))
+                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{m.Token:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,m.DeclaringType, query, true, rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,m.Name, query, true, rs.IsFocused))
             ])
             .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
@@ -476,11 +491,11 @@ public static class PeMetadataView
                 h.Cell("Constructor").Width(SizeHint.Fill),
                 h.Cell("Value").Width(SizeHint.Fixed(40))
             ])
-            .Row((r, a, _) =>
+            .Row((r, a, rs) =>
             [
-                r.Cell(c => HighlightHelper.HighlightCell(c, a.Parent, query, true)),
-                r.Cell(c => HighlightHelper.HighlightCell(c, a.Constructor, query, true)),
-                r.Cell(c => HighlightHelper.HighlightCell(c, a.Value ?? "", query, true))
+                r.Cell(c => FocusHighlightCell(c,a.Parent, query, true, rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,a.Constructor, query, true, rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,a.Value ?? "", query, true, rs.IsFocused))
             ])
             .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
@@ -513,13 +528,13 @@ public static class PeMetadataView
                 h.Cell("Size").Width(SizeHint.Fixed(12)),
                 h.Cell("Linked").Width(SizeHint.Fixed(8))
             ])
-            .Row((r, res, _) =>
+            .Row((r, res, rs) =>
             [
-                r.Cell(c => HighlightHelper.HighlightCell(c, res.Name, query, true)),
-                r.Cell(c => HighlightHelper.HighlightCell(c, res.Visibility, query, true)),
-                r.Cell(c => HexCell(c, $"0x{res.Offset:X8}")),
-                r.Cell(res.Size >= 0 ? FormatSize((int)res.Size, state) : "?"),
-                r.Cell(res.IsLinked ? "Yes" : "No")
+                r.Cell(c => FocusHighlightCell(c,res.Name, query, true, rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,res.Visibility, query, true, rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{res.Offset:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, c.Text(res.Size >= 0 ? FormatSize((int)res.Size, state) : "?"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, c.Text(res.IsLinked ? "Yes" : "No"), rs.IsFocused))
             ])
             .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
@@ -550,6 +565,21 @@ public static class PeMetadataView
     private static ThemePanelWidget HexCell<T>(WidgetContext<T> c, string text) where T : Hex1bWidget =>
         c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, AddressColor), c.Text(text));
 
+    private static readonly Hex1bColor FocusFg = Hex1bColor.Black;
+    private static readonly Hex1bColor FocusBg = Hex1bColor.FromRgb(0, 200, 180);
+
+    private static Hex1bWidget FocusStyle<T>(WidgetContext<T> c, Hex1bWidget child, bool isFocused)
+        where T : Hex1bWidget =>
+        isFocused ? c.ThemePanel(t => t
+            .Set(GlobalTheme.ForegroundColor, FocusFg)
+            .Set(GlobalTheme.BackgroundColor, FocusBg), child) : child;
+
+    private static Hex1bWidget FocusHighlightCell<T>(
+        WidgetContext<T> c, string text, string? query, bool isMatch, bool isFocused)
+        where T : Hex1bWidget =>
+        FocusStyle(c, HighlightHelper.HighlightCell(c, text, query, isMatch,
+            isFocused ? FocusFg : null, isFocused ? FocusBg : null), isFocused);
+
     private static HStackWidget PeLine<T>(WidgetContext<T> ctx, string label, string value) where T : Hex1bWidget
     {
         return ctx.HStack(row =>
@@ -559,6 +589,59 @@ public static class PeMetadataView
             row.Text(value)
         ]).FixedHeight(1);
     }
+
+    private static Hex1bWidget DetailLine<T>(WidgetContext<T> ctx, string line) where T : Hex1bWidget
+    {
+        var colonIdx = line.IndexOf(": ", StringComparison.Ordinal);
+        if (colonIdx < 0)
+            return ctx.Text($"  {line}");
+
+        var label = line[..colonIdx];
+        var value = line[(colonIdx + 2)..];
+
+        return ctx.HStack(row =>
+        [
+            row.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, LabelColor),
+                row.Text($"  {label}: ")).FixedWidth(22),
+            row.Text(ColorizeHexValues(value))
+        ]).FixedHeight(1);
+    }
+
+    private static string ColorizeHexValues(string text)
+    {
+        var sb = new StringBuilder(text.Length + 32);
+        var i = 0;
+        while (i < text.Length)
+        {
+            if (i + 2 < text.Length && text[i] == '0' && text[i + 1] is 'x' or 'X')
+            {
+                var start = i;
+                i += 2;
+                while (i < text.Length && IsHexDigit(text[i]))
+                    i++;
+                if (i > start + 2)
+                {
+                    sb.Append(AddressAnsi);
+                    sb.Append(text, start, i - start);
+                    sb.Append(AnsiReset);
+                }
+                else
+                {
+                    sb.Append(text, start, i - start);
+                }
+            }
+            else
+            {
+                sb.Append(text[i]);
+                i++;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static bool IsHexDigit(char c) =>
+        c is (>= '0' and <= '9') or (>= 'a' and <= 'f') or (>= 'A' and <= 'F');
 
     private static IReadOnlyList<object> GetActiveRowKeys(DotsiderState state)
     {

--- a/src/Dotsider/Views/StringsView.cs
+++ b/src/Dotsider/Views/StringsView.cs
@@ -14,6 +14,7 @@ namespace Dotsider.Views;
 public static class StringsView
 {
     private static readonly Hex1bColor AddressColor = Hex1bColor.FromRgb(100, 100, 130);
+    private static readonly Hex1bColor LabelColor = Hex1bColor.FromRgb(100, 130, 160);
     private static readonly string[] SourceTabs = ["User Strings (#US)", "Metadata (#Strings)", "Raw Binary"];
 
     /// <summary>
@@ -74,7 +75,7 @@ public static class StringsView
                 SearchBarHelper.AddSearchBar(widgets, outer, search, state.App);
 
                 // Sub-tab selector with strings table as content
-                widgets.Add(outer.TabPanel(tp =>
+                Hex1bWidget stringsTabs = outer.TabPanel(tp =>
                     [.. SourceTabs.Select((name, i) =>
                         tp.Tab(name, t => [BuildStringsTable(t, state, activeStrings, query)])
                             .Selected(state.StringsSourceTab == i)
@@ -89,7 +90,19 @@ public static class StringsView
                     state.App.Invalidate();
                 })
                 .Compact()
-                .Fill());
+                .Fill();
+
+                // Suppress the teal selected-tab highlight when the detail popup
+                // is open so it doesn't bleed through the transparent backdrop.
+                if (state.StringsDetailContent is not null)
+                {
+                    stringsTabs = outer.ThemePanel(t => t
+                        .Set(TabBarTheme.SelectedForegroundColor, Hex1bColor.FromRgb(140, 140, 160))
+                        .Set(TabBarTheme.SelectedBackgroundColor, Hex1bColor.Default),
+                        stringsTabs);
+                }
+
+                widgets.Add(stringsTabs);
 
                 // Status line
                 var statusParts = new List<string> { $"{activeStrings.Count} strings" };
@@ -203,7 +216,12 @@ public static class StringsView
                             outer.Border(
                                 outer.VScrollPanel(scroll =>
                                 [
-                                    scroll.Text($"  Length: {state.StringsDetailContent.Length}"),
+                                    scroll.HStack(row =>
+                                    [
+                                        row.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, LabelColor),
+                                            row.Text("  Length: ")),
+                                        row.Text(state.StringsDetailContent.Length.ToString())
+                                    ]).FixedHeight(1),
                                     scroll.Text(""),
                                     .. state.StringsDetailContent
                                         .Split('\n')
@@ -235,13 +253,18 @@ public static class StringsView
                 h.Cell("Offset").Width(SizeHint.Fixed(12)),
                 h.Cell("Value").Width(SizeHint.Fill)
             ])
-            .Row((r, entry, rowState) =>
+            .Row((r, entry, rs) =>
             [
-                r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, AddressColor),
-                    c.Text($"0x{entry.Offset:X8}"))),
-                r.Cell(c => HighlightHelper.HighlightCell(c,
-                    entry.Value.Length > 200 ? entry.Value[..200] + "..." : entry.Value,
-                    query, !string.IsNullOrEmpty(query)))
+                r.Cell(c => FocusStyle(c,
+                    c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, AddressColor),
+                        c.Text($"0x{entry.Offset:X8}")),
+                    rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,
+                    HighlightHelper.HighlightCell(c,
+                        entry.Value.Length > 200 ? entry.Value[..200] + "..." : entry.Value,
+                        query, !string.IsNullOrEmpty(query),
+                        rs.IsFocused ? FocusFg : null, rs.IsFocused ? FocusBg : null),
+                    rs.IsFocused))
             ])
             .Focus(state.StringsDetailContent is not null ? null : state.StringsFocusedKey)
             .OnFocusChanged(key => state.StringsFocusedKey = key)
@@ -252,6 +275,15 @@ public static class StringsView
             })
             .Compact().Fill();
     }
+
+    private static readonly Hex1bColor FocusFg = Hex1bColor.Black;
+    private static readonly Hex1bColor FocusBg = Hex1bColor.FromRgb(0, 200, 180);
+
+    private static Hex1bWidget FocusStyle<T>(WidgetContext<T> c, Hex1bWidget child, bool isFocused)
+        where T : Hex1bWidget =>
+        isFocused ? c.ThemePanel(t => t
+            .Set(GlobalTheme.ForegroundColor, FocusFg)
+            .Set(GlobalTheme.BackgroundColor, FocusBg), child) : child;
 
     private static string RowKey(StringEntry e) =>
         $"{e.Offset}:{e.Source}";

--- a/tests/Dotsider.Mcp.Tests/Dotsider.Mcp.Tests.csproj
+++ b/tests/Dotsider.Mcp.Tests/Dotsider.Mcp.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Dotsider.Tests/Dotsider.Tests.csproj
+++ b/tests/Dotsider.Tests/Dotsider.Tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Dotsider.Tests/PeMetadataViewTests.cs
+++ b/tests/Dotsider.Tests/PeMetadataViewTests.cs
@@ -524,6 +524,93 @@ public class PeMetadataViewTests(SampleAssemblyFixture samples) : IDisposable
         await runTask;
     }
 
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_SectionDetailPopup_ShowsColoredLabelsAndHexValues()
+    {
+        var (terminal, app) = CreateDotsiderApp();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Sections") && s.ContainsText(".text"),
+                TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.PeDetailContent is not null, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Detail"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Verify the detail content has the expected label:value structure
+        var content = _state!.PeDetailContent!;
+        Assert.Contains("Section:", content);
+        Assert.Contains("Virtual Address:", content);
+        Assert.Contains("0x", content); // Hex values present
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_TypeDefDetailPopup_ShowsTokenAndAttributes()
+    {
+        var (terminal, app) = CreateDotsiderApp();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Sections"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.PeSubTab == PeSubTabId.TypeDef, TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.PeDetailContent is not null, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Detail"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        var content = _state!.PeDetailContent!;
+        Assert.Contains("TypeDef:", content);
+        Assert.Contains("Token: 0x", content);
+        Assert.Contains("Attributes:", content);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_MethodDefDetailPopup_ShowsSignatureAndRva()
+    {
+        var (terminal, app) = CreateDotsiderApp();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Sections"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.PeSubTab == PeSubTabId.TypeDef, TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.PeSubTab == PeSubTabId.MethodDef, TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.PeDetailContent is not null, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Detail"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        var content = _state!.PeDetailContent!;
+        Assert.Contains("MethodDef:", content);
+        Assert.Contains("Token: 0x", content);
+        Assert.Contains("Signature:", content);
+        Assert.Contains("RVA: 0x", content);
+
+        cts.Cancel();
+        await runTask;
+    }
+
     public void Dispose()
     {
         _state?.Dispose();

--- a/tests/Dotsider.Tests/SessionDiagnosticsSocketTests.cs
+++ b/tests/Dotsider.Tests/SessionDiagnosticsSocketTests.cs
@@ -1,0 +1,172 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Dotsider.Core.Protocol;
+using Dotsider.Diagnostics;
+using Dotsider.Infrastructure;
+using Hex1b;
+using Hex1b.Diagnostics;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// End-to-end tests that start a real headless TUI with the production-equivalent
+/// manual terminal setup (McpDiagnosticsPresentationFilter), then exercise the
+/// hex1b diagnostics socket for sessions capture and screen capture workflows.
+/// </summary>
+[Collection("SampleAssemblies")]
+public class SessionDiagnosticsSocketTests(SampleAssemblyFixture samples)
+{
+    /// <summary>
+    /// Starts a headless TUI mirroring the production Program.cs setup:
+    /// manual Hex1bTerminal with McpDiagnosticsPresentationFilter.
+    /// Returns the diagnostics socket path and a CTS to stop the app.
+    /// </summary>
+    private async Task<(Hex1bTerminal terminal, Hex1bApp app, McpDiagnosticsPresentationFilter filter,
+        DotsiderDiagnosticsListener listener, DotsiderState state, Task runTask, CancellationTokenSource cts)>
+        StartTuiAsync()
+    {
+        var pendingMutations = new ConcurrentQueue<Action<DotsiderState>>();
+
+        var workload = new Hex1bAppWorkloadAdapter();
+        var filter = new McpDiagnosticsPresentationFilter("dotsider-test");
+
+        var terminalOptions = new Hex1bTerminalOptions
+        {
+            PresentationAdapter = new HeadlessPresentationAdapter(120, 30),
+            WorkloadAdapter = workload
+        };
+        terminalOptions.PresentationFilters.Add(filter);
+        var terminal = new Hex1bTerminal(terminalOptions);
+
+        DotsiderState? state = null;
+        Hex1bApp? app = null;
+
+        app = new Hex1bApp(
+            ctx =>
+            {
+                state ??= new DotsiderState(app!, samples.HelloWorldDll, pendingMutations);
+                var dotsiderApp = new DotsiderApp(state);
+                return dotsiderApp.Build(ctx);
+            },
+            new Hex1bAppOptions
+            {
+                WorkloadAdapter = workload,
+                Theme = DotsiderTheme.Create(),
+                EnableInputCoalescing = false
+            });
+
+        var listener = new DotsiderDiagnosticsListener(() => state);
+        listener.StartListening();
+
+        // Start the app and allow time for first render
+        var cts = new CancellationTokenSource();
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(50);
+
+        // Wait for the TUI state to be initialized and rendered
+        await TestHelpers.WaitUntilAsync(
+            () => state is not null,
+            TimeSpan.FromSeconds(10));
+        await Task.Delay(50);
+
+        return (terminal, app, filter, listener, state!, runTask, cts);
+    }
+
+    /// <summary>
+    /// Stops the app cleanly and disposes all resources.
+    /// </summary>
+    private static async Task StopAndDisposeAsync(
+        Hex1bTerminal terminal, Hex1bApp app,
+        McpDiagnosticsPresentationFilter filter,
+        DotsiderDiagnosticsListener listener,
+        DotsiderState state, Task runTask, CancellationTokenSource cts)
+    {
+        cts.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+
+        await listener.DisposeAsync();
+        state.Dispose();
+        app.Dispose();
+        await filter.DisposeAsync();
+        await terminal.DisposeAsync();
+        cts.Dispose();
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task DiagnosticsSocket_ExistsAfterTuiStart()
+    {
+        var (terminal, app, filter, listener, state, runTask, cts) = await StartTuiAsync();
+        try
+        {
+            Assert.True(File.Exists(filter.SocketPath),
+                $"Hex1b diagnostics socket was not created at {filter.SocketPath}");
+        }
+        finally
+        {
+            await StopAndDisposeAsync(terminal, app, filter, listener, state, runTask, cts);
+        }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task DiagnosticsSocket_RemovedAfterDispose()
+    {
+        var (terminal, app, filter, listener, state, runTask, cts) = await StartTuiAsync();
+        var socketPath = filter.SocketPath;
+
+        await StopAndDisposeAsync(terminal, app, filter, listener, state, runTask, cts);
+
+        Assert.False(File.Exists(socketPath),
+            $"Hex1b diagnostics socket was not cleaned up at {socketPath}");
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task SessionsCapture_ReturnsScreenContent_ViaRealSocket()
+    {
+        var (terminal, app, filter, listener, state, runTask, cts) = await StartTuiAsync();
+        try
+        {
+            // Send the same capture request that `dotsider sessions capture <pid>` uses
+            var requestJson = JsonSerializer.Serialize(
+                new { method = "capture", format = "text" }, DotsiderJsonOptions.Default);
+
+            var responseJson = await DotsiderClient.SendRawAsync(filter.SocketPath, requestJson, TestContext.Current.CancellationToken);
+            var response = JsonSerializer.Deserialize<JsonElement>(responseJson);
+
+            Assert.True(response.GetProperty("success").GetBoolean(), "Capture request failed");
+            Assert.True(response.TryGetProperty("data", out var data), "Capture response missing data");
+
+            var content = data.GetString()!;
+            Assert.NotEmpty(content);
+            Assert.Contains("dotsider", content, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            await StopAndDisposeAsync(terminal, app, filter, listener, state, runTask, cts);
+        }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task CaptureScreen_ReturnsAssemblyContent_ViaRealSocket()
+    {
+        var (terminal, app, filter, listener, state, runTask, cts) = await StartTuiAsync();
+        try
+        {
+            // Exercise the same code path that MCP capture_screen uses
+            var requestJson = JsonSerializer.Serialize(
+                new { method = "capture", format = "text" }, DotsiderJsonOptions.Default);
+
+            var responseJson = await DotsiderClient.SendRawAsync(filter.SocketPath, requestJson, TestContext.Current.CancellationToken);
+            var response = JsonSerializer.Deserialize<JsonElement>(responseJson);
+
+            Assert.True(response.GetProperty("success").GetBoolean());
+            var content = response.GetProperty("data").GetString()!;
+
+            // The General tab shows assembly info — verify real assembly data appears
+            Assert.Contains("HelloWorld", content);
+        }
+        finally
+        {
+            await StopAndDisposeAsync(terminal, app, filter, listener, state, runTask, cts);
+        }
+    }
+}

--- a/tests/Dotsider.Tests/StringsViewTests.cs
+++ b/tests/Dotsider.Tests/StringsViewTests.cs
@@ -251,6 +251,32 @@ public class StringsViewTests(SampleAssemblyFixture samples) : IDisposable
         await runTask;
     }
 
+    [Fact(Timeout = 30_000)]
+    public async Task Strings_DetailPopupShowsStringContent()
+    {
+        var (terminal, app) = CreateDotsiderApp();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("strings"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.StringsDetailContent is not null, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("String Detail") && s.ContainsText("Length:"),
+                TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // The detail popup should show both the Length label and the string value
+        Assert.NotNull(_state!.StringsDetailContent);
+        Assert.True(_state.StringsDetailContent.Length > 0);
+
+        cts.Cancel();
+        await runTask;
+    }
+
     public void Dispose()
     {
         _state?.Dispose();

--- a/tests/Dotsider.Website.Tests/Dotsider.Website.Tests.csproj
+++ b/tests/Dotsider.Website.Tests/Dotsider.Website.Tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Add syntax highlighting to PE/Metadata and Strings detail popups — labels get `LabelColor`, hex values get `AddressColor` with inline ANSI coloring, matching table/view styling
- Fix theme not being applied in the terminal by switching from `Hex1bTerminalBuilder` to direct `Hex1bTerminal` construction, so `DotsiderTheme` is read at `Hex1bApp` creation time
- Fix search highlight clearing focused-row and diff-color styling by teaching `HighlightHelper` to restore the caller's fg/bg after each match instead of resetting all attributes

## Additional changes
- Suppress selected-tab highlight bleed-through on detail popup backdrops via ThemePanel override
- Seed focused row on initial load, after drill-in, and restore on back navigation
- Set terminal cursor color to teal via OSC 12 in TUI mode only
- Add end-to-end tests for diagnostics socket lifecycle and real capture workflow

## Test plan
- [x] `dotnet test` — all 588 tests pass (526 Dotsider.Tests + 61 MCP + 1 Website)
- [x] Manual: open PE/Metadata detail popup — labels colored, hex values colored
- [x] Manual: open Strings detail popup — Length label colored
- [x] Manual: search in focused row — match highlighted, rest of cell keeps focus styling
- [x] Manual: drill into assembly ref, back with Backspace — focus restored to previous row
- [x] Manual: `dotsider sessions capture <pid>` works against running instance

Fixes #74