### PR TITLE
Fix Dynamic tab guards for .NET Framework and NativeAOT assemblies

### DIFF
--- a/Dotsider.slnx
+++ b/Dotsider.slnx
@@ -15,6 +15,8 @@
     <Project Path="samples/MinimalApi/MinimalApi.csproj" />
     <Project Path="samples/NativeLib/NativeLib.csproj" />
     <Project Path="samples/EmptyLib/EmptyLib.csproj" />
+    <Project Path="samples/NetFxConsole/NetFxConsole.csproj" />
+    <Project Path="samples/NativeAotConsole/NativeAotConsole.csproj" />
   </Folder>
 
   <Folder Name="/tests/">

--- a/README.md
+++ b/README.md
@@ -266,9 +266,11 @@ samples/
   MinimalApi/         ASP.NET Core minimal API (web SDK, hosted entry point)
   NativeLib/          Unsafe code, P/Invoke, pointer operations
   EmptyLib/           Minimal library (edge case testing)
+  NetFxConsole/       .NET Framework 4.8 console app (Dynamic tab guard testing)
+  NativeAotConsole/   NativeAOT-published console app (Dynamic tab tracing tests)
 
 tests/Dotsider.Tests/
-  SampleAssemblyFixture.cs   Builds all 7 samples once, shared across tests
+  SampleAssemblyFixture.cs   Builds all 9 samples once, shared across tests
   *Tests.cs                  Integration tests against real assemblies
 
 tests/Dotsider.Mcp.Tests/

--- a/samples/NativeAotConsole/NativeAotConsole.csproj
+++ b/samples/NativeAotConsole/NativeAotConsole.csproj
@@ -1,0 +1,12 @@
+<!-- FROZEN TEST FIXTURE — do not modify without updating Dotsider.Tests -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PublishAot>true</PublishAot>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/samples/NativeAotConsole/Program.cs
+++ b/samples/NativeAotConsole/Program.cs
@@ -1,0 +1,5 @@
+// A NativeAOT-published console app for testing dotsider's Dynamic tab.
+// Since .NET 8, NativeAOT supports EventPipe when published with
+// EventSourceSupport=true. The Dynamic tab should allow tracing attempts
+// for NativeAOT binaries rather than blocking unconditionally.
+Console.WriteLine("Hello from NativeAOT!");

--- a/samples/NativeAotConsole/README.md
+++ b/samples/NativeAotConsole/README.md
@@ -1,0 +1,8 @@
+# NativeAotConsole
+
+NativeAOT-published console app used to test that dotsider's Dynamic tab no longer unconditionally blocks NativeAOT binaries.
+
+- Published with `PublishAot=true` producing a self-contained native executable
+- Since .NET 8, NativeAOT supports EventPipe when `EventSourceSupport=true`
+- The Dynamic tab should allow tracing attempts rather than blocking with an incorrect message
+- Referenced by `SampleAssemblyFixture` in the test suite

--- a/samples/NetFxConsole/NetFxConsole.csproj
+++ b/samples/NetFxConsole/NetFxConsole.csproj
@@ -1,0 +1,13 @@
+<!-- FROZEN TEST FIXTURE — do not modify without updating Dotsider.Tests -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/samples/NetFxConsole/Program.cs
+++ b/samples/NetFxConsole/Program.cs
@@ -1,0 +1,15 @@
+// A .NET Framework 4.8 console app for testing dotsider's Dynamic tab guard.
+// EventPipe is not available on .NET Framework, so this assembly should
+// trigger a friendly message instead of hanging the tracer.
+using System;
+
+namespace NetFxConsole
+{
+    internal static class Program
+    {
+        static void Main()
+        {
+            Console.WriteLine("Hello from .NET Framework 4.8!");
+        }
+    }
+}

--- a/samples/NetFxConsole/README.md
+++ b/samples/NetFxConsole/README.md
@@ -1,0 +1,7 @@
+# NetFxConsole
+
+.NET Framework 4.8 console app used to test dotsider's Dynamic tab guard for non-CoreCLR assemblies.
+
+- Targets `net48` — EventPipe is not available on .NET Framework
+- The Dynamic tab should detect the framework moniker and show a friendly message instead of hanging
+- Referenced by `SampleAssemblyFixture` in the test suite

--- a/samples/README.md
+++ b/samples/README.md
@@ -11,5 +11,7 @@ Sample .NET projects used as test fixtures for dotsider's analysis, diff, and tr
 | [NativeLib](NativeLib/) | Library | P/Invoke, unsafe code, pointer arithmetic, fixed buffers |
 | [RichLibrary](RichLibrary/) | Library (NuGet) | Feature-rich baseline: generics, attributes, extension methods, dual JSON serializers |
 | [RichLibraryV2](RichLibraryV2/) | Library | Breaking changes from RichLibrary v1 for assembly diff testing |
+| [NetFxConsole](NetFxConsole/) | Console app (.NET Fx) | .NET Framework 4.8 target for Dynamic tab guard testing |
+| [NativeAotConsole](NativeAotConsole/) | Console app (NativeAOT) | NativeAOT-published binary for Dynamic tab tracing tests |
 
-All samples target .NET 10 with nullable reference types enabled.
+All managed samples target .NET 10 with nullable reference types enabled unless noted otherwise.

--- a/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
+++ b/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
@@ -304,7 +304,7 @@ internal sealed class DotsiderDiagnosticsListener(
         if (method is null)
             return DotsiderResponse.Fail($"Method not found: {request.TypeName}.{request.MethodName}");
 
-        var instructions = state.IlDisassembler.Disassemble(method);
+        var instructions = state.IlDisassembler!.Disassemble(method);
         return DotsiderResponse.Ok(new { Method = method, Instructions = instructions });
     }
 
@@ -325,7 +325,7 @@ internal sealed class DotsiderDiagnosticsListener(
             IReadOnlyList<IlInstruction> instructions;
             try
             {
-                instructions = state.IlDisassembler.Disassemble(method);
+                instructions = state.IlDisassembler!.Disassemble(method);
             }
             catch
             {
@@ -560,7 +560,11 @@ internal sealed class DotsiderDiagnosticsListener(
     private DotsiderResponse HandleStartTrace(DotsiderRequest request)
     {
         var state = RequireState();
-        if (!state.HasEntryPoint)
+        
+        if (state.IsNetFramework)
+            return DotsiderResponse.Fail("Assembly targets .NET Framework; EventPipe requires .NET Core 3.0+");
+
+        if (!state.HasEntryPoint && !state.IsNativeAot)
             return DotsiderResponse.Fail("Assembly has no entry point");
 
         if (state.Tracer?.ProcessState == TraceProcessState.Running)

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -514,7 +514,7 @@ public sealed class DotsiderApp(DotsiderState state)
                         : "Enter: Re-run";
                     hints.Add(s.Section(hint));
                 }
-                else if (_state.HasEntryPoint)
+                else if ((_state.HasEntryPoint || _state.IsNativeAot) && !_state.IsNetFramework)
                     hints.Add(s.Section("Enter: Launch"));
             }
 
@@ -636,8 +636,8 @@ public sealed class DotsiderApp(DotsiderState state)
     private static void CommitAnalyzer(DotsiderState state, AssemblyAnalyzer analyzer)
     {
         state.Analyzer = analyzer;
-        state.IlDisassembler = new IlDisassembler(analyzer);
         state.StringExtractor = new StringExtractor(analyzer);
+        state.IlDisassembler = analyzer.HasMetadata ? new IlDisassembler(analyzer) : null;
         var hexDoc = new HexRowDocument(new Hex1bDocument(analyzer.RawBytes.ToArray()));
         state.HexRowDoc = hexDoc;
         state.HexEditorState = new EditorState(hexDoc) { IsReadOnly = true };

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -24,8 +24,10 @@ public sealed class DotsiderState : IDisposable
         App = app;
         PendingMutations = pendingMutations ?? new();
         Analyzer = new AssemblyAnalyzer(filePath);
-        IlDisassembler = new IlDisassembler(Analyzer);
         StringExtractor = new StringExtractor(Analyzer);
+        if (Analyzer.HasMetadata)
+            IlDisassembler = new IlDisassembler(Analyzer);
+        
         var hexDoc = new HexRowDocument(new Hex1bDocument(Analyzer.RawBytes.ToArray()));
         HexRowDoc = hexDoc;
         HexEditorState = new EditorState(hexDoc) { IsReadOnly = true };
@@ -40,8 +42,9 @@ public sealed class DotsiderState : IDisposable
         App = app;
         PendingMutations = new();
         Analyzer = analyzer;
-        IlDisassembler = new IlDisassembler(Analyzer);
         StringExtractor = new StringExtractor(Analyzer);
+        if (Analyzer.HasMetadata)
+            IlDisassembler = new IlDisassembler(Analyzer);
         var hexDoc = new HexRowDocument(new Hex1bDocument(Analyzer.RawBytes.ToArray()));
         HexRowDoc = hexDoc;
         HexEditorState = new EditorState(hexDoc) { IsReadOnly = true };
@@ -60,8 +63,8 @@ public sealed class DotsiderState : IDisposable
     /// <summary>The core assembly analyzer (current top of navigation stack).</summary>
     public AssemblyAnalyzer Analyzer { get; internal set; }
 
-    /// <summary>The IL disassembler for method body inspection.</summary>
-    public IlDisassembler IlDisassembler { get; internal set; }
+    /// <summary>The IL disassembler for method body inspection. Null for NativeAOT binaries.</summary>
+    public IlDisassembler? IlDisassembler { get; internal set; }
 
     /// <summary>The string extractor for all string sources.</summary>
     public StringExtractor StringExtractor { get; internal set; }
@@ -124,7 +127,9 @@ public sealed class DotsiderState : IDisposable
     /// <summary>
     /// Expansion state map for IL Inspector tree nodes (keyed by stable namespace/type keys).
     /// </summary>
+    #pragma warning disable IDE0028
     public Dictionary<string, bool> IlTreeExpansionState { get; } = new(StringComparer.Ordinal);
+    #pragma warning restore IDE0028
 
     /// <summary>The editor state for the IL disassembly pane, or null if no method is selected.</summary>
     public EditorState? IlEditorState { get; set; }
@@ -288,6 +293,9 @@ public sealed class DotsiderState : IDisposable
 
     /// <summary>Whether the assembly appears to be NativeAOT (no CLR metadata).</summary>
     public bool IsNativeAot => !Analyzer.HasMetadata || Analyzer.ClrHeader is null;
+
+    /// <summary>Whether the assembly targets .NET Framework (not .NET Core / .NET 5+).</summary>
+    public bool IsNetFramework => Analyzer.TargetFramework?.StartsWith(".NETFramework", StringComparison.OrdinalIgnoreCase) == true;
 
     /// <summary>The runtime tracer instance, created on first launch.</summary>
     public RuntimeTracer? Tracer { get; set; }
@@ -467,8 +475,8 @@ public sealed class DotsiderState : IDisposable
         _focusedDepStack.Push(GeneralFocusedDep);
         NavigationStack.Push(Analyzer);
         Analyzer = newAnalyzer;
-        IlDisassembler = new IlDisassembler(Analyzer);
         StringExtractor = new StringExtractor(Analyzer);
+        IlDisassembler = Analyzer.HasMetadata ? new IlDisassembler(Analyzer) : null;
         var hexDoc = new HexRowDocument(new Hex1bDocument(Analyzer.RawBytes.ToArray()));
         HexRowDoc = hexDoc;
         HexEditorState = new EditorState(hexDoc) { IsReadOnly = true };
@@ -486,8 +494,8 @@ public sealed class DotsiderState : IDisposable
         NavigationError = null;
         Analyzer.Dispose();
         Analyzer = NavigationStack.Pop();
-        IlDisassembler = new IlDisassembler(Analyzer);
         StringExtractor = new StringExtractor(Analyzer);
+        IlDisassembler = Analyzer.HasMetadata ? new IlDisassembler(Analyzer) : null;
         var hexDoc = new HexRowDocument(new Hex1bDocument(Analyzer.RawBytes.ToArray()));
         HexRowDoc = hexDoc;
         HexEditorState = new EditorState(hexDoc) { IsReadOnly = true };

--- a/src/Dotsider/Views/DynamicAnalysisView.cs
+++ b/src/Dotsider/Views/DynamicAnalysisView.cs
@@ -47,15 +47,15 @@ public static class DynamicAnalysisView
     /// <returns>The root widget for the Dynamic tab.</returns>
     public static Hex1bWidget Build(WidgetContext<VStackWidget> ctx, DotsiderState state)
     {
-        // NativeAOT — no CLR metadata
-        if (state.IsNativeAot)
+        // .NET Framework — EventPipe is not available
+        if (state.IsNetFramework)
             return BuildMessageView(ctx,
-                "This assembly does not contain CLR metadata.",
-                "EventPipe requires the CoreCLR runtime.",
-                "NativeAOT binaries cannot be traced with this tool.");
+                "This assembly targets .NET Framework.",
+                "EventPipe tracing requires .NET Core 3.0 or later.",
+                $"Detected target: {state.Analyzer.TargetFramework}");
 
-        // Library DLL — no entry point
-        if (!state.HasEntryPoint)
+        // Library DLL — no entry point (but allow NativeAOT executables through)
+        if (!state.HasEntryPoint && !state.IsNativeAot)
             return BuildMessageView(ctx,
                 "This assembly is a library (no entry point).",
                 "Dynamic analysis requires an executable assembly.",
@@ -94,7 +94,8 @@ public static class DynamicAnalysisView
         [
             outer.Text(""),
             IdleLine(outer, "Assembly:   ", state.Analyzer.FileName),
-            IdleLine(outer, "Entry Point:", $"0x{state.Analyzer.ClrHeader!.EntryPointToken:X8}"),
+            IdleLine(outer, "Entry Point:", state.Analyzer.ClrHeader is { } clr
+                ? $"0x{clr.EntryPointToken:X8}" : "(native)"),
             IdleLine(outer, "Args:       ", argsDisplay),
             outer.Text(""),
             outer.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, Teal),

--- a/src/Dotsider/Views/IlInspectorView.cs
+++ b/src/Dotsider/Views/IlInspectorView.cs
@@ -340,7 +340,7 @@ public static class IlInspectorView
         if (state.IlEditorMethod?.Token != method.Token
             || !ReferenceEquals(state.IlEditorAnalyzer, state.Analyzer))
         {
-            var disassembly = state.IlDisassembler.FormatDisassembly(method);
+            var disassembly = state.IlDisassembler!.FormatDisassembly(method);
             var doc = new Hex1bDocument(disassembly);
             state.IlEditorState = new EditorState(doc) { IsReadOnly = true };
             state.IlEditorMethod = method;
@@ -451,7 +451,7 @@ public static class IlInspectorView
 
                 foreach (var method in methods)
                 {
-                    var disassembly = state.IlDisassembler.FormatDisassembly(method);
+                    var disassembly = state.IlDisassembler!.FormatDisassembly(method);
                     var lines = disassembly.Split('\n');
 
                     for (var lineIdx = 0; lineIdx < lines.Length; lineIdx++)

--- a/tests/Dotsider.Tests/DynamicTabGuardTests.cs
+++ b/tests/Dotsider.Tests/DynamicTabGuardTests.cs
@@ -1,0 +1,196 @@
+using System.Runtime.InteropServices;
+using Hex1b;
+using Hex1b.Automation;
+using Hex1b.Input;
+using Hex1b.Widgets;
+
+namespace Dotsider.Tests;
+
+[Collection("SampleAssemblies")]
+public class DynamicTabGuardTests(SampleAssemblyFixture samples) : IDisposable
+{
+    private Hex1bAppWorkloadAdapter? _workload;
+    private Hex1bTerminal? _terminal;
+    private Hex1bApp? _hex1bApp;
+    private DotsiderState? _state;
+
+    private Hex1bApp CreateApp()
+    {
+        _workload = new Hex1bAppWorkloadAdapter();
+        _terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(_workload)
+            .WithHeadless()
+            .WithDimensions(80, 24)
+            .Build();
+        _hex1bApp = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = _workload });
+        return _hex1bApp;
+    }
+
+    private (Hex1bTerminal terminal, Hex1bApp app) CreateDotsiderApp(string dllPath)
+    {
+        _workload = new Hex1bAppWorkloadAdapter();
+        _terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(_workload)
+            .WithHeadless()
+            .WithDimensions(120, 30)
+            .Build();
+        DotsiderApp? dotsiderApp = null;
+        _hex1bApp = new Hex1bApp(
+            ctx =>
+            {
+                _state ??= new DotsiderState(_hex1bApp!, dllPath);
+                dotsiderApp ??= new DotsiderApp(_state);
+                return Task.FromResult<Hex1bWidget>(dotsiderApp.Build(ctx));
+            },
+            new Hex1bAppOptions
+            {
+                WorkloadAdapter = _workload,
+                EnableInputCoalescing = false
+            });
+        return (_terminal, _hex1bApp);
+    }
+
+    public void Dispose()
+    {
+        _state?.Dispose();
+        _hex1bApp?.Dispose();
+        _terminal?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    // --- Unit tests ---
+
+    [Fact(Timeout = 30_000)]
+    public void IsNetFramework_TrueForNetFxConsole()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "net48 sample is Windows-only");
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.NetFxConsoleExe!);
+        Assert.True(state.IsNetFramework);
+        Assert.Contains(".NETFramework", state.Analyzer.TargetFramework);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void IsNetFramework_FalseForCoreApps()
+    {
+        var app = CreateApp();
+        string[] paths = [samples.HelloWorldDll, samples.RichLibraryDll, samples.ComplexAppDll];
+        foreach (var path in paths)
+        {
+            using var state = new DotsiderState(app, path);
+            Assert.False(state.IsNetFramework, $"IsNetFramework should be false for {Path.GetFileName(path)}");
+        }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void IsNativeAot_TrueForNativeAotConsole()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "NativeAOT produces ELF/Mach-O on non-Windows; dotsider requires PE");
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.NativeAotConsoleExe!);
+        Assert.True(state.IsNativeAot);
+    }
+
+    // --- Input sequence tests ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task Tab8_NetFramework_ShowsGuardMessage()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "net48 sample is Windows-only");
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.NetFxConsoleExe!);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.D8) // Navigate to Dynamic tab
+            .WaitUntil(s => s.ContainsText(".NET Framework"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Also confirm the second guard line is visible.
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.ContainsText("EventPipe tracing requires"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Verify tracer was NOT created
+        Assert.Null(_state!.Tracer);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task Tab8_NativeAot_ShowsIdleViewNotGuard()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "NativeAOT produces ELF/Mach-O on non-Windows; dotsider requires PE");
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.NativeAotConsoleExe!);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.D8) // Navigate to Dynamic tab
+            .WaitUntil(s => s.ContainsText("EventPipe") || s.ContainsText("Launch"),
+                TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Confirm the old guard text is NOT visible.
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => !s.ContainsText("CoreCLR") && !s.ContainsText("cannot be traced"),
+                TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task NativeAot_NavigateAllTabs_NoCrash()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "NativeAOT produces ELF/Mach-O on non-Windows; dotsider requires PE");
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.NativeAotConsoleExe!);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        // Wait for initial render
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // Navigate through every tab (1-8) — none should crash
+        for (var key = Hex1bKey.D1; key <= Hex1bKey.D8; key++)
+        {
+            await new Hex1bTerminalInputSequenceBuilder()
+                .Key(key)
+                .Build()
+                .ApplyAsync(terminal, cts.Token);
+
+            await Task.Delay(100, cts.Token);
+        }
+
+        // Verify Strings tab specifically rendered without throwing (tab 4 = Strings).
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.D4)
+            .WaitUntil(_ => _state!.CurrentTab == TabId.Strings, TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(TabId.Strings, _state!.CurrentTab);
+
+        cts.Cancel();
+        await runTask;
+    }
+}

--- a/tests/Dotsider.Tests/IlEditorDoubleClickIntegrationTests.cs
+++ b/tests/Dotsider.Tests/IlEditorDoubleClickIntegrationTests.cs
@@ -87,7 +87,7 @@ public class IlEditorDoubleClickIntegrationTests(SampleAssemblyFixture samples) 
         // Find a method whose IL contains a dotted name
         var method = _state!.Analyzer.MethodDefs
             .Where(m => m.Rva > 0)
-            .First(m => _state.IlDisassembler.FormatDisassembly(m).Contains("System."));
+            .First(m => _state.IlDisassembler!.FormatDisassembly(m).Contains("System."));
         SelectMethodInTree(method);
 
         await new Hex1bTerminalInputSequenceBuilder()
@@ -96,7 +96,7 @@ public class IlEditorDoubleClickIntegrationTests(SampleAssemblyFixture samples) 
             .ApplyAsync(terminal, ct);
 
         // Find first "System." in the disassembly
-        var disassembly = _state.IlDisassembler.FormatDisassembly(method);
+        var disassembly = _state.IlDisassembler!.FormatDisassembly(method);
         var systemIdx = disassembly.IndexOf("System.", StringComparison.Ordinal);
         Assert.True(systemIdx >= 0, "Expected 'System.' in disassembly");
 
@@ -172,7 +172,7 @@ public class IlEditorDoubleClickIntegrationTests(SampleAssemblyFixture samples) 
         // Find a method with dotted IL names
         var method = _state!.Analyzer.MethodDefs
             .Where(m => m.Rva > 0)
-            .First(m => _state.IlDisassembler.FormatDisassembly(m).Contains("System."));
+            .First(m => _state.IlDisassembler!.FormatDisassembly(m).Contains("System."));
         SelectMethodInTree(method);
 
         // Wait for the IL editor to fully render

--- a/tests/Dotsider.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Tests/SampleAssemblyFixture.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 
@@ -23,6 +24,12 @@ public class SampleAssemblyFixture : IAsyncLifetime
     // NuGet package
     public string RichLibraryNupkg { get; private set; } = null!;
 
+    // .NET Framework sample (Windows only — net48 requires Windows)
+    public string? NetFxConsoleExe { get; private set; }
+
+    // NativeAOT sample (Windows-only — ELF/Mach-O outputs aren't PE files)
+    public string? NativeAotConsoleExe { get; private set; }
+
     // Non-.NET binary for error case testing
     public string NonDotNetBinaryPath { get; private set; } = null!;
 
@@ -30,16 +37,27 @@ public class SampleAssemblyFixture : IAsyncLifetime
     {
         _repoRoot = TestHelpers.GetRepoRoot();
 
-        // Build all 7 samples in parallel
-        await Task.WhenAll(
+        // Build core samples in parallel
+        var builds = new List<Task>
+        {
             BuildProject("samples/HelloWorld"),
             BuildProject("samples/RichLibrary"),
             BuildProject("samples/RichLibraryV2"),
             BuildProject("samples/ComplexApp"),
             BuildProject("samples/MinimalApi"),
             BuildProject("samples/NativeLib"),
-            BuildProject("samples/EmptyLib")
-        );
+            BuildProject("samples/EmptyLib"),
+        };
+
+        // Both samples are Windows-only: net48 needs Windows, and NativeAOT
+        // outputs ELF/Mach-O on Linux/macOS which aren't PE files.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            builds.Add(BuildProject("samples/NetFxConsole"));
+            builds.Add(PublishNativeAotProject("samples/NativeAotConsole"));
+        }
+
+        await Task.WhenAll(builds);
 
         var config = "Debug";
         var tfm = "net10.0";
@@ -55,6 +73,16 @@ public class SampleAssemblyFixture : IAsyncLifetime
         NativeLibDll = SamplePath("NativeLib", config, tfm, "NativeLib.dll");
         EmptyLibDll = SamplePath("EmptyLib", config, tfm, "EmptyLib.dll");
 
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            NetFxConsoleExe = Path.Combine(_repoRoot, "samples", "NetFxConsole",
+                "bin", config, "net48", "NetFxConsole.exe");
+
+            var rid = RuntimeInformation.RuntimeIdentifier;
+            NativeAotConsoleExe = Path.Combine(_repoRoot, "samples", "NativeAotConsole",
+                "bin", "Release", tfm, rid, "publish", "NativeAotConsole.exe");
+        }
+
         RichLibraryNupkg = Path.Combine(_repoRoot, "samples", "RichLibrary",
             "bin", config, "RichLibrary.2.5.1.nupkg");
 
@@ -66,6 +94,10 @@ public class SampleAssemblyFixture : IAsyncLifetime
         Assert.True(File.Exists(HelloWorldDll), $"HelloWorld.dll not found at {HelloWorldDll}");
         Assert.True(File.Exists(RichLibraryDll), $"RichLibrary.dll not found at {RichLibraryDll}");
         Assert.True(File.Exists(RichLibraryNupkg), $"RichLibrary.nupkg not found at {RichLibraryNupkg}");
+        if (NetFxConsoleExe is not null)
+            Assert.True(File.Exists(NetFxConsoleExe), $"NetFxConsole.exe not found at {NetFxConsoleExe}");
+        if (NativeAotConsoleExe is not null)
+            Assert.True(File.Exists(NativeAotConsoleExe), $"NativeAotConsole.exe not found at {NativeAotConsoleExe}");
     }
 
     public ValueTask DisposeAsync()
@@ -81,6 +113,59 @@ public class SampleAssemblyFixture : IAsyncLifetime
 
     private string SamplePath(string project, string config, string tfm, string file)
         => Path.Combine(_repoRoot, "samples", project, "bin", config, tfm, file);
+
+    private async Task PublishNativeAotProject(string relativePath)
+    {
+        var lockName = "dotsider-build-" + relativePath.Replace('/', '-').Replace('\\', '-') + ".lock";
+        var lockPath = Path.Combine(Path.GetTempPath(), lockName);
+
+        FileStream lockFile;
+        while (true)
+        {
+            try
+            {
+                lockFile = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                break;
+            }
+            catch (IOException)
+            {
+                await Task.Delay(200);
+            }
+        }
+
+        try
+        {
+            var projectDir = Path.Combine(_repoRoot, relativePath);
+            var psi = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"publish -c Release -r {RuntimeInformation.RuntimeIdentifier} -v q",
+                WorkingDirectory = projectDir,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+
+            // NoDefaultCurrentDirectoryInExePath breaks the ILCompiler's
+            // findvcvarsall → VsDevCmd toolchain discovery (vswhere.exe
+            // is not resolved from the current directory inside FOR /F).
+            // Clear it for this process only.
+            psi.Environment.Remove("NoDefaultCurrentDirectoryInExePath");
+
+            var process = Process.Start(psi)!;
+            var stdout = await process.StandardOutput.ReadToEndAsync();
+            var stderr = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode != 0)
+                throw new InvalidOperationException(
+                    $"dotnet publish failed for {relativePath} (exit {process.ExitCode}):\n{stdout}\n{stderr}");
+        }
+        finally
+        {
+            lockFile.Dispose();
+        }
+    }
 
     private async Task BuildProject(string relativePath)
     {


### PR DESCRIPTION
The Dynamic tab either hung or showed wrong messages for .NET Framework and NativeAOT assemblies.

**.NET Framework** - pressing Enter started the tracer, which retried connecting to a diagnostic IPC endpoint that will never exist, then hung. Now detected upfront via `TargetFramework` moniker and shows a message like the existing no-entry-point guard.

**NativeAOT** - the guard unconditionally blocked tracing with "EventPipe requires the CoreCLR runtime" which is wrong since .NET 8 added EventPipe support for NativeAOT. Removed the block so users can attempt tracing. The existing timeout handles cases where `EventSourceSupport` wasn't enabled. All `IlDisassembler` construction sites are guarded behind `HasMetadata` so NativeAOT binaries don't crash on tab navigation or hex-save reload.

New samples: `NetFxConsole` (net48) and `NativeAotConsole` (PublishAot). Both are Windows-only in the test fixture because net48 needs Windows, and NativeAOT outputs ELF/Mach-O on Linux/macOS which dotsider's PE analyzer can't open. Six new tests in `DynamicTabGuardTests` covering both scenarios plus full tab navigation on a NativeAOT binary; skipped on non-Windows CI.

Fixes #73