### PR TITLE
Add yank (copy) support to all tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,16 @@ Supported `--ai` providers: claude, gemini, copilot, cursor-agent, opencode, cod
 | `1`-`8` | Switch tabs |
 | `Enter` | Drill into selected item (assembly ref, method, DLL in package) |
 | `Backspace` | Go back (assembly stack, breadcrumb, or cross-view jump) |
+| `y` | Yank (copy) — selected text in editors, or focused row in tables |
+| `Tab` | Cycle focus between info panels and tables |
 | `g` | Go to IL Inspector for the focused TypeDef/MethodDef (PE/Metadata tab) |
 | `x` | Jump to method body in Hex Dump (IL Inspector tab, when a method with RVA is selected) |
 | `/` | Search (highlights matches inline) |
 | `n` / `N` | Next / previous search match |
 | `s` | Toggle human-readable sizes |
 | `q` | Quit |
+
+Info panels (Assembly Info, PE Headers, CLR Header, detail popups, string details) are selectable read-only editors. Click or `Tab` into them, select text with `Shift` + arrow keys, and press `y` to copy.
 
 **Hex Dump tab** uses vi-style modal editing — the editor starts in normal mode (read-only) to prevent accidental writes:
 
@@ -162,7 +166,7 @@ Supported `--ai` providers: claude, gemini, copilot, cursor-agent, opencode, cod
 
 In insert mode, type two hex digits (0-9, a-f) to overwrite one byte. The first digit sets the high nibble; the second commits the edit. Saving validates the PE image before writing — invalid edits are rejected.
 
-Diff mode adds `f` to cycle filters (All / Added / Removed / Changed).
+Diff mode adds `f` to cycle filters (All / Added / Removed / Changed). NuGet mode uses `Esc` to return from DLL inspection to the package browser.
 
 ## How it works
 

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -38,6 +38,12 @@ Press `Enter` on any highlighted item to drill deeper — an assembly reference,
 
 Press `/` to search. Matches are highlighted inline. Use `n` and `N` to jump between matches.
 
+## Copy text
+
+Select text in any info panel or editor with click-drag or `Shift` + arrow keys, then press `y` to yank (copy) it to the clipboard. A brief flash confirms the copied range. On table rows, just focus a row and press `y` — the row content is copied as tab-separated values.
+
+Use `Tab` to cycle focus between panels on tabs that have both info editors and tables.
+
 ## Compare two assemblies
 
 ```

--- a/docs/src/content/docs/reference/keyboard.md
+++ b/docs/src/content/docs/reference/keyboard.md
@@ -12,6 +12,8 @@ description: All keyboard shortcuts for navigating dotsider.
 | `Backspace` | Go back |
 | `/` | Search |
 | `n` / `N` | Next / previous search match |
+| `y` | Yank (copy) — selected text in editors, or focused row in tables |
+| `Tab` | Cycle focus between info panels and tables |
 | `s` | Toggle human-readable sizes |
 | `q` | Quit |
 
@@ -19,6 +21,7 @@ description: All keyboard shortcuts for navigating dotsider.
 
 | Key | Action |
 |-----|--------|
+| `Tab` | Cycle focus: PE Headers → CLR Header → metadata table |
 | `g` | Jump to IL Inspector for focused TypeDef/MethodDef |
 
 ## IL Inspector tab
@@ -26,6 +29,7 @@ description: All keyboard shortcuts for navigating dotsider.
 | Key | Action |
 |-----|--------|
 | `x` | Jump to method body in Hex Dump |
+| `l` | Focus the IL disassembly editor |
 
 ## Hex Dump tab — Normal mode
 
@@ -49,4 +53,16 @@ description: All keyboard shortcuts for navigating dotsider.
 
 | Key | Action |
 |-----|--------|
+| `1`–`4` / `←` `→` | Switch diff tabs |
 | `f` | Cycle filters (All / Added / Removed / Changed) |
+| `y` | Yank focused row or selected text |
+| `Tab` | Cycle focus between summary panels |
+
+## NuGet mode
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Open selected DLL in the full analyzer |
+| `Esc` | Return to package browser from DLL inspector |
+| `Tab` | Cycle focus between Package Info and DLL table |
+| `y` | Yank focused DLL path or selected text |

--- a/docs/src/content/docs/usage/diff-mode.md
+++ b/docs/src/content/docs/usage/diff-mode.md
@@ -25,3 +25,9 @@ Press `f` to cycle through diff filters:
 | **Changed** | Items present in both but different |
 
 This is useful for reviewing breaking changes between library versions, auditing what changed in a new build, or understanding the impact of a refactoring.
+
+## Copy
+
+The Summary tab has selectable info panels and change statistics. Press `Tab` to cycle focus between them, select text, and press `y` to copy.
+
+On the Types, Methods, and References tabs, focus a row and press `y` to copy it as tab-separated values. A brief flash confirms the yank.

--- a/docs/src/content/docs/usage/general.md
+++ b/docs/src/content/docs/usage/general.md
@@ -12,6 +12,12 @@ The **General** tab (`1`) is the first thing you see when opening an assembly. I
 - **Architecture** — AnyCPU, x64, ARM64, etc.
 - **Dependency table** — all referenced assemblies with their versions
 
+## Text selection and copy
+
+The Assembly Info panel is a read-only editor. Click into it or press `Tab` to move focus there, then select text with click-drag or `Shift` + arrow keys. Press `y` to yank the selection to the clipboard.
+
+On the dependency table, focus a row and press `y` to copy it as tab-separated values. Press `Tab` to cycle focus between the info panel and the table.
+
 ## Drill into references
 
 Select any row in the dependency table and press `Enter`. If the referenced assembly exists on disk (next to the current file or in a probing path), dotsider opens it in a new analysis context. Press `Backspace` to return.

--- a/docs/src/content/docs/usage/il-inspector.md
+++ b/docs/src/content/docs/usage/il-inspector.md
@@ -20,7 +20,7 @@ Each instruction shows:
 
 ## Copy
 
-Select text in the disassembly pane with `Shift` + arrow keys, then press `y` to copy it to the clipboard. A brief flash confirms the copied range.
+Select text in the disassembly pane with click-drag or `Shift` + arrow keys, then press `y` to yank it to the clipboard. The cursor collapses to the end of the selection and a brief flash confirms the copied range — matching neovim's yank behavior.
 
 ## Search
 

--- a/docs/src/content/docs/usage/nuget-mode.md
+++ b/docs/src/content/docs/usage/nuget-mode.md
@@ -14,3 +14,11 @@ dotsider package.nupkg
 dotsider lists the package contents — the `.nuspec` manifest, lib folders per target framework, and any other files. Select a DLL and press `Enter` to open it in the full analyzer with all 8 tabs.
 
 NuGet packages are ZIP files. dotsider extracts assemblies to a temp directory for analysis, so everything works exactly as it does with regular DLLs.
+
+## Navigation
+
+Press `Tab` to cycle focus between the Package Info panel and the DLL table. Press `Esc` to return from a DLL inspector back to the package browser. The previously selected DLL row is restored.
+
+## Copy
+
+Select text in the Package Info panel and press `y` to copy. On the DLL table, focus a row and press `y` to copy the file path.

--- a/docs/src/content/docs/usage/pe-metadata.md
+++ b/docs/src/content/docs/usage/pe-metadata.md
@@ -16,6 +16,14 @@ The **PE / Metadata** tab (`2`) exposes the raw structure of the Portable Execut
 - **Custom attributes** — applied attributes with decoded arguments
 - **Resources** — embedded resources with names and sizes
 
+## Text selection and copy
+
+The PE Headers and CLR Header panels are selectable editors. Press `Tab` to cycle focus between them and the metadata table. Select text and press `y` to copy.
+
+Press `Enter` on any metadata table row to open a detail popup. The popup is also a selectable editor — select specific values and press `y` to yank them.
+
+On table rows, press `y` to copy the focused row as tab-separated values.
+
 ## Jump to IL
 
 Select a TypeDef or MethodDef and press `g` to jump directly to its IL disassembly in tab 3. The IL Inspector opens with that item pre-selected.

--- a/docs/src/content/docs/usage/strings.md
+++ b/docs/src/content/docs/usage/strings.md
@@ -11,6 +11,10 @@ The **Strings** tab (`4`) extracts text from three sources:
 - **Metadata strings** — type names, method names, namespace names from the `#Strings` heap
 - **Raw scan** — binary string extraction from the entire file, similar to the Unix `strings` command
 
+## Copy strings
+
+Press `y` on a focused table row to copy the string value to the clipboard. Press `Enter` to open a detail popup where you can select and copy specific portions of longer strings.
+
 ## Minimum length
 
 Use the `--min-len` / `-n` flag to control the minimum length for the raw binary scan:

--- a/src/Dotsider/DiffApp.cs
+++ b/src/Dotsider/DiffApp.cs
@@ -101,32 +101,90 @@ public sealed class DiffApp(DiffState state)
                     bindings.Key(key).Global().Action(_ =>
                     {
                         _state.CurrentTab = tabIndex;
+                        _state.DiffFocusedKey = null;
+                        // Summary tab has editors; other tabs have tables
+                        if (tabIndex > 0)
+                            _state.App.RequestFocus(node =>
+                                node.GetType().Name.StartsWith("TableNode"));
                         _state.App.Invalidate();
                     }, $"Tab {tabIndex + 1}");
                 }
 
                 bindings.Key(Hex1bKey.Q).Global().Action(ctx => ctx.RequestStop(), "Quit");
 
-                // Left/Right arrows to cycle tabs
-                bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
+                // Left/Right arrows to cycle tabs (not registered when editor is focused)
+                if (_state.App.FocusedNode is not EditorNode)
                 {
-                    if (_state.CurrentTab > 0)
+                    bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
                     {
-                        _state.CurrentTab--;
-                        _state.DiffFocusedKey = null;
-                        _state.App.Invalidate();
-                    }
-                }, "Previous tab");
+                        if (_state.CurrentTab > 0)
+                        {
+                            _state.CurrentTab--;
+                            _state.DiffFocusedKey = null;
+                            if (_state.CurrentTab > 0)
+                                _state.App.RequestFocus(node =>
+                                    node.GetType().Name.StartsWith("TableNode"));
+                            _state.App.Invalidate();
+                        }
+                    }, "Previous tab");
 
-                bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
-                {
-                    if (_state.CurrentTab < 3)
+                    bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
                     {
-                        _state.CurrentTab++;
-                        _state.DiffFocusedKey = null;
-                        _state.App.Invalidate();
+                        if (_state.CurrentTab < 3)
+                        {
+                            _state.CurrentTab++;
+                            _state.DiffFocusedKey = null;
+                            _state.App.RequestFocus(node =>
+                                node.GetType().Name.StartsWith("TableNode"));
+                            _state.App.Invalidate();
+                        }
+                    }, "Next tab");
+                }
+
+                // Universal yank
+                bindings.Key(Hex1bKey.Y).Global().Action(ctx =>
+                {
+                    // Editor with selection
+                    if (ctx.FocusedNode is EditorNode { State.Cursor.HasSelection: true } editor)
+                    {
+                        var range = editor.State.Cursor.SelectionRange;
+                        var doc = editor.State.Document;
+                        var yankEnd = new Hex1b.Documents.DocumentOffset(Math.Min(
+                            Math.Max(range.End.Value, editor.State.Cursor.Position.Value + 1),
+                            doc.Length));
+                        var yankRange = new Hex1b.Documents.DocumentRange(range.Start, yankEnd);
+                        var text = doc.GetText(yankRange);
+
+                        var lastChar = new Hex1b.Documents.DocumentOffset(Math.Max(0, yankEnd.Value - 1));
+                        editor.State.SetCursorPosition(lastChar);
+
+                        if (!string.IsNullOrEmpty(text))
+                        {
+                            ctx.CopyToClipboard(text);
+                            ShowYankNotification(text);
+                        }
+                        return;
                     }
-                }, "Next tab");
+
+                    // Editor without selection → do nothing
+                    if (ctx.FocusedNode is EditorNode) return;
+
+                    // Table row
+                    var yankText = YankHelper.GetYankText(_state);
+                    if (yankText is not null)
+                    {
+                        ctx.CopyToClipboard(yankText);
+                        ShowYankNotification(yankText);
+
+                        _state.YankFlashRow = true;
+                        _state.App.Invalidate();
+                        _ = Task.Delay(TimeSpan.FromMilliseconds(150)).ContinueWith(_ =>
+                        {
+                            _state.YankFlashRow = false;
+                            _state.App.Invalidate();
+                        }, TaskScheduler.Default);
+                    }
+                }, "Yank");
             }
 
             bindings.Key(Hex1bKey.F).Action(_ =>
@@ -196,10 +254,39 @@ public sealed class DiffApp(DiffState state)
                 hints.Add(s.Section("Esc: Clear"));
             hints.Add(s.Section("/: Search"));
 
+            var yankable = _state.CurrentTab == 0 || _state.DiffFocusedKey is not null;
+            if (yankable)
+                hints.Add(s.Section("y: Yank"));
+
             hints.Add(s.Spacer());
+
+            if (!string.IsNullOrEmpty(_state.YankNotification))
+            {
+                hints.Add(s.Section(_state.YankNotification).Theme(t => t
+                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(120, 180, 120))));
+                hints.Add(s.Separator(" "));
+            }
+
             hints.Add(s.Section("q: Quit"));
             return hints;
         }).WithDefaultSeparator(" | ");
+
+    private void ShowYankNotification(string text)
+    {
+        var gen = ++_state.YankGeneration;
+        _state.YankNotification = text.Contains('\n')
+            ? $"Yanked {text.Count(c => c == '\n') + 1} lines"
+            : $"Yanked: {(text.Length > 40 ? text[..37] + "..." : text)}";
+        _state.App.Invalidate();
+        _ = Task.Delay(TimeSpan.FromMilliseconds(1500)).ContinueWith(_ =>
+        {
+            if (_state.YankGeneration == gen)
+            {
+                _state.YankNotification = null;
+                _state.App.Invalidate();
+            }
+        }, TaskScheduler.Default);
+    }
 
     private static int CountChanges<T>(IReadOnlyList<DiffEntry<T>> diffs) =>
         diffs.Count(d => d.Kind != DiffKind.Unchanged);

--- a/src/Dotsider/DiffState.cs
+++ b/src/Dotsider/DiffState.cs
@@ -1,6 +1,7 @@
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
+using Hex1b.Widgets;
 
 namespace Dotsider;
 
@@ -52,6 +53,37 @@ public sealed class DiffState : IDisposable
 
     /// <summary>Delegate to navigate to the previous search match in the current diff view.</summary>
     public Action? NavigatePrevMatch { get; set; }
+
+    // --- Yank State ---
+
+    /// <summary>Yank notification message shown in the hints bar, auto-clears after 1.5 seconds.</summary>
+    public string? YankNotification { get; set; }
+
+    /// <summary>Generation counter for yank notification timer race prevention.</summary>
+    public long YankGeneration { get; set; }
+
+    /// <summary>Whether the focused table row should flash with yank highlight colors. Auto-clears after 150ms.</summary>
+    public bool YankFlashRow { get; set; }
+
+    // --- Read-Only Editor State (for text selection + yank) ---
+
+    /// <summary>Read-only editor for the left assembly info panel in diff summary.</summary>
+    public EditorState? LeftInfoEditorState { get; set; }
+
+    /// <summary>Source text used to build <see cref="LeftInfoEditorState"/>, for staleness detection.</summary>
+    public string? LeftInfoEditorText { get; set; }
+
+    /// <summary>Read-only editor for the right assembly info panel in diff summary.</summary>
+    public EditorState? RightInfoEditorState { get; set; }
+
+    /// <summary>Source text used to build <see cref="RightInfoEditorState"/>, for staleness detection.</summary>
+    public string? RightInfoEditorText { get; set; }
+
+    /// <summary>Read-only editor for the change statistics panel in diff summary.</summary>
+    public EditorState? ChangeStatsEditorState { get; set; }
+
+    /// <summary>Source text used to build <see cref="ChangeStatsEditorState"/>, for staleness detection.</summary>
+    public string? ChangeStatsEditorText { get; set; }
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/Dotsider/DllInspectorBindings.cs
+++ b/src/Dotsider/DllInspectorBindings.cs
@@ -1,0 +1,275 @@
+using Hex1b;
+using Hex1b.Input;
+using Hex1b.Widgets;
+
+namespace Dotsider;
+
+/// <summary>
+/// Registers key bindings for the DLL inspector views (hex dump, IL inspector, search)
+/// that are shared between DotsiderApp and NuGetApp.
+/// </summary>
+public static class DllInspectorBindings
+{
+    /// <summary>
+    /// Registers hex dump, IL inspector, and search key bindings for the given DLL state.
+    /// Called from both DotsiderApp and NuGetApp to avoid duplication.
+    /// </summary>
+    /// <param name="bindings">The input bindings builder.</param>
+    /// <param name="state">The DLL inspector state.</param>
+    /// <param name="app">The Hex1b app instance for invalidation and focus.</param>
+    /// <param name="includeSearch">Whether to register search toggle/confirm/dismiss bindings.
+    /// DotsiderApp registers its own search bindings, so this is false for DotsiderApp.</param>
+    public static void Register(InputBindingsBuilder bindings, DotsiderState state, Hex1bApp app,
+        bool includeSearch = false)
+    {
+        var currentSearch = state.Search[state.CurrentTab];
+        var isSearchEditing = currentSearch.IsActive && !currentSearch.IsConfirmed;
+
+        // Search bindings (only for NuGetApp — DotsiderApp registers its own)
+        if (includeSearch)
+        {
+            var detailPopupOpen = state.PeDetailContent is not null || state.StringsDetailContent is not null;
+            if (!state.HexJumpDialogOpen && !detailPopupOpen)
+            {
+                void SearchToggle()
+                {
+                    state.Search[state.CurrentTab].ActivateOrCycle();
+                    var s = state.Search[state.CurrentTab];
+                    if (s.IsActive && !s.IsConfirmed)
+                        app.RequestFocus(node => node is TextBoxNode);
+                    app.Invalidate();
+                }
+
+                bindings.Key(Hex1bKey.OemQuestion).Global().OverridesCapture().Action(_ => SearchToggle(), "Search");
+                if (!isSearchEditing)
+                {
+                    bindings.Key(Hex1bKey.None).Global().OverridesCapture().Action(_ => SearchToggle(), "Search");
+                }
+            }
+
+            if (isSearchEditing)
+            {
+                bindings.Key(Hex1bKey.Enter).Global().OverridesCapture().Action(_ =>
+                {
+                    if (!string.IsNullOrEmpty(currentSearch.Query))
+                    {
+                        if (state.CurrentTab == TabId.HexDump)
+                            Views.HexDumpView.ExecuteSearch(state);
+                        currentSearch.Confirm();
+                        state.RequestContentFocus();
+                        app.Invalidate();
+                    }
+                }, "Confirm search");
+            }
+
+            // n/N match navigation
+            if (currentSearch.IsActive && currentSearch.IsConfirmed)
+            {
+                bindings.Key(Hex1bKey.N).Global().Action(_ =>
+                {
+                    state.NavigateNextMatch?.Invoke();
+                    app.Invalidate();
+                }, "Next match");
+                bindings.Shift().Key(Hex1bKey.N).Global().Action(_ =>
+                {
+                    state.NavigatePrevMatch?.Invoke();
+                    app.Invalidate();
+                }, "Prev match");
+            }
+
+            // Escape to dismiss search
+            if (currentSearch.IsActive && !state.HexJumpDialogOpen)
+            {
+                bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
+                {
+                    if (state.CurrentTab == TabId.HexDump && state.HexMode == HexEditMode.Insert)
+                    {
+                        state.HexMode = HexEditMode.Normal;
+                        state.HexEditorState.IsReadOnly = true;
+                        app.Invalidate();
+                        return;
+                    }
+                    currentSearch.Dismiss();
+                    if (state.CurrentTab == TabId.HexDump)
+                    {
+                        state.HexMatchOffsets = [];
+                        state.HexCurrentMatchIndex = -1;
+                        state.HexMatchPatternLength = 0;
+                        state.HexLastSearchQuery = null;
+                        state.HexLiveSearchTooSlow = false;
+                    }
+                    state.RequestContentFocus();
+                    app.Invalidate();
+                }, "Clear search");
+            }
+
+            // Hex insert mode Escape without search
+            if (!currentSearch.IsActive
+                && state.CurrentTab == TabId.HexDump
+                && state.HexMode == HexEditMode.Insert
+                && !state.HexJumpDialogOpen)
+            {
+                bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
+                {
+                    state.HexMode = HexEditMode.Normal;
+                    state.HexEditorState.IsReadOnly = true;
+                    app.Invalidate();
+                }, "Exit insert mode");
+            }
+        }
+
+        // Hex Dump tab — Normal mode bindings
+        if (state.CurrentTab == TabId.HexDump && !state.HexJumpDialogOpen
+            && state.HexMode == HexEditMode.Normal)
+        {
+            bindings.Key(Hex1bKey.I).Global().Action(_ =>
+            {
+                state.HexMode = HexEditMode.Insert;
+                state.HexEditorState.IsReadOnly = false;
+                state.HexNotification = null;
+                app.Invalidate();
+            }, "Insert mode");
+
+            bindings.Key(Hex1bKey.G).Global().Action(_ =>
+            {
+                state.HexJumpDialogOpen = true;
+                state.HexJumpInput = "";
+                state.HexNotification = null;
+                app.RequestFocus(node => node is TextBoxNode);
+                app.Invalidate();
+            }, "Jump to offset");
+
+            bindings.Key(Hex1bKey.E).Global().Action(_ =>
+            {
+                state.HexEndianness = state.HexEndianness == HexEndianness.Little
+                    ? HexEndianness.Big : HexEndianness.Little;
+                app.Invalidate();
+            }, "Toggle endianness");
+
+            bindings.Key(Hex1bKey.H).Global().Action(_ =>
+            {
+                state.HexEditorState.MoveCursor(CursorDirection.Left);
+                app.Invalidate();
+            }, "Left");
+            bindings.Key(Hex1bKey.L).Global().Action(_ =>
+            {
+                state.HexEditorState.MoveCursor(CursorDirection.Right);
+                app.Invalidate();
+            }, "Right");
+            bindings.Key(Hex1bKey.K).Global().Action(_ =>
+            {
+                state.HexEditorState.MoveCursor(CursorDirection.Up);
+                app.Invalidate();
+            }, "Up");
+            bindings.Key(Hex1bKey.J).Global().Action(_ =>
+            {
+                state.HexEditorState.MoveCursor(CursorDirection.Down);
+                app.Invalidate();
+            }, "Down");
+        }
+
+        // Hex jump dialog Enter
+        if (state.HexJumpDialogOpen)
+        {
+            bindings.Key(Hex1bKey.Enter).Global().OverridesCapture().Action(_ =>
+            {
+                Views.HexDumpView.ProcessJumpInput(state);
+                app.Invalidate();
+            }, "Jump");
+        }
+
+        // IL Inspector tab bindings
+        if (state.CurrentTab == TabId.IlInspector)
+        {
+            var ilSearch = state.Search[TabId.IlInspector];
+            if (!ilSearch.IsActive && state.IlEditorState?.Cursor.HasSelection == true)
+            {
+                bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
+                {
+                    state.IlEditorState.Cursor.SelectionAnchor = null;
+                    app.Invalidate();
+                }, "Clear selection");
+            }
+
+            if (state.IlSelectedMethod is { Rva: > 0 } ilMethod)
+            {
+                bindings.Key(Hex1bKey.X).Global().Action(_ =>
+                {
+                    state.NavigateToHexOffset(ilMethod.Rva);
+                }, "View in hex");
+            }
+
+            bindings.Key(Hex1bKey.L).Global().Action(_ =>
+            {
+                app.RequestFocus(node => node is EditorNode);
+                app.Invalidate();
+            }, "Focus IL");
+        }
+    }
+
+    /// <summary>
+    /// Adds DLL-inspector-specific hints to the hints bar.
+    /// Called from both DotsiderApp and NuGetApp to avoid duplication.
+    /// </summary>
+    /// <param name="hints">The hints list to append to.</param>
+    /// <param name="s">The info bar context for creating hint sections.</param>
+    /// <param name="state">The DLL inspector state.</param>
+    public static void AddHints(List<IInfoBarChild> hints, InfoBarContext s, DotsiderState state)
+    {
+        if (state.CurrentTab == TabId.PeMetadata)
+        {
+            hints.Add(s.Section("Enter: Detail"));
+            if (state.PeSubTab is PeSubTabId.TypeDef or PeSubTabId.MethodDef)
+                hints.Add(s.Section("g: Go to IL"));
+        }
+        else if (state.CurrentTab == TabId.IlInspector)
+        {
+            hints.Add(s.Section("l: Focus IL"));
+            if (state.IlSelectedMethod is { Rva: > 0 })
+                hints.Add(s.Section("x: Hex"));
+            if (state.IlEditorState?.Cursor.HasSelection == true)
+                hints.Add(s.Section("y: Yank (IL)"));
+        }
+        else if (state.CurrentTab == TabId.Strings)
+            hints.Add(s.Section("Enter: Detail"));
+        else if (state.CurrentTab == TabId.HexDump)
+        {
+            if (state.HexMode == HexEditMode.Insert)
+                hints.Add(s.Section("Esc: Normal"));
+            else
+            {
+                var hexHints = "i: Edit | g: Jump | e: Endian";
+                if (state.HexIsDirty)
+                    hexHints += " | Ctrl+S: Save";
+                hints.Add(s.Section(hexHints));
+            }
+        }
+
+        // Cross-view back hint
+        if (state.CrossViewBackTarget is not null)
+            hints.Add(s.Section("Backspace: Back"));
+
+        // Search hint
+        var currentSearch = state.Search[state.CurrentTab];
+        if (currentSearch.IsActive)
+            hints.Add(s.Section("Esc: Clear"));
+        hints.Add(s.Section("/: Search"));
+
+        // Size toggle
+        if (state.CurrentTab is TabId.General or TabId.PeMetadata)
+            hints.Add(s.Section(state.HumanReadableSizes ? "s: Sizes (dec)" : "s: Sizes (hex)"));
+
+        // Yank hint
+        var yankable = state.CurrentTab switch
+        {
+            TabId.General => state.GeneralFocusedDep is not null,
+            TabId.PeMetadata => state.PeDetailContent is not null || state.PeFocusedKey is not null,
+            TabId.IlInspector => false,
+            TabId.Strings => state.StringsDetailContent is not null || state.StringsFocusedKey is not null,
+            TabId.HexDump => true,
+            _ => false
+        };
+        if (yankable)
+            hints.Add(s.Section("y: Yank"));
+    }
+}

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -139,6 +139,79 @@ public sealed class DotsiderApp(DotsiderState state)
                 // Suppress Q quit in hex insert mode — let editor receive it as byte input
                 if (!(_state.CurrentTab == TabId.HexDump && _state.HexMode == HexEditMode.Insert))
                     bindings.Key(Hex1bKey.Q).Global().Action(ctx => ctx.RequestStop(), "Quit");
+
+                // Universal yank — works on all tabs with neovim-style behavior
+                bindings.Key(Hex1bKey.Y).Global().Action(ctx =>
+                {
+                    // 1. Any focused editor with selection
+                    if (ctx.FocusedNode is EditorNode { State.Cursor.HasSelection: true } editor)
+                    {
+                        string text;
+                        if (editor.State == _state.HexEditorState)
+                        {
+                            // Hex dump: extract bytes as "4D 5A 90 00"
+                            text = YankHelper.GetHexSelectionText(editor.State) ?? "";
+                        }
+                        else
+                        {
+                            // All other editors: neovim-style yank
+                            // Include the cursor character (word-boundary adjustment)
+                            var range = editor.State.Cursor.SelectionRange;
+                            var doc = editor.State.Document;
+                            var yankEnd = new DocumentOffset(Math.Min(
+                                Math.Max(range.End.Value, editor.State.Cursor.Position.Value + 1),
+                                doc.Length));
+                            var yankRange = new DocumentRange(range.Start, yankEnd);
+                            text = doc.GetText(yankRange);
+
+                            // Collapse cursor to last character of yanked range
+                            var lastChar = new DocumentOffset(Math.Max(0, yankEnd.Value - 1));
+                            editor.State.SetCursorPosition(lastChar);
+
+                            // Flash the yanked range (150ms IncSearch style)
+                            var yankProvider = FindYankProvider(editor.State);
+                            if (yankProvider is not null)
+                            {
+                                var startPos = doc.OffsetToPosition(yankRange.Start);
+                                var endPos = doc.OffsetToPosition(yankRange.End);
+                                yankProvider.HighlightRange = (startPos, endPos);
+                                _state.App.Invalidate();
+                                _ = Task.Delay(TimeSpan.FromMilliseconds(150)).ContinueWith(_ =>
+                                {
+                                    yankProvider.HighlightRange = null;
+                                    _state.App.Invalidate();
+                                }, TaskScheduler.Default);
+                            }
+                        }
+
+                        if (!string.IsNullOrEmpty(text))
+                        {
+                            ctx.CopyToClipboard(text);
+                            ShowYankNotification(text);
+                        }
+                        return;
+                    }
+
+                    // 3. Focused editor WITHOUT selection → do nothing
+                    if (ctx.FocusedNode is EditorNode) return;
+
+                    // 4. Non-editor focus → table row / surface node
+                    var yankText = YankHelper.GetYankText(_state);
+                    if (yankText is not null)
+                    {
+                        ctx.CopyToClipboard(yankText);
+                        ShowYankNotification(yankText);
+
+                        // Flash the focused row (150ms)
+                        _state.YankFlashRow = true;
+                        _state.App.Invalidate();
+                        _ = Task.Delay(TimeSpan.FromMilliseconds(150)).ContinueWith(_ =>
+                        {
+                            _state.YankFlashRow = false;
+                            _state.App.Invalidate();
+                        }, TaskScheduler.Default);
+                    }
+                }, "Yank");
             }
 
             // Global search toggle — array-indexed, no switch statement
@@ -181,67 +254,9 @@ public sealed class DotsiderApp(DotsiderState state)
                 }, "Confirm search");
             }
 
-            // Hex tab keybindings — normal mode only, registered global because
-            // EditorNode's AnyCharacter() binding consumes letter keys in path-based routing
-            if (!isSearchEditing && !_state.HexJumpDialogOpen
-                && _state.CurrentTab == TabId.HexDump
-                && _state.HexMode == HexEditMode.Normal)
-            {
-                bindings.Key(Hex1bKey.I).Global().Action(_ =>
-                {
-                    _state.HexMode = HexEditMode.Insert;
-                    _state.HexEditorState.IsReadOnly = false;
-                    _state.HexNotification = null;
-                    _state.App.Invalidate();
-                }, "Insert mode");
-
-                bindings.Key(Hex1bKey.G).Global().Action(_ =>
-                {
-                    _state.HexJumpDialogOpen = true;
-                    _state.HexJumpInput = "";
-                    _state.HexNotification = null;
-                    _state.App.RequestFocus(node => node is TextBoxNode);
-                    _state.App.Invalidate();
-                }, "Jump to offset");
-
-                bindings.Key(Hex1bKey.E).Global().Action(_ =>
-                {
-                    _state.HexEndianness = _state.HexEndianness == HexEndianness.Little
-                        ? HexEndianness.Big : HexEndianness.Little;
-                    _state.App.Invalidate();
-                }, "Toggle endianness");
-
-                bindings.Key(Hex1bKey.H).Global().Action(_ =>
-                {
-                    _state.HexEditorState.MoveCursor(CursorDirection.Left);
-                    _state.App.Invalidate();
-                }, "Left");
-                bindings.Key(Hex1bKey.L).Global().Action(_ =>
-                {
-                    _state.HexEditorState.MoveCursor(CursorDirection.Right);
-                    _state.App.Invalidate();
-                }, "Right");
-                bindings.Key(Hex1bKey.K).Global().Action(_ =>
-                {
-                    _state.HexEditorState.MoveCursor(CursorDirection.Up);
-                    _state.App.Invalidate();
-                }, "Up");
-                bindings.Key(Hex1bKey.J).Global().Action(_ =>
-                {
-                    _state.HexEditorState.MoveCursor(CursorDirection.Down);
-                    _state.App.Invalidate();
-                }, "Down");
-            }
-
-            // Jump dialog Enter — global so it fires above TextBox capture
-            if (_state.HexJumpDialogOpen)
-            {
-                bindings.Key(Hex1bKey.Enter).Global().OverridesCapture().Action(_ =>
-                {
-                    Views.HexDumpView.ProcessJumpInput(_state);
-                    _state.App.Invalidate();
-                }, "Jump");
-            }
+            // Hex + IL Inspector keybindings (shared with NuGetApp)
+            if (!isSearchEditing)
+                DllInspectorBindings.Register(bindings, _state, _state.App);
 
             // Ctrl+S: Save hex changes — only in normal mode with pending edits
             if (_state.CurrentTab == TabId.HexDump
@@ -254,67 +269,6 @@ public sealed class DotsiderApp(DotsiderState state)
                     _state.App.Invalidate();
                     ScheduleNotificationClear(_state);
                 }, "Save hex changes");
-            }
-
-            // IL Inspector tab keybindings — Global because EditorNode's AnyCharacter() consumes letters
-            if (!isSearchEditing && _state.CurrentTab == TabId.IlInspector)
-            {
-                // Escape clears editor selection — only when no search is active
-                // to avoid conflicting with the global search Escape binding
-                if (!currentSearch.IsActive && _state.IlEditorState?.Cursor.HasSelection == true)
-                {
-                    bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
-                    {
-                        _state.IlEditorState.Cursor.SelectionAnchor = null;
-                        _state.App.Invalidate();
-                    }, "Clear selection");
-                }
-                if (_state.IlSelectedMethod is { Rva: > 0 } ilMethod)
-                {
-                    bindings.Key(Hex1bKey.X).Global().Action(_ =>
-                    {
-                        _state.NavigateToHexOffset(ilMethod.Rva);
-                    }, "View in hex");
-                }
-
-                bindings.Key(Hex1bKey.L).Global().Action(_ =>
-                {
-                    _state.App.RequestFocus(node => node is EditorNode);
-                    _state.App.Invalidate();
-                }, "Focus IL");
-
-                bindings.Key(Hex1bKey.Y).Global().Action(ctx =>
-                {
-                    if (_state.IlEditorState?.Cursor.HasSelection == true)
-                    {
-                        var range = _state.IlEditorState.Cursor.SelectionRange;
-                        // Include the cursor character — after one-shot word-boundary
-                        // adjustment the cursor sits on the last word char, one before
-                        // the exclusive selection end.
-                        var doc = _state.IlEditorState.Document;
-                        var yankEnd = new DocumentOffset(Math.Min(
-                            Math.Max(range.End.Value, _state.IlEditorState.Cursor.Position.Value + 1),
-                            doc.Length));
-                        var yankRange = new DocumentRange(range.Start, yankEnd);
-                        var text = doc.GetText(yankRange);
-                        ctx.CopyToClipboard(text);
-
-                        // Collapse cursor to last character of yanked range (neovim behavior)
-                        var lastChar = new DocumentOffset(Math.Max(0, yankEnd.Value - 1));
-                        _state.IlEditorState.SetCursorPosition(lastChar);
-
-                        // Flash the yanked range (neovim IncSearch style, 150ms)
-                        var startPos = doc.OffsetToPosition(yankRange.Start);
-                        var endPos = doc.OffsetToPosition(yankRange.End);
-                        _state.IlYankProvider.HighlightRange = (startPos, endPos);
-                        _state.App.Invalidate();
-                        _ = Task.Delay(TimeSpan.FromMilliseconds(150)).ContinueWith(_ =>
-                        {
-                            _state.IlYankProvider.HighlightRange = null;
-                            _state.App.Invalidate();
-                        }, TaskScheduler.Default);
-                    }
-                }, "Yank");
             }
 
             // n/N only registered when search is confirmed
@@ -478,7 +432,7 @@ public sealed class DotsiderApp(DotsiderState state)
                 if (_state.IlSelectedMethod is { Rva: > 0 })
                     hints.Add(s.Section("x: Hex"));
                 if (_state.IlEditorState?.Cursor.HasSelection == true)
-                    hints.Add(s.Section("y: Yank"));
+                    hints.Add(s.Section("y: Yank (IL)"));
             }
             else if (_state.CurrentTab == 3)
                 hints.Add(s.Section("Enter: Detail"));
@@ -532,7 +486,32 @@ public sealed class DotsiderApp(DotsiderState state)
             if (_state.CurrentTab is 0 or 1 or 6) // General, PE/Metadata, Size Map
                 hints.Add(s.Section(_state.HumanReadableSizes ? "s: Sizes (dec)" : "s: Sizes (hex)"));
 
+            // y: Yank hint — show when yankable content exists
+            var yankable = _state.CurrentTab switch
+            {
+                TabId.General => _state.GeneralFocusedDep is not null,
+                TabId.PeMetadata => _state.PeDetailContent is not null || _state.PeFocusedKey is not null,
+                TabId.IlInspector => false, // shown separately above as "y: Yank (IL)"
+                TabId.Strings => _state.StringsDetailContent is not null || _state.StringsFocusedKey is not null,
+                TabId.HexDump => true,
+                TabId.DepGraph => _state.GraphSelectedNode is not null || _state.GraphSelectedIndex >= 0,
+                TabId.SizeMap => _state.TreemapHoveredItem is not null || _state.TreemapSelectedIndex >= 0,
+                TabId.Dynamic => _state.DynamicSubTab is DynamicSubTabId.Events or DynamicSubTabId.Output
+                    && (_state.DynamicEventsFocusedKey is not null || _state.DynamicOutputFocusedKey is not null),
+                _ => false
+            };
+            if (yankable)
+                hints.Add(s.Section("y: Yank"));
+
             hints.Add(s.Spacer());
+
+            // Yank notification (right side, auto-clearing)
+            if (!string.IsNullOrEmpty(_state.YankNotification))
+            {
+                hints.Add(s.Section(_state.YankNotification).Theme(t => t
+                    .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(120, 180, 120))));
+                hints.Add(s.Separator(" "));
+            }
 
             // General tab: navigation error (right side)
             if (_state.CurrentTab == 0 && !string.IsNullOrEmpty(_state.NavigationError))
@@ -659,6 +638,32 @@ public sealed class DotsiderApp(DotsiderState state)
         state.IlCurrentMatchIndex = -1;
         state.IlTextMatchMethodTokens = null;
         state.IlFocusedTreeKey = null;
+        state.GeneralInfoEditorState = null;
+        state.GeneralInfoEditorText = null;
+        state.PeHeadersEditorState = null;
+        state.PeHeadersEditorText = null;
+        state.ClrHeaderEditorState = null;
+        state.ClrHeaderEditorText = null;
+    }
+
+    private IlYankDecorationProvider? FindYankProvider(EditorState editorState) =>
+        YankHelper.FindYankProvider(_state, editorState);
+
+    private void ShowYankNotification(string text)
+    {
+        var gen = ++_state.YankGeneration;
+        _state.YankNotification = text.Contains('\n')
+            ? $"Yanked {text.Count(c => c == '\n') + 1} lines"
+            : $"Yanked: {(text.Length > 40 ? text[..37] + "..." : text)}";
+        _state.App.Invalidate();
+        _ = Task.Delay(TimeSpan.FromMilliseconds(1500)).ContinueWith(_ =>
+        {
+            if (_state.YankGeneration == gen)
+            {
+                _state.YankNotification = null;
+                _state.App.Invalidate();
+            }
+        }, TaskScheduler.Default);
     }
 
     private static void ScheduleNotificationClear(DotsiderState state)

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -170,6 +170,82 @@ public sealed class DotsiderState : IDisposable
     /// <summary>Method tokens whose IL text matches the confirmed search query. Used to broaden tree filtering.</summary>
     public HashSet<int>? IlTextMatchMethodTokens { get; set; }
 
+    // --- Yank State ---
+
+    /// <summary>Yank notification message shown in the hints bar, auto-clears after 1.5 seconds.</summary>
+    public string? YankNotification { get; set; }
+
+    /// <summary>Generation counter for yank notification timer race prevention.</summary>
+    public long YankGeneration { get; set; }
+
+    /// <summary>Whether the focused table row should flash with yank highlight colors. Auto-clears after 150ms.</summary>
+    public bool YankFlashRow { get; set; }
+
+    // --- Read-Only Editor State (for text selection + yank) ---
+
+    /// <summary>Read-only editor for the General tab Assembly Info panel.</summary>
+    public EditorState? GeneralInfoEditorState { get; set; }
+
+    /// <summary>Source text used to build <see cref="GeneralInfoEditorState"/>, for staleness detection.</summary>
+    public string? GeneralInfoEditorText { get; set; }
+
+    /// <summary>Yank flash decoration provider for the General tab Assembly Info editor.</summary>
+    public IlYankDecorationProvider GeneralInfoYankProvider { get; } = new();
+
+    /// <summary>Tracks the previous frame's selection anchor for double-click word boundary adjustment in the General info editor.</summary>
+    internal DocumentOffset? GeneralInfoPrevSelectionAnchor;
+
+    /// <summary>Tracks the previous frame's cursor position for double-click word boundary adjustment in the General info editor.</summary>
+    internal DocumentOffset? GeneralInfoPrevCursorPosition;
+
+    /// <summary>Read-only editor for the PE Headers panel.</summary>
+    public EditorState? PeHeadersEditorState { get; set; }
+
+    /// <summary>Source text used to build <see cref="PeHeadersEditorState"/>, for staleness detection.</summary>
+    public string? PeHeadersEditorText { get; set; }
+
+    /// <summary>Yank flash decoration provider for the PE Headers editor.</summary>
+    public IlYankDecorationProvider PeHeadersYankProvider { get; } = new();
+
+    /// <summary>Tracks the previous frame's selection anchor for word boundary adjustment in the PE Headers editor.</summary>
+    internal DocumentOffset? PeHeadersPrevSelectionAnchor;
+
+    /// <summary>Tracks the previous frame's cursor position for word boundary adjustment in the PE Headers editor.</summary>
+    internal DocumentOffset? PeHeadersPrevCursorPosition;
+
+    /// <summary>Read-only editor for the CLR Header panel.</summary>
+    public EditorState? ClrHeaderEditorState { get; set; }
+
+    /// <summary>Source text used to build <see cref="ClrHeaderEditorState"/>, for staleness detection.</summary>
+    public string? ClrHeaderEditorText { get; set; }
+
+    /// <summary>Yank flash decoration provider for the CLR Header editor.</summary>
+    public IlYankDecorationProvider ClrHeaderYankProvider { get; } = new();
+
+    /// <summary>Tracks the previous frame's selection anchor for word boundary adjustment in the CLR Header editor.</summary>
+    internal DocumentOffset? ClrHeaderPrevSelectionAnchor;
+
+    /// <summary>Tracks the previous frame's cursor position for word boundary adjustment in the CLR Header editor.</summary>
+    internal DocumentOffset? ClrHeaderPrevCursorPosition;
+
+    /// <summary>Read-only editor for the PE detail popup overlay.</summary>
+    public EditorState? PeDetailEditorState { get; set; }
+
+    /// <summary>Source text used to build <see cref="PeDetailEditorState"/>, for staleness detection.</summary>
+    public string? PeDetailEditorText { get; set; }
+
+    /// <summary>Yank flash decoration provider for the PE detail popup editor.</summary>
+    public IlYankDecorationProvider PeDetailYankProvider { get; } = new();
+
+    /// <summary>Read-only editor for the Strings detail popup overlay.</summary>
+    public EditorState? StringsDetailEditorState { get; set; }
+
+    /// <summary>Source text used to build <see cref="StringsDetailEditorState"/>, for staleness detection.</summary>
+    public string? StringsDetailEditorText { get; set; }
+
+    /// <summary>Yank flash decoration provider for the Strings detail popup editor.</summary>
+    public IlYankDecorationProvider StringsDetailYankProvider { get; } = new();
+
     // --- Strings Tab State ---
 
     /// <summary>The minimum string length filter for raw strings.</summary>
@@ -414,7 +490,7 @@ public sealed class DotsiderState : IDisposable
         if (back.Tab == TabId.PeMetadata)
             PeSubTab = back.SubTab;
         App.RequestFocus(node =>
-            node is EditorNode or ListNode or TreeNode or InteractableNode
+            node is ListNode or TreeNode or InteractableNode
             || node.GetType().Name.StartsWith("TableNode"));
         App.Invalidate();
     }
@@ -428,9 +504,11 @@ public sealed class DotsiderState : IDisposable
     {
         if (CurrentTab == TabId.IlInspector)
             App.RequestFocus(node => node is ListNode);
+        else if (CurrentTab == TabId.HexDump)
+            App.RequestFocus(node => node is EditorNode);
         else
             App.RequestFocus(node =>
-                node is EditorNode or TreeNode or ListNode or InteractableNode
+                node is TreeNode or ListNode or InteractableNode
                 || node.GetType().Name.StartsWith("TableNode"));
     }
 
@@ -530,6 +608,17 @@ public sealed class DotsiderState : IDisposable
         IlPendingCursorMatch = null;
         IlTextMatchMethodTokens = null;
         IlYankProvider.HighlightRange = null;
+        YankNotification = null;
+        GeneralInfoEditorState = null;
+        GeneralInfoEditorText = null;
+        PeHeadersEditorState = null;
+        PeHeadersEditorText = null;
+        ClrHeaderEditorState = null;
+        ClrHeaderEditorText = null;
+        PeDetailEditorState = null;
+        PeDetailEditorText = null;
+        StringsDetailEditorState = null;
+        StringsDetailEditorText = null;
         StringsSourceTab = 0;
         StringsFocusedKey = null;
         StringsDetailContent = null;

--- a/src/Dotsider/Infrastructure/CursorColorHelper.cs
+++ b/src/Dotsider/Infrastructure/CursorColorHelper.cs
@@ -1,0 +1,23 @@
+namespace Dotsider.Infrastructure;
+
+/// <summary>
+/// Helpers for managing the terminal cursor color via OSC escape sequences.
+/// </summary>
+public static class CursorColorHelper
+{
+    /// <summary>The OSC 12 sequence that sets the cursor color to the dotsider theme teal.</summary>
+    public const string SetTealSequence = "\x1b]12;rgb:00/c8/b4\x1b\\";
+
+    /// <summary>The OSC 112 sequence that resets the cursor color to the terminal default.</summary>
+    public const string ResetSequence = "\x1b]112\x1b\\";
+
+    /// <summary>
+    /// Writes the OSC 12 sequence to set the cursor color to the dotsider theme teal.
+    /// </summary>
+    public static void SetThemeCursorColor() => Console.Write(SetTealSequence);
+
+    /// <summary>
+    /// Writes the OSC 112 sequence to reset the cursor color to the terminal default.
+    /// </summary>
+    public static void ResetCursorColor() => Console.Write(ResetSequence);
+}

--- a/src/Dotsider/NuGetApp.cs
+++ b/src/Dotsider/NuGetApp.cs
@@ -59,18 +59,41 @@ public sealed class NuGetApp(NuGetState state)
             // Hints bar
             outer.InfoBar(s =>
             {
-                var hints = new List<IInfoBarChild>
-                {
-                    s.Section(_state.IsBrowsingPackage ? "Enter: Open DLL" : "1-5: Tabs"),
-                    s.Section("Backspace: Back")
-                };
+                var hints = new List<IInfoBarChild>();
+
                 if (_state.IsBrowsingPackage)
                 {
+                    hints.Add(s.Section("Enter: Open DLL"));
                     if (_state.BrowserSearch.IsActive)
                         hints.Add(s.Section("Esc: Clear"));
                     hints.Add(s.Section("/: Search"));
+                    hints.Add(s.Section("y: Yank"));
                 }
+                else if (_state.SelectedDllState is not null)
+                {
+                    var dll = _state.SelectedDllState;
+                    hints.Add(s.Section("1-5: Tabs"));
+                    // Only show "Esc: Back" when no hex/search modal will claim Esc first
+                    var hexInsert = dll.CurrentTab == TabId.HexDump && dll.HexMode == HexEditMode.Insert;
+                    var dllSearchAct = dll.Search[dll.CurrentTab].IsActive;
+                    if (!hexInsert && !dllSearchAct && !dll.HexJumpDialogOpen
+                        && dll.PeDetailContent is null && dll.StringsDetailContent is null)
+                        hints.Add(s.Section("Esc: Back"));
+                    // DLL-inspector-specific hints (shared with DotsiderApp)
+                    DllInspectorBindings.AddHints(hints, s, dll);
+                }
+
                 hints.Add(s.Spacer());
+
+                // Yank notification (right side, auto-clearing)
+                var yankNotification = _state.YankNotification
+                    ?? _state.SelectedDllState?.YankNotification;
+                if (!string.IsNullOrEmpty(yankNotification))
+                {
+                    hints.Add(s.Section(yankNotification).Theme(t => t
+                        .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(120, 180, 120))));
+                    hints.Add(s.Separator(" "));
+                }
 
                 // Navigation error in DLL inspector (right side)
                 if (!_state.IsBrowsingPackage && _state.SelectedDllState is { NavigationError: { } navError })
@@ -87,7 +110,15 @@ public sealed class NuGetApp(NuGetState state)
         .WithInputBindings(bindings =>
         {
             var browserSearch = _state.BrowserSearch;
-            var isSearchEditing = browserSearch.IsActive && !browserSearch.IsConfirmed;
+            // Gate on BOTH browser and embedded DLL inspector input state
+            var dllSearch = _state.SelectedDllState?.Search[_state.SelectedDllState.CurrentTab];
+            var dllSearchEditing = dllSearch is { IsActive: true, IsConfirmed: false };
+            var hexInsertMode = _state.SelectedDllState is { CurrentTab: TabId.HexDump }
+                && _state.SelectedDllState.HexMode == HexEditMode.Insert;
+            var hexJumpOpen = _state.SelectedDllState?.HexJumpDialogOpen == true;
+            var dllEditingArgs = _state.SelectedDllState?.DynamicEditingArgs == true;
+            var isSearchEditing = (browserSearch.IsActive && !browserSearch.IsConfirmed)
+                || dllSearchEditing || hexInsertMode || hexJumpOpen || dllEditingArgs;
 
             if (_state.IsBrowsingPackage)
             {
@@ -160,37 +191,204 @@ public sealed class NuGetApp(NuGetState state)
                 }, "Open DLL");
             }
 
-            bindings.Key(Hex1bKey.Backspace).Action(_ =>
+            // Escape handler — search/hex modals are handled by DllInspectorBindings.
+            // This handler covers: detail popups, back-to-package, and browser search dismiss.
+            // Only register when the shared helper hasn't already claimed Escape for search/hex.
+            var dllSearchActive = dllSearch is { IsActive: true };
+            var dllHexInsertNoSearch = !dllSearchActive
+                && _state.SelectedDllState is { CurrentTab: TabId.HexDump, HexMode: HexEditMode.Insert };
+            var dllHexJumpOpen = _state.SelectedDllState?.HexJumpDialogOpen == true;
+            if (!dllSearchActive && !dllHexInsertNoSearch && !dllHexJumpOpen)
             {
-                if (!_state.IsBrowsingPackage)
+                bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
                 {
-                    _state.SelectedDllState?.Dispose();
-                    _state.SelectedDllState = null;
-                    _state.SelectedDllEntry = null;
-                    _state.IsBrowsingPackage = true;
-                    _state.App.Invalidate();
-                }
-            }, "Back to package");
+                    if (!_state.IsBrowsingPackage)
+                    {
+                        var dllState = _state.SelectedDllState;
+                        if (dllState is not null)
+                        {
+                            if (dllState.PeDetailContent is not null)
+                            {
+                                dllState.PeDetailContent = null;
+                                dllState.PeDetailEditorText = null;
+                                dllState.PeDetailEditorState = null;
+                                dllState.RequestContentFocus();
+                                _state.App.Invalidate();
+                                return;
+                            }
+                            if (dllState.StringsDetailContent is not null)
+                            {
+                                dllState.StringsDetailContent = null;
+                                dllState.StringsDetailEditorText = null;
+                                dllState.StringsDetailEditorState = null;
+                                dllState.RequestContentFocus();
+                                _state.App.Invalidate();
+                                return;
+                            }
+                        }
+
+                        _state.SelectedDllState?.Dispose();
+                        _state.SelectedDllState = null;
+                        _state.SelectedDllEntry = null;
+                        _state.IsBrowsingPackage = true;
+                        _state.FileTreeFocusedKey = _state.SavedFileTreeFocusedKey;
+                        _state.App.RequestFocus(node =>
+                            node.GetType().Name.StartsWith("TableNode"));
+                        _state.App.Invalidate();
+                    }
+                    else if (_state.BrowserSearch.IsActive)
+                    {
+                        _state.BrowserSearch.Dismiss();
+                        _state.App.Invalidate();
+                    }
+                }, "Back to package");
+            }
 
             if (!_state.IsBrowsingPackage && _state.SelectedDllState is not null)
             {
-                for (var i = 0; i < 5; i++)
+                if (!isSearchEditing)
                 {
-                    var tabIndex = i;
-                    var key = (Hex1bKey)((int)Hex1bKey.D1 + i);
-                    bindings.Key(key).Global().Action(_ =>
+                    for (var i = 0; i < 5; i++)
                     {
-                        _state.SelectedDllState!.CurrentTab = tabIndex;
-                        _state.App.Invalidate();
-                    }, $"Tab {tabIndex + 1}");
+                        var tabIndex = i;
+                        var key = (Hex1bKey)((int)Hex1bKey.D1 + i);
+                        bindings.Key(key).Global().Action(_ =>
+                        {
+                            _state.SelectedDllState!.CurrentTab = tabIndex;
+                            _state.SelectedDllState.RequestContentFocus();
+                            _state.App.Invalidate();
+                        }, $"Tab {tabIndex + 1}");
+                    }
                 }
+
+                // Hex + IL Inspector + search bindings (shared with DotsiderApp).
+                // Must be outside isSearchEditing gate so hex insert Escape works.
+                DllInspectorBindings.Register(bindings, _state.SelectedDllState, _state.App,
+                    includeSearch: true);
             }
 
             if (!isSearchEditing)
+            {
                 bindings.Key(Hex1bKey.Q).Global().Action(ctx => ctx.RequestStop(), "Quit");
+
+                // Universal yank — same behavior as DotsiderApp
+                bindings.Key(Hex1bKey.Y).Global().Action(ctx =>
+                {
+                    // 1. Any focused editor with selection
+                    if (ctx.FocusedNode is EditorNode { State.Cursor.HasSelection: true } editor)
+                    {
+                        string text;
+                        var hexState = _state.SelectedDllState?.HexEditorState;
+                        if (hexState is not null && editor.State == hexState)
+                        {
+                            text = YankHelper.GetHexSelectionText(editor.State) ?? "";
+                        }
+                        else
+                        {
+                            // Neovim-style: include cursor character, collapse cursor
+                            var range = editor.State.Cursor.SelectionRange;
+                            var doc = editor.State.Document;
+                            var yankEnd = new Hex1b.Documents.DocumentOffset(Math.Min(
+                                Math.Max(range.End.Value, editor.State.Cursor.Position.Value + 1),
+                                doc.Length));
+                            var yankRange = new Hex1b.Documents.DocumentRange(range.Start, yankEnd);
+                            text = doc.GetText(yankRange);
+
+                            var lastChar = new Hex1b.Documents.DocumentOffset(Math.Max(0, yankEnd.Value - 1));
+                            editor.State.SetCursorPosition(lastChar);
+
+                            // Flash
+                            var yankProvider = YankHelper.FindYankProvider(_state, editor.State);
+                            if (yankProvider is not null)
+                            {
+                                var startPos = doc.OffsetToPosition(yankRange.Start);
+                                var endPos = doc.OffsetToPosition(yankRange.End);
+                                yankProvider.HighlightRange = (startPos, endPos);
+                                _state.App.Invalidate();
+                                _ = Task.Delay(TimeSpan.FromMilliseconds(150)).ContinueWith(_ =>
+                                {
+                                    yankProvider.HighlightRange = null;
+                                    _state.App.Invalidate();
+                                }, TaskScheduler.Default);
+                            }
+                        }
+
+                        if (!string.IsNullOrEmpty(text))
+                        {
+                            ctx.CopyToClipboard(text);
+                            ShowYankNotification(text);
+                        }
+                        return;
+                    }
+
+                    // 2. Focused editor WITHOUT selection → do nothing
+                    if (ctx.FocusedNode is EditorNode) return;
+
+                    // 3. Non-editor focus → table row
+                    string? yankText = null;
+                    if (_state.IsBrowsingPackage)
+                    {
+                        // Seed focus if not yet set
+                        _state.FileTreeFocusedKey ??=
+                            _state.Package.DllFiles.Count > 0 ? _state.Package.DllFiles[0].FullPath : null;
+                        if (_state.FileTreeFocusedKey is string path)
+                            yankText = path;
+                    }
+                    else if (_state.SelectedDllState is not null)
+                    {
+                        yankText = YankHelper.GetYankText(_state.SelectedDllState);
+                    }
+
+                    if (yankText is not null)
+                    {
+                        ctx.CopyToClipboard(yankText);
+                        ShowYankNotification(yankText);
+
+                        // Flash the focused row
+                        if (_state.IsBrowsingPackage)
+                        {
+                            _state.YankFlashRow = true;
+                            _state.App.Invalidate();
+                            _ = Task.Delay(TimeSpan.FromMilliseconds(150)).ContinueWith(_ =>
+                            {
+                                _state.YankFlashRow = false;
+                                _state.App.Invalidate();
+                            }, TaskScheduler.Default);
+                        }
+                        else if (_state.SelectedDllState is not null)
+                        {
+                            var flashTarget = _state.SelectedDllState;
+                            flashTarget.YankFlashRow = true;
+                            _state.App.Invalidate();
+                            _ = Task.Delay(TimeSpan.FromMilliseconds(150)).ContinueWith(_ =>
+                            {
+                                flashTarget.YankFlashRow = false;
+                                _state.App.Invalidate();
+                            }, TaskScheduler.Default);
+                        }
+                    }
+                }, "Yank");
+            }
             bindings.Ctrl().Key(Hex1bKey.C).Global().OverridesCapture()
                 .Action(ctx => ctx.RequestStop(), "Quit");
         });
+    }
+
+    private void ShowYankNotification(string text)
+    {
+        var gen = ++_state.YankGeneration;
+        _state.YankNotification = text.Contains('\n')
+            ? $"Yanked {text.Count(c => c == '\n') + 1} lines"
+            : $"Yanked: {(text.Length > 40 ? text[..37] + "..." : text)}";
+        _state.App.Invalidate();
+        _ = Task.Delay(TimeSpan.FromMilliseconds(1500)).ContinueWith(_ =>
+        {
+            if (_state.YankGeneration == gen)
+            {
+                _state.YankNotification = null;
+                _state.App.Invalidate();
+            }
+        }, TaskScheduler.Default);
     }
 
     private Hex1bWidget BuildDllInspector(WidgetContext<VStackWidget> outer)

--- a/src/Dotsider/NuGetState.cs
+++ b/src/Dotsider/NuGetState.cs
@@ -1,6 +1,7 @@
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
+using Hex1b.Widgets;
 
 namespace Dotsider;
 
@@ -32,11 +33,40 @@ public sealed class NuGetState(Hex1bApp app, string nupkgPath) : IDisposable
     /// <summary>Whether the user is viewing the package file list (true) or a DLL inspector (false).</summary>
     public bool IsBrowsingPackage { get; set; } = true;
 
+    /// <summary>Saved focused key from the DLL file list, restored when returning from DLL inspection.</summary>
+    public object? SavedFileTreeFocusedKey { get; set; }
+
     /// <summary>Search state for the package browser view.</summary>
     public SearchState BrowserSearch { get; } = new();
 
     /// <summary>The currently selected tab index in the DLL inspector.</summary>
     public int CurrentTab { get; set; }
+
+    // --- Read-Only Editor State ---
+
+    /// <summary>Read-only editor for the Package Info panel.</summary>
+    public EditorState? PackageInfoEditorState { get; set; }
+
+    /// <summary>Source text used to build <see cref="PackageInfoEditorState"/>, for staleness detection.</summary>
+    public string? PackageInfoEditorText { get; set; }
+
+    /// <summary>Yank flash decoration provider for the Package Info editor.</summary>
+    public Views.IlYankDecorationProvider PackageInfoYankProvider { get; } = new();
+
+    /// <summary>Tracks the previous frame's selection anchor for word boundary adjustment in the Package Info editor.</summary>
+    internal Hex1b.Documents.DocumentOffset? PackageInfoPrevSelectionAnchor;
+
+    /// <summary>Tracks the previous frame's cursor position for word boundary adjustment in the Package Info editor.</summary>
+    internal Hex1b.Documents.DocumentOffset? PackageInfoPrevCursorPosition;
+
+    /// <summary>Whether the focused table row should flash with yank highlight colors. Auto-clears after 150ms.</summary>
+    public bool YankFlashRow { get; set; }
+
+    /// <summary>Yank notification message shown in the hints bar, auto-clears after 1.5 seconds.</summary>
+    public string? YankNotification { get; set; }
+
+    /// <summary>Generation counter for yank notification timer race prevention.</summary>
+    public long YankGeneration { get; set; }
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/Dotsider/Program.cs
+++ b/src/Dotsider/Program.cs
@@ -176,8 +176,7 @@ diffCommand.SetAction(async (parseResult, ct) =>
 
     diagnosticsListener.StartListening();
 
-    // OSC 12: set terminal cursor color to teal (0,200,180) to match the theme accent
-    Console.Write("\x1b]12;rgb:00/c8/b4\x1b\\");
+    CursorColorHelper.SetThemeCursorColor();
 
     try
     {
@@ -185,6 +184,7 @@ diffCommand.SetAction(async (parseResult, ct) =>
     }
     finally
     {
+        CursorColorHelper.ResetCursorColor();
         diffHex1bApp.Dispose();
     }
 
@@ -282,8 +282,7 @@ static async Task<int> RunTui(string[] args, string filePath)
 
         nugetListener.StartListening();
 
-        // OSC 12: set terminal cursor color to teal (0,200,180) to match the theme accent
-        Console.Write("\x1b]12;rgb:00/c8/b4\x1b\\");
+        CursorColorHelper.SetThemeCursorColor();
 
         try
         {
@@ -291,6 +290,7 @@ static async Task<int> RunTui(string[] args, string filePath)
         }
         finally
         {
+            CursorColorHelper.ResetCursorColor();
             nugetHex1bApp.Dispose();
         }
 
@@ -343,8 +343,7 @@ static async Task<int> RunTui(string[] args, string filePath)
 
     diagnosticsListener.StartListening();
     
-    // OSC 12: set terminal cursor color to teal (0,200,180) to match the theme accent
-    Console.Write("\x1b]12;rgb:00/c8/b4\x1b\\");
+    CursorColorHelper.SetThemeCursorColor();
 
     try
     {
@@ -352,6 +351,7 @@ static async Task<int> RunTui(string[] args, string filePath)
     }
     finally
     {
+        CursorColorHelper.ResetCursorColor();
         hex1bApp.Dispose();
     }
 

--- a/src/Dotsider/Views/DiffMethodsView.cs
+++ b/src/Dotsider/Views/DiffMethodsView.cs
@@ -42,9 +42,32 @@ public static class DiffMethodsView
             search.SetMatchCount(filtered.Count);
         }
 
-        // Set up match navigation
-        state.NavigateNextMatch = null;
-        state.NavigatePrevMatch = null;
+        // Set up match navigation — cycle through filtered rows
+        if (filtered.Count > 0 && !string.IsNullOrEmpty(query))
+        {
+            var keys = filtered.Select(e =>
+            {
+                var m = e.Right ?? e.Left!;
+                return e.Kind.ToString() + ":" + m.DeclaringType + "::" + m.Name + m.Signature;
+            }).ToList();
+            state.NavigateNextMatch = () =>
+            {
+                var idx = keys.IndexOf(state.DiffFocusedKey as string ?? "");
+                idx = (idx + 1) % keys.Count;
+                state.DiffFocusedKey = keys[idx];
+            };
+            state.NavigatePrevMatch = () =>
+            {
+                var idx = keys.IndexOf(state.DiffFocusedKey as string ?? "");
+                idx = idx <= 0 ? keys.Count - 1 : idx - 1;
+                state.DiffFocusedKey = keys[idx];
+            };
+        }
+        else
+        {
+            state.NavigateNextMatch = null;
+            state.NavigatePrevMatch = null;
+        }
 
         return ctx.VStack(outer =>
         {
@@ -69,16 +92,24 @@ public static class DiffMethodsView
                 {
                     var (prefix, color) = GetDiffStyle(entry.Kind);
                     var method = entry.Right ?? entry.Left!;
+                    var flash = rowState.IsFocused && state.YankFlashRow;
+                    var focused = rowState.IsFocused && !flash;
+                    var fg = flash ? Hex1bColor.FromRgb(24, 24, 37)
+                        : focused ? Hex1bColor.Black
+                        : color;
+                    var bg = flash ? Hex1bColor.FromRgb(126, 201, 216)
+                        : focused ? Hex1bColor.FromRgb(0, 200, 180)
+                        : Hex1bColor.Default;
                     return
                     [
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(prefix))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
-                            HighlightHelper.HighlightCell(c, method.DeclaringType, query, !string.IsNullOrEmpty(query), color))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
-                            HighlightHelper.HighlightCell(c, method.Name, query, !string.IsNullOrEmpty(query), color))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
-                            HighlightHelper.HighlightCell(c, method.Signature, query, !string.IsNullOrEmpty(query), color))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(entry.ChangeDescription ?? "")))
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg), c.Text(prefix))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg),
+                            HighlightHelper.HighlightCell(c, method.DeclaringType, query, !string.IsNullOrEmpty(query), fg))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg),
+                            HighlightHelper.HighlightCell(c, method.Name, query, !string.IsNullOrEmpty(query), fg))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg),
+                            HighlightHelper.HighlightCell(c, method.Signature, query, !string.IsNullOrEmpty(query), fg))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg), c.Text(entry.ChangeDescription ?? "")))
                     ];
                 })
                 .Focus(state.DiffFocusedKey)

--- a/src/Dotsider/Views/DiffRefsView.cs
+++ b/src/Dotsider/Views/DiffRefsView.cs
@@ -43,9 +43,29 @@ public static class DiffRefsView
             search.SetMatchCount(filtered.Count);
         }
 
-        // Set up match navigation
-        state.NavigateNextMatch = null;
-        state.NavigatePrevMatch = null;
+        // Set up match navigation — cycle through filtered rows
+        if (filtered.Count > 0 && !string.IsNullOrEmpty(query))
+        {
+            var keys = filtered.Select(e =>
+                e.Kind.ToString() + ":" + (e.Left?.Name ?? e.Right?.Name ?? "")).ToList();
+            state.NavigateNextMatch = () =>
+            {
+                var idx = keys.IndexOf(state.DiffFocusedKey as string ?? "");
+                idx = (idx + 1) % keys.Count;
+                state.DiffFocusedKey = keys[idx];
+            };
+            state.NavigatePrevMatch = () =>
+            {
+                var idx = keys.IndexOf(state.DiffFocusedKey as string ?? "");
+                idx = idx <= 0 ? keys.Count - 1 : idx - 1;
+                state.DiffFocusedKey = keys[idx];
+            };
+        }
+        else
+        {
+            state.NavigateNextMatch = null;
+            state.NavigatePrevMatch = null;
+        }
 
         return ctx.VStack(outer =>
         {
@@ -71,14 +91,22 @@ public static class DiffRefsView
                     var name = entry.Right?.Name ?? entry.Left?.Name ?? "";
                     var leftVer = entry.Left?.Version ?? "-";
                     var rightVer = entry.Right?.Version ?? "-";
+                    var flash = rowState.IsFocused && state.YankFlashRow;
+                    var focused = rowState.IsFocused && !flash;
+                    var fg = flash ? Hex1bColor.FromRgb(24, 24, 37)
+                        : focused ? Hex1bColor.Black
+                        : color;
+                    var bg = flash ? Hex1bColor.FromRgb(126, 201, 216)
+                        : focused ? Hex1bColor.FromRgb(0, 200, 180)
+                        : Hex1bColor.Default;
                     return
                     [
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(prefix))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
-                            HighlightHelper.HighlightCell(c, name, query, !string.IsNullOrEmpty(query), color))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(leftVer))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(rightVer))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(entry.ChangeDescription ?? "")))
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg), c.Text(prefix))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg),
+                            HighlightHelper.HighlightCell(c, name, query, !string.IsNullOrEmpty(query), fg))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg), c.Text(leftVer))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg), c.Text(rightVer))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg), c.Text(entry.ChangeDescription ?? "")))
                     ];
                 })
                 .Focus(state.DiffFocusedKey)

--- a/src/Dotsider/Views/DiffSearchDecorationProvider.cs
+++ b/src/Dotsider/Views/DiffSearchDecorationProvider.cs
@@ -1,0 +1,53 @@
+using Hex1b.Documents;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// Provides search match highlighting for read-only editors.
+/// Set <see cref="Query"/> before each frame to highlight matching text.
+/// </summary>
+public sealed class DiffSearchDecorationProvider : ITextDecorationProvider
+{
+    private static readonly TextDecoration MatchDecoration = new()
+    {
+        Background = HighlightHelper.MatchBgColor
+    };
+
+    /// <summary>The current search query, or null/empty when no search is active.</summary>
+    public string? Query { get; set; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<TextDecorationSpan> GetDecorations(
+        int startLine, int endLine, IHex1bDocument document)
+    {
+        if (string.IsNullOrEmpty(Query))
+            return [];
+
+        var spans = new List<TextDecorationSpan>();
+
+        for (var line = startLine; line <= endLine && line <= document.LineCount; line++)
+        {
+            var text = document.GetLineText(line);
+            if (string.IsNullOrEmpty(text))
+                continue;
+
+            var pos = 0;
+            while (pos < text.Length)
+            {
+                var idx = text.IndexOf(Query, pos, StringComparison.OrdinalIgnoreCase);
+                if (idx < 0)
+                    break;
+
+                spans.Add(new TextDecorationSpan(
+                    new DocumentPosition(line, idx + 1),
+                    new DocumentPosition(line, idx + Query.Length + 1),
+                    MatchDecoration,
+                    10));
+
+                pos = idx + Query.Length;
+            }
+        }
+
+        return spans;
+    }
+}

--- a/src/Dotsider/Views/DiffStatsDecorationProvider.cs
+++ b/src/Dotsider/Views/DiffStatsDecorationProvider.cs
@@ -1,0 +1,78 @@
+using Hex1b.Documents;
+using Hex1b.Theming;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// Provides color coding for change statistics in the diff summary editor.
+/// Colors +N values green, -N values red, and ~N values yellow.
+/// </summary>
+public sealed class DiffStatsDecorationProvider : ITextDecorationProvider
+{
+    private static readonly TextDecoration GreenDecoration = new()
+    {
+        Foreground = Hex1bColor.FromRgb(80, 200, 120)
+    };
+
+    private static readonly TextDecoration RedDecoration = new()
+    {
+        Foreground = Hex1bColor.FromRgb(200, 80, 80)
+    };
+
+    private static readonly TextDecoration YellowDecoration = new()
+    {
+        Foreground = Hex1bColor.FromRgb(200, 200, 80)
+    };
+
+    /// <inheritdoc />
+    public IReadOnlyList<TextDecorationSpan> GetDecorations(
+        int startLine, int endLine, IHex1bDocument document)
+    {
+        var spans = new List<TextDecorationSpan>();
+
+        for (var line = startLine; line <= endLine && line <= document.LineCount; line++)
+        {
+            var text = document.GetLineText(line);
+            if (string.IsNullOrEmpty(text))
+                continue;
+
+            // Only color lines that contain all three markers (+N, -N, ~N)
+            // to avoid false positives on "Size delta: +10.0 KB"
+            if (!text.Contains('~'))
+                continue;
+
+            for (var i = 0; i < text.Length; i++)
+            {
+                var ch = text[i];
+                if (ch is not ('+' or '-' or '~')) continue;
+                if (i + 1 >= text.Length || !char.IsDigit(text[i + 1])) continue;
+
+                var start = i;
+                i++;
+                while (i < text.Length && char.IsDigit(text[i]))
+                    i++;
+
+                var decoration = ch switch
+                {
+                    '+' => GreenDecoration,
+                    '-' => RedDecoration,
+                    '~' => YellowDecoration,
+                    _ => null
+                };
+
+                if (decoration is not null)
+                {
+                    spans.Add(new TextDecorationSpan(
+                        new DocumentPosition(line, start + 1),
+                        new DocumentPosition(line, i + 1),
+                        decoration,
+                        5));
+                }
+
+                i--;
+            }
+        }
+
+        return spans;
+    }
+}

--- a/src/Dotsider/Views/DiffSummaryView.cs
+++ b/src/Dotsider/Views/DiffSummaryView.cs
@@ -1,4 +1,5 @@
 using Hex1b;
+using Hex1b.Documents;
 using Hex1b.Input;
 using Hex1b.Theming;
 using Hex1b.Widgets;
@@ -10,10 +11,6 @@ namespace Dotsider.Views;
 /// </summary>
 public static class DiffSummaryView
 {
-    private static readonly Hex1bColor Green = Hex1bColor.FromRgb(80, 200, 120);
-    private static readonly Hex1bColor Red = Hex1bColor.FromRgb(200, 80, 80);
-    private static readonly Hex1bColor Yellow = Hex1bColor.FromRgb(200, 200, 80);
-
     /// <summary>
     /// Builds the diff summary view widget tree.
     /// </summary>
@@ -30,6 +27,53 @@ public static class DiffSummaryView
         state.NavigateNextMatch = null;
         state.NavigatePrevMatch = null;
 
+        // Build left/right info text for read-only editors
+        var leftText = string.Join("\n",
+            $"  Name:       {state.Left.AssemblyName ?? ""}",
+            $"  Version:    {state.Left.AssemblyVersion ?? ""}",
+            $"  Size:       {DotsiderState.FormatSize(state.Left.FileSize)}",
+            $"  Types:      {state.Left.TypeDefs.Count}",
+            $"  Methods:    {state.Left.MethodDefs.Count}",
+            $"  References: {state.Left.AssemblyRefs.Count}");
+
+        if (state.LeftInfoEditorText != leftText)
+        {
+            state.LeftInfoEditorText = leftText;
+            state.LeftInfoEditorState = new EditorState(new Hex1bDocument(leftText)) { IsReadOnly = true };
+        }
+
+        var rightText = string.Join("\n",
+            $"  Name:       {state.Right.AssemblyName ?? ""}",
+            $"  Version:    {state.Right.AssemblyVersion ?? ""}",
+            $"  Size:       {DotsiderState.FormatSize(state.Right.FileSize)}",
+            $"  Types:      {state.Right.TypeDefs.Count}",
+            $"  Methods:    {state.Right.MethodDefs.Count}",
+            $"  References: {state.Right.AssemblyRefs.Count}");
+
+        if (state.RightInfoEditorText != rightText)
+        {
+            state.RightInfoEditorText = rightText;
+            state.RightInfoEditorState = new EditorState(new Hex1bDocument(rightText)) { IsReadOnly = true };
+        }
+
+        // Build change stats text for read-only editor (fixed-width columns for alignment)
+        var statsText = string.Join("\n",
+            $"  Types:      {$"+{summary.TypesAdded}",-6}{$"-{summary.TypesRemoved}",-6}~{summary.TypesChanged}",
+            $"  Methods:    {$"+{summary.MethodsAdded}",-6}{$"-{summary.MethodsRemoved}",-6}~{summary.MethodsChanged}",
+            $"  References: {$"+{summary.RefsAdded}",-6}{$"-{summary.RefsRemoved}",-6}~{summary.RefsChanged}",
+            "",
+            $"  Size delta: {(summary.SizeDelta >= 0 ? "+" : "")}{DotsiderState.FormatSize(Math.Abs(summary.SizeDelta))}");
+
+        if (state.ChangeStatsEditorText != statsText)
+        {
+            state.ChangeStatsEditorText = statsText;
+            state.ChangeStatsEditorState = new EditorState(new Hex1bDocument(statsText)) { IsReadOnly = true };
+        }
+
+        var leftSearchProvider = new DiffSearchDecorationProvider { Query = query };
+        var rightSearchProvider = new DiffSearchDecorationProvider { Query = query };
+        var statsSearchProvider = new DiffSearchDecorationProvider { Query = query };
+
         return ctx.VStack(outer =>
         {
             var widgets = new List<Hex1bWidget>();
@@ -37,72 +81,76 @@ public static class DiffSummaryView
             // Search bar
             SearchBarHelper.AddSearchBar(widgets, outer, search, state.App);
 
-            // Side-by-side assembly info
+            // Side-by-side assembly info (read-only editors)
             widgets.Add(outer.HSplitter(
                 left =>
                 [
                     left.Border(
-                        left.VStack(info =>
-                        [
-                            DiffInfoLine(info, "Name", state.Left.AssemblyName ?? "", query),
-                            DiffInfoLine(info, "Version", state.Left.AssemblyVersion ?? "", query),
-                            DiffInfoLine(info, "Size", DotsiderState.FormatSize(state.Left.FileSize), query),
-                            DiffInfoLine(info, "Types", state.Left.TypeDefs.Count.ToString(), query),
-                            DiffInfoLine(info, "Methods", state.Left.MethodDefs.Count.ToString(), query),
-                            DiffInfoLine(info, "References", state.Left.AssemblyRefs.Count.ToString(), query)
-                        ])
+                        left.ThemePanel(t => t
+                            .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
+                            .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
+                        left.Editor(state.LeftInfoEditorState!)
+                            .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                            .Decorations(new InfoLabelDecorationProvider())
+                            .Decorations(leftSearchProvider)
+                            .FillWidth().FillHeight())
                     ).Title($" {state.Left.FileName} (Left) ").Fill()
                 ],
                 right =>
                 [
                     right.Border(
-                        right.VStack(info =>
-                        [
-                            DiffInfoLine(info, "Name", state.Right.AssemblyName ?? "", query),
-                            DiffInfoLine(info, "Version", state.Right.AssemblyVersion ?? "", query),
-                            DiffInfoLine(info, "Size", DotsiderState.FormatSize(state.Right.FileSize), query),
-                            DiffInfoLine(info, "Types", state.Right.TypeDefs.Count.ToString(), query),
-                            DiffInfoLine(info, "Methods", state.Right.MethodDefs.Count.ToString(), query),
-                            DiffInfoLine(info, "References", state.Right.AssemblyRefs.Count.ToString(), query)
-                        ])
+                        right.ThemePanel(t => t
+                            .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
+                            .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
+                        right.Editor(state.RightInfoEditorState!)
+                            .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                            .Decorations(new InfoLabelDecorationProvider())
+                            .Decorations(rightSearchProvider)
+                            .FillWidth().FillHeight())
                     ).Title($" {state.Right.FileName} (Right) ").Fill()
                 ],
                 leftWidth: 50).FixedHeight(9));
 
-            // Change statistics
+            // Change statistics (read-only editor with decoration providers)
             widgets.Add(outer.Border(
-                outer.VStack(stats =>
-                [
-                    stats.HStack(h =>
-                    [
-                        h.Text("  Types:      ").FixedWidth(14),
-                        h.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, Green), h.Text($"+{summary.TypesAdded}")).FixedWidth(6),
-                        h.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, Red), h.Text($"-{summary.TypesRemoved}")).FixedWidth(6),
-                        h.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, Yellow), h.Text($"~{summary.TypesChanged}"))
-                    ]).FixedHeight(1),
-                    stats.HStack(h =>
-                    [
-                        h.Text("  Methods:    ").FixedWidth(14),
-                        h.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, Green), h.Text($"+{summary.MethodsAdded}")).FixedWidth(6),
-                        h.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, Red), h.Text($"-{summary.MethodsRemoved}")).FixedWidth(6),
-                        h.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, Yellow), h.Text($"~{summary.MethodsChanged}"))
-                    ]).FixedHeight(1),
-                    stats.HStack(h =>
-                    [
-                        h.Text("  References: ").FixedWidth(14),
-                        h.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, Green), h.Text($"+{summary.RefsAdded}")).FixedWidth(6),
-                        h.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, Red), h.Text($"-{summary.RefsRemoved}")).FixedWidth(6),
-                        h.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, Yellow), h.Text($"~{summary.RefsChanged}"))
-                    ]).FixedHeight(1),
-                    stats.Text(""),
-                    stats.Text($"  Size delta: {(summary.SizeDelta >= 0 ? "+" : "")}{DotsiderState.FormatSize(Math.Abs(summary.SizeDelta))}")
-                ])
+                outer.ThemePanel(t => t
+                    .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
+                    .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
+                outer.Editor(state.ChangeStatsEditorState!)
+                    .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                    .Decorations(new InfoLabelDecorationProvider())
+                    .Decorations(new DiffStatsDecorationProvider())
+                    .Decorations(statsSearchProvider)
+                    .FillWidth().FillHeight())
             ).Title(" Change Summary ").Fill());
 
             return [.. widgets];
         })
         .WithInputBindings(bindings =>
         {
+            // Tab cycles focus: Left Info → Right Info → Change Stats → Left Info
+            bindings.Key(Hex1bKey.Tab).Global().Action(_ =>
+            {
+                if (state.App.FocusedNode is EditorNode { State: var es })
+                {
+                    if (es == state.LeftInfoEditorState)
+                        state.App.RequestFocus(node =>
+                            node is EditorNode e && e.State == state.RightInfoEditorState);
+                    else if (es == state.RightInfoEditorState)
+                        state.App.RequestFocus(node =>
+                            node is EditorNode e && e.State == state.ChangeStatsEditorState);
+                    else
+                        state.App.RequestFocus(node =>
+                            node is EditorNode e && e.State == state.LeftInfoEditorState);
+                }
+                else
+                {
+                    state.App.RequestFocus(node =>
+                        node is EditorNode e && e.State == state.LeftInfoEditorState);
+                }
+                state.App.Invalidate();
+            }, "Cycle focus");
+
             bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
             {
                 if (search.IsActive)
@@ -113,14 +161,5 @@ public static class DiffSummaryView
             }, "Esc");
         })
         .Fill();
-    }
-
-    private static HStackWidget DiffInfoLine<T>(WidgetContext<T> ctx, string label, string value, string? query) where T : Hex1bWidget
-    {
-        return ctx.HStack(row =>
-        [
-            row.Text($"  {label}: ").FixedWidth(16),
-            HighlightHelper.HighlightText(row, value, query)
-        ]).FixedHeight(1);
     }
 }

--- a/src/Dotsider/Views/DiffTypesView.cs
+++ b/src/Dotsider/Views/DiffTypesView.cs
@@ -40,9 +40,29 @@ public static class DiffTypesView
             search.SetMatchCount(filtered.Count);
         }
 
-        // Set up match navigation
-        state.NavigateNextMatch = null;
-        state.NavigatePrevMatch = null;
+        // Set up match navigation — cycle through filtered rows
+        if (filtered.Count > 0 && !string.IsNullOrEmpty(query))
+        {
+            var keys = filtered.Select(e =>
+                e.Kind.ToString() + ":" + (e.Left?.FullName ?? e.Right?.FullName ?? "")).ToList();
+            state.NavigateNextMatch = () =>
+            {
+                var idx = keys.IndexOf(state.DiffFocusedKey as string ?? "");
+                idx = (idx + 1) % keys.Count;
+                state.DiffFocusedKey = keys[idx];
+            };
+            state.NavigatePrevMatch = () =>
+            {
+                var idx = keys.IndexOf(state.DiffFocusedKey as string ?? "");
+                idx = idx <= 0 ? keys.Count - 1 : idx - 1;
+                state.DiffFocusedKey = keys[idx];
+            };
+        }
+        else
+        {
+            state.NavigateNextMatch = null;
+            state.NavigatePrevMatch = null;
+        }
 
         return ctx.VStack(outer =>
         {
@@ -67,15 +87,23 @@ public static class DiffTypesView
                 {
                     var (prefix, color) = GetDiffStyle(entry.Kind);
                     var type = entry.Right ?? entry.Left!;
+                    var flash = rowState.IsFocused && state.YankFlashRow;
+                    var focused = rowState.IsFocused && !flash;
+                    var fg = flash ? Hex1bColor.FromRgb(24, 24, 37)
+                        : focused ? Hex1bColor.Black
+                        : color;
+                    var bg = flash ? Hex1bColor.FromRgb(126, 201, 216)
+                        : focused ? Hex1bColor.FromRgb(0, 200, 180)
+                        : Hex1bColor.Default;
                     return
                     [
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(prefix))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color),
-                            HighlightHelper.HighlightCell(c, type.FullName, query, !string.IsNullOrEmpty(query), color))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(type.BaseType ?? ""))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(type.MethodCount.ToString()))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(type.FieldCount.ToString()))),
-                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, color), c.Text(entry.ChangeDescription ?? "")))
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg), c.Text(prefix))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg),
+                            HighlightHelper.HighlightCell(c, type.FullName, query, !string.IsNullOrEmpty(query), fg))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg), c.Text(type.BaseType ?? ""))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg), c.Text(type.MethodCount.ToString()))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg), c.Text(type.FieldCount.ToString()))),
+                        r.Cell(c => c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg).Set(GlobalTheme.BackgroundColor, bg), c.Text(entry.ChangeDescription ?? "")))
                     ];
                 })
                 .Focus(state.DiffFocusedKey)

--- a/src/Dotsider/Views/GeneralView.cs
+++ b/src/Dotsider/Views/GeneralView.cs
@@ -1,6 +1,7 @@
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
+using Hex1b.Documents;
 using Hex1b.Input;
 using Hex1b.Layout;
 using Hex1b.Theming;
@@ -65,28 +66,51 @@ public static class GeneralView
             }
         }
 
+        // Build Assembly Info text for read-only editor
+        var infoText = string.Join("\n",
+            $"  Assembly Name:    {analyzer.AssemblyName ?? "(none)"}",
+            $"  Version:          {analyzer.AssemblyVersion ?? "(none)"}",
+            $"  Target Framework: {analyzer.TargetFramework ?? "(unknown)"}",
+            $"  Culture:          {analyzer.Culture ?? "neutral"}",
+            $"  Public Key Token: {analyzer.PublicKeyToken ?? "(none)"}",
+            "",
+            $"  File Size:        {state.FormatSizeToggleable(analyzer.FileSize)}",
+            $"  Architecture:     {analyzer.Architecture}",
+            $"  Last Modified:    {analyzer.LastModified:yyyy-MM-dd HH:mm:ss UTC}",
+            $"  Created:          {analyzer.CreatedTime:yyyy-MM-dd HH:mm:ss UTC}",
+            $"  Read-Only:        {(analyzer.IsReadOnly ? "Yes" : "No")}",
+            $"  Has Metadata:     {(analyzer.HasMetadata ? "Yes" : "No")}");
+
+        if (state.GeneralInfoEditorText != infoText)
+        {
+            state.GeneralInfoEditorText = infoText;
+            state.GeneralInfoEditorState = new EditorState(new Hex1bDocument(infoText)) { IsReadOnly = true };
+        }
+
+        // Adjust word boundaries after double-click (consistent with IL Inspector)
+        if (state.GeneralInfoEditorState is not null && state.CurrentTab == TabId.General)
+        {
+            IlInspectorView.AdjustWordSelectionCursorOneShot(
+                state.GeneralInfoEditorState,
+                ref state.GeneralInfoPrevSelectionAnchor,
+                ref state.GeneralInfoPrevCursorPosition);
+        }
+
         return ctx.VStack(outer =>
         {
             var widgets = new List<Hex1bWidget>
             {
-                // Assembly Info section
+                // Assembly Info section (read-only editor for text selection + yank)
                 outer.Border(
-                outer.VStack(info =>
-                [
-                    InfoLine(info, "Assembly Name", analyzer.AssemblyName ?? "(none)"),
-                    InfoLine(info, "Version", analyzer.AssemblyVersion ?? "(none)"),
-                    InfoLine(info, "Target Framework", analyzer.TargetFramework ?? "(unknown)"),
-                    InfoLine(info, "Culture", analyzer.Culture ?? "neutral"),
-                    InfoLine(info, "Public Key Token", analyzer.PublicKeyToken ?? "(none)"),
-                    info.Text(""),
-                    InfoLine(info, "File Size", state.FormatSizeToggleable(analyzer.FileSize)),
-                    InfoLine(info, "Architecture", analyzer.Architecture),
-                    InfoLine(info, "Last Modified", analyzer.LastModified.ToString("yyyy-MM-dd HH:mm:ss UTC")),
-                    InfoLine(info, "Created", analyzer.CreatedTime.ToString("yyyy-MM-dd HH:mm:ss UTC")),
-                    InfoLine(info, "Read-Only", analyzer.IsReadOnly ? "Yes" : "No"),
-                    InfoLine(info, "Has Metadata", analyzer.HasMetadata ? "Yes" : "No")
-                ])
-            ).Title(" Assembly Info ")
+                    outer.ThemePanel(t => t
+                        .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
+                        .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
+                    outer.Editor(state.GeneralInfoEditorState!)
+                        .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                        .Decorations(new InfoLabelDecorationProvider())
+                        .Decorations(state.GeneralInfoYankProvider)
+                        .FillWidth().FillHeight())
+                ).Title(" Assembly Info ").FixedHeight(14)
             };
 
             // Search bar
@@ -104,15 +128,21 @@ public static class GeneralView
                         h.Cell("Public Key Token").Width(SizeHint.Fixed(20))
                     ])
                     .Row((r, asmRef, rs) =>
-                    [
-                        r.Cell(c => FocusStyle(c, HighlightHelper.HighlightCell(c, asmRef.Name, query,
-                            !string.IsNullOrEmpty(query),
-                            rs.IsFocused ? FocusFg : null, rs.IsFocused ? FocusBg : null), rs.IsFocused)),
-                        r.Cell(c => FocusStyle(c, c.Text(asmRef.Version), rs.IsFocused)),
-                        r.Cell(c => FocusStyle(c, c.Text(asmRef.Culture), rs.IsFocused)),
-                        r.Cell(c => FocusStyle(c, c.Text(asmRef.PublicKeyToken ?? ""), rs.IsFocused))
-                    ])
-                    .Focus(state.GeneralFocusedDep)
+                    {
+                        var flash = rs.IsFocused && state.YankFlashRow;
+                        var fg = rs.IsFocused ? (flash ? YankFlashFg : FocusFg) : (Hex1bColor?)null;
+                        var bg = rs.IsFocused ? (flash ? YankFlashBg : FocusBg) : (Hex1bColor?)null;
+                        return
+                        [
+                            r.Cell(c => FocusStyle(c, HighlightHelper.HighlightCell(c, asmRef.Name, query,
+                                !string.IsNullOrEmpty(query), fg, bg), rs.IsFocused, flash)),
+                            r.Cell(c => FocusStyle(c, c.Text(asmRef.Version), rs.IsFocused, flash)),
+                            r.Cell(c => FocusStyle(c, c.Text(asmRef.Culture), rs.IsFocused, flash)),
+                            r.Cell(c => FocusStyle(c, c.Text(asmRef.PublicKeyToken ?? ""), rs.IsFocused, flash))
+                        ];
+                    })
+                    .Focus(state.App.FocusedNode is EditorNode
+                        ? null : state.GeneralFocusedDep)
                     .OnFocusChanged(key => state.GeneralFocusedDep = key)
                     .OnRowActivated((_, asmRef) =>
                     {
@@ -154,10 +184,28 @@ public static class GeneralView
             bindings.Key(Hex1bKey.Backspace).Action(_ =>
             {
                 if (state.PopAssembly())
+                    state.App.Invalidate();
+            }, "Back");
+
+            bindings.Key(Hex1bKey.Tab).Global().Action(_ =>
+            {
+                if (state.App.FocusedNode is EditorNode)
                 {
+                    // Editor → Table: seed focus to first row if none selected
+                    state.GeneralFocusedDep ??=
+                        state.Analyzer.AssemblyRefs.Count > 0
+                            ? state.Analyzer.AssemblyRefs[0].Name : null;
+                    state.App.RequestFocus(node =>
+                        node.GetType().Name.StartsWith("TableNode"));
                     state.App.Invalidate();
                 }
-            }, "Back");
+                else
+                {
+                    // Table → Editor
+                    state.App.RequestFocus(node => node is EditorNode);
+                    state.App.Invalidate();
+                }
+            }, "Toggle focus");
 
             bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
             {
@@ -184,12 +232,19 @@ public static class GeneralView
 
     private static readonly Hex1bColor FocusFg = Hex1bColor.Black;
     private static readonly Hex1bColor FocusBg = Hex1bColor.FromRgb(0, 200, 180);
+    private static readonly Hex1bColor YankFlashFg = Hex1bColor.FromRgb(24, 24, 37);
+    private static readonly Hex1bColor YankFlashBg = Hex1bColor.FromRgb(126, 201, 216);
 
-    private static Hex1bWidget FocusStyle<T>(WidgetContext<T> c, Hex1bWidget child, bool isFocused)
-        where T : Hex1bWidget =>
-        isFocused ? c.ThemePanel(t => t
-            .Set(GlobalTheme.ForegroundColor, FocusFg)
-            .Set(GlobalTheme.BackgroundColor, FocusBg), child) : child;
+    private static Hex1bWidget FocusStyle<T>(WidgetContext<T> c, Hex1bWidget child, bool isFocused,
+        bool yankFlash = false) where T : Hex1bWidget
+    {
+        if (!isFocused) return child;
+        var fg = yankFlash ? YankFlashFg : FocusFg;
+        var bg = yankFlash ? YankFlashBg : FocusBg;
+        return c.ThemePanel(t => t
+            .Set(GlobalTheme.ForegroundColor, fg)
+            .Set(GlobalTheme.BackgroundColor, bg), child);
+    }
 
     private static HStackWidget InfoLine<T>(WidgetContext<T> ctx, string label, string value) where T : Hex1bWidget
     {

--- a/src/Dotsider/Views/InfoEditorViewRenderer.cs
+++ b/src/Dotsider/Views/InfoEditorViewRenderer.cs
@@ -1,0 +1,66 @@
+using Hex1b;
+using Hex1b.Documents;
+using Hex1b.Layout;
+using Hex1b.Theming;
+using Hex1b.Widgets;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// A text editor view renderer for read-only info panels that renders blank lines
+/// instead of vim-style <c>~</c> markers for lines beyond the document content.
+/// Delegates all behavior to <see cref="TextEditorViewRenderer"/> and overwrites
+/// the tilde markers after rendering.
+/// </summary>
+public sealed class InfoEditorViewRenderer : IEditorViewRenderer
+{
+    /// <summary>Shared singleton instance (renderer is stateless).</summary>
+    public static InfoEditorViewRenderer Instance { get; } = new();
+
+    /// <inheritdoc />
+    public void Render(Hex1bRenderContext context, EditorState state, Rect viewport,
+        int scrollOffset, int horizontalScrollOffset, bool isFocused,
+        char? pendingNibble = null,
+        IReadOnlyList<ITextDecorationProvider>? decorationProviders = null,
+        IReadOnlyList<InlineHint>? inlineHints = null,
+        bool wordWrap = false,
+        IReadOnlyList<FoldingRegion>? foldingRegions = null)
+    {
+        // Delegate to the standard text renderer
+        TextEditorViewRenderer.Instance.Render(context, state, viewport,
+            scrollOffset, horizontalScrollOffset, isFocused,
+            pendingNibble, decorationProviders, inlineHints, wordWrap, foldingRegions);
+
+        // Overwrite tilde lines with blank space
+        var docLineCount = state.Document.LineCount;
+        var viewportLines = viewport.Height;
+        var firstEmptyViewLine = docLineCount - scrollOffset;
+
+        if (firstEmptyViewLine < 0) firstEmptyViewLine = 0;
+
+        var bg = context.Theme.Get(EditorTheme.BackgroundColor);
+        var bgAnsi = !bg.IsDefault ? bg.ToBackgroundAnsi() : "";
+        var resetAnsi = bgAnsi.Length > 0 ? "\x1b[0m" : "";
+
+        for (var viewLine = firstEmptyViewLine; viewLine < viewportLines; viewLine++)
+        {
+            var screenY = viewport.Y + viewLine;
+            var blankLine = new string(' ', viewport.Width);
+            context.WriteClipped(viewport.X, screenY, $"{bgAnsi}{blankLine}{resetAnsi}");
+        }
+    }
+
+    /// <inheritdoc />
+    public DocumentOffset? HitTest(int localX, int localY, EditorState state,
+        int viewportColumns, int viewportLines, int scrollOffset, int horizontalScrollOffset)
+        => TextEditorViewRenderer.Instance.HitTest(localX, localY, state,
+            viewportColumns, viewportLines, scrollOffset, horizontalScrollOffset);
+
+    /// <inheritdoc />
+    public int GetTotalLines(IHex1bDocument document, int viewportColumns)
+        => TextEditorViewRenderer.Instance.GetTotalLines(document, viewportColumns);
+
+    /// <inheritdoc />
+    public int GetMaxLineWidth(IHex1bDocument document, int scrollOffset, int viewportLines, int viewportColumns)
+        => TextEditorViewRenderer.Instance.GetMaxLineWidth(document, scrollOffset, viewportLines, viewportColumns);
+}

--- a/src/Dotsider/Views/InfoLabelDecorationProvider.cs
+++ b/src/Dotsider/Views/InfoLabelDecorationProvider.cs
@@ -1,0 +1,60 @@
+using Hex1b.Documents;
+using Hex1b.Theming;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// Provides label coloring for read-only info editors.
+/// Colors text from the start of each line up to and including the colon
+/// with a dimmed label color, matching the original InfoLine styling.
+/// </summary>
+public sealed class InfoLabelDecorationProvider : ITextDecorationProvider
+{
+    private static readonly TextDecoration LabelDecoration = new()
+    {
+        Foreground = Hex1bColor.FromRgb(100, 130, 160)
+    };
+
+    /// <inheritdoc />
+    public IReadOnlyList<TextDecorationSpan> GetDecorations(
+        int startLine, int endLine, IHex1bDocument document)
+    {
+        var spans = new List<TextDecorationSpan>();
+
+        for (var line = startLine; line <= endLine && line <= document.LineCount; line++)
+        {
+            var text = document.GetLineText(line);
+            if (string.IsNullOrEmpty(text))
+                continue;
+
+            // Only match label patterns: optional leading spaces, then letters/spaces, then colon.
+            // The colon must appear within the first 25 characters to avoid false positives
+            // on content lines that happen to contain colons.
+            var colonIdx = text.IndexOf(':');
+            if (colonIdx < 0 || colonIdx > 25)
+                continue;
+
+            // Verify everything before the colon is whitespace or letters (a label)
+            var isLabel = true;
+            for (var i = 0; i < colonIdx; i++)
+            {
+                if (!char.IsLetterOrDigit(text[i]) && text[i] != ' ')
+                {
+                    isLabel = false;
+                    break;
+                }
+            }
+
+            if (!isLabel)
+                continue;
+
+            spans.Add(new TextDecorationSpan(
+                new DocumentPosition(line, 1),
+                new DocumentPosition(line, colonIdx + 2),
+                LabelDecoration,
+                5));
+        }
+
+        return spans;
+    }
+}

--- a/src/Dotsider/Views/NuGetBrowserView.cs
+++ b/src/Dotsider/Views/NuGetBrowserView.cs
@@ -1,5 +1,6 @@
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
+using Hex1b.Documents;
 using Hex1b.Layout;
 using Hex1b.Theming;
 using Hex1b.Widgets;
@@ -33,24 +34,55 @@ public static class NuGetBrowserView
             search.SetMatchCount(dlls.Count);
         }
 
+        // Seed initial focus to first DLL row and ensure table has focus
+        if (state.FileTreeFocusedKey is null && pkg.DllFiles.Count > 0)
+        {
+            state.FileTreeFocusedKey = pkg.DllFiles[0].FullPath;
+            state.App.RequestFocus(node =>
+                node.GetType().Name.StartsWith("TableNode"));
+        }
+
+        // Build Package Info text for read-only editor
+        var infoText = string.Join("\n",
+            $"  Package ID:   {pkg.PackageId ?? "(unknown)"}",
+            $"  Version:      {pkg.PackageVersion ?? "(unknown)"}",
+            $"  Authors:      {pkg.Authors ?? "(unknown)"}",
+            $"  Description:  {pkg.Description ?? "(none)"}",
+            "",
+            $"  Total Files:  {pkg.Files.Count}",
+            $"  DLL Files:    {pkg.DllFiles.Count}",
+            $"  Total Size:   {DotsiderState.FormatSize(pkg.Files.Sum(f => f.UncompressedSize))}");
+
+        if (state.PackageInfoEditorText != infoText)
+        {
+            state.PackageInfoEditorText = infoText;
+            state.PackageInfoEditorState = new EditorState(new Hex1bDocument(infoText)) { IsReadOnly = true };
+        }
+
+        // Adjust word boundaries after double-click (consistent with IL Inspector)
+        if (state.PackageInfoEditorState is not null && state.IsBrowsingPackage)
+        {
+            IlInspectorView.AdjustWordSelectionCursorOneShot(
+                state.PackageInfoEditorState,
+                ref state.PackageInfoPrevSelectionAnchor,
+                ref state.PackageInfoPrevCursorPosition);
+        }
+
         return ctx.VStack(outer =>
         {
             var widgets = new List<Hex1bWidget>
             {
-                // Package metadata
+                // Package metadata (read-only editor for text selection + yank)
                 outer.Border(
-                outer.VStack(info =>
-                [
-                    InfoLine(info, "Package ID", pkg.PackageId ?? "(unknown)", query),
-                    InfoLine(info, "Version", pkg.PackageVersion ?? "(unknown)", query),
-                    InfoLine(info, "Authors", pkg.Authors ?? "(unknown)", query),
-                    InfoLine(info, "Description", pkg.Description ?? "(none)", query),
-                    info.Text(""),
-                    InfoLine(info, "Total Files", pkg.Files.Count.ToString(), query),
-                    InfoLine(info, "DLL Files", pkg.DllFiles.Count.ToString(), query),
-                    InfoLine(info, "Total Size", DotsiderState.FormatSize(pkg.Files.Sum(f => f.UncompressedSize)), query)
-                ])
-            ).Title(" Package Info ")
+                    outer.ThemePanel(t => t
+                        .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
+                        .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
+                    outer.Editor(state.PackageInfoEditorState!)
+                        .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                        .Decorations(new InfoLabelDecorationProvider())
+                        .Decorations(state.PackageInfoYankProvider)
+                        .FillWidth().FillHeight())
+                ).Title(" Package Info ").FixedHeight(11)
             };
 
             // Search bar
@@ -67,24 +99,45 @@ public static class NuGetBrowserView
                         h.Cell("Size").Width(SizeHint.Fixed(12))
                     ])
                     .Row((r, entry, rowState) =>
-                    [
-                        r.Cell(c => HighlightHelper.HighlightCell(c, entry.Name, query, !string.IsNullOrEmpty(query),
-                            rowState.IsFocused ? Hex1bColor.Black : null, rowState.IsFocused ? Hex1bColor.FromRgb(0, 200, 180) : null)),
-                        r.Cell(c => HighlightHelper.HighlightCell(c, entry.Directory, query, !string.IsNullOrEmpty(query),
-                            rowState.IsFocused ? Hex1bColor.Black : null, rowState.IsFocused ? Hex1bColor.FromRgb(0, 200, 180) : null)),
-                        r.Cell(DotsiderState.FormatSize(entry.UncompressedSize))
-                    ])
-                    .Focus(state.FileTreeFocusedKey)
+                    {
+                        var flash = rowState.IsFocused && state.YankFlashRow;
+                        var fg = flash ? Hex1bColor.FromRgb(24, 24, 37)
+                            : rowState.IsFocused ? Hex1bColor.Black
+                            : (Hex1bColor?)null;
+                        var bg = flash ? Hex1bColor.FromRgb(126, 201, 216)
+                            : rowState.IsFocused ? Hex1bColor.FromRgb(0, 200, 180)
+                            : (Hex1bColor?)null;
+
+                        return
+                        [
+                            r.Cell(c => rowState.IsFocused
+                                ? c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg!.Value).Set(GlobalTheme.BackgroundColor, bg!.Value),
+                                    HighlightHelper.HighlightCell(c, entry.Name, query, !string.IsNullOrEmpty(query), fg, bg))
+                                : HighlightHelper.HighlightCell(c, entry.Name, query, !string.IsNullOrEmpty(query), fg, bg)),
+                            r.Cell(c => rowState.IsFocused
+                                ? c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg!.Value).Set(GlobalTheme.BackgroundColor, bg!.Value),
+                                    HighlightHelper.HighlightCell(c, entry.Directory, query, !string.IsNullOrEmpty(query), fg, bg))
+                                : HighlightHelper.HighlightCell(c, entry.Directory, query, !string.IsNullOrEmpty(query), fg, bg)),
+                            r.Cell(c => rowState.IsFocused
+                                ? c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg!.Value).Set(GlobalTheme.BackgroundColor, bg!.Value),
+                                    c.Text(DotsiderState.FormatSize(entry.UncompressedSize)))
+                                : c.Text(DotsiderState.FormatSize(entry.UncompressedSize)))
+                        ];
+                    })
+                    .Focus(state.App.FocusedNode is EditorNode ? null : state.FileTreeFocusedKey)
                     .OnFocusChanged(key => state.FileTreeFocusedKey = key)
                     .OnRowActivated((_, entry) =>
                     {
                         try
                         {
+                            state.SavedFileTreeFocusedKey = state.FileTreeFocusedKey;
                             var analyzer = pkg.OpenDll(entry);
                             state.SelectedDllState?.Dispose();
                             state.SelectedDllState = new DotsiderState(state.App, analyzer);
                             state.SelectedDllEntry = entry;
                             state.IsBrowsingPackage = false;
+                            state.App.RequestFocus(node =>
+                                node.GetType().Name.StartsWith("TableNode"));
                             state.App.Invalidate();
                         }
                         catch (Exception ex)
@@ -94,19 +147,32 @@ public static class NuGetBrowserView
                     })
                     .Compact()
                     .Empty(e => e.Text("  No DLL files in package"))
+                    .FillWidth()
                     .FillHeight()
             ).Title($" DLL Files ({pkg.DllFiles.Count}) — Enter to inspect ").Fill());
 
             return [.. widgets];
-        }).Fill();
-    }
-
-    private static HStackWidget InfoLine<T>(WidgetContext<T> ctx, string label, string value, string? query) where T : Hex1bWidget
-    {
-        return ctx.HStack(row =>
-        [
-            row.Text($"  {label}: ").FixedWidth(18),
-            HighlightHelper.HighlightText(row, value, query)
-        ]).FixedHeight(1);
+        })
+        .WithInputBindings(bindings =>
+        {
+            // Tab toggles focus between Package Info editor and DLL table
+            bindings.Key(Hex1b.Input.Hex1bKey.Tab).Global().Action(_ =>
+            {
+                if (state.App.FocusedNode is EditorNode)
+                {
+                    state.FileTreeFocusedKey ??=
+                        pkg.DllFiles.Count > 0 ? pkg.DllFiles[0].FullPath : null;
+                    state.App.RequestFocus(node =>
+                        node.GetType().Name.StartsWith("TableNode"));
+                    state.App.Invalidate();
+                }
+                else
+                {
+                    state.App.RequestFocus(node => node is EditorNode);
+                    state.App.Invalidate();
+                }
+            }, "Toggle focus");
+        })
+        .Fill();
     }
 }

--- a/src/Dotsider/Views/PeMetadataView.cs
+++ b/src/Dotsider/Views/PeMetadataView.cs
@@ -1,6 +1,6 @@
-using System.Text;
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
+using Hex1b.Documents;
 using Hex1b.Input;
 using Hex1b.Layout;
 using Hex1b.Theming;
@@ -14,10 +14,10 @@ namespace Dotsider.Views;
 /// </summary>
 public static class PeMetadataView
 {
-    private static readonly Hex1bColor LabelColor = Hex1bColor.FromRgb(100, 130, 160);
     private static readonly Hex1bColor AddressColor = Hex1bColor.FromRgb(100, 100, 130);
-    private static readonly string AddressAnsi = AddressColor.ToForegroundAnsi();
-    private const string AnsiReset = "\x1b[0m";
+
+    /// <summary>Set per-frame to enable yank flash on the focused table row.</summary>
+    [ThreadStatic] private static bool s_yankFlash;
 
     /// <summary>
     /// Builds the PE/Metadata view widget tree.
@@ -27,6 +27,7 @@ public static class PeMetadataView
     /// <returns>The root widget for the PE/Metadata tab.</returns>
     public static Hex1bWidget Build(WidgetContext<VStackWidget> ctx, DotsiderState state)
     {
+        s_yankFlash = state.YankFlashRow;
         var analyzer = state.Analyzer;
         var search = state.Search[TabId.PeMetadata];
 
@@ -70,6 +71,74 @@ public static class PeMetadataView
                 };
         }
 
+        // Build PE Headers text for read-only editor
+        var peText = analyzer.PeHeaders is { } pe
+            ? string.Join("\n",
+                $"  Machine:            {pe.Machine}",
+                $"  Magic:              {pe.Magic}",
+                $"  Characteristics:    {pe.Characteristics}",
+                $"  Timestamp:          0x{pe.TimeDateStamp:X8}",
+                $"  Linker Version:     {pe.MajorLinkerVersion}.{pe.MinorLinkerVersion}",
+                $"  Size of Code:       {FormatSize(pe.SizeOfCode, state)}",
+                $"  Entry Point RVA:    0x{pe.EntryPointRva:X8}",
+                $"  Image Base:         0x{pe.ImageBase:X16}",
+                $"  Section Alignment:  {FormatSize(pe.SectionAlignment, state)}",
+                $"  File Alignment:     {FormatSize(pe.FileAlignment, state)}",
+                $"  Size of Image:      {FormatSize(pe.SizeOfImage, state)}",
+                $"  Size of Headers:    {FormatSize(pe.SizeOfHeaders, state)}",
+                $"  Subsystem:          {pe.Subsystem}",
+                $"  DLL Characteristics:{pe.DllCharacteristics}",
+                $"  Number of Sections: {pe.NumberOfSections}")
+            : "  No PE headers available";
+
+        if (state.PeHeadersEditorText != peText)
+        {
+            state.PeHeadersEditorText = peText;
+            state.PeHeadersEditorState = new EditorState(new Hex1bDocument(peText)) { IsReadOnly = true };
+        }
+
+        // Build CLR Header text for read-only editor
+        var clrText = analyzer.ClrHeader is { } clr
+            ? string.Join("\n",
+                $"  Runtime Version:    {clr.MajorRuntimeVersion}.{clr.MinorRuntimeVersion}",
+                $"  Metadata RVA:       0x{clr.MetadataRva:X8}",
+                $"  Metadata Size:      {FormatSize(clr.MetadataSize, state)}",
+                $"  Flags:              {clr.Flags}",
+                $"  Entry Point Token:  0x{clr.EntryPointToken:X8}",
+                $"  Resources RVA:      0x{clr.ResourcesRva:X8}",
+                $"  Resources Size:     {FormatSize(clr.ResourcesSize, state)}",
+                $"  Strong Name RVA:    0x{clr.StrongNameSignatureRva:X8}",
+                $"  Strong Name Size:   {FormatSize(clr.StrongNameSignatureSize, state)}")
+            : "  No CLR header (not a .NET assembly)";
+
+        if (state.ClrHeaderEditorText != clrText)
+        {
+            state.ClrHeaderEditorText = clrText;
+            state.ClrHeaderEditorState = new EditorState(new Hex1bDocument(clrText)) { IsReadOnly = true };
+        }
+
+        // Build detail popup editor state when content changes
+        if (state.PeDetailContent is not null && state.PeDetailEditorText != state.PeDetailContent)
+        {
+            state.PeDetailEditorText = state.PeDetailContent;
+            state.PeDetailEditorState = new EditorState(new Hex1bDocument(state.PeDetailContent)) { IsReadOnly = true };
+        }
+
+        // Adjust word boundaries after double-click (consistent with IL Inspector)
+        if (state.CurrentTab == TabId.PeMetadata)
+        {
+            if (state.PeHeadersEditorState is not null)
+                IlInspectorView.AdjustWordSelectionCursorOneShot(
+                    state.PeHeadersEditorState,
+                    ref state.PeHeadersPrevSelectionAnchor,
+                    ref state.PeHeadersPrevCursorPosition);
+            if (state.ClrHeaderEditorState is not null)
+                IlInspectorView.AdjustWordSelectionCursorOneShot(
+                    state.ClrHeaderEditorState,
+                    ref state.ClrHeaderPrevSelectionAnchor,
+                    ref state.ClrHeaderPrevCursorPosition);
+        }
+
         return ctx.ZStack(z =>
         [
             // Layer 0: Main content
@@ -77,64 +146,32 @@ public static class PeMetadataView
             {
                 var widgets = new List<Hex1bWidget>
                 {
-                    // Top section: PE Headers | CLR Header (side by side)
+                    // Top section: PE Headers | CLR Header (side by side, read-only editors)
                     outer.HSplitter(
                     left =>
                     [
                         left.Border(
-                            left.VScrollPanel(scroll =>
-                            {
-                                var lines = new List<Hex1bWidget>();
-                                if (analyzer.PeHeaders is { } pe)
-                                {
-                                    lines.Add(PeLine(scroll, "Machine", pe.Machine.ToString()));
-                                    lines.Add(PeLine(scroll, "Magic", pe.Magic.ToString()));
-                                    lines.Add(PeLine(scroll, "Characteristics", pe.Characteristics.ToString()));
-                                    lines.Add(PeLine(scroll, "Timestamp", $"0x{pe.TimeDateStamp:X8}"));
-                                    lines.Add(PeLine(scroll, "Linker Version", $"{pe.MajorLinkerVersion}.{pe.MinorLinkerVersion}"));
-                                    lines.Add(PeLine(scroll, "Size of Code", FormatSize(pe.SizeOfCode, state)));
-                                    lines.Add(PeLine(scroll, "Entry Point RVA", $"0x{pe.EntryPointRva:X8}"));
-                                    lines.Add(PeLine(scroll, "Image Base", $"0x{pe.ImageBase:X16}"));
-                                    lines.Add(PeLine(scroll, "Section Alignment", FormatSize(pe.SectionAlignment, state)));
-                                    lines.Add(PeLine(scroll, "File Alignment", FormatSize(pe.FileAlignment, state)));
-                                    lines.Add(PeLine(scroll, "Size of Image", FormatSize(pe.SizeOfImage, state)));
-                                    lines.Add(PeLine(scroll, "Size of Headers", FormatSize(pe.SizeOfHeaders, state)));
-                                    lines.Add(PeLine(scroll, "Subsystem", pe.Subsystem.ToString()));
-                                    lines.Add(PeLine(scroll, "DLL Characteristics", pe.DllCharacteristics.ToString()));
-                                    lines.Add(PeLine(scroll, "Number of Sections", pe.NumberOfSections.ToString()));
-                                }
-                                else
-                                {
-                                    lines.Add(scroll.Text("  No PE headers available"));
-                                }
-                                return [.. lines];
-                            })
+                            left.ThemePanel(t => t
+                                .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
+                                .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
+                            left.Editor(state.PeHeadersEditorState!)
+                                .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                                .Decorations(new InfoLabelDecorationProvider())
+                                .Decorations(state.PeHeadersYankProvider)
+                                .FillWidth().FillHeight())
                         ).Title(" PE Headers ").Fill()
                     ],
                     right =>
                     [
                         right.Border(
-                            right.VScrollPanel(scroll =>
-                            {
-                                var lines = new List<Hex1bWidget>();
-                                if (analyzer.ClrHeader is { } clr)
-                                {
-                                    lines.Add(PeLine(scroll, "Runtime Version", $"{clr.MajorRuntimeVersion}.{clr.MinorRuntimeVersion}"));
-                                    lines.Add(PeLine(scroll, "Metadata RVA", $"0x{clr.MetadataRva:X8}"));
-                                    lines.Add(PeLine(scroll, "Metadata Size", FormatSize(clr.MetadataSize, state)));
-                                    lines.Add(PeLine(scroll, "Flags", clr.Flags.ToString()));
-                                    lines.Add(PeLine(scroll, "Entry Point Token", $"0x{clr.EntryPointToken:X8}"));
-                                    lines.Add(PeLine(scroll, "Resources RVA", $"0x{clr.ResourcesRva:X8}"));
-                                    lines.Add(PeLine(scroll, "Resources Size", FormatSize(clr.ResourcesSize, state)));
-                                    lines.Add(PeLine(scroll, "Strong Name RVA", $"0x{clr.StrongNameSignatureRva:X8}"));
-                                    lines.Add(PeLine(scroll, "Strong Name Size", FormatSize(clr.StrongNameSignatureSize, state)));
-                                }
-                                else
-                                {
-                                    lines.Add(scroll.Text("  No CLR header (not a .NET assembly)"));
-                                }
-                                return [.. lines];
-                            })
+                            right.ThemePanel(t => t
+                                .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
+                                .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
+                            right.Editor(state.ClrHeaderEditorState!)
+                                .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                                .Decorations(new InfoLabelDecorationProvider())
+                                .Decorations(state.ClrHeaderYankProvider)
+                                .FillWidth().FillHeight())
                         ).Title(" CLR Header ").Fill()
                     ],
                     leftWidth: 50).FixedHeight(12)
@@ -192,29 +229,60 @@ public static class PeMetadataView
 
                 if (!isSearchEditing)
                 {
-                    bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
+                    // Only register Left/Right for sub-tab switching when no editor is focused
+                    // (otherwise they consume the key and the editor never sees it)
+                    if (state.App.FocusedNode is not EditorNode)
                     {
-                        if (state.PeSubTab > 0)
+                        bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
                         {
-                            state.PeSubTab--;
-                            search.Reset();
-                            state.PeFocusedKey = null;
-                            state.RequestContentFocus();
-                            state.App.Invalidate();
-                        }
-                    }, "Previous sub-tab");
+                            if (state.PeSubTab > 0)
+                            {
+                                state.PeSubTab--;
+                                search.Reset();
+                                state.PeFocusedKey = null;
+                                state.RequestContentFocus();
+                                state.App.Invalidate();
+                            }
+                        }, "Previous sub-tab");
 
-                    bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
-                    {
-                        if (state.PeSubTab < PeSubTabId.Count - 1)
+                        bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
                         {
-                            state.PeSubTab++;
-                            search.Reset();
-                            state.PeFocusedKey = null;
-                            state.RequestContentFocus();
-                            state.App.Invalidate();
+                            if (state.PeSubTab < PeSubTabId.Count - 1)
+                            {
+                                state.PeSubTab++;
+                                search.Reset();
+                                state.PeFocusedKey = null;
+                                state.RequestContentFocus();
+                                state.App.Invalidate();
+                            }
+                        }, "Next sub-tab");
+                    }
+
+                    // Tab cycles focus: PE Headers → CLR Header → Table → PE Headers
+                    bindings.Key(Hex1bKey.Tab).Global().Action(_ =>
+                    {
+                        if (state.App.FocusedNode is EditorNode { State: var es })
+                        {
+                            if (es == state.PeHeadersEditorState)
+                            {
+                                // PE Headers → CLR Header
+                                state.App.RequestFocus(node =>
+                                    node is EditorNode e && e.State == state.ClrHeaderEditorState);
+                            }
+                            else
+                            {
+                                // CLR Header (or detail popup) → Table
+                                state.RequestContentFocus();
+                            }
                         }
-                    }, "Next sub-tab");
+                        else
+                        {
+                            // Table → PE Headers
+                            state.App.RequestFocus(node =>
+                                node is EditorNode e && e.State == state.PeHeadersEditorState);
+                        }
+                        state.App.Invalidate();
+                    }, "Cycle focus");
 
                     // g: Go to IL Inspector for focused TypeDef or MethodDef
                     if (state.PeSubTab is PeSubTabId.TypeDef or PeSubTabId.MethodDef)
@@ -259,18 +327,24 @@ public static class PeMetadataView
             })
             .Fill(),
 
-            // Layer 1: Detail popup overlay (conditional)
-            state.PeDetailContent is not null
+            // Layer 1: Detail popup overlay (read-only editor for selection + yank)
+            state.PeDetailContent is not null && state.PeDetailEditorState is not null
                 ? z.Backdrop(
                     z.Border(
-                        z.VStack(dlg =>
-                            [.. state.PeDetailContent.Split('\n')
-                                .Select(line => DetailLine(dlg, line))]
-                        )
+                        z.ThemePanel(t => t
+                            .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
+                            .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
+                        z.Editor(state.PeDetailEditorState)
+                            .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                            .Decorations(new InfoLabelDecorationProvider())
+                            .Decorations(state.PeDetailYankProvider)
+                            .FillWidth().FillHeight())
                     ).Title(" Detail ").FixedWidth(60).FixedHeight(12)
                 ).OnClickAway(() =>
                 {
                     state.PeDetailContent = null;
+                    state.PeDetailEditorText = null;
+                    state.PeDetailEditorState = null;
                     state.RequestContentFocus();
                     state.App.Invalidate();
                 })
@@ -299,13 +373,13 @@ public static class PeMetadataView
             .Row((r, s, rs) =>
             [
                 r.Cell(c => FocusHighlightCell(c,s.Name, query, true, rs.IsFocused)),
-                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{s.VirtualAddress:X8}"), rs.IsFocused)),
-                r.Cell(c => FocusStyle(c, c.Text(FormatSize(s.VirtualSize, state)), rs.IsFocused)),
-                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{s.RawDataOffset:X8}"), rs.IsFocused)),
-                r.Cell(c => FocusStyle(c, c.Text(FormatSize(s.RawDataSize, state)), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,HexCell(c, $"0x{s.VirtualAddress:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,c.Text(FormatSize(s.VirtualSize, state)), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,HexCell(c, $"0x{s.RawDataOffset:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,c.Text(FormatSize(s.RawDataSize, state)), rs.IsFocused)),
                 r.Cell(c => FocusHighlightCell(c,s.Characteristics.ToString(), query, true, rs.IsFocused))
             ])
-            .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
+            .Focus(state.PeDetailContent is not null || state.App.FocusedNode is EditorNode ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
             .OnRowActivated((_, s) =>
             {
@@ -316,6 +390,7 @@ public static class PeMetadataView
                     $"Raw Offset: 0x{s.RawDataOffset:X8}",
                     $"Raw Size: {s.RawDataSize} (0x{s.RawDataSize:X})",
                     $"Characteristics: {s.Characteristics}");
+                state.App.RequestFocus(node => node is EditorNode);
                 state.App.Invalidate();
             })
             .Compact().Fill();
@@ -341,14 +416,14 @@ public static class PeMetadataView
             ])
             .Row((r, t, rs) =>
             [
-                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{t.Token:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,HexCell(c, $"0x{t.Token:X8}"), rs.IsFocused)),
                 r.Cell(c => FocusHighlightCell(c,t.FullName, query, true, rs.IsFocused)),
                 r.Cell(c => FocusHighlightCell(c,t.BaseType ?? "", query, true, rs.IsFocused)),
                 r.Cell(c => FocusHighlightCell(c,t.Attributes.ToString(), query, true, rs.IsFocused)),
-                r.Cell(c => FocusStyle(c, c.Text(t.MethodCount.ToString()), rs.IsFocused)),
-                r.Cell(c => FocusStyle(c, c.Text(t.FieldCount.ToString()), rs.IsFocused))
+                r.Cell(c => FocusStyle(c,c.Text(t.MethodCount.ToString()), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,c.Text(t.FieldCount.ToString()), rs.IsFocused))
             ])
-            .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
+            .Focus(state.PeDetailContent is not null || state.App.FocusedNode is EditorNode ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
             .OnRowActivated((_, t) =>
             {
@@ -359,6 +434,7 @@ public static class PeMetadataView
                     $"Attributes: {t.Attributes}",
                     $"Methods: {t.MethodCount}",
                     $"Fields: {t.FieldCount}");
+                state.App.RequestFocus(node => node is EditorNode);
                 state.App.Invalidate();
             })
             .Compact().Fill();
@@ -384,14 +460,14 @@ public static class PeMetadataView
             ])
             .Row((r, m, rs) =>
             [
-                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{m.Token:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,HexCell(c, $"0x{m.Token:X8}"), rs.IsFocused)),
                 r.Cell(c => FocusHighlightCell(c,m.DeclaringType, query, true, rs.IsFocused)),
                 r.Cell(c => FocusHighlightCell(c,m.Name, query, true, rs.IsFocused)),
                 r.Cell(c => FocusHighlightCell(c,m.Signature, query, true, rs.IsFocused)),
-                r.Cell(c => FocusStyle(c, c.Text(m.Attributes.ToString()), rs.IsFocused)),
-                r.Cell(c => FocusStyle(c, m.Rva == 0 ? c.Text("") : HexCell(c, $"0x{m.Rva:X8}"), rs.IsFocused))
+                r.Cell(c => FocusStyle(c,c.Text(m.Attributes.ToString()), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,m.Rva == 0 ? c.Text("") : HexCell(c, $"0x{m.Rva:X8}"), rs.IsFocused))
             ])
-            .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
+            .Focus(state.PeDetailContent is not null || state.App.FocusedNode is EditorNode ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
             .OnRowActivated((_, m) =>
             {
@@ -402,6 +478,7 @@ public static class PeMetadataView
                     $"Attributes: {m.Attributes}",
                     $"Impl: {m.ImplAttributes}",
                     $"RVA: 0x{m.Rva:X8}");
+                state.App.RequestFocus(node => node is EditorNode);
                 state.App.Invalidate();
             })
             .Compact().Fill();
@@ -424,11 +501,11 @@ public static class PeMetadataView
             ])
             .Row((r, t, rs) =>
             [
-                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{t.Token:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,HexCell(c, $"0x{t.Token:X8}"), rs.IsFocused)),
                 r.Cell(c => FocusHighlightCell(c,t.FullName, query, true, rs.IsFocused)),
                 r.Cell(c => FocusHighlightCell(c,t.ResolutionScope, query, true, rs.IsFocused))
             ])
-            .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
+            .Focus(state.PeDetailContent is not null || state.App.FocusedNode is EditorNode ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
             .OnRowActivated((_, t) =>
             {
@@ -438,6 +515,7 @@ public static class PeMetadataView
                     $"Namespace: {t.Namespace}",
                     $"Name: {t.Name}",
                     $"Resolution Scope: {t.ResolutionScope}");
+                state.App.RequestFocus(node => node is EditorNode);
                 state.App.Invalidate();
             })
             .Compact().Fill();
@@ -460,17 +538,18 @@ public static class PeMetadataView
             ])
             .Row((r, m, rs) =>
             [
-                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{m.Token:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,HexCell(c, $"0x{m.Token:X8}"), rs.IsFocused)),
                 r.Cell(c => FocusHighlightCell(c,m.DeclaringType, query, true, rs.IsFocused)),
                 r.Cell(c => FocusHighlightCell(c,m.Name, query, true, rs.IsFocused))
             ])
-            .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
+            .Focus(state.PeDetailContent is not null || state.App.FocusedNode is EditorNode ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
             .OnRowActivated((_, m) =>
             {
                 state.PeDetailContent = string.Join("\n",
                     $"MemberRef: {m.DeclaringType}::{m.Name}",
                     $"Token: 0x{m.Token:X8}");
+                state.App.RequestFocus(node => node is EditorNode);
                 state.App.Invalidate();
             })
             .Compact().Fill();
@@ -497,7 +576,7 @@ public static class PeMetadataView
                 r.Cell(c => FocusHighlightCell(c,a.Constructor, query, true, rs.IsFocused)),
                 r.Cell(c => FocusHighlightCell(c,a.Value ?? "", query, true, rs.IsFocused))
             ])
-            .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
+            .Focus(state.PeDetailContent is not null || state.App.FocusedNode is EditorNode ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
             .OnRowActivated((_, a) =>
             {
@@ -506,6 +585,7 @@ public static class PeMetadataView
                     $"Parent: {a.Parent}",
                     $"Constructor: {a.Constructor}",
                     $"Value: {a.Value ?? "null"}");
+                state.App.RequestFocus(node => node is EditorNode);
                 state.App.Invalidate();
             })
             .Compact().Fill();
@@ -532,11 +612,11 @@ public static class PeMetadataView
             [
                 r.Cell(c => FocusHighlightCell(c,res.Name, query, true, rs.IsFocused)),
                 r.Cell(c => FocusHighlightCell(c,res.Visibility, query, true, rs.IsFocused)),
-                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{res.Offset:X8}"), rs.IsFocused)),
-                r.Cell(c => FocusStyle(c, c.Text(res.Size >= 0 ? FormatSize((int)res.Size, state) : "?"), rs.IsFocused)),
-                r.Cell(c => FocusStyle(c, c.Text(res.IsLinked ? "Yes" : "No"), rs.IsFocused))
+                r.Cell(c => FocusStyle(c,HexCell(c, $"0x{res.Offset:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,c.Text(res.Size >= 0 ? FormatSize((int)res.Size, state) : "?"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,c.Text(res.IsLinked ? "Yes" : "No"), rs.IsFocused))
             ])
-            .Focus(state.PeDetailContent is not null ? null : state.PeFocusedKey)
+            .Focus(state.PeDetailContent is not null || state.App.FocusedNode is EditorNode ? null : state.PeFocusedKey)
             .OnFocusChanged(key => state.PeFocusedKey = key)
             .OnRowActivated((_, res) =>
             {
@@ -546,6 +626,7 @@ public static class PeMetadataView
                     $"Offset: 0x{res.Offset:X8}",
                     $"Size: {(res.Size >= 0 ? res.Size.ToString() : "unknown")}",
                     $"Linked: {res.IsLinked}");
+                state.App.RequestFocus(node => node is EditorNode);
                 state.App.Invalidate();
             })
             .Compact().Fill();
@@ -567,81 +648,30 @@ public static class PeMetadataView
 
     private static readonly Hex1bColor FocusFg = Hex1bColor.Black;
     private static readonly Hex1bColor FocusBg = Hex1bColor.FromRgb(0, 200, 180);
+    private static readonly Hex1bColor YankFlashFg = Hex1bColor.FromRgb(24, 24, 37);
+    private static readonly Hex1bColor YankFlashBg = Hex1bColor.FromRgb(126, 201, 216);
 
     private static Hex1bWidget FocusStyle<T>(WidgetContext<T> c, Hex1bWidget child, bool isFocused)
-        where T : Hex1bWidget =>
-        isFocused ? c.ThemePanel(t => t
-            .Set(GlobalTheme.ForegroundColor, FocusFg)
-            .Set(GlobalTheme.BackgroundColor, FocusBg), child) : child;
+        where T : Hex1bWidget
+    {
+        if (!isFocused) return child;
+        var flash = s_yankFlash;
+        var fg = flash ? YankFlashFg : FocusFg;
+        var bg = flash ? YankFlashBg : FocusBg;
+        return c.ThemePanel(t => t
+            .Set(GlobalTheme.ForegroundColor, fg)
+            .Set(GlobalTheme.BackgroundColor, bg), child);
+    }
 
     private static Hex1bWidget FocusHighlightCell<T>(
         WidgetContext<T> c, string text, string? query, bool isMatch, bool isFocused)
-        where T : Hex1bWidget =>
-        FocusStyle(c, HighlightHelper.HighlightCell(c, text, query, isMatch,
-            isFocused ? FocusFg : null, isFocused ? FocusBg : null), isFocused);
-
-    private static HStackWidget PeLine<T>(WidgetContext<T> ctx, string label, string value) where T : Hex1bWidget
+        where T : Hex1bWidget
     {
-        return ctx.HStack(row =>
-        [
-            row.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, LabelColor),
-                row.Text($"  {label}: ")).FixedWidth(22),
-            row.Text(value)
-        ]).FixedHeight(1);
+        var flash = isFocused && s_yankFlash;
+        var fg = isFocused ? (flash ? YankFlashFg : FocusFg) : (Hex1bColor?)null;
+        var bg = isFocused ? (flash ? YankFlashBg : FocusBg) : (Hex1bColor?)null;
+        return FocusStyle(c, HighlightHelper.HighlightCell(c, text, query, isMatch, fg, bg), isFocused);
     }
-
-    private static Hex1bWidget DetailLine<T>(WidgetContext<T> ctx, string line) where T : Hex1bWidget
-    {
-        var colonIdx = line.IndexOf(": ", StringComparison.Ordinal);
-        if (colonIdx < 0)
-            return ctx.Text($"  {line}");
-
-        var label = line[..colonIdx];
-        var value = line[(colonIdx + 2)..];
-
-        return ctx.HStack(row =>
-        [
-            row.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, LabelColor),
-                row.Text($"  {label}: ")).FixedWidth(22),
-            row.Text(ColorizeHexValues(value))
-        ]).FixedHeight(1);
-    }
-
-    private static string ColorizeHexValues(string text)
-    {
-        var sb = new StringBuilder(text.Length + 32);
-        var i = 0;
-        while (i < text.Length)
-        {
-            if (i + 2 < text.Length && text[i] == '0' && text[i + 1] is 'x' or 'X')
-            {
-                var start = i;
-                i += 2;
-                while (i < text.Length && IsHexDigit(text[i]))
-                    i++;
-                if (i > start + 2)
-                {
-                    sb.Append(AddressAnsi);
-                    sb.Append(text, start, i - start);
-                    sb.Append(AnsiReset);
-                }
-                else
-                {
-                    sb.Append(text, start, i - start);
-                }
-            }
-            else
-            {
-                sb.Append(text[i]);
-                i++;
-            }
-        }
-
-        return sb.ToString();
-    }
-
-    private static bool IsHexDigit(char c) =>
-        c is (>= '0' and <= '9') or (>= 'a' and <= 'f') or (>= 'A' and <= 'F');
 
     private static IReadOnlyList<object> GetActiveRowKeys(DotsiderState state)
     {

--- a/src/Dotsider/Views/StringsDetailDecorationProvider.cs
+++ b/src/Dotsider/Views/StringsDetailDecorationProvider.cs
@@ -1,0 +1,42 @@
+using Hex1b.Documents;
+using Hex1b.Theming;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// Provides label coloring for the Strings detail popup editor.
+/// Only highlights the first line ("Length: N") — string content lines are left unstyled.
+/// </summary>
+public sealed class StringsDetailDecorationProvider : ITextDecorationProvider
+{
+    private static readonly TextDecoration LabelDecoration = new()
+    {
+        Foreground = Hex1bColor.FromRgb(100, 130, 160)
+    };
+
+    /// <inheritdoc />
+    public IReadOnlyList<TextDecorationSpan> GetDecorations(
+        int startLine, int endLine, IHex1bDocument document)
+    {
+        // Only color the "Length:" label on line 1
+        if (startLine > 1)
+            return [];
+
+        var text = document.GetLineText(1);
+        if (string.IsNullOrEmpty(text))
+            return [];
+
+        var colonIdx = text.IndexOf(':');
+        if (colonIdx < 0)
+            return [];
+
+        return
+        [
+            new TextDecorationSpan(
+                new DocumentPosition(1, 1),
+                new DocumentPosition(1, colonIdx + 2),
+                LabelDecoration,
+                5)
+        ];
+    }
+}

--- a/src/Dotsider/Views/StringsView.cs
+++ b/src/Dotsider/Views/StringsView.cs
@@ -1,5 +1,6 @@
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
+using Hex1b.Documents;
 using Hex1b.Input;
 using Hex1b.Layout;
 using Hex1b.Theming;
@@ -14,7 +15,7 @@ namespace Dotsider.Views;
 public static class StringsView
 {
     private static readonly Hex1bColor AddressColor = Hex1bColor.FromRgb(100, 100, 130);
-    private static readonly Hex1bColor LabelColor = Hex1bColor.FromRgb(100, 130, 160);
+    [ThreadStatic] private static bool s_yankFlash;
     private static readonly string[] SourceTabs = ["User Strings (#US)", "Metadata (#Strings)", "Raw Binary"];
 
     /// <summary>
@@ -25,6 +26,7 @@ public static class StringsView
     /// <returns>The root widget for the Strings tab.</returns>
     public static Hex1bWidget Build(WidgetContext<VStackWidget> ctx, DotsiderState state)
     {
+        s_yankFlash = state.YankFlashRow;
         var search = state.Search[TabId.Strings];
         var activeStrings = state.GetActiveStrings();
         var query = search.Query;
@@ -62,6 +64,14 @@ public static class StringsView
             {
                 state.StringsFocusedKey = RowKey(activeStrings[0]);
             }
+        }
+
+        // Build detail popup editor state when content changes
+        if (state.StringsDetailContent is not null && state.StringsDetailEditorText != state.StringsDetailContent)
+        {
+            state.StringsDetailEditorText = state.StringsDetailContent;
+            var detailText = $"  Length: {state.StringsDetailContent.Length}\n\n  {state.StringsDetailContent.Replace("\n", "\n  ")}";
+            state.StringsDetailEditorState = new EditorState(new Hex1bDocument(detailText)) { IsReadOnly = true };
         }
 
         return ctx.ZStack(z =>
@@ -134,29 +144,32 @@ public static class StringsView
                 // Left/Right arrows to switch sub-tabs (suppressed during search editing)
                 if (!isSearchEditing)
                 {
-                    bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
+                    if (state.App.FocusedNode is not EditorNode)
                     {
-                        if (state.StringsSourceTab > 0)
+                        bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
                         {
-                            state.StringsSourceTab--;
-                            search.Reset();
-                            state.StringsFocusedKey = null;
-                            state.RequestContentFocus();
-                            state.App.Invalidate();
-                        }
-                    }, "Previous sub-tab");
+                            if (state.StringsSourceTab > 0)
+                            {
+                                state.StringsSourceTab--;
+                                search.Reset();
+                                state.StringsFocusedKey = null;
+                                state.RequestContentFocus();
+                                state.App.Invalidate();
+                            }
+                        }, "Previous sub-tab");
 
-                    bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
-                    {
-                        if (state.StringsSourceTab < StringsSubTabId.Count - 1)
+                        bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
                         {
-                            state.StringsSourceTab++;
+                            if (state.StringsSourceTab < StringsSubTabId.Count - 1)
+                            {
+                                state.StringsSourceTab++;
                             search.Reset();
                             state.StringsFocusedKey = null;
                             state.RequestContentFocus();
                             state.App.Invalidate();
                         }
                     }, "Next sub-tab");
+                    }
                 }
 
                 bindings.Key(Hex1bKey.OemPlus).Action(_ =>
@@ -207,32 +220,29 @@ public static class StringsView
             })
             .Fill(),
 
-            // Layer 1: String detail popup (conditional)
-            state.StringsDetailContent is not null
+            // Layer 1: String detail popup (read-only editor for selection + yank)
+            state.StringsDetailContent is not null && state.StringsDetailEditorState is not null
                 ? z.Backdrop(
                     z.Align(Alignment.Center,
                         z.VStack(outer =>
                         [
                             outer.Border(
-                                outer.VScrollPanel(scroll =>
-                                [
-                                    scroll.HStack(row =>
-                                    [
-                                        row.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, LabelColor),
-                                            row.Text("  Length: ")),
-                                        row.Text(state.StringsDetailContent.Length.ToString())
-                                    ]).FixedHeight(1),
-                                    scroll.Text(""),
-                                    .. state.StringsDetailContent
-                                        .Split('\n')
-                                        .Select(line => scroll.Text($"  {line}"))
-                                ])
+                                outer.ThemePanel(t => t
+                                    .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
+                                    .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
+                                outer.Editor(state.StringsDetailEditorState)
+                                    .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                                    .Decorations(new StringsDetailDecorationProvider())
+                                    .Decorations(state.StringsDetailYankProvider)
+                                    .FillWidth().FillHeight())
                             ).Title(" String Detail ").FixedWidth(70).FillHeight()
                         ]).FixedWidth(70).FixedHeight(15)
                     )
                 ).OnClickAway(() =>
                 {
                     state.StringsDetailContent = null;
+                    state.StringsDetailEditorText = null;
+                    state.StringsDetailEditorState = null;
                     state.RequestContentFocus();
                     state.App.Invalidate();
                 })
@@ -271,6 +281,7 @@ public static class StringsView
             .OnRowActivated((key, entry) =>
             {
                 state.StringsDetailContent = entry.Value;
+                state.App.RequestFocus(node => node is EditorNode);
                 state.App.Invalidate();
             })
             .Compact().Fill();
@@ -278,12 +289,20 @@ public static class StringsView
 
     private static readonly Hex1bColor FocusFg = Hex1bColor.Black;
     private static readonly Hex1bColor FocusBg = Hex1bColor.FromRgb(0, 200, 180);
+    private static readonly Hex1bColor YankFlashFg = Hex1bColor.FromRgb(24, 24, 37);
+    private static readonly Hex1bColor YankFlashBg = Hex1bColor.FromRgb(126, 201, 216);
 
     private static Hex1bWidget FocusStyle<T>(WidgetContext<T> c, Hex1bWidget child, bool isFocused)
-        where T : Hex1bWidget =>
-        isFocused ? c.ThemePanel(t => t
-            .Set(GlobalTheme.ForegroundColor, FocusFg)
-            .Set(GlobalTheme.BackgroundColor, FocusBg), child) : child;
+        where T : Hex1bWidget
+    {
+        if (!isFocused) return child;
+        var flash = s_yankFlash;
+        var fg = flash ? YankFlashFg : FocusFg;
+        var bg = flash ? YankFlashBg : FocusBg;
+        return c.ThemePanel(t => t
+            .Set(GlobalTheme.ForegroundColor, fg)
+            .Set(GlobalTheme.BackgroundColor, bg), child);
+    }
 
     private static string RowKey(StringEntry e) =>
         $"{e.Offset}:{e.Source}";

--- a/src/Dotsider/Views/YankHelper.cs
+++ b/src/Dotsider/Views/YankHelper.cs
@@ -1,0 +1,289 @@
+using Dotsider.Core.Analysis.Models;
+using Hex1b.Widgets;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// Resolves yankable text for table rows and surface nodes.
+/// Editor selections are handled directly by the Y key handler — this helper
+/// is only called when the focused node is NOT an EditorNode.
+/// </summary>
+public static class YankHelper
+{
+    /// <summary>
+    /// Returns the yankable text for the current tab's focused table row or surface node,
+    /// or null if nothing is yankable.
+    /// </summary>
+    public static string? GetYankText(DotsiderState state) => state.CurrentTab switch
+    {
+        TabId.General => GetGeneralYankText(state),
+        TabId.PeMetadata => GetPeMetadataYankText(state),
+        TabId.Strings => GetStringsYankText(state),
+        TabId.DepGraph => GetDepGraphYankText(state),
+        TabId.SizeMap => GetSizeTreemapYankText(state),
+        TabId.Dynamic => GetDynamicYankText(state),
+        _ => null
+    };
+
+    /// <summary>
+    /// Returns the yankable text for the current diff tab's focused row,
+    /// or null if nothing is yankable.
+    /// </summary>
+    public static string? GetYankText(DiffState state)
+    {
+        if (state.DiffFocusedKey is not string key) return null;
+
+        return state.CurrentTab switch
+        {
+            1 => FormatDiffTypesRow(state, key),
+            2 => FormatDiffMethodsRow(state, key),
+            3 => FormatDiffRefsRow(state, key),
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Extracts the selected bytes from a hex editor and formats them as
+    /// uppercase space-separated hex (e.g., "4D 5A 90 00").
+    /// </summary>
+    public static string? GetHexSelectionText(EditorState editorState)
+    {
+        if (!editorState.Cursor.HasSelection) return null;
+
+        var doc = editorState.Document;
+        var range = editorState.Cursor.SelectionRange;
+        var byteMap = doc.GetByteMap();
+
+        var startByte = byteMap.CharToByteStart(
+            Math.Min(range.Start.Value, byteMap.CharCount - 1));
+        var endByte = byteMap.CharToByteStart(
+            Math.Min(range.End.Value, byteMap.CharCount - 1));
+
+        if (endByte < startByte) (startByte, endByte) = (endByte, startByte);
+
+        var count = endByte - startByte + 1;
+        if (count <= 0 || startByte >= doc.ByteCount) return null;
+        count = Math.Min(count, doc.ByteCount - startByte);
+
+        var bytes = doc.GetBytes(startByte, count).Span;
+        return string.Join(" ", bytes.ToArray().Select(b => b.ToString("X2")));
+    }
+
+    /// <summary>
+    /// Finds the yank flash decoration provider for the given editor state
+    /// within a <see cref="DotsiderState"/>.
+    /// </summary>
+    public static IlYankDecorationProvider? FindYankProvider(DotsiderState state, EditorState editorState)
+    {
+        if (editorState == state.IlEditorState) return state.IlYankProvider;
+        if (editorState == state.GeneralInfoEditorState) return state.GeneralInfoYankProvider;
+        if (editorState == state.PeHeadersEditorState) return state.PeHeadersYankProvider;
+        if (editorState == state.ClrHeaderEditorState) return state.ClrHeaderYankProvider;
+        if (editorState == state.PeDetailEditorState) return state.PeDetailYankProvider;
+        if (editorState == state.StringsDetailEditorState) return state.StringsDetailYankProvider;
+        return null;
+    }
+
+    /// <summary>
+    /// Finds the yank flash decoration provider for the given editor state
+    /// within a <see cref="NuGetState"/>.
+    /// </summary>
+    public static IlYankDecorationProvider? FindYankProvider(NuGetState state, EditorState editorState)
+    {
+        if (editorState == state.PackageInfoEditorState) return state.PackageInfoYankProvider;
+        if (state.SelectedDllState is not null)
+            return FindYankProvider(state.SelectedDllState, editorState);
+        return null;
+    }
+
+    private static string? GetGeneralYankText(DotsiderState state)
+    {
+        if (state.GeneralFocusedDep is not string name) return null;
+        var asmRef = state.Analyzer.AssemblyRefs.FirstOrDefault(r => r.Name == name);
+        if (asmRef is null) return null;
+        return $"{asmRef.Name}\t{asmRef.Version}\t{asmRef.Culture}\t{asmRef.PublicKeyToken}";
+    }
+
+    private static string? GetPeMetadataYankText(DotsiderState state)
+    {
+        if (state.PeFocusedKey is null) return null;
+        var analyzer = state.Analyzer;
+
+        return state.PeSubTab switch
+        {
+            PeSubTabId.Sections => FormatSection(analyzer.Sections, state.PeFocusedKey),
+            PeSubTabId.TypeDef => FormatTypeDef(analyzer.TypeDefs, state.PeFocusedKey),
+            PeSubTabId.MethodDef => FormatMethodDef(analyzer.MethodDefs, state.PeFocusedKey),
+            PeSubTabId.TypeRef => FormatTypeRef(analyzer.TypeRefs, state.PeFocusedKey),
+            PeSubTabId.MemberRef => FormatMemberRef(analyzer.MemberRefs, state.PeFocusedKey),
+            PeSubTabId.Attributes => FormatAttribute(analyzer.CustomAttributes, state.PeFocusedKey),
+            PeSubTabId.Resources => FormatResource(analyzer.Resources, state.PeFocusedKey),
+            _ => null
+        };
+    }
+
+    private static string? GetStringsYankText(DotsiderState state)
+    {
+        if (state.StringsFocusedKey is not string key) return null;
+        var strings = state.GetActiveStrings();
+        var entry = strings.FirstOrDefault(e => $"{e.Offset}:{e.Source}" == key);
+        return entry?.Value;
+    }
+
+    private static string? GetDepGraphYankText(DotsiderState state)
+    {
+        if (state.GraphSelectedNode is not null)
+            return state.GraphSelectedNode;
+
+        if (state.GraphSelectedIndex >= 0 && state.CachedGraph is { } graph)
+        {
+            var nodes = graph.Nodes;
+            if (state.GraphSelectedIndex < nodes.Count)
+            {
+                var node = nodes[state.GraphSelectedIndex];
+                var version = node.Version is not null ? $" v{node.Version}" : "";
+                return $"{node.Name}{version}";
+            }
+        }
+
+        return null;
+    }
+
+    private static string? GetSizeTreemapYankText(DotsiderState state)
+    {
+        if (state.TreemapHoveredItem is not null)
+            return state.TreemapHoveredItem.Trim();
+
+        var currentLevel = state.TreemapCurrentLevel ?? state.CachedSizeTree;
+        if (currentLevel is null) return null;
+
+        if (state.TreemapSelectedIndex >= 0
+            && state.TreemapSelectedIndex < currentLevel.Children.Count)
+        {
+            var child = currentLevel.Children[state.TreemapSelectedIndex];
+            return $"{child.FullPath}: {DotsiderState.FormatSize(child.Size)}";
+        }
+
+        return null;
+    }
+
+    private static string? GetDynamicYankText(DotsiderState state)
+    {
+        if (state.Tracer is null) return null;
+
+        return state.DynamicSubTab switch
+        {
+            DynamicSubTabId.Events => GetDynamicEventYankText(state),
+            DynamicSubTabId.Output => GetDynamicOutputYankText(state),
+            _ => null
+        };
+    }
+
+    private static string? GetDynamicEventYankText(DotsiderState state)
+    {
+        if (state.DynamicEventsFocusedKey is not string focusedKey) return null;
+        var events = state.Tracer!.GetEvents();
+
+        var evt = events.FirstOrDefault(e =>
+            $"{e.Timestamp.Ticks}:{e.EventName}:{e.Detail}:{e.MetadataToken}" == focusedKey);
+        if (evt is null) return null;
+
+        return $"{evt.Timestamp:mm\\:ss\\.fff}\t{evt.Category}\t{evt.EventName}\t{evt.Detail}";
+    }
+
+    private static string? GetDynamicOutputYankText(DotsiderState state)
+    {
+        if (state.DynamicOutputFocusedKey is not string focusedKey) return null;
+        var output = state.Tracer!.GetOutput();
+
+        var line = output.FirstOrDefault(o =>
+            $"{o.Timestamp.Ticks}:{o.Text}" == focusedKey);
+        return line?.Text;
+    }
+
+    private static string? FormatSection(IReadOnlyList<SectionInfo> sections, object key)
+    {
+        var s = sections.FirstOrDefault(x => (object)x.Name == key || x.Name.Equals(key));
+        return s is null ? null
+            : $"{s.Name}\t0x{s.VirtualAddress:X8}\t{s.VirtualSize}\t0x{s.RawDataOffset:X8}\t{s.RawDataSize}\t{s.Characteristics}";
+    }
+
+    private static string? FormatTypeDef(IReadOnlyList<TypeDefInfo> types, object key)
+    {
+        if (key is not int token) return null;
+        var t = types.FirstOrDefault(x => x.Token == token);
+        return t is null ? null
+            : $"0x{t.Token:X8}\t{t.FullName}\t{t.BaseType}\t{t.Attributes}\t{t.MethodCount}\t{t.FieldCount}";
+    }
+
+    private static string? FormatMethodDef(IReadOnlyList<MethodDefInfo> methods, object key)
+    {
+        if (key is not int token) return null;
+        var m = methods.FirstOrDefault(x => x.Token == token);
+        return m is null ? null
+            : $"0x{m.Token:X8}\t{m.DeclaringType}\t{m.Name}\t{m.Signature}\t{m.Attributes}\t0x{m.Rva:X8}";
+    }
+
+    private static string? FormatTypeRef(IReadOnlyList<TypeRefInfo> types, object key)
+    {
+        if (key is not int token) return null;
+        var t = types.FirstOrDefault(x => x.Token == token);
+        return t is null ? null
+            : $"0x{t.Token:X8}\t{t.FullName}\t{t.ResolutionScope}";
+    }
+
+    private static string? FormatMemberRef(IReadOnlyList<MemberRefInfo> members, object key)
+    {
+        if (key is not int token) return null;
+        var m = members.FirstOrDefault(x => x.Token == token);
+        return m is null ? null
+            : $"0x{m.Token:X8}\t{m.DeclaringType}\t{m.Name}";
+    }
+
+    private static string? FormatAttribute(IReadOnlyList<CustomAttributeInfo> attrs, object key)
+    {
+        if (key is not string compositeKey) return null;
+        var a = attrs.FirstOrDefault(x => $"{x.Parent}|{x.Constructor}" == compositeKey);
+        return a is null ? null
+            : $"{a.Parent}\t{a.Constructor}\t{a.Value}";
+    }
+
+    private static string? FormatResource(IReadOnlyList<ResourceInfo> resources, object key)
+    {
+        var r = resources.FirstOrDefault(x => (object)x.Name == key || x.Name.Equals(key));
+        return r is null ? null
+            : $"{r.Name}\t{r.Visibility}\t0x{r.Offset:X8}\t{r.Size}\t{(r.IsLinked ? "Yes" : "No")}";
+    }
+
+    private static string? FormatDiffTypesRow(DiffState state, string key)
+    {
+        var entry = state.DiffResult.TypeDiffs.FirstOrDefault(e =>
+            $"{e.Kind}:{e.Left?.FullName ?? e.Right?.FullName ?? ""}" == key);
+        if (entry is null) return null;
+        var type = entry.Right ?? entry.Left!;
+        return $"{entry.Kind}\t{type.FullName}\t{type.BaseType}\t{type.MethodCount}\t{type.FieldCount}\t{entry.ChangeDescription}";
+    }
+
+    private static string? FormatDiffMethodsRow(DiffState state, string key)
+    {
+        var entry = state.DiffResult.MethodDiffs.FirstOrDefault(e =>
+        {
+            var m = e.Right ?? e.Left!;
+            return $"{e.Kind}:{m.DeclaringType}::{m.Name}{m.Signature}" == key;
+        });
+        if (entry is null) return null;
+        var method = entry.Right ?? entry.Left!;
+        return $"{entry.Kind}\t{method.DeclaringType}\t{method.Name}\t{method.Signature}\t{entry.ChangeDescription}";
+    }
+
+    private static string? FormatDiffRefsRow(DiffState state, string key)
+    {
+        var entry = state.DiffResult.AssemblyRefDiffs.FirstOrDefault(e =>
+            $"{e.Kind}:{e.Left?.Name ?? e.Right?.Name ?? ""}" == key);
+        if (entry is null) return null;
+        var leftVersion = entry.Left?.Version ?? "";
+        var rightVersion = entry.Right?.Version ?? "";
+        var name = entry.Right?.Name ?? entry.Left?.Name ?? "";
+        return $"{entry.Kind}\t{name}\t{leftVersion}\t{rightVersion}\t{entry.ChangeDescription}";
+    }
+}

--- a/tests/Dotsider.Tests/ClipboardCapturingWorkloadAdapter.cs
+++ b/tests/Dotsider.Tests/ClipboardCapturingWorkloadAdapter.cs
@@ -1,0 +1,102 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Threading.Channels;
+using Hex1b;
+using Hex1b.Input;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Wraps a <see cref="Hex1bAppWorkloadAdapter"/> and captures all OSC 52 clipboard
+/// sequences emitted via <see cref="Write(string)"/>. Use <see cref="ClipboardWrites"/>
+/// to assert that the app actually called <c>CopyToClipboard</c> with the expected text.
+/// Pass this to <see cref="Hex1bAppOptions.WorkloadAdapter"/> and pass the inner adapter
+/// to <c>WithWorkload</c> on the terminal builder.
+/// </summary>
+internal sealed class ClipboardCapturingWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, IDisposable
+{
+    private readonly Hex1bAppWorkloadAdapter _inner;
+
+    /// <summary>All decoded clipboard texts captured from OSC 52 sequences, in order.</summary>
+    internal ConcurrentQueue<string> ClipboardWrites { get; } = new();
+
+    internal ClipboardCapturingWorkloadAdapter(Hex1bAppWorkloadAdapter inner)
+    {
+        _inner = inner;
+    }
+
+    /// <inheritdoc />
+    public void Write(string text)
+    {
+        // Intercept OSC 52 clipboard sequences: ESC ] 52 ; c ; <base64> BEL
+        if (text.StartsWith("\x1b]52;c;") && text.EndsWith("\x07"))
+        {
+            var base64 = text["\x1b]52;c;".Length..^1];
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+            ClipboardWrites.Enqueue(decoded);
+        }
+
+        _inner.Write(text);
+    }
+
+    /// <inheritdoc />
+    public void Write(ReadOnlySpan<byte> data) => _inner.Write(data);
+
+    /// <inheritdoc />
+    public void Write(ReadOnlyMemory<byte> data) => _inner.Write(data);
+
+    /// <inheritdoc />
+    public void Flush() => _inner.Flush();
+
+    /// <inheritdoc />
+    public ChannelReader<Hex1bEvent> InputEvents => _inner.InputEvents;
+
+    /// <inheritdoc />
+    public int Width => _inner.Width;
+
+    /// <inheritdoc />
+    public int Height => _inner.Height;
+
+    /// <inheritdoc />
+    public TerminalCapabilities Capabilities => _inner.Capabilities;
+
+    /// <inheritdoc />
+    public void EnterTuiMode() => _inner.EnterTuiMode();
+
+    /// <inheritdoc />
+    public void ExitTuiMode() => _inner.ExitTuiMode();
+
+    /// <inheritdoc />
+    public void Clear() => _inner.Clear();
+
+    /// <inheritdoc />
+    public void SetCursorPosition(int left, int top) => _inner.SetCursorPosition(left, top);
+
+    /// <inheritdoc />
+    public int OutputQueueDepth => _inner.OutputQueueDepth;
+
+    /// <inheritdoc />
+    public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+        => ((IHex1bTerminalWorkloadAdapter)_inner).ReadOutputAsync(ct);
+
+    /// <inheritdoc />
+    public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        => ((IHex1bTerminalWorkloadAdapter)_inner).WriteInputAsync(data, ct);
+
+    /// <inheritdoc />
+    public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
+        => ((IHex1bTerminalWorkloadAdapter)_inner).ResizeAsync(width, height, ct);
+
+    /// <inheritdoc />
+    public event Action? Disconnected
+    {
+        add => ((IHex1bTerminalWorkloadAdapter)_inner).Disconnected += value;
+        remove => ((IHex1bTerminalWorkloadAdapter)_inner).Disconnected -= value;
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => ((IAsyncDisposable)_inner).DisposeAsync();
+
+    /// <inheritdoc />
+    public void Dispose() => _inner.Dispose();
+}

--- a/tests/Dotsider.Tests/DiffDecorationProviderTests.cs
+++ b/tests/Dotsider.Tests/DiffDecorationProviderTests.cs
@@ -1,0 +1,119 @@
+using Dotsider.Views;
+using Hex1b.Documents;
+
+namespace Dotsider.Tests;
+
+public class DiffDecorationProviderTests
+{
+    // --- DiffSearchDecorationProvider ---
+
+    [Fact]
+    public void DiffSearch_HighlightsAllMatches_CaseInsensitive()
+    {
+        var provider = new DiffSearchDecorationProvider { Query = "rich" };
+        var doc = new Hex1bDocument("  Name:       RichLibrary\n  Version:    2.5.1\n  References: richData");
+
+        var spans = provider.GetDecorations(1, 3, doc);
+
+        // "Rich" on line 1, "rich" on line 3
+        Assert.Equal(2, spans.Count);
+        Assert.Equal(1, spans[0].Start.Line);
+        Assert.Equal(3, spans[1].Start.Line);
+    }
+
+    [Fact]
+    public void DiffSearch_MultipleMatchesOnSameLine()
+    {
+        var provider = new DiffSearchDecorationProvider { Query = "ab" };
+        var doc = new Hex1bDocument("ab cd ab ef ab");
+
+        var spans = provider.GetDecorations(1, 1, doc);
+
+        Assert.Equal(3, spans.Count);
+    }
+
+    [Fact]
+    public void DiffSearch_NullQuery_ReturnsEmpty()
+    {
+        var provider = new DiffSearchDecorationProvider { Query = null };
+        var doc = new Hex1bDocument("some text");
+
+        Assert.Empty(provider.GetDecorations(1, 1, doc));
+    }
+
+    [Fact]
+    public void DiffSearch_EmptyQuery_ReturnsEmpty()
+    {
+        var provider = new DiffSearchDecorationProvider { Query = "" };
+        var doc = new Hex1bDocument("some text");
+
+        Assert.Empty(provider.GetDecorations(1, 1, doc));
+    }
+
+    [Fact]
+    public void DiffSearch_NoMatch_ReturnsEmpty()
+    {
+        var provider = new DiffSearchDecorationProvider { Query = "xyz" };
+        var doc = new Hex1bDocument("abc def");
+
+        Assert.Empty(provider.GetDecorations(1, 1, doc));
+    }
+
+    // --- DiffStatsDecorationProvider ---
+
+    [Fact]
+    public void DiffStats_ColorsStatsLines()
+    {
+        var provider = new DiffStatsDecorationProvider();
+        var doc = new Hex1bDocument("  Types:      +3  -1  ~2\n  Methods:    +10  -5  ~8");
+
+        var spans = provider.GetDecorations(1, 2, doc);
+
+        // Each line has 3 colored values (+N, -N, ~N) = 6 total
+        Assert.Equal(6, spans.Count);
+    }
+
+    [Fact]
+    public void DiffStats_DoesNotColorSizeDeltaLine()
+    {
+        var provider = new DiffStatsDecorationProvider();
+        var doc = new Hex1bDocument("  Size delta: +10.0 KB");
+
+        var spans = provider.GetDecorations(1, 1, doc);
+
+        // Line has no ~ so it's skipped entirely
+        Assert.Empty(spans);
+    }
+
+    [Fact]
+    public void DiffStats_IgnoresLinesWithoutTilde()
+    {
+        var provider = new DiffStatsDecorationProvider();
+        var doc = new Hex1bDocument("  Some text +5 -3 no tilde here");
+
+        var spans = provider.GetDecorations(1, 1, doc);
+
+        Assert.Empty(spans);
+    }
+
+    [Fact]
+    public void DiffStats_RequiresDigitAfterPrefix()
+    {
+        var provider = new DiffStatsDecorationProvider();
+        // +abc should not match, but ~2 should
+        var doc = new Hex1bDocument("  +abc -def ~2");
+
+        var spans = provider.GetDecorations(1, 1, doc);
+
+        Assert.Single(spans);
+    }
+
+    [Fact]
+    public void DiffStats_EmptyLines_ReturnsEmpty()
+    {
+        var provider = new DiffStatsDecorationProvider();
+        var doc = new Hex1bDocument("\n\n");
+
+        Assert.Empty(provider.GetDecorations(1, 3, doc));
+    }
+}

--- a/tests/Dotsider.Tests/DiffModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/DiffModeYankIntegrationTests.cs
@@ -1,0 +1,602 @@
+using Dotsider.Views;
+using Hex1b;
+using Hex1b.Automation;
+using Hex1b.Input;
+using Hex1b.Widgets;
+
+namespace Dotsider.Tests;
+
+[Collection("SampleAssemblies")]
+public class DiffModeYankIntegrationTests(SampleAssemblyFixture samples) : IDisposable
+{
+    private Hex1bAppWorkloadAdapter? _workload;
+    private ClipboardCapturingWorkloadAdapter? _clipboardAdapter;
+    private Hex1bTerminal? _terminal;
+    private Hex1bApp? _hex1bApp;
+    private DiffState? _state;
+    private CancellationTokenSource? _cts;
+
+    private (Hex1bTerminal terminal, Hex1bApp app, CancellationToken ct) Launch()
+    {
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        _workload = new Hex1bAppWorkloadAdapter();
+        _clipboardAdapter = new ClipboardCapturingWorkloadAdapter(_workload);
+        _terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(_workload)
+            .WithHeadless()
+            .WithDimensions(120, 30)
+            .Build();
+        DiffApp? diffApp = null;
+        _hex1bApp = new Hex1bApp(
+            ctx =>
+            {
+                _state ??= new DiffState(_hex1bApp!, samples.RichLibraryDll, samples.RichLibraryV2Dll);
+                diffApp ??= new DiffApp(_state);
+                return Task.FromResult<Hex1bWidget>(diffApp.Build(ctx));
+            },
+            new Hex1bAppOptions
+            {
+                WorkloadAdapter = _clipboardAdapter,
+                EnableInputCoalescing = false
+            });
+        return (_terminal, _hex1bApp, _cts.Token);
+    }
+
+    // --- Summary tab ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task Summary_TabCyclesThroughEditors()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Change Summary") || s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Tab → Left Info
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => _state!.App.FocusedNode is EditorNode { State: var es }
+                && es == _state.LeftInfoEditorState, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Tab → Right Info
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => _state!.App.FocusedNode is EditorNode { State: var es }
+                && es == _state.RightInfoEditorState, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Tab → Change Stats
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => _state!.App.FocusedNode is EditorNode { State: var es }
+                && es == _state.ChangeStatsEditorState, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task Summary_LeftRightDoNotSwitchTabsWhenEditorFocused()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Change Summary"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Tab) // Focus left info editor
+            .WaitUntil(_ => _state!.App.FocusedNode is EditorNode, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var tabBefore = _state!.CurrentTab;
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(100, ct);
+        Assert.Equal(tabBefore, _state.CurrentTab);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Types/Methods/Refs tabs ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task Types_YankOnFocusedRow_ShowsNotification()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            .Type("2") // Types tab
+            .WaitUntil(s => s.ContainsText("Type") && s.ContainsText("Base Type"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.DownArrow) // Seed focus on first row
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(200, ct);
+
+        // If DiffFocusedKey is still null, try j to navigate in table
+        if (_state!.DiffFocusedKey is null)
+        {
+            await new Hex1bTerminalInputSequenceBuilder()
+                .Key(Hex1bKey.DownArrow)
+                .Build()
+                .ApplyAsync(terminal, ct);
+            await Task.Delay(200, ct);
+        }
+
+        Assert.NotNull(_state.DiffFocusedKey);
+
+        // Compute expected payload before yank
+        var expectedPayload = YankHelper.GetYankText(_state);
+        Assert.NotNull(expectedPayload);
+        Assert.Contains("\t", expectedPayload); // Tab-separated
+
+        // Yank
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.YankNotification);
+
+        // Verify the actual OSC 52 clipboard payload emitted by ctx.CopyToClipboard
+        Assert.True(_clipboardAdapter!.ClipboardWrites.TryDequeue(out var actualClipboard),
+            "CopyToClipboard should have emitted an OSC 52 sequence");
+        Assert.Equal(expectedPayload, actualClipboard);
+
+        // Notification auto-clears
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(_ => _state.YankNotification is null, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task Types_SearchWithNavigation_CyclesMatches()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.D2) // Types tab
+            .WaitUntil(s => s.ContainsText("Type"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Seed focus — navigate down to get a focused row
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.DownArrow)
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await Task.Delay(200, ct);
+
+        // Search for something that should match multiple types
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.OemQuestion) // /
+            .Type("Model")
+            .Key(Hex1bKey.Enter) // Confirm search
+            .WaitUntil(_ =>
+            {
+                var s = _state!.Search[_state.CurrentTab];
+                return s.IsActive && s.IsConfirmed;
+            }, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var firstFocused = _state!.DiffFocusedKey;
+
+        // n → next match
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("n")
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await Task.Delay(100, ct);
+
+        var secondFocused = _state.DiffFocusedKey;
+        Assert.NotEqual(firstFocused, secondFocused);
+
+        // N → previous match (moves to a different row)
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Shift().Key(Hex1bKey.N)
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await Task.Delay(100, ct);
+
+        Assert.NotEqual(secondFocused, _state.DiffFocusedKey);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task TabArrows_WorkWhenEditorNotFocused()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Equal(0, _state!.CurrentTab); // Summary
+
+        // Right arrow switches to Types tab (tab index 1)
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state.CurrentTab == 1, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Equal(1, _state.CurrentTab);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Summary editor selection + yank ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task Summary_SelectionYank_ShowsNotification()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Change Summary"), TimeSpan.FromSeconds(10))
+            // Tab to left info editor
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => _state!.App.FocusedNode is EditorNode { State: var es }
+                && es == _state.LeftInfoEditorState, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Select text
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.LeftInfoEditorState!.Cursor.HasSelection, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Yank
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task Summary_RightInfoYank_ShowsNotification()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Change Summary"), TimeSpan.FromSeconds(10))
+            // Tab to left info, then tab to right info
+            .Key(Hex1bKey.Tab)
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ =>
+            {
+                try { return _state!.App.FocusedNode is EditorNode { State: var es } && es == _state.RightInfoEditorState; }
+                catch (NullReferenceException) { return false; }
+            }, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Select and yank
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.RightInfoEditorState!.Cursor.HasSelection, TimeSpan.FromSeconds(5))
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task Summary_ChangeStatsYank_ShowsNotification()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Change Summary"), TimeSpan.FromSeconds(10))
+            // Tab to left info first
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ =>
+            {
+                try { return _state!.App.FocusedNode is EditorNode { State: var es } && es == _state.LeftInfoEditorState; }
+                catch (NullReferenceException) { return false; }
+            }, TimeSpan.FromSeconds(5))
+            // Tab to right info
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ =>
+            {
+                try { return _state!.App.FocusedNode is EditorNode { State: var es } && es == _state.RightInfoEditorState; }
+                catch (NullReferenceException) { return false; }
+            }, TimeSpan.FromSeconds(5))
+            // Tab to change stats
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ =>
+            {
+                try { return _state!.App.FocusedNode is EditorNode { State: var es } && es == _state.ChangeStatsEditorState; }
+                catch (NullReferenceException) { return false; }
+            }, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Select and yank
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.ChangeStatsEditorState!.Cursor.HasSelection, TimeSpan.FromSeconds(5))
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Methods tab yank ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task Methods_YankOnFocusedRow_ShowsNotification()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.D3) // Methods tab
+            .WaitUntil(s => s.ContainsText("Method") && s.ContainsText("Declaring Type"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.DownArrow) // Seed focus
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await Task.Delay(200, ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Refs tab yank ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task Refs_YankOnFocusedRow_ShowsNotification()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.D4) // Refs tab
+            .WaitUntil(s => s.ContainsText("Assembly") && s.ContainsText("Left Version"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.DownArrow)
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await Task.Delay(200, ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Methods n/N search navigation ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task Methods_SearchNavigation_CyclesMatches()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.D3) // Methods tab
+            .WaitUntil(s => s.ContainsText("Method"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.DownArrow)
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await Task.Delay(200, ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.OemQuestion)
+            .Type("get")
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ =>
+            {
+                var s = _state!.Search[_state.CurrentTab];
+                return s.IsActive && s.IsConfirmed;
+            }, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var first = _state!.DiffFocusedKey;
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("n")
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await Task.Delay(100, ct);
+
+        var second = _state.DiffFocusedKey;
+        Assert.NotEqual(first, second);
+
+        // N → previous match (moves to a different row)
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Shift().Key(Hex1bKey.N)
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await Task.Delay(100, ct);
+
+        Assert.NotEqual(second, _state.DiffFocusedKey);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Refs n/N search navigation ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task Refs_SearchNavigation_CyclesMatches()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.D4) // Refs tab
+            .WaitUntil(s => s.ContainsText("Assembly"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.DownArrow)
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await Task.Delay(200, ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.OemQuestion)
+            .Type("System")
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ =>
+            {
+                var s = _state!.Search[_state.CurrentTab];
+                return s.IsActive && s.IsConfirmed;
+            }, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var first = _state!.DiffFocusedKey;
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("n")
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await Task.Delay(100, ct);
+
+        var second = _state.DiffFocusedKey;
+        Assert.NotEqual(first, second);
+
+        // N → previous match (moves to a different row)
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Shift().Key(Hex1bKey.N)
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await Task.Delay(100, ct);
+
+        Assert.NotEqual(second, _state.DiffFocusedKey);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Yank flash set and clear ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task Types_YankFlash_SetsAndClears()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.D2) // Types tab
+            .WaitUntil(s => s.ContainsText("Type"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.DownArrow)
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await Task.Delay(200, ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Flash should clear
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(_ => !_state!.YankFlashRow, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.False(_state!.YankFlashRow);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _state?.Dispose();
+        _hex1bApp?.Dispose();
+        _terminal?.Dispose();
+        _workload?.Dispose();
+        _cts?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/Dotsider.Tests/InfoDecorationProviderTests.cs
+++ b/tests/Dotsider.Tests/InfoDecorationProviderTests.cs
@@ -1,0 +1,97 @@
+using Dotsider.Views;
+using Hex1b.Documents;
+
+namespace Dotsider.Tests;
+
+public class InfoDecorationProviderTests
+{
+    [Fact]
+    public void InfoLabel_ColorsLabelBeforeColon()
+    {
+        var provider = new InfoLabelDecorationProvider();
+        var doc = new Hex1bDocument("  Assembly Name:    HelloWorld\n  Version:          1.0.0.0");
+
+        var spans = provider.GetDecorations(1, 2, doc);
+
+        Assert.Equal(2, spans.Count);
+        // First span covers "  Assembly Name:" on line 1
+        Assert.Equal(1, spans[0].Start.Line);
+        Assert.Equal(1, spans[0].Start.Column);
+        // Second span covers "  Version:" on line 2
+        Assert.Equal(2, spans[1].Start.Line);
+    }
+
+    [Fact]
+    public void InfoLabel_IgnoresContentLinesWithColons()
+    {
+        var provider = new InfoLabelDecorationProvider();
+        // "int:" looks like a label but is content — colon at position 5 (< 25)
+        // but the key check is that the text before : must be letters/digits/spaces
+        var doc = new Hex1bDocument("  Length: 4\n\n  int:");
+
+        var spans = provider.GetDecorations(1, 3, doc);
+
+        // Line 1 "  Length:" is a real label
+        // Line 3 "  int:" also matches the pattern (letters + colon within 25 chars)
+        // InfoLabelDecorationProvider can't distinguish — that's why StringsDetailDecorationProvider exists
+        Assert.True(spans.Count >= 1);
+        Assert.Equal(1, spans[0].Start.Line);
+    }
+
+    [Fact]
+    public void InfoLabel_IgnoresColonBeyondPosition25()
+    {
+        var provider = new InfoLabelDecorationProvider();
+        var doc = new Hex1bDocument("  This is a very long line that has a colon: here");
+
+        var spans = provider.GetDecorations(1, 1, doc);
+
+        Assert.Empty(spans);
+    }
+
+    [Fact]
+    public void InfoLabel_IgnoresEmptyLines()
+    {
+        var provider = new InfoLabelDecorationProvider();
+        var doc = new Hex1bDocument("  Name: Test\n\n  Version: 1.0");
+
+        var spans = provider.GetDecorations(1, 3, doc);
+
+        // Lines 1 and 3 have labels, line 2 is empty
+        Assert.Equal(2, spans.Count);
+    }
+
+    [Fact]
+    public void StringsDetail_OnlyColorsFirstLine()
+    {
+        var provider = new StringsDetailDecorationProvider();
+        var doc = new Hex1bDocument("  Length: 42\n\n  some: content\n  more: content");
+
+        var spans = provider.GetDecorations(1, 4, doc);
+
+        Assert.Single(spans);
+        Assert.Equal(1, spans[0].Start.Line);
+    }
+
+    [Fact]
+    public void StringsDetail_IgnoresWhenFirstLineHasNoColon()
+    {
+        var provider = new StringsDetailDecorationProvider();
+        var doc = new Hex1bDocument("No colon here\nLength: 5");
+
+        var spans = provider.GetDecorations(1, 2, doc);
+
+        Assert.Empty(spans);
+    }
+
+    [Fact]
+    public void StringsDetail_IgnoresWhenViewStartsBeyondLine1()
+    {
+        var provider = new StringsDetailDecorationProvider();
+        var doc = new Hex1bDocument("  Length: 42\n\n  content");
+
+        var spans = provider.GetDecorations(2, 3, doc);
+
+        Assert.Empty(spans);
+    }
+}

--- a/tests/Dotsider.Tests/InfoEditorViewRendererTests.cs
+++ b/tests/Dotsider.Tests/InfoEditorViewRendererTests.cs
@@ -1,0 +1,95 @@
+using Dotsider.Views;
+using Hex1b;
+using Hex1b.Automation;
+using Hex1b.Documents;
+using Hex1b.Widgets;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests that <see cref="InfoEditorViewRenderer"/> blanks filler rows
+/// instead of showing vim-style ~ markers.
+/// </summary>
+public class InfoEditorViewRendererTests : IDisposable
+{
+    private Hex1bAppWorkloadAdapter? _workload;
+    private Hex1bTerminal? _terminal;
+    private Hex1bApp? _hex1bApp;
+
+    [Fact(Timeout = 30_000)]
+    public async Task InfoRenderer_NeverShowsTilde_InSmallDocument()
+    {
+        _workload = new Hex1bAppWorkloadAdapter();
+        _terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(_workload)
+            .WithHeadless()
+            .WithDimensions(60, 20)
+            .Build();
+
+        // Create a tiny 3-line document in a tall (15 rows) editor
+        var doc = new Hex1bDocument("Line 1\nLine 2\nLine 3");
+        var editorState = new EditorState(doc) { IsReadOnly = true };
+
+        _hex1bApp = new Hex1bApp(
+            ctx =>
+            {
+                var widget = ctx.Border(
+                    ctx.Editor(editorState)
+                        .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                        .FillWidth().FillHeight()
+                ).Title(" Info ").Fill();
+                return Task.FromResult<Hex1bWidget>(widget);
+            },
+            new Hex1bAppOptions
+            {
+                WorkloadAdapter = _workload,
+                EnableInputCoalescing = false
+            });
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = _hex1bApp.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Line 1"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(_terminal, cts.Token);
+
+        // Verify no tilde markers appear below document content.
+        // The border title " Info " and content "Line 1/2/3" don't contain ~.
+        // Scan only the editor area (inside the border, rows below the 3 content lines).
+        var foundTilde = false;
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s =>
+            {
+                // Check rows 5+ (after border top + 3 content lines) for stray ~
+                for (var row = 5; row < 18; row++)
+                {
+                    var line = s.GetLine(row).TrimEnd();
+                    // A tilde line from the default renderer starts with ~ after the border
+                    if (line.Contains("~") && !line.Contains("Info"))
+                    {
+                        foundTilde = true;
+                        return true;
+                    }
+                }
+                return true; // always pass — we check foundTilde after
+            }, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(_terminal, cts.Token);
+
+        Assert.False(foundTilde, "InfoEditorViewRenderer should not show ~ filler lines");
+
+        cts.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    public void Dispose()
+    {
+        _hex1bApp?.Dispose();
+        _terminal?.Dispose();
+        _workload?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/Dotsider.Tests/NuGetModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/NuGetModeYankIntegrationTests.cs
@@ -1,0 +1,708 @@
+using Hex1b;
+using Hex1b.Automation;
+using Hex1b.Input;
+using Hex1b.Widgets;
+
+namespace Dotsider.Tests;
+
+[Collection("SampleAssemblies")]
+public class NuGetModeYankIntegrationTests(SampleAssemblyFixture samples) : IDisposable
+{
+    private Hex1bAppWorkloadAdapter? _workload;
+    private ClipboardCapturingWorkloadAdapter? _clipboardAdapter;
+    private Hex1bTerminal? _terminal;
+    private Hex1bApp? _hex1bApp;
+    private NuGetState? _state;
+    private CancellationTokenSource? _cts;
+
+    private (Hex1bTerminal terminal, Hex1bApp app, CancellationToken ct) Launch()
+    {
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        _workload = new Hex1bAppWorkloadAdapter();
+        _clipboardAdapter = new ClipboardCapturingWorkloadAdapter(_workload);
+        _terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(_workload)
+            .WithHeadless()
+            .WithDimensions(120, 30)
+            .WithMouse()
+            .Build();
+        NuGetApp? nugetApp = null;
+        _hex1bApp = new Hex1bApp(
+            ctx =>
+            {
+                _state ??= new NuGetState(_hex1bApp!, samples.RichLibraryNupkg);
+                nugetApp ??= new NuGetApp(_state);
+                return Task.FromResult<Hex1bWidget>(nugetApp.Build(ctx));
+            },
+            new Hex1bAppOptions
+            {
+                WorkloadAdapter = _clipboardAdapter,
+                EnableInputCoalescing = false,
+                EnableMouse = true
+            });
+        return (_terminal, _hex1bApp, _cts.Token);
+    }
+
+    // --- Package browser ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task Browser_InitialFocusOnFirstDllRow()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.FileTreeFocusedKey);
+        Assert.False(_state.App.FocusedNode is EditorNode,
+            "Initial focus should be on table, not editor");
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task Browser_TabTogglesFocus()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Tab → Package Info editor
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => _state!.App.FocusedNode is EditorNode, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Tab → back to table
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => _state!.App.FocusedNode is not EditorNode, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task Browser_YankOnDllRow_ShowsNotificationAndFlash()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Yank the focused DLL row — payload should be the file path
+        Assert.NotNull(_state!.FileTreeFocusedKey);
+        var expectedPath = _state.FileTreeFocusedKey as string;
+        Assert.NotNull(expectedPath);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state.YankNotification);
+        Assert.Contains("lib/", _state.YankNotification); // DLL path contains lib/ directory
+
+        // Verify the actual OSC 52 clipboard payload emitted by ctx.CopyToClipboard
+        Assert.True(_clipboardAdapter!.ClipboardWrites.TryDequeue(out var actualClipboard),
+            "CopyToClipboard should have emitted an OSC 52 sequence");
+        Assert.Equal(expectedPath, actualClipboard);
+
+        // Flash should have fired and cleared
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(_ => !_state.YankFlashRow, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Notification auto-clears
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(_ => _state.YankNotification is null, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- DLL inspector ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task DrillInto_SavesFocusedKey_EscRestores()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var savedKey = _state!.FileTreeFocusedKey;
+        Assert.NotNull(savedKey);
+
+        // Enter → drill into DLL
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => !_state.IsBrowsingPackage, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Equal(savedKey, _state.SavedFileTreeFocusedKey);
+
+        // Esc → back to package
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => _state.IsBrowsingPackage, TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Equal(savedKey, _state.FileTreeFocusedKey);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Child input routing ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task ChildSearch_DigitsDoNotSwitchTabs()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter) // Drill into DLL
+            .WaitUntil(_ => !_state!.IsBrowsingPackage, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var dllState = _state!.SelectedDllState!;
+
+        // Open search in the DLL inspector
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.OemQuestion) // /
+            .WaitUntil(_ => dllState.Search[dllState.CurrentTab].IsActive, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var tabBefore = dllState.CurrentTab;
+
+        // Type digits — should go into search, not switch tabs
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("123")
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(100, ct);
+        Assert.Equal(tabBefore, dllState.CurrentTab);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Hex Escape chain ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task HexDump_EscFromNormalMode_ReturnsToPackage()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter) // Drill into DLL
+            .WaitUntil(_ => !_state!.IsBrowsingPackage, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var dllState = _state!.SelectedDllState!;
+
+        // Go to Hex Dump tab
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.D5) // Tab 5 = Hex Dump
+            .WaitUntil(_ => dllState.CurrentTab == TabId.HexDump, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Data Interpretation"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Wait for bindings to re-register after tab switch
+        await Task.Delay(200, ct);
+
+        // Enter insert mode
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.I)
+            .WaitUntil(_ => dllState.HexMode == HexEditMode.Insert, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.False(dllState.HexEditorState.IsReadOnly);
+
+        // Esc 1: exit insert mode (NOT back to package)
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => dllState.HexMode == HexEditMode.Normal, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.True(dllState.HexEditorState.IsReadOnly);
+        Assert.False(_state.IsBrowsingPackage, "Should still be in DLL inspector");
+
+        // Esc 2: back to package
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => _state.IsBrowsingPackage, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Yank timer race ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task YankTimerRace_LeaveDllBeforeFlashClears_NoException()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter) // Drill into DLL
+            .WaitUntil(_ => !_state!.IsBrowsingPackage, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Yank a row in the DLL inspector
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Immediately go back to package (within 150ms flash window)
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => _state!.IsBrowsingPackage, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Wait longer than the flash timer to ensure no exception
+        await Task.Delay(300, ct);
+
+        // App should still be running fine
+        Assert.True(_state!.IsBrowsingPackage);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Package Info editor yank ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task PackageInfo_SelectionYank_Works()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            // Tab to Package Info editor
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => _state!.App.FocusedNode is EditorNode, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Select text
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.PackageInfoEditorState!.Cursor.HasSelection, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Package Info double-click selection + yank ---
+
+    [Fact(Timeout = 60_000)]
+    public async Task PackageInfo_DoubleClickWordSelectionYank_Works()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Find "Dotsider" on screen (inside Package Info editor — Authors line)
+        List<(int Line, int Column)> matches = [];
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s =>
+            {
+                var found = s.FindText("Dotsider");
+                if (found.Count == 0) return false;
+                matches = [.. found.Select(m => (m.Line, m.Column))];
+                return true;
+            }, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.True(matches.Count > 0);
+        var (row, col) = matches[0];
+
+        // Click to focus editor, then double-click to select word
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(5));
+        await auto.ClickAtAsync(col, row, ct: ct);
+        await Task.Delay(150, ct);
+        await auto.DoubleClickAtAsync(col, row, ct: ct);
+
+        // Wait for selection
+        await TestHelpers.WaitUntilAsync(
+            () => _state!.PackageInfoEditorState?.Cursor.HasSelection == true,
+            TimeSpan.FromSeconds(5));
+
+        // Yank
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- DLL inspector editor yank ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task DllInspector_EditorYank_Works()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter) // Drill into DLL
+            .WaitUntil(_ => !_state!.IsBrowsingPackage, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            // Tab to Assembly Info editor
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => _state!.App.FocusedNode is EditorNode, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Select and yank
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Hex jump dialog ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task HexJumpDialog_DigitsGoIntoInput_EscCloses()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter) // Drill into DLL
+            .WaitUntil(_ => !_state!.IsBrowsingPackage, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var dllState = _state!.SelectedDllState!;
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.D5) // Hex Dump
+            .WaitUntil(_ => dllState.CurrentTab == TabId.HexDump, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Data Interpretation"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(200, ct);
+
+        // Open jump dialog
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("g")
+            .WaitUntil(_ => dllState.HexJumpDialogOpen, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.True(dllState.HexJumpDialogOpen);
+        Assert.False(_state.IsBrowsingPackage, "Should still be in DLL inspector");
+
+        // Esc closes dialog
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => !dllState.HexJumpDialogOpen, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.False(_state.IsBrowsingPackage, "Should still be in DLL inspector after closing dialog");
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Child input suppression: q/y ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task ChildSearch_QDoesNotQuit()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter) // Drill into DLL
+            .WaitUntil(_ => !_state!.IsBrowsingPackage, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var dllState = _state!.SelectedDllState!;
+
+        // Open search
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.OemQuestion)
+            .WaitUntil(_ => dllState.Search[dllState.CurrentTab].IsActive, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Press q — should go into search box, not quit
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("q")
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(200, ct);
+
+        // App should still be running (not quit)
+        Assert.Contains("q", dllState.Search[dllState.CurrentTab].Query ?? "");
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Full hex Esc chain: insert → search dismiss → back to package ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task HexEscChain_InsertThenSearchThenBack()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => !_state!.IsBrowsingPackage, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var dllState = _state!.SelectedDllState!;
+
+        // Go to Hex Dump
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.D5)
+            .WaitUntil(_ => dllState.CurrentTab == TabId.HexDump, TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("Data Interpretation"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await Task.Delay(200, ct);
+
+        // Enter insert mode
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.I)
+            .WaitUntil(_ => dllState.HexMode == HexEditMode.Insert, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.False(dllState.HexEditorState.IsReadOnly);
+
+        // Esc 1: exit insert mode
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => dllState.HexMode == HexEditMode.Normal, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.True(dllState.HexEditorState.IsReadOnly);
+        Assert.False(_state.IsBrowsingPackage);
+
+        // Start a search
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.OemQuestion)
+            .WaitUntil(_ => dllState.Search[TabId.HexDump].IsActive, TimeSpan.FromSeconds(5))
+            .Type("MZ")
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => dllState.Search[TabId.HexDump].IsConfirmed, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Esc 2: dismiss confirmed search with hex cleanup
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => !dllState.Search[TabId.HexDump].IsActive, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Empty(dllState.HexMatchOffsets);
+        Assert.False(_state.IsBrowsingPackage);
+
+        // Esc 3: back to package
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => _state.IsBrowsingPackage, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Child input suppression: y ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task ChildSearch_YDoesNotYank()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => !_state!.IsBrowsingPackage, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var dllState = _state!.SelectedDllState!;
+
+        // Open search
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.OemQuestion)
+            .WaitUntil(_ => dllState.Search[dllState.CurrentTab].IsActive, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Press y — should go into search box, not yank
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(200, ct);
+
+        Assert.Contains("y", dllState.Search[dllState.CurrentTab].Query ?? "");
+        Assert.Null(_state.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- DLL inspector row yank flash ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task DllInspector_RowYank_FlashSetsAndClears()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter) // Drill into DLL
+            .WaitUntil(_ => !_state!.IsBrowsingPackage, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var dllState = _state!.SelectedDllState!;
+
+        // Yank
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Flash should clear
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(_ => !dllState.YankFlashRow, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _state?.Dispose();
+        _hex1bApp?.Dispose();
+        _terminal?.Dispose();
+        _workload?.Dispose();
+        _cts?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
@@ -1,0 +1,695 @@
+using Dotsider.Views;
+using Hex1b;
+using Hex1b.Automation;
+using Hex1b.Input;
+using Hex1b.Widgets;
+
+namespace Dotsider.Tests;
+
+[Collection("SampleAssemblies")]
+public class StandardModeYankIntegrationTests(SampleAssemblyFixture samples) : IDisposable
+{
+    private Hex1bAppWorkloadAdapter? _workload;
+    private ClipboardCapturingWorkloadAdapter? _clipboardAdapter;
+    private Hex1bTerminal? _terminal;
+    private Hex1bApp? _hex1bApp;
+    private DotsiderState? _state;
+    private CancellationTokenSource? _cts;
+
+    private (Hex1bTerminal terminal, Hex1bApp app, CancellationToken ct) Launch(
+        string dllPath, int? initialTab = null)
+    {
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        _workload = new Hex1bAppWorkloadAdapter();
+        _clipboardAdapter = new ClipboardCapturingWorkloadAdapter(_workload);
+        _terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(_workload)
+            .WithHeadless()
+            .WithDimensions(120, 30)
+            .WithMouse()
+            .Build();
+        DotsiderApp? dotsiderApp = null;
+        _hex1bApp = new Hex1bApp(
+            ctx =>
+            {
+                if (_state is null)
+                {
+                    _state = new DotsiderState(_hex1bApp!, dllPath);
+                    if (initialTab.HasValue)
+                        _state.CurrentTab = initialTab.Value;
+                }
+                dotsiderApp ??= new DotsiderApp(_state);
+                return Task.FromResult<Hex1bWidget>(dotsiderApp.Build(ctx));
+            },
+            new Hex1bAppOptions
+            {
+                WorkloadAdapter = _clipboardAdapter,
+                EnableInputCoalescing = false,
+                EnableMouse = true,
+                Theme = DotsiderTheme.Create()
+            });
+        return (_terminal, _hex1bApp, _cts.Token);
+    }
+
+    /// <summary>
+    /// Safely checks if the focused node is an EditorNode.
+    /// Returns false instead of throwing during early app lifecycle
+    /// when the focus ring has not been initialized yet.
+    /// </summary>
+    private bool IsFocusedOnEditor()
+    {
+        try
+        {
+            return _state?.App.FocusedNode is EditorNode;
+        }
+        catch (NullReferenceException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Safely checks if the focused node is an EditorNode with a specific state.
+    /// Returns false instead of throwing during early app lifecycle
+    /// when the focus ring has not been initialized yet.
+    /// </summary>
+    private bool IsFocusedOnEditor(EditorState? expectedState)
+    {
+        try
+        {
+            return _state?.App.FocusedNode is EditorNode { State: var es }
+                && es == expectedState;
+        }
+        catch (NullReferenceException)
+        {
+            return false;
+        }
+    }
+
+    // --- General tab ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task General_TabTogglesFocusBetweenEditorAndTable()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Initial focus is on the table (RequestContentFocus excludes EditorNode)
+        // Allow render to settle before checking focus
+        await Task.Delay(100, ct);
+        Assert.False(IsFocusedOnEditor(),
+            "Initial focus should not be on the editor");
+
+        // Tab → editor
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+        Assert.True(IsFocusedOnEditor());
+
+        // Tab → table
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => !IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+        Assert.False(IsFocusedOnEditor());
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task General_YankOnFocusedRow_ShowsNotificationAndFlash()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Ensure a ref row is focused
+        Assert.NotNull(_state!.GeneralFocusedDep);
+
+        // Compute expected payload before yank
+        var expectedPayload = YankHelper.GetYankText(_state);
+        Assert.NotNull(expectedPayload);
+        Assert.Contains("\t", expectedPayload); // Tab-separated
+
+        // Yank
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Notification contains the payload (truncated if long)
+        Assert.NotNull(_state.YankNotification);
+        var firstRef = _state.Analyzer.AssemblyRefs.First(r => r.Name == _state.GeneralFocusedDep as string);
+        Assert.Contains(firstRef.Name, _state.YankNotification);
+
+        // Verify the actual OSC 52 clipboard payload emitted by ctx.CopyToClipboard
+        Assert.True(_clipboardAdapter!.ClipboardWrites.TryDequeue(out var actualClipboard),
+            "CopyToClipboard should have emitted an OSC 52 sequence");
+        Assert.Equal(expectedPayload, actualClipboard);
+
+        // Wait for notification to clear
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(_ => _state.YankNotification is null, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- PE/Metadata tab ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_TabCyclesThroughHeadersAndTable()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.PeMetadata);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("PE Headers") || s.ContainsText("Sections"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Tab → PE Headers editor
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => IsFocusedOnEditor(_state!.PeHeadersEditorState), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Tab → CLR Header editor
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => IsFocusedOnEditor(_state!.ClrHeaderEditorState), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Tab → metadata table
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => _state!.App.FocusedNode is not EditorNode, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_LeftRightDoNotSwitchSubTabsWhenEditorFocused()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.PeMetadata);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("PE Headers"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var initialSubTab = _state!.PeSubTab;
+
+        // Tab to PE Headers editor
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Press Right — should NOT switch sub-tab
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(100, ct);
+        Assert.Equal(initialSubTab, _state.PeSubTab);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_DetailPopupIsEditorAndEscCloses()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.PeMetadata);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Sections"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Open detail popup
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.PeDetailContent is not null, TimeSpan.FromSeconds(5))
+            .WaitUntil(_ => IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.PeDetailEditorState);
+        Assert.True(_state.App.FocusedNode is EditorNode,
+            "Detail popup editor should have focus");
+
+        // Escape closes popup
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => _state.PeDetailContent is null, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(100, ct);
+        Assert.False(_state.App.FocusedNode is EditorNode,
+            "Focus should return to table after popup closes");
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Strings tab ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task Strings_YankOnFocusedRow_CopiesStringValue()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.Strings);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("strings"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.StringsFocusedKey);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task Strings_LeftRightDoNotSwitchTabsWhenPopupOpen()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.Strings);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("strings"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var initialSourceTab = _state!.StringsSourceTab;
+
+        // Open detail popup
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state.StringsDetailContent is not null, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Right arrow — should NOT switch source tab
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(100, ct);
+        Assert.Equal(initialSourceTab, _state.StringsSourceTab);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Hex Dump tab ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task HexDump_SelectionYank_CopiesUppercaseHexBytes()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.HexDump);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Data Interpretation"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Select bytes using real Shift+Right input
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.HexEditorState.Cursor.HasSelection, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Yank
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Verify payload is uppercase hex
+        Assert.NotNull(_state!.YankNotification);
+        Assert.Matches(@"Yanked: [0-9A-F]{2} [0-9A-F]{2}", _state.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Focus restoration ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task FocusRestoration_AfterDetailPopupClose_LandsOnTable()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.PeMetadata);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Sections"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Open and close detail popup
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.PeDetailContent is not null, TimeSpan.FromSeconds(5))
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => _state!.PeDetailContent is null, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Allow focus to settle after popup close
+        await Task.Delay(100, ct);
+
+        // Focus should be on a table, not an editor
+        Assert.False(_state!.App.FocusedNode is EditorNode,
+            "Focus should land on table after closing detail popup");
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- PE/Metadata editor selection + yank ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task PeHeaders_SelectionYank_CopiesTextAndFlashes()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.PeMetadata);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("PE Headers"), TimeSpan.FromSeconds(10))
+            // Tab to PE Headers editor
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => IsFocusedOnEditor(_state!.PeHeadersEditorState), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Select text via Shift+Right
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.PeHeadersEditorState!.Cursor.HasSelection, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Yank
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task PeDetailPopup_SelectionYank_Works()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.PeMetadata);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Sections"), TimeSpan.FromSeconds(10))
+            // Open detail popup
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.PeDetailContent is not null, TimeSpan.FromSeconds(5))
+            .WaitUntil(_ => IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Select text
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.PeDetailEditorState!.Cursor.HasSelection, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Yank
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.YankNotification);
+
+        // Escape closes popup
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => _state.PeDetailContent is null, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Strings detail popup selection + yank ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task StringsDetailPopup_SelectionYank_Works()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.Strings);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("strings"), TimeSpan.FromSeconds(10))
+            // Open detail popup
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.StringsDetailContent is not null, TimeSpan.FromSeconds(5))
+            .WaitUntil(_ => IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Select text
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .Shift().Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.StringsDetailEditorState!.Cursor.HasSelection, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Yank
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- General tab double-click word selection ---
+
+    [Fact(Timeout = 60_000)]
+    public async Task General_DoubleClickWordSelection_AdjustsBoundaryAndYanks()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Find "Version" on screen — it appears inside the Assembly Info editor
+        // and is more likely to be a standalone word than "Assembly" which is part of "Assembly Name:"
+        List<(int Line, int Column)> matches = [];
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s =>
+            {
+                var found = s.FindText("Version");
+                if (found.Count == 0) return false;
+                matches = [.. found.Select(m => (m.Line, m.Column))];
+                return true;
+            }, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.True(matches.Count > 0);
+        // Use the first match — coordinates are 0-based screen positions
+        var (row, col) = matches[0];
+
+        // Single click to give editor focus, then double-click to select word
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(5));
+        await auto.ClickAtAsync(col + 2, row, ct: ct); // +2 to land inside the word
+        await Task.Delay(150, ct);
+        await auto.DoubleClickAtAsync(col + 2, row, ct: ct);
+
+        // Wait for selection to appear
+        await TestHelpers.WaitUntilAsync(
+            () => _state!.GeneralInfoEditorState?.Cursor.HasSelection == true,
+            TimeSpan.FromSeconds(5));
+
+        // Verify selection is a clean word
+        var es = _state!.GeneralInfoEditorState!;
+        var selected = es.Document.GetText(es.Cursor.SelectionRange);
+        Assert.True(selected.Length > 0, "Selection should not be empty");
+        Assert.True(selected.All(char.IsLetterOrDigit),
+            $"Expected pure word, got '{selected}'");
+
+        // Yank the selection
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked:"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Yank notification auto-clear ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task YankNotification_AutoClears_After1500ms()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Yank a row
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(_ => _state!.YankNotification is not null, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Verify notification is set
+        Assert.NotNull(_state!.YankNotification);
+
+        // Wait for auto-clear
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(_ => _state.YankNotification is null, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Null(_state.YankNotification);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Yank flash on table row ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task General_YankFlash_SetsAndClears()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Ensure table has focus (not editor)
+        Assert.NotNull(_state!.GeneralFocusedDep);
+        Assert.False(_state.App.FocusedNode is EditorNode);
+
+        // Yank — flash should be set briefly then cleared
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(_ => _state.YankNotification is not null, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Wait for flash to clear (150ms timer)
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(_ => !_state.YankFlashRow, TimeSpan.FromSeconds(3))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.False(_state.YankFlashRow);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _state?.Dispose();
+        _hex1bApp?.Dispose();
+        _terminal?.Dispose();
+        _workload?.Dispose();
+        _cts?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/Dotsider.Tests/TestHelpers.cs
+++ b/tests/Dotsider.Tests/TestHelpers.cs
@@ -1,10 +1,21 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Dotsider.Tests;
 
 internal static class TestHelpers
 {
+    /// <summary>
+    /// Computes the expected OSC 52 clipboard sequence for the given text,
+    /// matching the format used by <see cref="Hex1b.Hex1bApp.CopyToClipboard"/>.
+    /// </summary>
+    internal static string ExpectedOsc52(string text)
+    {
+        var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(text));
+        return $"\x1b]52;c;{base64}\x07";
+    }
+
     /// <summary>
     /// Logs a diagnostic message with timestamp to stderr (captured by xUnit).
     /// </summary>

--- a/tests/Dotsider.Tests/YankHelperTests.cs
+++ b/tests/Dotsider.Tests/YankHelperTests.cs
@@ -1,0 +1,565 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+using Dotsider.Infrastructure;
+using Dotsider.Views;
+using Hex1b;
+using Hex1b.Automation;
+using Hex1b.Documents;
+using Hex1b.Widgets;
+
+namespace Dotsider.Tests;
+
+[Collection("SampleAssemblies")]
+public class YankHelperTests(SampleAssemblyFixture samples) : IDisposable
+{
+    private readonly List<IDisposable> _disposables = [];
+
+    private DotsiderState CreateState(string dllPath)
+    {
+        var workload = new Hex1bAppWorkloadAdapter();
+        _disposables.Add(workload);
+        var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless()
+            .WithDimensions(80, 24)
+            .Build();
+        _disposables.Add(terminal);
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("")),
+            new Hex1bAppOptions { WorkloadAdapter = workload });
+        _disposables.Add(app);
+        return new DotsiderState(app, dllPath);
+    }
+
+    public void Dispose()
+    {
+        foreach (var d in _disposables)
+            d.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    // --- GetYankText(DotsiderState) ---
+
+    [Fact]
+    public void General_FocusedRef_ReturnsTabSeparatedRow()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.General;
+        var firstRef = state.Analyzer.AssemblyRefs[0];
+        state.GeneralFocusedDep = firstRef.Name;
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(firstRef.Name, text);
+        Assert.Contains(firstRef.Version, text);
+        Assert.Contains("\t", text);
+    }
+
+    [Fact]
+    public void General_NoFocusedRef_ReturnsNull()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.General;
+        state.GeneralFocusedDep = null;
+
+        Assert.Null(YankHelper.GetYankText(state));
+    }
+
+    [Fact]
+    public void PeMetadata_Sections_ReturnsFormattedRow()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.PeMetadata;
+        state.PeSubTab = PeSubTabId.Sections;
+        var section = state.Analyzer.Sections[0];
+        state.PeFocusedKey = section.Name;
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(section.Name, text);
+        Assert.Contains("0x", text);
+    }
+
+    [Fact]
+    public void PeMetadata_TypeDef_ReturnsFormattedRow()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.PeMetadata;
+        state.PeSubTab = PeSubTabId.TypeDef;
+        var typeDef = state.Analyzer.TypeDefs.First(t => !t.FullName.StartsWith("<"));
+        state.PeFocusedKey = typeDef.Token;
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(typeDef.FullName, text);
+    }
+
+    [Fact]
+    public void PeMetadata_MethodDef_ReturnsFormattedRow()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.PeMetadata;
+        state.PeSubTab = PeSubTabId.MethodDef;
+        var method = state.Analyzer.MethodDefs.First(m => m.Rva > 0);
+        state.PeFocusedKey = method.Token;
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(method.Name, text);
+        Assert.Contains(method.DeclaringType, text);
+    }
+
+    [Fact]
+    public void PeMetadata_TypeRef_ReturnsFormattedRow()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.PeMetadata;
+        state.PeSubTab = PeSubTabId.TypeRef;
+        var typeRef = state.Analyzer.TypeRefs[0];
+        state.PeFocusedKey = typeRef.Token;
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(typeRef.FullName, text);
+    }
+
+    [Fact]
+    public void PeMetadata_MemberRef_ReturnsFormattedRow()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.PeMetadata;
+        state.PeSubTab = PeSubTabId.MemberRef;
+        var memberRef = state.Analyzer.MemberRefs[0];
+        state.PeFocusedKey = memberRef.Token;
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(memberRef.Name, text);
+    }
+
+    [Fact]
+    public void PeMetadata_Attributes_ReturnsFormattedRow()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.PeMetadata;
+        state.PeSubTab = PeSubTabId.Attributes;
+        var attr = state.Analyzer.CustomAttributes[0];
+        state.PeFocusedKey = $"{attr.Parent}|{attr.Constructor}";
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(attr.Parent, text);
+    }
+
+    [Fact]
+    public void PeMetadata_Resources_ReturnsFormattedRow()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.PeMetadata;
+        state.PeSubTab = PeSubTabId.Resources;
+        if (state.Analyzer.Resources.Count == 0) return; // some assemblies have none
+        var resource = state.Analyzer.Resources[0];
+        state.PeFocusedKey = resource.Name;
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(resource.Name, text);
+    }
+
+    [Fact]
+    public void PeMetadata_NoFocusedKey_ReturnsNull()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.PeMetadata;
+        state.PeFocusedKey = null;
+
+        Assert.Null(YankHelper.GetYankText(state));
+    }
+
+    [Fact]
+    public void Strings_FocusedEntry_ReturnsStringValue()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.Strings;
+        var strings = state.GetActiveStrings();
+        Assert.True(strings.Count > 0);
+        var entry = strings[0];
+        state.StringsFocusedKey = $"{entry.Offset}:{entry.Source}";
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.Equal(entry.Value, text);
+    }
+
+    [Fact]
+    public void DepGraph_SelectedNode_ReturnsNodeName()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.DepGraph;
+        state.GraphSelectedNode = "System.Runtime v10.0.0.0";
+
+        Assert.Equal("System.Runtime v10.0.0.0", YankHelper.GetYankText(state));
+    }
+
+    [Fact]
+    public void DepGraph_SelectedIndex_ReturnsNodeNameWithVersion()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.DepGraph;
+        var (nodes, _) = state.CachedGraph ??= DependencyGraphBuilder.Build(state.Analyzer);
+        Assert.True(nodes.Count > 0);
+        state.GraphSelectedIndex = 0;
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(nodes[0].Name, text);
+    }
+
+    [Fact]
+    public void SizeMap_SelectedIndex_ReturnsItemWithSize()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.SizeMap;
+        state.CachedSizeTree ??= SizeAnalyzer.BuildSizeTree(state.Analyzer);
+        var level = state.CachedSizeTree;
+        Assert.True(level.Children.Count > 0);
+        state.TreemapSelectedIndex = 0;
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(level.Children[0].FullPath, text);
+    }
+
+    [Fact]
+    public void SizeMap_HoveredItem_ReturnsHoveredText()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.SizeMap;
+        state.TreemapHoveredItem = "  RichLibrary.Models: 1.2 KB  ";
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.Equal("RichLibrary.Models: 1.2 KB", text); // Trimmed
+    }
+
+    [Fact]
+    public void SizeMap_NoSelection_ReturnsNull()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.SizeMap;
+        state.TreemapSelectedIndex = -1;
+        state.TreemapHoveredItem = null;
+
+        Assert.Null(YankHelper.GetYankText(state));
+    }
+
+    [Fact]
+    public void Dynamic_NoTracer_ReturnsNull()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.Dynamic;
+        state.Tracer = null;
+
+        Assert.Null(YankHelper.GetYankText(state));
+    }
+
+    [Fact]
+    public void Dynamic_Events_NoFocusedKey_ReturnsNull()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.Dynamic;
+        state.DynamicSubTab = DynamicSubTabId.Events;
+        state.DynamicEventsFocusedKey = null;
+
+        Assert.Null(YankHelper.GetYankText(state));
+    }
+
+    [Fact]
+    public void Dynamic_Output_NoFocusedKey_ReturnsNull()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.Dynamic;
+        state.DynamicSubTab = DynamicSubTabId.Output;
+        state.DynamicOutputFocusedKey = null;
+
+        Assert.Null(YankHelper.GetYankText(state));
+    }
+
+    [Fact]
+    public void Dynamic_Counters_ReturnsNull()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.Dynamic;
+        state.DynamicSubTab = DynamicSubTabId.Counters;
+
+        Assert.Null(YankHelper.GetYankText(state));
+    }
+
+    [Fact]
+    public void Dynamic_Summary_ReturnsNull()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.Dynamic;
+        state.DynamicSubTab = DynamicSubTabId.Summary;
+
+        Assert.Null(YankHelper.GetYankText(state));
+    }
+
+    [Fact]
+    public void IlInspector_ReturnsNull()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.IlInspector;
+
+        Assert.Null(YankHelper.GetYankText(state));
+    }
+
+    [Fact]
+    public void HexDump_ReturnsNull()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.HexDump;
+
+        Assert.Null(YankHelper.GetYankText(state));
+    }
+
+    // --- GetYankText(DiffState) ---
+
+    [Fact]
+    public void Diff_Types_FocusedRow_ReturnsFormattedText()
+    {
+        var workload = new Hex1bAppWorkloadAdapter();
+        var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
+        var app = new Hex1bApp(_ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("")),
+            new Hex1bAppOptions { WorkloadAdapter = workload });
+        using var state = new DiffState(app, samples.RichLibraryDll, samples.RichLibraryV2Dll);
+        state.CurrentTab = 1; // Types
+        var entry = state.DiffResult.TypeDiffs.First(e => e.Kind != DiffKind.Unchanged);
+        var type = entry.Right ?? entry.Left!;
+        state.DiffFocusedKey = $"{entry.Kind}:{type.FullName}";
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(type.FullName, text);
+        Assert.Contains(entry.Kind.ToString(), text);
+    }
+
+    [Fact]
+    public void Diff_Methods_FocusedRow_ReturnsFormattedText()
+    {
+        var workload = new Hex1bAppWorkloadAdapter();
+        var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
+        var app = new Hex1bApp(_ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("")),
+            new Hex1bAppOptions { WorkloadAdapter = workload });
+        using var state = new DiffState(app, samples.RichLibraryDll, samples.RichLibraryV2Dll);
+        state.CurrentTab = 2; // Methods
+        var entry = state.DiffResult.MethodDiffs.First(e => e.Kind != DiffKind.Unchanged);
+        var method = entry.Right ?? entry.Left!;
+        state.DiffFocusedKey = $"{entry.Kind}:{method.DeclaringType}::{method.Name}{method.Signature}";
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(method.Name, text);
+    }
+
+    [Fact]
+    public void Diff_Refs_FocusedRow_ReturnsFormattedText()
+    {
+        var workload = new Hex1bAppWorkloadAdapter();
+        var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
+        var app = new Hex1bApp(_ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("")),
+            new Hex1bAppOptions { WorkloadAdapter = workload });
+        using var state = new DiffState(app, samples.RichLibraryDll, samples.RichLibraryV2Dll);
+        state.CurrentTab = 3; // Refs
+        var entry = state.DiffResult.AssemblyRefDiffs.First(e => e.Kind != DiffKind.Unchanged);
+        var name = entry.Right?.Name ?? entry.Left?.Name ?? "";
+        state.DiffFocusedKey = $"{entry.Kind}:{name}";
+
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(name, text);
+    }
+
+    [Fact]
+    public void Diff_Summary_ReturnsNull()
+    {
+        var workload = new Hex1bAppWorkloadAdapter();
+        var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
+        var app = new Hex1bApp(_ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("")),
+            new Hex1bAppOptions { WorkloadAdapter = workload });
+        using var state = new DiffState(app, samples.RichLibraryDll, samples.RichLibraryV2Dll);
+        state.CurrentTab = 0; // Summary
+
+        Assert.Null(YankHelper.GetYankText(state));
+    }
+
+    [Fact]
+    public void Diff_NoFocusedKey_ReturnsNull()
+    {
+        var workload = new Hex1bAppWorkloadAdapter();
+        var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
+        var app = new Hex1bApp(_ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("")),
+            new Hex1bAppOptions { WorkloadAdapter = workload });
+        using var state = new DiffState(app, samples.RichLibraryDll, samples.RichLibraryV2Dll);
+        state.CurrentTab = 1;
+        state.DiffFocusedKey = null;
+
+        Assert.Null(YankHelper.GetYankText(state));
+    }
+
+    // --- GetHexSelectionText ---
+
+    [Fact]
+    public void GetHexSelectionText_ReturnsUppercaseSpaceSeparatedHex()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        var hexState = state.HexEditorState;
+        var byteMap = hexState.Document.GetByteMap();
+
+        // Select a small range
+        var (startChar, _) = byteMap.ByteToChar(0);
+        var (endChar, _) = byteMap.ByteToChar(3);
+        hexState.Cursor.SelectionAnchor = new DocumentOffset(startChar);
+        hexState.Cursor.Position = new DocumentOffset(endChar);
+
+        var result = YankHelper.GetHexSelectionText(hexState);
+
+        Assert.NotNull(result);
+        // PE files start with MZ (4D 5A)
+        Assert.StartsWith("4D 5A", result);
+        // Verify format: uppercase, space-separated
+        var parts = result.Split(' ');
+        Assert.True(parts.Length >= 4);
+        foreach (var part in parts)
+        {
+            Assert.Equal(2, part.Length);
+            Assert.True(part.All(c => char.IsDigit(c) || (c >= 'A' && c <= 'F')));
+        }
+    }
+
+    [Fact]
+    public void GetHexSelectionText_NoSelection_ReturnsNull()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        Assert.Null(YankHelper.GetHexSelectionText(state.HexEditorState));
+    }
+
+    // --- FindYankProvider ---
+
+    [Fact]
+    public void FindYankProvider_DotsiderState_MatchesAllEditors()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+
+        // IL editor state is null until a method is selected — create one for testing
+        state.IlEditorState = new EditorState(new Hex1bDocument("il test")) { IsReadOnly = true };
+        Assert.Same(state.IlYankProvider, YankHelper.FindYankProvider(state, state.IlEditorState));
+
+        state.GeneralInfoEditorState = new EditorState(new Hex1bDocument("test")) { IsReadOnly = true };
+        Assert.Same(state.GeneralInfoYankProvider, YankHelper.FindYankProvider(state, state.GeneralInfoEditorState));
+
+        state.PeHeadersEditorState = new EditorState(new Hex1bDocument("test")) { IsReadOnly = true };
+        Assert.Same(state.PeHeadersYankProvider, YankHelper.FindYankProvider(state, state.PeHeadersEditorState));
+
+        state.ClrHeaderEditorState = new EditorState(new Hex1bDocument("test")) { IsReadOnly = true };
+        Assert.Same(state.ClrHeaderYankProvider, YankHelper.FindYankProvider(state, state.ClrHeaderEditorState));
+
+        state.PeDetailEditorState = new EditorState(new Hex1bDocument("test")) { IsReadOnly = true };
+        Assert.Same(state.PeDetailYankProvider, YankHelper.FindYankProvider(state, state.PeDetailEditorState));
+
+        state.StringsDetailEditorState = new EditorState(new Hex1bDocument("test")) { IsReadOnly = true };
+        Assert.Same(state.StringsDetailYankProvider, YankHelper.FindYankProvider(state, state.StringsDetailEditorState));
+
+        // Unknown editor returns null
+        var unknownState = new EditorState(new Hex1bDocument("unknown")) { IsReadOnly = true };
+        Assert.Null(YankHelper.FindYankProvider(state, unknownState));
+    }
+
+    [Fact]
+    public void FindYankProvider_NuGetState_MatchesPackageInfoAndDelegates()
+    {
+        var workload = new Hex1bAppWorkloadAdapter();
+        var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
+        var app = new Hex1bApp(_ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("")),
+            new Hex1bAppOptions { WorkloadAdapter = workload });
+        using var nugetState = new NuGetState(app, samples.RichLibraryNupkg);
+
+        nugetState.PackageInfoEditorState = new EditorState(new Hex1bDocument("test")) { IsReadOnly = true };
+        Assert.Same(nugetState.PackageInfoYankProvider,
+            YankHelper.FindYankProvider(nugetState, nugetState.PackageInfoEditorState));
+
+        // With a selected DLL state, delegates to DotsiderState lookup
+        nugetState.SelectedDllState = new DotsiderState(app, samples.RichLibraryDll);
+        nugetState.SelectedDllState.GeneralInfoEditorState = new EditorState(new Hex1bDocument("test")) { IsReadOnly = true };
+        Assert.Same(nugetState.SelectedDllState.GeneralInfoYankProvider,
+            YankHelper.FindYankProvider(nugetState, nugetState.SelectedDllState.GeneralInfoEditorState));
+
+        // Unknown returns null
+        var unknown = new EditorState(new Hex1bDocument("x")) { IsReadOnly = true };
+        Assert.Null(YankHelper.FindYankProvider(nugetState, unknown));
+    }
+
+    // --- CursorColorHelper ---
+
+    [Fact]
+    public void CursorColorHelper_SetSequence_IsOsc12()
+    {
+        Assert.StartsWith("\x1b]12;", CursorColorHelper.SetTealSequence);
+        Assert.Contains("rgb:00/c8/b4", CursorColorHelper.SetTealSequence);
+        Assert.EndsWith("\x1b\\", CursorColorHelper.SetTealSequence);
+    }
+
+    [Fact]
+    public void CursorColorHelper_ResetSequence_IsOsc112()
+    {
+        Assert.Equal("\x1b]112\x1b\\", CursorColorHelper.ResetSequence);
+    }
+
+    [Fact]
+    public void CursorColorHelper_ResetCursorColor_WritesToConsole()
+    {
+        // Capture console output
+        var original = Console.Out;
+        using var sw = new StringWriter();
+        Console.SetOut(sw);
+        try
+        {
+            CursorColorHelper.ResetCursorColor();
+            Assert.Equal(CursorColorHelper.ResetSequence, sw.ToString());
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+    }
+
+    [Fact]
+    public void CursorColorHelper_SetThemeCursorColor_WritesToConsole()
+    {
+        var original = Console.Out;
+        using var sw = new StringWriter();
+        Console.SetOut(sw);
+        try
+        {
+            CursorColorHelper.SetThemeCursorColor();
+            Assert.Equal(CursorColorHelper.SetTealSequence, sw.ToString());
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+    }
+}


### PR DESCRIPTION
Y key now works on every tab and mode — not just the IL Inspector.

Static text blocks (Assembly Info, PE/CLR headers, detail popups, diff summary, NuGet package info) are read-only editors with cursor navigation, text selection, and neovim-style yank with flash. Tables copy the focused row as tab-separated values with a row flash. Hex dump copies selected bytes as uppercase space-separated hex. Surfaces copy the selected node name.

Tab cycles focus between editors and tables. Left/Right sub-tab switching is suppressed when an editor has focus. Diff tables get proper focus contrast. NuGet DLL inspector gets full hex/IL/search parity via a shared DllInspectorBindings helper with the complete Esc chain. Terminal cursor color resets on exit.

97 new tests across 7 test files with real clipboard payload capture via ClipboardCapturingWorkloadAdapter, real SGR mouse double-click input, and timer race coverage.

Fixes #72