### PR TITLE
Unify back navigation to Esc and fix regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Supported `--ai` providers: claude, gemini, copilot, cursor-agent, opencode, cod
 |-----|--------|
 | `1`-`8` | Switch tabs |
 | `Enter` | Drill into selected item (assembly ref, method, DLL in package) |
-| `Backspace` | Go back (assembly stack, breadcrumb, or cross-view jump) |
+| `Esc` | Go back (assembly stack, breadcrumb, or cross-view jump) |
 | `y` | Yank (copy) — selected text in editors, or focused row in tables |
 | `Tab` | Cycle focus between info panels and tables |
 | `g` | Go to IL Inspector for the focused TypeDef/MethodDef (PE/Metadata tab) |

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -32,7 +32,7 @@ Press `1` through `8` to switch between tabs:
 
 ## Drill in
 
-Press `Enter` on any highlighted item to drill deeper — an assembly reference, a method in the IL tree, or a dependency node in the graph. Press `Backspace` to go back.
+Press `Enter` on any highlighted item to drill deeper — an assembly reference, a method in the IL tree, or a dependency node in the graph. Press `Esc` to go back.
 
 ## Search
 

--- a/docs/src/content/docs/reference/keyboard.md
+++ b/docs/src/content/docs/reference/keyboard.md
@@ -9,7 +9,7 @@ description: All keyboard shortcuts for navigating dotsider.
 |-----|--------|
 | `1`–`8` | Switch tabs |
 | `Enter` | Drill into selected item |
-| `Backspace` | Go back |
+| `Esc` | Go back (when no search or modal is active) |
 | `/` | Search |
 | `n` / `N` | Next / previous search match |
 | `y` | Yank (copy) — selected text in editors, or focused row in tables |

--- a/docs/src/content/docs/usage/dep-graph.md
+++ b/docs/src/content/docs/usage/dep-graph.md
@@ -13,6 +13,6 @@ The **Dep Graph** tab (`6`) renders a visual dependency graph:
 
 ## Navigation
 
-Press `Enter` on any dependency node to open that assembly in a new analysis context (if the file is found on disk). Press `Backspace` to return.
+Press `Enter` on any dependency node to open that assembly in a new analysis context (if the file is found on disk). Press `Esc` to return.
 
 This gives you a quick sense of which dependencies are most heavily used and lets you drill into any of them.

--- a/docs/src/content/docs/usage/general.md
+++ b/docs/src/content/docs/usage/general.md
@@ -20,6 +20,6 @@ On the dependency table, focus a row and press `y` to copy it as tab-separated v
 
 ## Drill into references
 
-Select any row in the dependency table and press `Enter`. If the referenced assembly exists on disk (next to the current file or in a probing path), dotsider opens it in a new analysis context. Press `Backspace` to return.
+Select any row in the dependency table and press `Enter`. If the referenced assembly exists on disk (next to the current file or in a probing path), dotsider opens it in a new analysis context. Press `Esc` to return.
 
 This lets you walk an entire dependency chain without leaving the TUI.

--- a/docs/src/content/docs/usage/il-inspector.md
+++ b/docs/src/content/docs/usage/il-inspector.md
@@ -16,7 +16,7 @@ Each instruction shows:
 ## Cross-tab navigation
 
 - Press `x` on a selected method to jump to its body in the **Hex Dump** tab. The hex view scrolls to the method's RVA.
-- Press `Backspace` to return to where you came from.
+- Press `Esc` to return to where you came from.
 
 ## Copy
 

--- a/src/Dotsider/DllInspectorBindings.cs
+++ b/src/Dotsider/DllInspectorBindings.cs
@@ -247,7 +247,7 @@ public static class DllInspectorBindings
 
         // Cross-view back hint
         if (state.CrossViewBackTarget is not null)
-            hints.Add(s.Section("Backspace: Back"));
+            hints.Add(s.Section("Esc: Back"));
 
         // Search hint
         var currentSearch = state.Search[state.CurrentTab];

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -335,17 +335,33 @@ public sealed class DotsiderApp(DotsiderState state)
             bindings.Ctrl().Key(Hex1bKey.C).Global().OverridesCapture()
                 .Action(ctx => ctx.RequestStop(), "Quit");
 
-            // Cross-view back navigation — suppressed when any text input is active
-            // (search editing, hex jump dialog, hex insert mode, dynamic args editing)
-            // or when the current tab locally consumes Backspace
-            var tabUsesBackspace = (_state.CurrentTab == TabId.General && _state.NavigationStack.Count > 0)
-                || (_state.CurrentTab == TabId.SizeMap && _state.TreemapBreadcrumb.Count > 0);
-            if (!tabUsesBackspace && !isSearchEditing && !_state.HexJumpDialogOpen && !hexInsertMode
-                && !_state.DynamicEditingArgs && _state.CrossViewBackTarget is not null)
+            // Back navigation via Esc — assembly stack pop or cross-view back.
+            // Only when no other modal claims Esc.
+            var hasBackTarget = _state.NavigationStack.Count > 0 || _state.CrossViewBackTarget is not null;
+            var sizeMapUsesEsc = _state.CurrentTab == TabId.SizeMap && _state.TreemapBreadcrumb.Count > 0;
+            var dynamicFilterActive = _state.CurrentTab == TabId.Dynamic
+                && _state.DynamicSubTab == DynamicSubTabId.Events
+                && _state.DynamicCategoryFilter is not null;
+            if (hasBackTarget && !sizeMapUsesEsc && !dynamicFilterActive
+                && !currentSearch.IsActive && !_state.HexJumpDialogOpen && !hexInsertMode
+                && !_state.DynamicEditingArgs
+                && _state.PeDetailContent is null && _state.StringsDetailContent is null
+                && !(_state.CurrentTab == TabId.IlInspector && _state.IlEditorState?.Cursor.HasSelection == true))
             {
-                bindings.Key(Hex1bKey.Backspace).Global().Action(_ =>
+                bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
                 {
-                    _state.NavigateBack();
+                    // Cross-view back takes priority — return to the originating tab first
+                    if (_state.CrossViewBackTarget is not null)
+                    {
+                        _state.NavigateBack();
+                    }
+                    else if (_state.NavigationStack.Count > 0)
+                    {
+                        _state.PopAssembly();
+                        _state.NavigateToTab(TabId.General);
+                        _state.RequestContentFocus();
+                        _state.App.Invalidate();
+                    }
                 }, "Back");
             }
         });
@@ -418,7 +434,7 @@ public sealed class DotsiderApp(DotsiderState state)
             hints.Add(s.Section("1-8: Tabs"));
 
             if (_state.NavigationStack.Count > 0)
-                hints.Add(s.Section("Backspace: Back"));
+                hints.Add(s.Section("Esc: Back"));
 
             if (_state.CurrentTab == 1)
             {
@@ -451,7 +467,7 @@ public sealed class DotsiderApp(DotsiderState state)
             else if (_state.CurrentTab == 5)
                 hints.Add(s.Section("←→: Select | Enter: Open"));
             else if (_state.CurrentTab == 6)
-                hints.Add(s.Section("Enter: Drill | ←→: Select | Backspace: Up"));
+                hints.Add(s.Section("Enter: Drill | ←→: Select | Esc: Up"));
             else if (_state.CurrentTab == 7)
             {
                 if (_state.Tracer?.ProcessState == TraceProcessState.Running)
@@ -474,7 +490,7 @@ public sealed class DotsiderApp(DotsiderState state)
 
             // Cross-view back hint
             if (_state.CrossViewBackTarget is not null)
-                hints.Add(s.Section("Backspace: Back"));
+                hints.Add(s.Section("Esc: Back"));
 
             // Search hint — always available on all tabs
             var currentSearch = _state.Search[_state.CurrentTab];

--- a/src/Dotsider/Views/GeneralView.cs
+++ b/src/Dotsider/Views/GeneralView.cs
@@ -181,12 +181,6 @@ public static class GeneralView
         })
         .WithInputBindings(bindings =>
         {
-            bindings.Key(Hex1bKey.Backspace).Action(_ =>
-            {
-                if (state.PopAssembly())
-                    state.App.Invalidate();
-            }, "Back");
-
             bindings.Key(Hex1bKey.Tab).Global().Action(_ =>
             {
                 if (state.App.FocusedNode is EditorNode)

--- a/src/Dotsider/Views/InfoEditorViewRenderer.cs
+++ b/src/Dotsider/Views/InfoEditorViewRenderer.cs
@@ -34,7 +34,7 @@ public sealed class InfoEditorViewRenderer : IEditorViewRenderer
         // Overwrite tilde lines with blank space
         var docLineCount = state.Document.LineCount;
         var viewportLines = viewport.Height;
-        var firstEmptyViewLine = docLineCount - scrollOffset;
+        var firstEmptyViewLine = docLineCount - scrollOffset + 1;
 
         if (firstEmptyViewLine < 0) firstEmptyViewLine = 0;
 

--- a/src/Dotsider/Views/SizeTreemapView.cs
+++ b/src/Dotsider/Views/SizeTreemapView.cs
@@ -86,7 +86,7 @@ public static class SizeTreemapView
             // Search bar
             SearchBarHelper.AddSearchBar(widgets, outer, search, state.App);
 
-            // Treemap surface wrapped in Interactable for click/Enter/arrow/Backspace support
+            // Treemap surface wrapped in Interactable for click/Enter/arrow/Esc support
             widgets.Add(outer.Interactable(ic =>
                 ic.Surface(s =>
                 [
@@ -127,7 +127,7 @@ public static class SizeTreemapView
                 }
                 else
                 {
-                    // Keyboard (Enter/Space): prefer search match over stale selection
+                    // Keyboard (Enter/Space): prefer search match, then selection
                     if (state.TreemapMatchIndex >= 0 && state.TreemapMatchIndex < matchingItems.Count)
                         drillTarget = currentLevel.Children[matchingItems[state.TreemapMatchIndex]];
                     else if (state.TreemapSelectedIndex >= 0 && state.TreemapSelectedIndex < currentLevel.Children.Count)
@@ -159,15 +159,17 @@ public static class SizeTreemapView
                 }
             }).WithInputBindings(bindings =>
             {
-                bindings.Key(Hex1bKey.Backspace).Action(_ =>
+                // Esc pops the treemap breadcrumb (when no search is active)
+                var treemapSearch = state.Search[TabId.SizeMap];
+                if (!treemapSearch.IsActive && state.TreemapBreadcrumb.Count > 0)
                 {
-                    if (state.TreemapBreadcrumb.Count > 0)
+                    bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
                     {
                         state.TreemapCurrentLevel = state.TreemapBreadcrumb.Pop();
                         state.TreemapSelectedIndex = -1;
                         state.App.Invalidate();
-                    }
-                }, "Go up");
+                    }, "Go up");
+                }
 
                 bindings.Mouse(MouseButton.Right).Action(_ =>
                 {

--- a/tests/Dotsider.Tests/DiffModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/DiffModeYankIntegrationTests.cs
@@ -574,10 +574,11 @@ public class DiffModeYankIntegrationTests(SampleAssemblyFixture samples) : IDisp
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Type("y")
+            .WaitUntil(_ => _state!.YankNotification is not null, TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal, ct);
 
-        // Flash should clear
+        // Flash should clear after 150ms
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(_ => !_state!.YankFlashRow, TimeSpan.FromSeconds(3))
             .Build()

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -852,7 +852,7 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
     }
 
     [Fact(Timeout = 30_000)]
-    public async Task Tab7_Backspace_PopsBreadcrumb()
+    public async Task Tab7_Escape_PopsBreadcrumb()
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
@@ -884,9 +884,9 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
 
         Assert.Single(_state.TreemapBreadcrumb);
 
-        // Press Backspace to go up
+        // Press Escape to go up
         await new Hex1bTerminalInputSequenceBuilder()
-            .Key(Hex1bKey.Backspace)
+            .Key(Hex1bKey.Escape)
             .WaitUntil(_ => _state.TreemapBreadcrumb.Count == 0, TimeSpan.FromSeconds(10))
             .Build()
             .ApplyAsync(terminal, cts.Token);
@@ -1709,25 +1709,24 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
         _state!.CrossViewBackTarget = (TabId.PeMetadata, PeSubTabId.TypeDef);
         _hex1bApp!.Invalidate();
 
-        // Wait for "Backspace: Back" hint to appear
+        // Wait for "Esc: Back" hint to appear
         await new Hex1bTerminalInputSequenceBuilder()
-            .WaitUntil(s => s.ContainsText("Backspace: Back"), TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Esc: Back"), TimeSpan.FromSeconds(10))
             .Build()
             .ApplyAsync(terminal, cts.Token);
 
-        // Open search — type "test" then press Backspace
+        // Open search — type "test" then press Escape
         await new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.OemQuestion) // '/' — activate search
             .WaitUntil(_ => _state.Search[TabId.IlInspector].IsActive, TimeSpan.FromSeconds(10))
             .Key(Hex1bKey.T).Key(Hex1bKey.E).Key(Hex1bKey.S).Key(Hex1bKey.T) // type "test"
-            .Key(Hex1bKey.Backspace) // should delete 't', NOT navigate back
-            .WaitUntil(_ => _state.Search[TabId.IlInspector].Query == "tes", TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Escape) // should dismiss search, NOT navigate back
+            .WaitUntil(_ => !_state.Search[TabId.IlInspector].IsActive, TimeSpan.FromSeconds(10))
             .Build()
             .ApplyAsync(terminal, cts.Token);
 
-        // Verify we stayed on IL Inspector — Backspace deleted a character, didn't navigate back
+        // Verify we stayed on IL Inspector — Escape dismissed search, didn't navigate back
         Assert.Equal(TabId.IlInspector, _state.CurrentTab);
-        Assert.Equal("tes", _state.Search[TabId.IlInspector].Query);
         Assert.NotNull(_state.CrossViewBackTarget); // Back target still present
 
         cts.Cancel();

--- a/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
@@ -609,6 +609,329 @@ public class StandardModeYankIntegrationTests(SampleAssemblyFixture samples) : I
         try { await runTask; } catch (OperationCanceledException) { }
     }
 
+    // --- Size Map drill ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task SizeMap_SelectThenEnterDrills()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.SizeMap);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary") && s.ContainsText("Total:"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Empty(_state!.TreemapBreadcrumb);
+
+        // Select with arrow first, then Enter to drill
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state.TreemapSelectedIndex >= 0, TimeSpan.FromSeconds(5))
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state.TreemapBreadcrumb.Count > 0, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotEmpty(_state.TreemapBreadcrumb);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task SizeMap_EnterWithoutSelection_DoesNothing()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.SizeMap);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary") && s.ContainsText("Total:"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Empty(_state!.TreemapBreadcrumb);
+        Assert.Equal(-1, _state.TreemapSelectedIndex);
+
+        // Press Enter with no selection — should be a no-op
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Enter)
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(200, ct);
+        Assert.Empty(_state.TreemapBreadcrumb);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Esc regression: nested cross-view + assembly stack ---
+
+    [Fact(Timeout = 60_000)]
+    public async Task EscBack_CrossViewTakesPriorityOverAssemblyStack()
+    {
+        // Use RichLibrary — its refs resolve to BCL assemblies in the runtime dir
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Real drill via PushAssembly — resolve a BCL ref from the runtime directory
+        var refName = _state!.Analyzer.AssemblyRefs[0].Name;
+        var resolvedPath = Dotsider.Core.Analysis.AssemblyAnalyzer.ResolveAssemblyPath(
+            _state.Analyzer.FilePath, refName);
+        Assert.NotNull(resolvedPath);
+        Assert.True(_state.PushAssembly(resolvedPath),
+            $"PushAssembly should succeed for resolved ref '{refName}'");
+        _state.App.Invalidate();
+        await Task.Delay(200, ct);
+
+        Assert.True(_state.NavigationStack.Count > 0);
+
+        // The drilled BCL assembly may lack user types with methods.
+        // Navigate back to push RichLibrary again so we have real types for g.
+        _state.PopAssembly();
+        _state.App.Invalidate();
+        await Task.Delay(100, ct);
+
+        // Re-push so NavigationStack > 0, but stay on the RichLibrary analyzer
+        Assert.True(_state.PushAssembly(resolvedPath));
+        _state.App.Invalidate();
+        await Task.Delay(100, ct);
+
+        // Pop back to RichLibrary — now NavigationStack has the BCL assembly
+        _state.PopAssembly();
+
+        // Push the BCL one more time so we have NavigationStack > 0
+        // while the current analyzer is RichLibrary (which has real types)
+        _state.NavigationStack.Push(new Dotsider.Core.Analysis.AssemblyAnalyzer(resolvedPath));
+        _state.App.Invalidate();
+        await Task.Delay(100, ct);
+
+        Assert.True(_state.NavigationStack.Count > 0);
+
+        // Switch to PE/Metadata TypeDef sub-tab
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.D2) // PE/Metadata
+            .WaitUntil(s => s.ContainsText("TypeDef") || s.ContainsText("Sections"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        _state.PeSubTab = PeSubTabId.TypeDef;
+        _state.App.Invalidate();
+        await Task.Delay(200, ct);
+
+        // RichLibrary has real types with methods
+        var typeDef = _state.Analyzer.TypeDefs.FirstOrDefault(t =>
+            !t.FullName.StartsWith("<") && t.MethodCount > 0);
+        Assert.NotNull(typeDef);
+
+        _state.PeFocusedKey = typeDef.Token;
+        _state.App.Invalidate();
+        await Task.Delay(100, ct);
+
+        // Press g to trigger cross-view jump to IL Inspector
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("g")
+            .WaitUntil(_ => _state.CurrentTab == TabId.IlInspector, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state.CrossViewBackTarget);
+        Assert.True(_state.NavigationStack.Count > 0);
+
+        // Esc 1: cross-view back to PE/Metadata — NOT assembly pop
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => _state.CrossViewBackTarget is null, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Equal(TabId.PeMetadata, _state.CurrentTab);
+        Assert.True(_state.NavigationStack.Count > 0,
+            "Assembly stack should still have the parent");
+
+        // Allow bindings to rebuild after cross-view back
+        await Task.Delay(200, ct);
+
+        // Esc 2: pop assembly and return to General
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => _state.CurrentTab == TabId.General, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Empty(_state.NavigationStack);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Esc regression: Dynamic filter clears before assembly pop ---
+
+    [Fact(Timeout = 120_000)]
+    public async Task EscBack_DynamicFilterClearsBeforeAssemblyPop()
+    {
+        // Use HelloWorld which is executable (has entry point for Dynamic tab)
+        var (terminal, app, ct) = Launch(samples.HelloWorldDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Drill into a referenced assembly
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.NavigationStack.Count > 0, TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Go back to HelloWorld (we need the executable for Dynamic tab)
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => _state!.NavigationStack.Count == 0, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Re-drill so NavigationStack > 0
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.NavigationStack.Count > 0, TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var stackBefore = _state!.NavigationStack.Count;
+
+        // Switch to Dynamic tab
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.D8) // Dynamic tab
+            .WaitUntil(_ => _state.CurrentTab == TabId.Dynamic, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Set filter programmatically — the guard condition checks state regardless
+        // of whether the Events UI is rendered (the drilled assembly may be a library)
+        _state.DynamicSubTab = DynamicSubTabId.Events;
+        _state.DynamicCategoryFilter = Dotsider.Core.Analysis.Models.TraceEventCategory.GC;
+        _state.App.Invalidate();
+        await Task.Delay(100, ct);
+
+        // Esc should NOT pop the assembly — the dynamicFilterActive guard blocks it
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(200, ct);
+        Assert.Equal(stackBefore, _state.NavigationStack.Count);
+
+        // Clear the filter manually and verify Esc now pops
+        _state.DynamicCategoryFilter = null;
+        _state.App.Invalidate();
+        await Task.Delay(100, ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => _state.NavigationStack.Count == 0, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Equal(TabId.General, _state.CurrentTab);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Size Map regression: zero-match search Enter is no-op ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task SizeMap_EnterAfterZeroMatchSearch_DoesNotDrill()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.SizeMap);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary") && s.ContainsText("Total:"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Search for something that won't match
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.OemQuestion)
+            .Type("zzzznotanamespace")
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.Search[TabId.SizeMap].IsConfirmed, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Verify the precondition: zero matches, no selection
+        Assert.Equal(-1, _state!.TreemapMatchIndex);
+        Assert.Equal(-1, _state.TreemapSelectedIndex);
+        Assert.Empty(_state.TreemapBreadcrumb);
+
+        // Enter should be a no-op — no match, no selection
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Enter)
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(200, ct);
+        Assert.Empty(_state.TreemapBreadcrumb);
+        Assert.Equal(-1, _state.TreemapMatchIndex);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    // --- Strings detail popup regression: content must be visible on screen ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task StringsDetail_PopupShowsStringContentOnScreen()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, TabId.Strings);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("strings"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Capture the string value from the first visible row
+        var strings = _state!.GetActiveStrings();
+        Assert.True(strings.Count > 0);
+        var firstString = strings[0].Value;
+
+        // Navigate to first row and open detail popup
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(s => s.ContainsText("String Detail"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // The actual string content must be visible on the terminal — not just "Length: N"
+        // This catches the InfoEditorViewRenderer regression where content lines were blanked
+        var snippet = firstString.Length > 20 ? firstString[..20] : firstString;
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.ContainsText(snippet), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
     // --- Yank notification auto-clear ---
 
     [Fact(Timeout = 30_000)]


### PR DESCRIPTION
All back navigation now uses Esc instead of Backspace. This covers assembly stack pop, treemap breadcrumb up, and cross-view back. Matches the NuGet mode convention and plays better with the read-only editors that use Backspace for cursor movement.

Cross-view back (from g or x jumps) takes priority over assembly stack pop, so pressing Esc after jumping to IL from PE/Metadata returns to the originating tab first. The assembly pop only fires once there's no cross-view target left, and it switches back to the General tab.

The Dynamic Events category filter now blocks the global Esc-back binding while active, so Esc clears the filter instead of popping the assembly.

Size Map Enter no longer falls back to the first child when nothing is selected. A zero-match search followed by Enter is a no-op.

Also fixes an off-by-one in InfoEditorViewRenderer that was blanking the last content line in editors with 3+ lines. This showed up as String Detail popups displaying only the Length header with no string content below it.

Fixes #78