### PR TITLE
Support vim text objects (iw, iW, yiw, yiW) in read-only editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ Supported `--ai` providers: claude, gemini, copilot, cursor-agent, opencode, cod
 | `Enter` | Drill into selected item (assembly ref, method, DLL in package) |
 | `Esc` | Go back (assembly stack, breadcrumb, or cross-view jump) |
 | `y` | Yank (copy) — selected text in editors, or focused row in tables |
+| `iw` | Select inner word (vim text object) |
+| `iW` | Select inner WORD (whitespace-delimited — grabs fully-qualified names) |
+| `yiw` / `yiW` | Select + yank word/WORD in one motion |
 | `Tab` | Cycle focus between info panels and tables |
 | `g` | Go to IL Inspector for the focused TypeDef/MethodDef (PE/Metadata tab) |
 | `x` | Jump to method body in Hex Dump (IL Inspector tab, when a method with RVA is selected) |
@@ -150,7 +153,7 @@ Supported `--ai` providers: claude, gemini, copilot, cursor-agent, opencode, cod
 | `s` | Toggle human-readable sizes |
 | `q` | Quit |
 
-Info panels (Assembly Info, PE Headers, CLR Header, detail popups, string details) are selectable read-only editors. Click or `Tab` into them, select text with `Shift` + arrow keys, and press `y` to copy.
+Info panels (Assembly Info, PE Headers, CLR Header, detail popups, string details) are selectable read-only editors. Click or `Tab` into them, select text with `Shift` + arrow keys, and press `y` to copy. For word-level selection without the mouse, `iw` selects the word under the cursor and `iW` selects the full whitespace-delimited token — `yiw` copies it in one keystroke.
 
 **Hex Dump tab** uses vi-style modal editing — the editor starts in normal mode (read-only) to prevent accidental writes:
 

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -42,6 +42,8 @@ Press `/` to search. Matches are highlighted inline. Use `n` and `N` to jump bet
 
 Select text in any info panel or editor with click-drag or `Shift` + arrow keys, then press `y` to yank (copy) it to the clipboard. A brief flash confirms the copied range. On table rows, just focus a row and press `y` — the row content is copied as tab-separated values.
 
+For quick word selection, press `iw` to select the word under the cursor, or `iW` to select a whitespace-delimited WORD (useful for fully-qualified type names). Combine with yank: `yiw` selects and copies in one motion.
+
 Use `Tab` to cycle focus between panels on tabs that have both info editors and tables.
 
 ## Compare two assemblies

--- a/docs/src/content/docs/reference/keyboard.md
+++ b/docs/src/content/docs/reference/keyboard.md
@@ -13,6 +13,10 @@ description: All keyboard shortcuts for navigating dotsider.
 | `/` | Search |
 | `n` / `N` | Next / previous search match |
 | `y` | Yank (copy) — selected text in editors, or focused row in tables |
+| `iw` | Select inner word under cursor (letters, digits, underscores) |
+| `iW` | Select inner WORD under cursor (whitespace-delimited) |
+| `yiw` | Select + yank inner word in one motion |
+| `yiW` | Select + yank inner WORD in one motion |
 | `Tab` | Cycle focus between info panels and tables |
 | `s` | Toggle human-readable sizes |
 | `q` | Quit |

--- a/docs/src/content/docs/usage/diff-mode.md
+++ b/docs/src/content/docs/usage/diff-mode.md
@@ -28,6 +28,6 @@ This is useful for reviewing breaking changes between library versions, auditing
 
 ## Copy
 
-The Summary tab has selectable info panels and change statistics. Press `Tab` to cycle focus between them, select text, and press `y` to copy.
+The Summary tab has selectable info panels and change statistics. Press `Tab` to cycle focus between them, select text, and press `y` to copy. `iw` and `yiw` work in these panels for quick word-level copying.
 
 On the Types, Methods, and References tabs, focus a row and press `y` to copy it as tab-separated values. A brief flash confirms the yank.

--- a/docs/src/content/docs/usage/general.md
+++ b/docs/src/content/docs/usage/general.md
@@ -16,6 +16,8 @@ The **General** tab (`1`) is the first thing you see when opening an assembly. I
 
 The Assembly Info panel is a read-only editor. Click into it or press `Tab` to move focus there, then select text with click-drag or `Shift` + arrow keys. Press `y` to yank the selection to the clipboard.
 
+You can also use vim-style text objects: `iw` selects the word under the cursor, `iW` selects a whitespace-delimited WORD (handy for grabbing a version string or assembly name in one keystroke). `yiw` and `yiW` select and copy in one motion.
+
 On the dependency table, focus a row and press `y` to copy it as tab-separated values. Press `Tab` to cycle focus between the info panel and the table.
 
 ## Drill into references

--- a/docs/src/content/docs/usage/il-inspector.md
+++ b/docs/src/content/docs/usage/il-inspector.md
@@ -22,6 +22,8 @@ Each instruction shows:
 
 Select text in the disassembly pane with click-drag or `Shift` + arrow keys, then press `y` to yank it to the clipboard. The cursor collapses to the end of the selection and a brief flash confirms the copied range — matching neovim's yank behavior.
 
+`iw` selects the word under the cursor (an opcode, a token, a label). `yiw` copies it directly. `iW` grabs the full whitespace-delimited token, which is useful for qualified names in operands.
+
 ## Search
 
 Press `/` to search method names or IL content. Matches are highlighted in both the tree and disassembly panes.

--- a/docs/src/content/docs/usage/nuget-mode.md
+++ b/docs/src/content/docs/usage/nuget-mode.md
@@ -21,4 +21,4 @@ Press `Tab` to cycle focus between the Package Info panel and the DLL table. Pre
 
 ## Copy
 
-Select text in the Package Info panel and press `y` to copy. On the DLL table, focus a row and press `y` to copy the file path.
+Select text in the Package Info panel and press `y` to copy. `iw` and `yiw` work here for quick word selection. On the DLL table, focus a row and press `y` to copy the file path.

--- a/docs/src/content/docs/usage/pe-metadata.md
+++ b/docs/src/content/docs/usage/pe-metadata.md
@@ -18,7 +18,7 @@ The **PE / Metadata** tab (`2`) exposes the raw structure of the Portable Execut
 
 ## Text selection and copy
 
-The PE Headers and CLR Header panels are selectable editors. Press `Tab` to cycle focus between them and the metadata table. Select text and press `y` to copy.
+The PE Headers and CLR Header panels are selectable editors. Press `Tab` to cycle focus between them and the metadata table. Select text and press `y` to copy. `iw` and `yiw` work here too — quick way to grab a single header value.
 
 Press `Enter` on any metadata table row to open a detail popup. The popup is also a selectable editor — select specific values and press `y` to yank them.
 

--- a/docs/src/content/docs/usage/strings.md
+++ b/docs/src/content/docs/usage/strings.md
@@ -13,7 +13,7 @@ The **Strings** tab (`4`) extracts text from three sources:
 
 ## Copy strings
 
-Press `y` on a focused table row to copy the string value to the clipboard. Press `Enter` to open a detail popup where you can select and copy specific portions of longer strings.
+Press `y` on a focused table row to copy the string value to the clipboard. Press `Enter` to open a detail popup where you can select and copy specific portions of longer strings. In the detail popup, `iw` and `yiw` let you grab individual words without reaching for the mouse.
 
 ## Minimum length
 

--- a/src/Dotsider/DiffApp.cs
+++ b/src/Dotsider/DiffApp.cs
@@ -25,6 +25,7 @@ public sealed class DiffApp(DiffState state)
     /// <returns>The root widget of the diff application.</returns>
     public Hex1bWidget Build(RootContext ctx)
     {
+        _state.PerformEditorYank ??= PerformEditorYank;
         var summary = _state.DiffResult.MetadataSummary;
         var changeCount = summary.TypesAdded + summary.TypesRemoved + summary.TypesChanged +
                           summary.MethodsAdded + summary.MethodsRemoved + summary.MethodsChanged;
@@ -91,6 +92,10 @@ public sealed class DiffApp(DiffState state)
             var currentSearch = _state.Search[_state.CurrentTab];
             var isSearchEditing = currentSearch.IsActive && !currentSearch.IsConfirmed;
 
+            // VimReset wraps all Global bindings to cancel pending vim text-object sequences
+            Action<InputBindingActionContext> VimReset(Action<InputBindingActionContext> action)
+                => ctx => { _state.VimPending = VimMotionState.Idle; action(ctx); };
+
             // Number keys 1-4, f, q suppressed during search editing to let TextBox receive input
             if (!isSearchEditing)
             {
@@ -98,7 +103,7 @@ public sealed class DiffApp(DiffState state)
                 {
                     var tabIndex = i;
                     var key = (Hex1bKey)((int)Hex1bKey.D1 + i);
-                    bindings.Key(key).Global().Action(_ =>
+                    bindings.Key(key).Global().Action(VimReset(_ =>
                     {
                         _state.CurrentTab = tabIndex;
                         _state.DiffFocusedKey = null;
@@ -107,15 +112,15 @@ public sealed class DiffApp(DiffState state)
                             _state.App.RequestFocus(node =>
                                 node.GetType().Name.StartsWith("TableNode"));
                         _state.App.Invalidate();
-                    }, $"Tab {tabIndex + 1}");
+                    }), $"Tab {tabIndex + 1}");
                 }
 
-                bindings.Key(Hex1bKey.Q).Global().Action(ctx => ctx.RequestStop(), "Quit");
+                bindings.Key(Hex1bKey.Q).Global().Action(VimReset(ctx => ctx.RequestStop()), "Quit");
 
                 // Left/Right arrows to cycle tabs (not registered when editor is focused)
                 if (_state.App.FocusedNode is not EditorNode)
                 {
-                    bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
+                    bindings.Key(Hex1bKey.LeftArrow).Global().Action(VimReset(_ =>
                     {
                         if (_state.CurrentTab > 0)
                         {
@@ -126,9 +131,9 @@ public sealed class DiffApp(DiffState state)
                                     node.GetType().Name.StartsWith("TableNode"));
                             _state.App.Invalidate();
                         }
-                    }, "Previous tab");
+                    }), "Previous tab");
 
-                    bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
+                    bindings.Key(Hex1bKey.RightArrow).Global().Action(VimReset(_ =>
                     {
                         if (_state.CurrentTab < 3)
                         {
@@ -138,38 +143,37 @@ public sealed class DiffApp(DiffState state)
                                 node.GetType().Name.StartsWith("TableNode"));
                             _state.App.Invalidate();
                         }
-                    }, "Next tab");
+                    }), "Next tab");
                 }
 
                 // Universal yank
                 bindings.Key(Hex1bKey.Y).Global().Action(ctx =>
                 {
+                    // Timeout check
+                    if (_state.VimPending != VimMotionState.Idle
+                        && (DateTime.UtcNow - _state.VimPendingTimestamp).TotalSeconds > 1.0)
+                        _state.VimPending = VimMotionState.Idle;
+
                     // Editor with selection
                     if (ctx.FocusedNode is EditorNode { State.Cursor.HasSelection: true } editor)
                     {
-                        var range = editor.State.Cursor.SelectionRange;
-                        var doc = editor.State.Document;
-                        var yankEnd = new Hex1b.Documents.DocumentOffset(Math.Min(
-                            Math.Max(range.End.Value, editor.State.Cursor.Position.Value + 1),
-                            doc.Length));
-                        var yankRange = new Hex1b.Documents.DocumentRange(range.Start, yankEnd);
-                        var text = doc.GetText(yankRange);
-
-                        var lastChar = new Hex1b.Documents.DocumentOffset(Math.Max(0, yankEnd.Value - 1));
-                        editor.State.SetCursorPosition(lastChar);
-
-                        if (!string.IsNullOrEmpty(text))
-                        {
-                            ctx.CopyToClipboard(text);
-                            ShowYankNotification(text);
-                        }
+                        _state.VimPending = VimMotionState.Idle;
+                        PerformEditorYank(ctx, editor);
                         return;
                     }
 
-                    // Editor without selection → do nothing
-                    if (ctx.FocusedNode is EditorNode) return;
+                    // Editor without selection → arm operator-pending for yiw/yiW
+                    if (ctx.FocusedNode is EditorNode noSelEditor)
+                    {
+                        _state.VimPending = VimMotionState.WaitingForYMotion;
+                        _state.VimPendingEditor = noSelEditor.State;
+                        _state.VimPendingCursorOffset = noSelEditor.State.Cursor.Position.Value;
+                        _state.VimPendingTimestamp = DateTime.UtcNow;
+                        return;
+                    }
 
                     // Table row
+                    _state.VimPending = VimMotionState.Idle;
                     var yankText = YankHelper.GetYankText(_state);
                     if (yankText is not null)
                     {
@@ -187,11 +191,11 @@ public sealed class DiffApp(DiffState state)
                 }, "Yank");
             }
 
-            bindings.Key(Hex1bKey.F).Action(_ =>
+            bindings.Key(Hex1bKey.F).Action(VimReset(_ =>
             {
                 _state.FilterMode = (DiffFilterMode)(((int)_state.FilterMode + 1) % 4);
                 _state.App.Invalidate();
-            }, "Cycle filter");
+            }), "Cycle filter");
 
             // Global search toggle (same dual-binding strategy as DotsiderApp)
             void searchToggle()
@@ -203,40 +207,40 @@ public sealed class DiffApp(DiffState state)
                 _state.App.Invalidate();
             }
 
-            bindings.Key(Hex1bKey.OemQuestion).Global().OverridesCapture().Action(_ => searchToggle(), "Search");
+            bindings.Key(Hex1bKey.OemQuestion).Global().OverridesCapture().Action(VimReset(_ => searchToggle()), "Search");
             if (!isSearchEditing)
             {
-                bindings.Key(Hex1bKey.None).Global().OverridesCapture().Action(_ => searchToggle(), "Search");
+                bindings.Key(Hex1bKey.None).Global().OverridesCapture().Action(VimReset(_ => searchToggle()), "Search");
             }
             if (isSearchEditing)
             {
-                bindings.Key(Hex1bKey.Enter).Global().OverridesCapture().Action(_ =>
+                bindings.Key(Hex1bKey.Enter).Global().OverridesCapture().Action(VimReset(_ =>
                 {
                     if (!string.IsNullOrEmpty(currentSearch.Query))
                     {
                         currentSearch.Confirm();
                         _state.App.Invalidate();
                     }
-                }, "Confirm search");
+                }), "Confirm search");
             }
 
             // n/N only registered when search is confirmed
             if (currentSearch.IsActive && currentSearch.IsConfirmed)
             {
-                bindings.Key(Hex1bKey.N).Global().Action(_ =>
+                bindings.Key(Hex1bKey.N).Global().Action(VimReset(_ =>
                 {
                     _state.NavigateNextMatch?.Invoke();
                     _state.App.Invalidate();
-                }, "Next match");
-                bindings.Shift().Key(Hex1bKey.N).Global().Action(_ =>
+                }), "Next match");
+                bindings.Shift().Key(Hex1bKey.N).Global().Action(VimReset(_ =>
                 {
                     _state.NavigatePrevMatch?.Invoke();
                     _state.App.Invalidate();
-                }, "Prev match");
+                }), "Prev match");
             }
 
             bindings.Ctrl().Key(Hex1bKey.C).Global().OverridesCapture()
-                .Action(ctx => ctx.RequestStop(), "Quit");
+                .Action(VimReset(ctx => ctx.RequestStop()), "Quit");
         });
     }
 
@@ -258,6 +262,17 @@ public sealed class DiffApp(DiffState state)
             if (yankable)
                 hints.Add(s.Section("y: Yank"));
 
+            // iw/iW hint — show when a read-only editor is focused
+            try
+            {
+                if (_state.App.FocusedNode is EditorNode)
+                    hints.Add(s.Section("iw: Word | iW: WORD"));
+            }
+            catch (NullReferenceException)
+            {
+                // Focus ring not yet initialized
+            }
+
             hints.Add(s.Spacer());
 
             if (!string.IsNullOrEmpty(_state.YankNotification))
@@ -270,6 +285,30 @@ public sealed class DiffApp(DiffState state)
             hints.Add(s.Section("q: Quit"));
             return hints;
         }).WithDefaultSeparator(" | ");
+
+    /// <summary>
+    /// Performs a neovim-style yank on the focused diff editor's selection.
+    /// No flash — matches existing diff mode behavior.
+    /// </summary>
+    private void PerformEditorYank(InputBindingActionContext ctx, EditorNode editor)
+    {
+        var range = editor.State.Cursor.SelectionRange;
+        var doc = editor.State.Document;
+        var yankEnd = new Hex1b.Documents.DocumentOffset(Math.Min(
+            Math.Max(range.End.Value, editor.State.Cursor.Position.Value + 1),
+            doc.Length));
+        var yankRange = new Hex1b.Documents.DocumentRange(range.Start, yankEnd);
+        var text = doc.GetText(yankRange);
+
+        var lastChar = new Hex1b.Documents.DocumentOffset(Math.Max(0, yankEnd.Value - 1));
+        editor.State.SetCursorPosition(lastChar);
+
+        if (!string.IsNullOrEmpty(text))
+        {
+            ctx.CopyToClipboard(text);
+            ShowYankNotification(text);
+        }
+    }
 
     private void ShowYankNotification(string text)
     {

--- a/src/Dotsider/DiffState.cs
+++ b/src/Dotsider/DiffState.cs
@@ -65,6 +65,23 @@ public sealed class DiffState : IDisposable
     /// <summary>Whether the focused table row should flash with yank highlight colors. Auto-clears after 150ms.</summary>
     public bool YankFlashRow { get; set; }
 
+    // --- Vim Text Object State ---
+
+    /// <summary>Current state of a pending vim text-object sequence (iw, iW, yiw, yiW).</summary>
+    public VimMotionState VimPending { get; set; }
+
+    /// <summary>The editor that started the current vim text-object sequence, for affinity checking.</summary>
+    public EditorState? VimPendingEditor { get; set; }
+
+    /// <summary>Cursor position when the text-object sequence was armed, for cursor affinity.</summary>
+    public int VimPendingCursorOffset { get; set; }
+
+    /// <summary>Timestamp when the text-object sequence was armed, for 1-second timeout.</summary>
+    public DateTime VimPendingTimestamp { get; set; }
+
+    /// <summary>Delegate to perform a neovim-style editor yank, set by the host app (DiffApp).</summary>
+    public Action<Hex1b.Input.InputBindingActionContext, EditorNode>? PerformEditorYank { get; set; }
+
     // --- Read-Only Editor State (for text selection + yank) ---
 
     /// <summary>Read-only editor for the left assembly info panel in diff summary.</summary>

--- a/src/Dotsider/DllInspectorBindings.cs
+++ b/src/Dotsider/DllInspectorBindings.cs
@@ -19,8 +19,9 @@ public static class DllInspectorBindings
     /// <param name="app">The Hex1b app instance for invalidation and focus.</param>
     /// <param name="includeSearch">Whether to register search toggle/confirm/dismiss bindings.
     /// DotsiderApp registers its own search bindings, so this is false for DotsiderApp.</param>
+    /// <param name="resetVimPending">Optional callback to reset the vim text-object pending state to idle.</param>
     public static void Register(InputBindingsBuilder bindings, DotsiderState state, Hex1bApp app,
-        bool includeSearch = false)
+        bool includeSearch = false, Action? resetVimPending = null)
     {
         var currentSearch = state.Search[state.CurrentTab];
         var isSearchEditing = currentSearch.IsActive && !currentSearch.IsConfirmed;
@@ -40,10 +41,18 @@ public static class DllInspectorBindings
                     app.Invalidate();
                 }
 
-                bindings.Key(Hex1bKey.OemQuestion).Global().OverridesCapture().Action(_ => SearchToggle(), "Search");
+                bindings.Key(Hex1bKey.OemQuestion).Global().OverridesCapture().Action(_ =>
+                {
+                    resetVimPending?.Invoke();
+                    SearchToggle();
+                }, "Search");
                 if (!isSearchEditing)
                 {
-                    bindings.Key(Hex1bKey.None).Global().OverridesCapture().Action(_ => SearchToggle(), "Search");
+                    bindings.Key(Hex1bKey.None).Global().OverridesCapture().Action(_ =>
+                    {
+                        resetVimPending?.Invoke();
+                        SearchToggle();
+                    }, "Search");
                 }
             }
 
@@ -51,6 +60,7 @@ public static class DllInspectorBindings
             {
                 bindings.Key(Hex1bKey.Enter).Global().OverridesCapture().Action(_ =>
                 {
+                    resetVimPending?.Invoke();
                     if (!string.IsNullOrEmpty(currentSearch.Query))
                     {
                         if (state.CurrentTab == TabId.HexDump)
@@ -67,11 +77,13 @@ public static class DllInspectorBindings
             {
                 bindings.Key(Hex1bKey.N).Global().Action(_ =>
                 {
+                    resetVimPending?.Invoke();
                     state.NavigateNextMatch?.Invoke();
                     app.Invalidate();
                 }, "Next match");
                 bindings.Shift().Key(Hex1bKey.N).Global().Action(_ =>
                 {
+                    resetVimPending?.Invoke();
                     state.NavigatePrevMatch?.Invoke();
                     app.Invalidate();
                 }, "Prev match");
@@ -82,6 +94,7 @@ public static class DllInspectorBindings
             {
                 bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
                 {
+                    resetVimPending?.Invoke();
                     if (state.CurrentTab == TabId.HexDump && state.HexMode == HexEditMode.Insert)
                     {
                         state.HexMode = HexEditMode.Normal;
@@ -111,6 +124,7 @@ public static class DllInspectorBindings
             {
                 bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
                 {
+                    resetVimPending?.Invoke();
                     state.HexMode = HexEditMode.Normal;
                     state.HexEditorState.IsReadOnly = true;
                     app.Invalidate();
@@ -124,6 +138,7 @@ public static class DllInspectorBindings
         {
             bindings.Key(Hex1bKey.I).Global().Action(_ =>
             {
+                resetVimPending?.Invoke();
                 state.HexMode = HexEditMode.Insert;
                 state.HexEditorState.IsReadOnly = false;
                 state.HexNotification = null;
@@ -132,6 +147,7 @@ public static class DllInspectorBindings
 
             bindings.Key(Hex1bKey.G).Global().Action(_ =>
             {
+                resetVimPending?.Invoke();
                 state.HexJumpDialogOpen = true;
                 state.HexJumpInput = "";
                 state.HexNotification = null;
@@ -141,6 +157,7 @@ public static class DllInspectorBindings
 
             bindings.Key(Hex1bKey.E).Global().Action(_ =>
             {
+                resetVimPending?.Invoke();
                 state.HexEndianness = state.HexEndianness == HexEndianness.Little
                     ? HexEndianness.Big : HexEndianness.Little;
                 app.Invalidate();
@@ -148,21 +165,25 @@ public static class DllInspectorBindings
 
             bindings.Key(Hex1bKey.H).Global().Action(_ =>
             {
+                resetVimPending?.Invoke();
                 state.HexEditorState.MoveCursor(CursorDirection.Left);
                 app.Invalidate();
             }, "Left");
             bindings.Key(Hex1bKey.L).Global().Action(_ =>
             {
+                resetVimPending?.Invoke();
                 state.HexEditorState.MoveCursor(CursorDirection.Right);
                 app.Invalidate();
             }, "Right");
             bindings.Key(Hex1bKey.K).Global().Action(_ =>
             {
+                resetVimPending?.Invoke();
                 state.HexEditorState.MoveCursor(CursorDirection.Up);
                 app.Invalidate();
             }, "Up");
             bindings.Key(Hex1bKey.J).Global().Action(_ =>
             {
+                resetVimPending?.Invoke();
                 state.HexEditorState.MoveCursor(CursorDirection.Down);
                 app.Invalidate();
             }, "Down");
@@ -173,6 +194,7 @@ public static class DllInspectorBindings
         {
             bindings.Key(Hex1bKey.Enter).Global().OverridesCapture().Action(_ =>
             {
+                resetVimPending?.Invoke();
                 Views.HexDumpView.ProcessJumpInput(state);
                 app.Invalidate();
             }, "Jump");
@@ -195,12 +217,14 @@ public static class DllInspectorBindings
             {
                 bindings.Key(Hex1bKey.X).Global().Action(_ =>
                 {
+                    resetVimPending?.Invoke();
                     state.NavigateToHexOffset(ilMethod.Rva);
                 }, "View in hex");
             }
 
             bindings.Key(Hex1bKey.L).Global().Action(_ =>
             {
+                resetVimPending?.Invoke();
                 app.RequestFocus(node => node is EditorNode);
                 app.Invalidate();
             }, "Focus IL");
@@ -242,6 +266,20 @@ public static class DllInspectorBindings
                 if (state.HexIsDirty)
                     hexHints += " | Ctrl+S: Save";
                 hints.Add(s.Section(hexHints));
+            }
+        }
+
+        // iw/iW hint — show when a read-only editor is focused (not hex dump)
+        if (state.CurrentTab != TabId.HexDump)
+        {
+            try
+            {
+                if (state.App.FocusedNode is EditorNode)
+                    hints.Add(s.Section("iw: Word"));
+            }
+            catch (NullReferenceException)
+            {
+                // Focus ring may not be initialized yet
             }
         }
 

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -21,6 +21,7 @@ public sealed class DotsiderApp(DotsiderState state)
 {
     private readonly DotsiderState _state = state;
     private bool _initialFocusRequested;
+    private bool _yankDelegateSet;
 
     /// <summary>
     /// Builds the root widget tree for the current frame.
@@ -39,6 +40,13 @@ public sealed class DotsiderApp(DotsiderState state)
             _initialFocusRequested = true;
             SeedFocusedRowIfNeeded();
             RequestContentFocus();
+        }
+
+        // Wire up the yank delegate for text object support
+        if (!_yankDelegateSet)
+        {
+            _yankDelegateSet = true;
+            _state.PerformEditorYank = PerformEditorYank;
         }
 
 
@@ -105,6 +113,10 @@ public sealed class DotsiderApp(DotsiderState state)
             var currentSearch = _state.Search[_state.CurrentTab];
             var isSearchEditing = currentSearch.IsActive && !currentSearch.IsConfirmed;
 
+            // VimReset wraps all Global bindings to cancel pending vim text-object sequences
+            Action<InputBindingActionContext> VimReset(Action<InputBindingActionContext> action)
+                => ctx => { _state.VimPending = VimMotionState.Idle; action(ctx); };
+
             // Number keys 1-8, s, q suppressed during search editing, jump dialog,
             // or hex insert mode to let EditorNode/TextBox receive character input
             var hexInsertMode = _state.CurrentTab == TabId.HexDump && _state.HexMode == HexEditMode.Insert;
@@ -114,13 +126,13 @@ public sealed class DotsiderApp(DotsiderState state)
                 {
                     var tabIndex = i;
                     var key = (Hex1bKey)((int)Hex1bKey.D1 + i);
-                    bindings.Key(key).Global().Action(_ =>
+                    bindings.Key(key).Global().Action(VimReset(_ =>
                     {
                         SelectTab(tabIndex);
                         SeedFocusedRowIfNeeded();
                         RequestContentFocus();
                         _state.App.Invalidate();
-                    }, $"Tab {tabIndex + 1}");
+                    }), $"Tab {tabIndex + 1}");
                 }
 
                 // Suppress size toggle on Dynamic Events sub-tab (S = Socket filter)
@@ -129,73 +141,51 @@ public sealed class DotsiderApp(DotsiderState state)
                     || (_state.CurrentTab == TabId.HexDump && _state.HexMode == HexEditMode.Insert);
                 if (!suppressSizeToggle)
                 {
-                    bindings.Key(Hex1bKey.S).Global().Action(_ =>
+                    bindings.Key(Hex1bKey.S).Global().Action(VimReset(_ =>
                     {
                         _state.HumanReadableSizes = !_state.HumanReadableSizes;
                         _state.App.Invalidate();
-                    }, "Toggle size format");
+                    }), "Toggle size format");
                 }
 
                 // Suppress Q quit in hex insert mode — let editor receive it as byte input
                 if (!(_state.CurrentTab == TabId.HexDump && _state.HexMode == HexEditMode.Insert))
-                    bindings.Key(Hex1bKey.Q).Global().Action(ctx => ctx.RequestStop(), "Quit");
+                    bindings.Key(Hex1bKey.Q).Global().Action(VimReset(ctx => ctx.RequestStop()), "Quit");
 
                 // Universal yank — works on all tabs with neovim-style behavior
                 bindings.Key(Hex1bKey.Y).Global().Action(ctx =>
                 {
+                    // Timeout check — reset stale vim pending state
+                    if (_state.VimPending != VimMotionState.Idle
+                        && (DateTime.UtcNow - _state.VimPendingTimestamp).TotalSeconds > 1.0)
+                        _state.VimPending = VimMotionState.Idle;
+
                     // 1. Any focused editor with selection
                     if (ctx.FocusedNode is EditorNode { State.Cursor.HasSelection: true } editor)
                     {
-                        string text;
-                        if (editor.State == _state.HexEditorState)
-                        {
-                            // Hex dump: extract bytes as "4D 5A 90 00"
-                            text = YankHelper.GetHexSelectionText(editor.State) ?? "";
-                        }
-                        else
-                        {
-                            // All other editors: neovim-style yank
-                            // Include the cursor character (word-boundary adjustment)
-                            var range = editor.State.Cursor.SelectionRange;
-                            var doc = editor.State.Document;
-                            var yankEnd = new DocumentOffset(Math.Min(
-                                Math.Max(range.End.Value, editor.State.Cursor.Position.Value + 1),
-                                doc.Length));
-                            var yankRange = new DocumentRange(range.Start, yankEnd);
-                            text = doc.GetText(yankRange);
-
-                            // Collapse cursor to last character of yanked range
-                            var lastChar = new DocumentOffset(Math.Max(0, yankEnd.Value - 1));
-                            editor.State.SetCursorPosition(lastChar);
-
-                            // Flash the yanked range (150ms IncSearch style)
-                            var yankProvider = FindYankProvider(editor.State);
-                            if (yankProvider is not null)
-                            {
-                                var startPos = doc.OffsetToPosition(yankRange.Start);
-                                var endPos = doc.OffsetToPosition(yankRange.End);
-                                yankProvider.HighlightRange = (startPos, endPos);
-                                _state.App.Invalidate();
-                                _ = Task.Delay(TimeSpan.FromMilliseconds(150)).ContinueWith(_ =>
-                                {
-                                    yankProvider.HighlightRange = null;
-                                    _state.App.Invalidate();
-                                }, TaskScheduler.Default);
-                            }
-                        }
-
-                        if (!string.IsNullOrEmpty(text))
-                        {
-                            ctx.CopyToClipboard(text);
-                            ShowYankNotification(text);
-                        }
+                        _state.VimPending = VimMotionState.Idle;
+                        PerformEditorYank(ctx, editor);
                         return;
                     }
 
-                    // 3. Focused editor WITHOUT selection → do nothing
-                    if (ctx.FocusedNode is EditorNode) return;
+                    // 2. Focused editor WITHOUT selection → arm operator-pending for yiw/yiW
+                    if (ctx.FocusedNode is EditorNode noSelEditor)
+                    {
+                        // Don't arm on hex dump normal mode (I conflicts with Insert)
+                        if (_state.CurrentTab == TabId.HexDump && _state.HexMode == HexEditMode.Normal)
+                        {
+                            _state.VimPending = VimMotionState.Idle;
+                            return;
+                        }
+                        _state.VimPending = VimMotionState.WaitingForYMotion;
+                        _state.VimPendingEditor = noSelEditor.State;
+                        _state.VimPendingCursorOffset = noSelEditor.State.Cursor.Position.Value;
+                        _state.VimPendingTimestamp = DateTime.UtcNow;
+                        return;
+                    }
 
-                    // 4. Non-editor focus → table row / surface node
+                    // 3. Non-editor focus → table row / surface node
+                    _state.VimPending = VimMotionState.Idle;
                     var yankText = YankHelper.GetYankText(_state);
                     if (yankText is not null)
                     {
@@ -230,15 +220,15 @@ public sealed class DotsiderApp(DotsiderState state)
             var detailPopupOpen = _state.PeDetailContent is not null || _state.StringsDetailContent is not null;
             if (!_state.HexJumpDialogOpen && !detailPopupOpen)
             {
-                bindings.Key(Hex1bKey.OemQuestion).Global().OverridesCapture().Action(_ => SearchToggle(), "Search");
+                bindings.Key(Hex1bKey.OemQuestion).Global().OverridesCapture().Action(VimReset(_ => SearchToggle()), "Search");
                 if (!isSearchEditing)
                 {
-                    bindings.Key(Hex1bKey.None).Global().OverridesCapture().Action(_ => SearchToggle(), "Search");
+                    bindings.Key(Hex1bKey.None).Global().OverridesCapture().Action(VimReset(_ => SearchToggle()), "Search");
                 }
             }
             if (isSearchEditing)
             {
-                bindings.Key(Hex1bKey.Enter).Global().OverridesCapture().Action(_ =>
+                bindings.Key(Hex1bKey.Enter).Global().OverridesCapture().Action(VimReset(_ =>
                 {
                     if (!string.IsNullOrEmpty(currentSearch.Query))
                     {
@@ -246,44 +236,44 @@ public sealed class DotsiderApp(DotsiderState state)
                         if (_state.CurrentTab == TabId.HexDump)
                             Views.HexDumpView.ExecuteSearch(_state);
                         currentSearch.Confirm();
-                        // Restore focus from the search TextBox back to the content area.
                         // Restore focus from the search TextBox back to the content area
                         RequestContentFocus();
                         _state.App.Invalidate();
                     }
-                }, "Confirm search");
+                }), "Confirm search");
             }
 
             // Hex + IL Inspector keybindings (shared with NuGetApp)
             if (!isSearchEditing)
-                DllInspectorBindings.Register(bindings, _state, _state.App);
+                DllInspectorBindings.Register(bindings, _state, _state.App,
+                    resetVimPending: () => _state.VimPending = VimMotionState.Idle);
 
             // Ctrl+S: Save hex changes — only in normal mode with pending edits
             if (_state.CurrentTab == TabId.HexDump
                 && _state.HexMode == HexEditMode.Normal
                 && _state.HexIsDirty)
             {
-                bindings.Ctrl().Key(Hex1bKey.S).Global().OverridesCapture().Action(_ =>
+                bindings.Ctrl().Key(Hex1bKey.S).Global().OverridesCapture().Action(VimReset(_ =>
                 {
                     SaveHexChanges(_state);
                     _state.App.Invalidate();
                     ScheduleNotificationClear(_state);
-                }, "Save hex changes");
+                }), "Save hex changes");
             }
 
             // n/N only registered when search is confirmed
             if (currentSearch.IsActive && currentSearch.IsConfirmed)
             {
-                bindings.Key(Hex1bKey.N).Global().Action(_ =>
+                bindings.Key(Hex1bKey.N).Global().Action(VimReset(_ =>
                 {
                     _state.NavigateNextMatch?.Invoke();
                     _state.App.Invalidate();
-                }, "Next match");
-                bindings.Shift().Key(Hex1bKey.N).Global().Action(_ =>
+                }), "Next match");
+                bindings.Shift().Key(Hex1bKey.N).Global().Action(VimReset(_ =>
                 {
                     _state.NavigatePrevMatch?.Invoke();
                     _state.App.Invalidate();
-                }, "Prev match");
+                }), "Prev match");
             }
 
             // Global Escape to dismiss search (editing or confirmed) — must be
@@ -292,7 +282,7 @@ public sealed class DotsiderApp(DotsiderState state)
             // would otherwise consume the key in the focus-based routing walk.
             if (currentSearch.IsActive && !_state.HexJumpDialogOpen)
             {
-                bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
+                bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(VimReset(_ =>
                 {
                     // In hex insert mode, Esc exits insert first — search stays active
                     if (_state.CurrentTab == TabId.HexDump && _state.HexMode == HexEditMode.Insert)
@@ -314,7 +304,7 @@ public sealed class DotsiderApp(DotsiderState state)
                     }
                     RequestContentFocus();
                     _state.App.Invalidate();
-                }, "Clear search");
+                }), "Clear search");
             }
 
             // Hex insert mode without search: Global Escape to exit insert mode —
@@ -324,16 +314,16 @@ public sealed class DotsiderApp(DotsiderState state)
                 && _state.HexMode == HexEditMode.Insert
                 && !_state.HexJumpDialogOpen)
             {
-                bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
+                bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(VimReset(_ =>
                 {
                     _state.HexMode = HexEditMode.Normal;
                     _state.HexEditorState.IsReadOnly = true;
                     _state.App.Invalidate();
-                }, "Exit insert mode");
+                }), "Exit insert mode");
             }
 
             bindings.Ctrl().Key(Hex1bKey.C).Global().OverridesCapture()
-                .Action(ctx => ctx.RequestStop(), "Quit");
+                .Action(VimReset(ctx => ctx.RequestStop()), "Quit");
 
             // Back navigation via Esc — assembly stack pop or cross-view back.
             // Only when no other modal claims Esc.
@@ -348,7 +338,7 @@ public sealed class DotsiderApp(DotsiderState state)
                 && _state.PeDetailContent is null && _state.StringsDetailContent is null
                 && !(_state.CurrentTab == TabId.IlInspector && _state.IlEditorState?.Cursor.HasSelection == true))
             {
-                bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
+                bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(VimReset(_ =>
                 {
                     // Cross-view back takes priority — return to the originating tab first
                     if (_state.CrossViewBackTarget is not null)
@@ -362,7 +352,7 @@ public sealed class DotsiderApp(DotsiderState state)
                         _state.RequestContentFocus();
                         _state.App.Invalidate();
                     }
-                }, "Back");
+                }), "Back");
             }
         });
     }
@@ -519,6 +509,18 @@ public sealed class DotsiderApp(DotsiderState state)
             if (yankable)
                 hints.Add(s.Section("y: Yank"));
 
+            // iw/iW hint — show when a read-only editor is focused (not hex dump)
+            try
+            {
+                if (_state.App.FocusedNode is EditorNode
+                    && _state.CurrentTab != TabId.HexDump)
+                    hints.Add(s.Section("iw: Word | iW: WORD"));
+            }
+            catch (NullReferenceException)
+            {
+                // Focus ring not yet initialized
+            }
+
             hints.Add(s.Spacer());
 
             // Yank notification (right side, auto-clearing)
@@ -664,6 +666,57 @@ public sealed class DotsiderApp(DotsiderState state)
 
     private IlYankDecorationProvider? FindYankProvider(EditorState editorState) =>
         YankHelper.FindYankProvider(_state, editorState);
+
+    /// <summary>
+    /// Performs a neovim-style yank on the focused editor's selection or current text-object range.
+    /// Handles hex dump byte extraction, cursor collapse, flash, clipboard, and notification.
+    /// </summary>
+    private void PerformEditorYank(InputBindingActionContext ctx, EditorNode editor)
+    {
+        string text;
+        if (editor.State == _state.HexEditorState)
+        {
+            // Hex dump: extract bytes as "4D 5A 90 00"
+            text = YankHelper.GetHexSelectionText(editor.State) ?? "";
+        }
+        else
+        {
+            // All other editors: neovim-style yank
+            // Include the cursor character (word-boundary adjustment)
+            var range = editor.State.Cursor.SelectionRange;
+            var doc = editor.State.Document;
+            var yankEnd = new DocumentOffset(Math.Min(
+                Math.Max(range.End.Value, editor.State.Cursor.Position.Value + 1),
+                doc.Length));
+            var yankRange = new DocumentRange(range.Start, yankEnd);
+            text = doc.GetText(yankRange);
+
+            // Collapse cursor to last character of yanked range
+            var lastChar = new DocumentOffset(Math.Max(0, yankEnd.Value - 1));
+            editor.State.SetCursorPosition(lastChar);
+
+            // Flash the yanked range (150ms IncSearch style)
+            var yankProvider = FindYankProvider(editor.State);
+            if (yankProvider is not null)
+            {
+                var startPos = doc.OffsetToPosition(yankRange.Start);
+                var endPos = doc.OffsetToPosition(yankRange.End);
+                yankProvider.HighlightRange = (startPos, endPos);
+                _state.App.Invalidate();
+                _ = Task.Delay(TimeSpan.FromMilliseconds(150)).ContinueWith(_ =>
+                {
+                    yankProvider.HighlightRange = null;
+                    _state.App.Invalidate();
+                }, TaskScheduler.Default);
+            }
+        }
+
+        if (!string.IsNullOrEmpty(text))
+        {
+            ctx.CopyToClipboard(text);
+            ShowYankNotification(text);
+        }
+    }
 
     private void ShowYankNotification(string text)
     {

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -181,6 +181,23 @@ public sealed class DotsiderState : IDisposable
     /// <summary>Whether the focused table row should flash with yank highlight colors. Auto-clears after 150ms.</summary>
     public bool YankFlashRow { get; set; }
 
+    // --- Vim Text Object State ---
+
+    /// <summary>Current state of a pending vim text-object sequence (iw, iW, yiw, yiW).</summary>
+    public VimMotionState VimPending { get; set; }
+
+    /// <summary>The editor that started the current vim text-object sequence, for affinity checking.</summary>
+    public EditorState? VimPendingEditor { get; set; }
+
+    /// <summary>Cursor position when the text-object sequence was armed, for cursor affinity.</summary>
+    public int VimPendingCursorOffset { get; set; }
+
+    /// <summary>Timestamp when the text-object sequence was armed, for 1-second timeout.</summary>
+    public DateTime VimPendingTimestamp { get; set; }
+
+    /// <summary>Delegate to perform a neovim-style editor yank, set by the host app (DotsiderApp/NuGetApp).</summary>
+    public Action<Hex1b.Input.InputBindingActionContext, EditorNode>? PerformEditorYank { get; set; }
+
     // --- Read-Only Editor State (for text selection + yank) ---
 
     /// <summary>Read-only editor for the General tab Assembly Info panel.</summary>
@@ -609,6 +626,10 @@ public sealed class DotsiderState : IDisposable
         IlTextMatchMethodTokens = null;
         IlYankProvider.HighlightRange = null;
         YankNotification = null;
+        VimPending = VimMotionState.Idle;
+        VimPendingEditor = null;
+        VimPendingCursorOffset = 0;
+        VimPendingTimestamp = default;
         GeneralInfoEditorState = null;
         GeneralInfoEditorText = null;
         PeHeadersEditorState = null;

--- a/src/Dotsider/NuGetApp.cs
+++ b/src/Dotsider/NuGetApp.cs
@@ -25,6 +25,12 @@ public sealed class NuGetApp(NuGetState state)
     /// <returns>The root widget of the NuGet application.</returns>
     public Hex1bWidget Build(RootContext ctx)
     {
+        _state.PerformEditorYank ??= PerformEditorYank;
+
+        // Wire yank delegate on the embedded DLL state too
+        if (_state.SelectedDllState is { PerformEditorYank: null } dllSetup)
+            dllSetup.PerformEditorYank = PerformEditorYank;
+
         // Drain pending mutations from the diagnostics socket listener
         if (_state.SelectedDllState is { } dllState)
         {
@@ -83,6 +89,19 @@ public sealed class NuGetApp(NuGetState state)
                     DllInspectorBindings.AddHints(hints, s, dll);
                 }
 
+                // iw/iW hint — show when a read-only editor is focused (not hex dump)
+                try
+                {
+                    var isHexDump = _state.SelectedDllState is
+                        { CurrentTab: TabId.HexDump };
+                    if (_state.App.FocusedNode is EditorNode && !isHexDump)
+                        hints.Add(s.Section("iw: Word | iW: WORD"));
+                }
+                catch (NullReferenceException)
+                {
+                    // Focus ring not yet initialized
+                }
+
                 hints.Add(s.Spacer());
 
                 // Yank notification (right side, auto-clearing)
@@ -109,6 +128,10 @@ public sealed class NuGetApp(NuGetState state)
         ])
         .WithInputBindings(bindings =>
         {
+            // VimReset wraps all Global bindings to cancel pending vim text-object sequences
+            Action<InputBindingActionContext> VimReset(Action<InputBindingActionContext> action)
+                => ctx => { _state.VimPending = VimMotionState.Idle; action(ctx); };
+
             var browserSearch = _state.BrowserSearch;
             // Gate on BOTH browser and embedded DLL inspector input state
             var dllSearch = _state.SelectedDllState?.Search[_state.SelectedDllState.CurrentTab];
@@ -130,31 +153,31 @@ public sealed class NuGetApp(NuGetState state)
                         _state.App.RequestFocus(node => node is TextBoxNode);
                     _state.App.Invalidate();
                 }
-                bindings.Key(Hex1bKey.OemQuestion).Global().OverridesCapture().Action(_ => SearchToggle(), "Search");
+                bindings.Key(Hex1bKey.OemQuestion).Global().OverridesCapture().Action(VimReset(_ => SearchToggle()), "Search");
                 if (!isSearchEditing)
                 {
-                    bindings.Key(Hex1bKey.None).Global().OverridesCapture().Action(_ => SearchToggle(), "Search");
+                    bindings.Key(Hex1bKey.None).Global().OverridesCapture().Action(VimReset(_ => SearchToggle()), "Search");
                 }
                 if (isSearchEditing)
                 {
-                    bindings.Key(Hex1bKey.Enter).Global().OverridesCapture().Action(_ =>
+                    bindings.Key(Hex1bKey.Enter).Global().OverridesCapture().Action(VimReset(_ =>
                     {
                         if (!string.IsNullOrEmpty(browserSearch.Query))
                         {
                             browserSearch.Confirm();
                             _state.App.Invalidate();
                         }
-                    }, "Confirm search");
+                    }), "Confirm search");
                 }
 
-                bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
+                bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(VimReset(_ =>
                 {
                     if (browserSearch.IsActive)
                     {
                         browserSearch.Dismiss();
                         _state.App.Invalidate();
                     }
-                }, "Esc");
+                }), "Esc");
 
                 bindings.Key(Hex1bKey.Enter).Action(_ =>
                 {
@@ -200,7 +223,7 @@ public sealed class NuGetApp(NuGetState state)
             var dllHexJumpOpen = _state.SelectedDllState?.HexJumpDialogOpen == true;
             if (!dllSearchActive && !dllHexInsertNoSearch && !dllHexJumpOpen)
             {
-                bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
+                bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(VimReset(_ =>
                 {
                     if (!_state.IsBrowsingPackage)
                     {
@@ -241,7 +264,7 @@ public sealed class NuGetApp(NuGetState state)
                         _state.BrowserSearch.Dismiss();
                         _state.App.Invalidate();
                     }
-                }, "Back to package");
+                }), "Back to package");
             }
 
             if (!_state.IsBrowsingPackage && _state.SelectedDllState is not null)
@@ -252,79 +275,76 @@ public sealed class NuGetApp(NuGetState state)
                     {
                         var tabIndex = i;
                         var key = (Hex1bKey)((int)Hex1bKey.D1 + i);
-                        bindings.Key(key).Global().Action(_ =>
+                        bindings.Key(key).Global().Action(VimReset(_ =>
                         {
                             _state.SelectedDllState!.CurrentTab = tabIndex;
                             _state.SelectedDllState.RequestContentFocus();
                             _state.App.Invalidate();
-                        }, $"Tab {tabIndex + 1}");
+                        }), $"Tab {tabIndex + 1}");
                     }
                 }
 
                 // Hex + IL Inspector + search bindings (shared with DotsiderApp).
                 // Must be outside isSearchEditing gate so hex insert Escape works.
                 DllInspectorBindings.Register(bindings, _state.SelectedDllState, _state.App,
-                    includeSearch: true);
+                    includeSearch: true,
+                    resetVimPending: () => _state.VimPending = VimMotionState.Idle);
             }
 
             if (!isSearchEditing)
             {
-                bindings.Key(Hex1bKey.Q).Global().Action(ctx => ctx.RequestStop(), "Quit");
+                bindings.Key(Hex1bKey.Q).Global().Action(VimReset(ctx => ctx.RequestStop()), "Quit");
 
                 // Universal yank — same behavior as DotsiderApp
                 bindings.Key(Hex1bKey.Y).Global().Action(ctx =>
                 {
+                    // Timeout check
+                    if (_state.VimPending != VimMotionState.Idle
+                        && (DateTime.UtcNow - _state.VimPendingTimestamp).TotalSeconds > 1.0)
+                        _state.VimPending = VimMotionState.Idle;
+
                     // 1. Any focused editor with selection
                     if (ctx.FocusedNode is EditorNode { State.Cursor.HasSelection: true } editor)
                     {
-                        string text;
-                        var hexState = _state.SelectedDllState?.HexEditorState;
-                        if (hexState is not null && editor.State == hexState)
-                        {
-                            text = YankHelper.GetHexSelectionText(editor.State) ?? "";
-                        }
-                        else
-                        {
-                            // Neovim-style: include cursor character, collapse cursor
-                            var range = editor.State.Cursor.SelectionRange;
-                            var doc = editor.State.Document;
-                            var yankEnd = new Hex1b.Documents.DocumentOffset(Math.Min(
-                                Math.Max(range.End.Value, editor.State.Cursor.Position.Value + 1),
-                                doc.Length));
-                            var yankRange = new Hex1b.Documents.DocumentRange(range.Start, yankEnd);
-                            text = doc.GetText(yankRange);
-
-                            var lastChar = new Hex1b.Documents.DocumentOffset(Math.Max(0, yankEnd.Value - 1));
-                            editor.State.SetCursorPosition(lastChar);
-
-                            // Flash
-                            var yankProvider = YankHelper.FindYankProvider(_state, editor.State);
-                            if (yankProvider is not null)
-                            {
-                                var startPos = doc.OffsetToPosition(yankRange.Start);
-                                var endPos = doc.OffsetToPosition(yankRange.End);
-                                yankProvider.HighlightRange = (startPos, endPos);
-                                _state.App.Invalidate();
-                                _ = Task.Delay(TimeSpan.FromMilliseconds(150)).ContinueWith(_ =>
-                                {
-                                    yankProvider.HighlightRange = null;
-                                    _state.App.Invalidate();
-                                }, TaskScheduler.Default);
-                            }
-                        }
-
-                        if (!string.IsNullOrEmpty(text))
-                        {
-                            ctx.CopyToClipboard(text);
-                            ShowYankNotification(text);
-                        }
+                        _state.VimPending = VimMotionState.Idle;
+                        PerformEditorYank(ctx, editor);
                         return;
                     }
 
-                    // 2. Focused editor WITHOUT selection → do nothing
-                    if (ctx.FocusedNode is EditorNode) return;
+                    // 2. Focused editor WITHOUT selection → arm operator-pending for yiw/yiW
+                    if (ctx.FocusedNode is EditorNode noSelEditor)
+                    {
+                        // Don't arm on hex dump normal mode (I conflicts with Insert)
+                        var isHexNormal = _state.SelectedDllState is
+                            { CurrentTab: TabId.HexDump, HexMode: HexEditMode.Normal };
+                        if (isHexNormal)
+                        {
+                            _state.VimPending = VimMotionState.Idle;
+                            return;
+                        }
+
+                        // Arm on the correct state: DLL inspector views read from
+                        // SelectedDllState, browser views read from NuGetState.
+                        if (!_state.IsBrowsingPackage && _state.SelectedDllState is { } dllArm)
+                        {
+                            dllArm.VimPending = VimMotionState.WaitingForYMotion;
+                            dllArm.VimPendingEditor = noSelEditor.State;
+                            dllArm.VimPendingCursorOffset = noSelEditor.State.Cursor.Position.Value;
+                            dllArm.VimPendingTimestamp = DateTime.UtcNow;
+                        }
+                        else
+                        {
+                            _state.VimPending = VimMotionState.WaitingForYMotion;
+                            _state.VimPendingEditor = noSelEditor.State;
+                            _state.VimPendingCursorOffset = noSelEditor.State.Cursor.Position.Value;
+                            _state.VimPendingTimestamp = DateTime.UtcNow;
+                        }
+                        
+                        return;
+                    }
 
                     // 3. Non-editor focus → table row
+                    _state.VimPending = VimMotionState.Idle;
                     string? yankText = null;
                     if (_state.IsBrowsingPackage)
                     {
@@ -370,8 +390,55 @@ public sealed class NuGetApp(NuGetState state)
                 }, "Yank");
             }
             bindings.Ctrl().Key(Hex1bKey.C).Global().OverridesCapture()
-                .Action(ctx => ctx.RequestStop(), "Quit");
+                .Action(VimReset(ctx => ctx.RequestStop()), "Quit");
         });
+    }
+
+    /// <summary>
+    /// Performs a neovim-style yank on the focused editor's selection.
+    /// Handles hex dump byte extraction, cursor collapse, flash, clipboard, and notification.
+    /// </summary>
+    private void PerformEditorYank(InputBindingActionContext ctx, EditorNode editor)
+    {
+        string text;
+        var hexState = _state.SelectedDllState?.HexEditorState;
+        if (hexState is not null && editor.State == hexState)
+        {
+            text = YankHelper.GetHexSelectionText(editor.State) ?? "";
+        }
+        else
+        {
+            var range = editor.State.Cursor.SelectionRange;
+            var doc = editor.State.Document;
+            var yankEnd = new Hex1b.Documents.DocumentOffset(Math.Min(
+                Math.Max(range.End.Value, editor.State.Cursor.Position.Value + 1),
+                doc.Length));
+            var yankRange = new Hex1b.Documents.DocumentRange(range.Start, yankEnd);
+            text = doc.GetText(yankRange);
+
+            var lastChar = new Hex1b.Documents.DocumentOffset(Math.Max(0, yankEnd.Value - 1));
+            editor.State.SetCursorPosition(lastChar);
+
+            var yankProvider = YankHelper.FindYankProvider(_state, editor.State);
+            if (yankProvider is not null)
+            {
+                var startPos = doc.OffsetToPosition(yankRange.Start);
+                var endPos = doc.OffsetToPosition(yankRange.End);
+                yankProvider.HighlightRange = (startPos, endPos);
+                _state.App.Invalidate();
+                _ = Task.Delay(TimeSpan.FromMilliseconds(150)).ContinueWith(_ =>
+                {
+                    yankProvider.HighlightRange = null;
+                    _state.App.Invalidate();
+                }, TaskScheduler.Default);
+            }
+        }
+
+        if (!string.IsNullOrEmpty(text))
+        {
+            ctx.CopyToClipboard(text);
+            ShowYankNotification(text);
+        }
     }
 
     private void ShowYankNotification(string text)

--- a/src/Dotsider/NuGetState.cs
+++ b/src/Dotsider/NuGetState.cs
@@ -65,6 +65,23 @@ public sealed class NuGetState(Hex1bApp app, string nupkgPath) : IDisposable
     /// <summary>Yank notification message shown in the hints bar, auto-clears after 1.5 seconds.</summary>
     public string? YankNotification { get; set; }
 
+    // --- Vim Text Object State ---
+
+    /// <summary>Current state of a pending vim text-object sequence (iw, iW, yiw, yiW).</summary>
+    public VimMotionState VimPending { get; set; }
+
+    /// <summary>The editor that started the current vim text-object sequence, for affinity checking.</summary>
+    public EditorState? VimPendingEditor { get; set; }
+
+    /// <summary>Cursor position when the text-object sequence was armed, for cursor affinity.</summary>
+    public int VimPendingCursorOffset { get; set; }
+
+    /// <summary>Timestamp when the text-object sequence was armed, for 1-second timeout.</summary>
+    public DateTime VimPendingTimestamp { get; set; }
+
+    /// <summary>Delegate to perform a neovim-style editor yank, set by the host app (NuGetApp).</summary>
+    public Action<Hex1b.Input.InputBindingActionContext, EditorNode>? PerformEditorYank { get; set; }
+
     /// <summary>Generation counter for yank notification timer race prevention.</summary>
     public long YankGeneration { get; set; }
 

--- a/src/Dotsider/Views/DiffMethodsView.cs
+++ b/src/Dotsider/Views/DiffMethodsView.cs
@@ -124,6 +124,7 @@ public static class DiffMethodsView
         {
             bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
             {
+                state.VimPending = VimMotionState.Idle;
                 if (search.IsActive)
                 {
                     search.Dismiss();

--- a/src/Dotsider/Views/DiffRefsView.cs
+++ b/src/Dotsider/Views/DiffRefsView.cs
@@ -121,6 +121,7 @@ public static class DiffRefsView
         {
             bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
             {
+                state.VimPending = VimMotionState.Idle;
                 if (search.IsActive)
                 {
                     search.Dismiss();

--- a/src/Dotsider/Views/DiffSummaryView.cs
+++ b/src/Dotsider/Views/DiffSummaryView.cs
@@ -93,6 +93,19 @@ public static class DiffSummaryView
                             .WithViewRenderer(InfoEditorViewRenderer.Instance)
                             .Decorations(new InfoLabelDecorationProvider())
                             .Decorations(leftSearchProvider)
+                            .WithInputBindings(bindings =>
+                            {
+                                TextObjectHelper.ConfigureReadOnlyEditorBindings(
+                                    bindings,
+                                    state.LeftInfoEditorState!,
+                                    () => state.VimPending,
+                                    () => state.VimPendingEditor,
+                                    () => state.VimPendingCursorOffset,
+                                    () => state.VimPendingTimestamp,
+                                    (s, e, o) => { state.VimPending = s; state.VimPendingEditor = e; state.VimPendingCursorOffset = o; state.VimPendingTimestamp = DateTime.UtcNow; },
+                                    state.PerformEditorYank,
+                                    () => state.App.Invalidate());
+                            })
                             .FillWidth().FillHeight())
                     ).Title($" {state.Left.FileName} (Left) ").Fill()
                 ],
@@ -106,6 +119,19 @@ public static class DiffSummaryView
                             .WithViewRenderer(InfoEditorViewRenderer.Instance)
                             .Decorations(new InfoLabelDecorationProvider())
                             .Decorations(rightSearchProvider)
+                            .WithInputBindings(bindings =>
+                            {
+                                TextObjectHelper.ConfigureReadOnlyEditorBindings(
+                                    bindings,
+                                    state.RightInfoEditorState!,
+                                    () => state.VimPending,
+                                    () => state.VimPendingEditor,
+                                    () => state.VimPendingCursorOffset,
+                                    () => state.VimPendingTimestamp,
+                                    (s, e, o) => { state.VimPending = s; state.VimPendingEditor = e; state.VimPendingCursorOffset = o; state.VimPendingTimestamp = DateTime.UtcNow; },
+                                    state.PerformEditorYank,
+                                    () => state.App.Invalidate());
+                            })
                             .FillWidth().FillHeight())
                     ).Title($" {state.Right.FileName} (Right) ").Fill()
                 ],
@@ -121,6 +147,19 @@ public static class DiffSummaryView
                     .Decorations(new InfoLabelDecorationProvider())
                     .Decorations(new DiffStatsDecorationProvider())
                     .Decorations(statsSearchProvider)
+                    .WithInputBindings(bindings =>
+                    {
+                        TextObjectHelper.ConfigureReadOnlyEditorBindings(
+                            bindings,
+                            state.ChangeStatsEditorState!,
+                            () => state.VimPending,
+                            () => state.VimPendingEditor,
+                            () => state.VimPendingCursorOffset,
+                            () => state.VimPendingTimestamp,
+                            (s, e, o) => { state.VimPending = s; state.VimPendingEditor = e; state.VimPendingCursorOffset = o; state.VimPendingTimestamp = DateTime.UtcNow; },
+                            state.PerformEditorYank,
+                            () => state.App.Invalidate());
+                    })
                     .FillWidth().FillHeight())
             ).Title(" Change Summary ").Fill());
 
@@ -131,6 +170,7 @@ public static class DiffSummaryView
             // Tab cycles focus: Left Info → Right Info → Change Stats → Left Info
             bindings.Key(Hex1bKey.Tab).Global().Action(_ =>
             {
+                state.VimPending = VimMotionState.Idle;
                 if (state.App.FocusedNode is EditorNode { State: var es })
                 {
                     if (es == state.LeftInfoEditorState)
@@ -153,6 +193,7 @@ public static class DiffSummaryView
 
             bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
             {
+                state.VimPending = VimMotionState.Idle;
                 if (search.IsActive)
                 {
                     search.Dismiss();

--- a/src/Dotsider/Views/DiffTypesView.cs
+++ b/src/Dotsider/Views/DiffTypesView.cs
@@ -118,6 +118,7 @@ public static class DiffTypesView
         {
             bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
             {
+                state.VimPending = VimMotionState.Idle;
                 if (search.IsActive)
                 {
                     search.Dismiss();

--- a/src/Dotsider/Views/DynamicAnalysisView.cs
+++ b/src/Dotsider/Views/DynamicAnalysisView.cs
@@ -111,6 +111,7 @@ public static class DynamicAnalysisView
         {
             bindings.Key(Hex1bKey.Enter).Global().Action(_ =>
             {
+                state.VimPending = VimMotionState.Idle;
                 if (!state.DynamicEditingArgs)
                 {
                     state.Tracer = new RuntimeTracer(
@@ -124,6 +125,7 @@ public static class DynamicAnalysisView
 
             bindings.Key(Hex1bKey.A).Global().Action(_ =>
             {
+                state.VimPending = VimMotionState.Idle;
                 state.DynamicEditingArgs = !state.DynamicEditingArgs;
                 state.App.Invalidate();
             }, "Edit args");
@@ -187,6 +189,7 @@ public static class DynamicAnalysisView
             {
                 bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
                 {
+                    state.VimPending = VimMotionState.Idle;
                     if (state.DynamicSubTab > 0)
                     {
                         state.DynamicSubTab--;
@@ -196,6 +199,7 @@ public static class DynamicAnalysisView
 
                 bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
                 {
+                    state.VimPending = VimMotionState.Idle;
                     if (state.DynamicSubTab < DynamicSubTabId.Count - 1)
                     {
                         state.DynamicSubTab++;
@@ -207,6 +211,7 @@ public static class DynamicAnalysisView
             // Ctrl+K to stop the traced process
             bindings.Ctrl().Key(Hex1bKey.K).Global().Action(_ =>
             {
+                state.VimPending = VimMotionState.Idle;
                 tracer.Stop();
                 state.App.Invalidate();
             }, "Stop traced process");
@@ -220,6 +225,7 @@ public static class DynamicAnalysisView
             {
                 bindings.Key(Hex1bKey.Enter).Global().Action(_ =>
                 {
+                    state.VimPending = VimMotionState.Idle;
                     if (TryNavigateJitEvent(state, tracer))
                         return;
 

--- a/src/Dotsider/Views/GeneralView.cs
+++ b/src/Dotsider/Views/GeneralView.cs
@@ -109,6 +109,19 @@ public static class GeneralView
                         .WithViewRenderer(InfoEditorViewRenderer.Instance)
                         .Decorations(new InfoLabelDecorationProvider())
                         .Decorations(state.GeneralInfoYankProvider)
+                        .WithInputBindings(bindings =>
+                        {
+                            TextObjectHelper.ConfigureReadOnlyEditorBindings(
+                                bindings,
+                                state.GeneralInfoEditorState!,
+                                () => state.VimPending,
+                                () => state.VimPendingEditor,
+                                () => state.VimPendingCursorOffset,
+                                () => state.VimPendingTimestamp,
+                                (s, e, o) => { state.VimPending = s; state.VimPendingEditor = e; state.VimPendingCursorOffset = o; state.VimPendingTimestamp = DateTime.UtcNow; },
+                                state.PerformEditorYank,
+                                () => state.App.Invalidate());
+                        })
                         .FillWidth().FillHeight())
                 ).Title(" Assembly Info ").FixedHeight(14)
             };
@@ -183,6 +196,7 @@ public static class GeneralView
         {
             bindings.Key(Hex1bKey.Tab).Global().Action(_ =>
             {
+                state.VimPending = VimMotionState.Idle;
                 if (state.App.FocusedNode is EditorNode)
                 {
                     // Editor → Table: seed focus to first row if none selected

--- a/src/Dotsider/Views/IlEditorHostWidget.cs
+++ b/src/Dotsider/Views/IlEditorHostWidget.cs
@@ -48,6 +48,19 @@ public sealed record IlEditorHostWidget : CompositeWidget<IlEditorHostNode>
                 .Decorations(AppState.IlSyntaxProvider)
                 .Decorations(AppState.IlSearchProvider)
                 .Decorations(AppState.IlYankProvider)
+                .WithInputBindings(bindings =>
+                {
+                    TextObjectHelper.ConfigureReadOnlyEditorBindings(
+                        bindings,
+                        State,
+                        () => AppState.VimPending,
+                        () => AppState.VimPendingEditor,
+                        () => AppState.VimPendingCursorOffset,
+                        () => AppState.VimPendingTimestamp,
+                        (s, e, o) => { AppState.VimPending = s; AppState.VimPendingEditor = e; AppState.VimPendingCursorOffset = o; AppState.VimPendingTimestamp = DateTime.UtcNow; },
+                        AppState.PerformEditorYank,
+                        () => AppState.App.Invalidate());
+                })
                 .FillWidth()
                 .FillHeight())
             .FillWidth()

--- a/src/Dotsider/Views/NuGetBrowserView.cs
+++ b/src/Dotsider/Views/NuGetBrowserView.cs
@@ -81,6 +81,19 @@ public static class NuGetBrowserView
                         .WithViewRenderer(InfoEditorViewRenderer.Instance)
                         .Decorations(new InfoLabelDecorationProvider())
                         .Decorations(state.PackageInfoYankProvider)
+                        .WithInputBindings(bindings =>
+                        {
+                            TextObjectHelper.ConfigureReadOnlyEditorBindings(
+                                bindings,
+                                state.PackageInfoEditorState!,
+                                () => state.VimPending,
+                                () => state.VimPendingEditor,
+                                () => state.VimPendingCursorOffset,
+                                () => state.VimPendingTimestamp,
+                                (s, e, o) => { state.VimPending = s; state.VimPendingEditor = e; state.VimPendingCursorOffset = o; state.VimPendingTimestamp = DateTime.UtcNow; },
+                                state.PerformEditorYank,
+                                () => state.App.Invalidate());
+                        })
                         .FillWidth().FillHeight())
                 ).Title(" Package Info ").FixedHeight(11)
             };
@@ -158,6 +171,7 @@ public static class NuGetBrowserView
             // Tab toggles focus between Package Info editor and DLL table
             bindings.Key(Hex1b.Input.Hex1bKey.Tab).Global().Action(_ =>
             {
+                state.VimPending = VimMotionState.Idle;
                 if (state.App.FocusedNode is EditorNode)
                 {
                     state.FileTreeFocusedKey ??=

--- a/src/Dotsider/Views/PeMetadataView.cs
+++ b/src/Dotsider/Views/PeMetadataView.cs
@@ -158,6 +158,19 @@ public static class PeMetadataView
                                 .WithViewRenderer(InfoEditorViewRenderer.Instance)
                                 .Decorations(new InfoLabelDecorationProvider())
                                 .Decorations(state.PeHeadersYankProvider)
+                                .WithInputBindings(bindings =>
+                                {
+                                    TextObjectHelper.ConfigureReadOnlyEditorBindings(
+                                        bindings,
+                                        state.PeHeadersEditorState!,
+                                        () => state.VimPending,
+                                        () => state.VimPendingEditor,
+                                        () => state.VimPendingCursorOffset,
+                                        () => state.VimPendingTimestamp,
+                                        (s, e, o) => { state.VimPending = s; state.VimPendingEditor = e; state.VimPendingCursorOffset = o; state.VimPendingTimestamp = DateTime.UtcNow; },
+                                        state.PerformEditorYank,
+                                        () => state.App.Invalidate());
+                                })
                                 .FillWidth().FillHeight())
                         ).Title(" PE Headers ").Fill()
                     ],
@@ -171,6 +184,19 @@ public static class PeMetadataView
                                 .WithViewRenderer(InfoEditorViewRenderer.Instance)
                                 .Decorations(new InfoLabelDecorationProvider())
                                 .Decorations(state.ClrHeaderYankProvider)
+                                .WithInputBindings(bindings =>
+                                {
+                                    TextObjectHelper.ConfigureReadOnlyEditorBindings(
+                                        bindings,
+                                        state.ClrHeaderEditorState!,
+                                        () => state.VimPending,
+                                        () => state.VimPendingEditor,
+                                        () => state.VimPendingCursorOffset,
+                                        () => state.VimPendingTimestamp,
+                                        (s, e, o) => { state.VimPending = s; state.VimPendingEditor = e; state.VimPendingCursorOffset = o; state.VimPendingTimestamp = DateTime.UtcNow; },
+                                        state.PerformEditorYank,
+                                        () => state.App.Invalidate());
+                                })
                                 .FillWidth().FillHeight())
                         ).Title(" CLR Header ").Fill()
                     ],
@@ -235,6 +261,7 @@ public static class PeMetadataView
                     {
                         bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
                         {
+                            state.VimPending = VimMotionState.Idle;
                             if (state.PeSubTab > 0)
                             {
                                 state.PeSubTab--;
@@ -247,6 +274,7 @@ public static class PeMetadataView
 
                         bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
                         {
+                            state.VimPending = VimMotionState.Idle;
                             if (state.PeSubTab < PeSubTabId.Count - 1)
                             {
                                 state.PeSubTab++;
@@ -261,6 +289,7 @@ public static class PeMetadataView
                     // Tab cycles focus: PE Headers → CLR Header → Table → PE Headers
                     bindings.Key(Hex1bKey.Tab).Global().Action(_ =>
                     {
+                        state.VimPending = VimMotionState.Idle;
                         if (state.App.FocusedNode is EditorNode { State: var es })
                         {
                             if (es == state.PeHeadersEditorState)
@@ -289,6 +318,7 @@ public static class PeMetadataView
                     {
                         bindings.Key(Hex1bKey.G).Global().Action(_ =>
                         {
+                            state.VimPending = VimMotionState.Idle;
                             if (state.PeFocusedKey is int token)
                             {
                                 if (state.PeSubTab == PeSubTabId.TypeDef)
@@ -319,6 +349,7 @@ public static class PeMetadataView
                 {
                     bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
                     {
+                        state.VimPending = VimMotionState.Idle;
                         state.PeDetailContent = null;
                         state.RequestContentFocus();
                         state.App.Invalidate();
@@ -338,6 +369,19 @@ public static class PeMetadataView
                             .WithViewRenderer(InfoEditorViewRenderer.Instance)
                             .Decorations(new InfoLabelDecorationProvider())
                             .Decorations(state.PeDetailYankProvider)
+                            .WithInputBindings(bindings =>
+                            {
+                                TextObjectHelper.ConfigureReadOnlyEditorBindings(
+                                    bindings,
+                                    state.PeDetailEditorState!,
+                                    () => state.VimPending,
+                                    () => state.VimPendingEditor,
+                                    () => state.VimPendingCursorOffset,
+                                    () => state.VimPendingTimestamp,
+                                    (s, e, o) => { state.VimPending = s; state.VimPendingEditor = e; state.VimPendingCursorOffset = o; state.VimPendingTimestamp = DateTime.UtcNow; },
+                                    state.PerformEditorYank,
+                                    () => state.App.Invalidate());
+                            })
                             .FillWidth().FillHeight())
                     ).Title(" Detail ").FixedWidth(60).FixedHeight(12)
                 ).OnClickAway(() =>

--- a/src/Dotsider/Views/SizeTreemapView.cs
+++ b/src/Dotsider/Views/SizeTreemapView.cs
@@ -165,6 +165,7 @@ public static class SizeTreemapView
                 {
                     bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
                     {
+                        state.VimPending = VimMotionState.Idle;
                         state.TreemapCurrentLevel = state.TreemapBreadcrumb.Pop();
                         state.TreemapSelectedIndex = -1;
                         state.App.Invalidate();

--- a/src/Dotsider/Views/StringsView.cs
+++ b/src/Dotsider/Views/StringsView.cs
@@ -148,6 +148,7 @@ public static class StringsView
                     {
                         bindings.Key(Hex1bKey.LeftArrow).Global().Action(_ =>
                         {
+                            state.VimPending = VimMotionState.Idle;
                             if (state.StringsSourceTab > 0)
                             {
                                 state.StringsSourceTab--;
@@ -160,6 +161,7 @@ public static class StringsView
 
                         bindings.Key(Hex1bKey.RightArrow).Global().Action(_ =>
                         {
+                            state.VimPending = VimMotionState.Idle;
                             if (state.StringsSourceTab < StringsSubTabId.Count - 1)
                             {
                                 state.StringsSourceTab++;
@@ -212,6 +214,7 @@ public static class StringsView
                 {
                     bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
                     {
+                        state.VimPending = VimMotionState.Idle;
                         state.StringsDetailContent = null;
                         state.RequestContentFocus();
                         state.App.Invalidate();
@@ -234,6 +237,19 @@ public static class StringsView
                                     .WithViewRenderer(InfoEditorViewRenderer.Instance)
                                     .Decorations(new StringsDetailDecorationProvider())
                                     .Decorations(state.StringsDetailYankProvider)
+                                    .WithInputBindings(bindings =>
+                                    {
+                                        TextObjectHelper.ConfigureReadOnlyEditorBindings(
+                                            bindings,
+                                            state.StringsDetailEditorState!,
+                                            () => state.VimPending,
+                                            () => state.VimPendingEditor,
+                                            () => state.VimPendingCursorOffset,
+                                            () => state.VimPendingTimestamp,
+                                            (s, e, o) => { state.VimPending = s; state.VimPendingEditor = e; state.VimPendingCursorOffset = o; state.VimPendingTimestamp = DateTime.UtcNow; },
+                                            state.PerformEditorYank,
+                                            () => state.App.Invalidate());
+                                    })
                                     .FillWidth().FillHeight())
                             ).Title(" String Detail ").FixedWidth(70).FillHeight()
                         ]).FixedWidth(70).FixedHeight(15)

--- a/src/Dotsider/Views/TextObjectHelper.cs
+++ b/src/Dotsider/Views/TextObjectHelper.cs
@@ -1,0 +1,334 @@
+using Hex1b;
+using Hex1b.Documents;
+using Hex1b.Input;
+using Hex1b.Widgets;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// Implements vim-style text object selection (iw, iW) and configures
+/// read-only editor bindings for the vim text-object state machine.
+/// </summary>
+public static class TextObjectHelper
+{
+    /// <summary>
+    /// Selects the inner word under the cursor (vim <c>iw</c> semantics).
+    /// Word characters are letters, digits, and underscores. Punctuation and
+    /// whitespace each form their own classes. Newlines are boundaries.
+    /// </summary>
+    /// <param name="state">The editor state to modify.</param>
+    public static void SelectInnerWord(EditorState state)
+    {
+        if (state.Document.Length == 0) return;
+        var offset = state.Cursor.Position.Value;
+        if (offset >= state.Document.Length) return;
+
+        var text = state.Document.GetText();
+        var ch = text[offset];
+        var charClass = ClassifyChar(ch);
+
+        // Find contiguous run of same class
+        var start = offset;
+        while (start > 0 && ClassifyChar(text[start - 1]) == charClass && text[start - 1] != '\n' && ch != '\n')
+            start--;
+
+        var end = offset;
+        if (ch == '\n')
+        {
+            // Newline is its own "word"
+            end = offset + 1;
+        }
+        else
+        {
+            while (end < text.Length && ClassifyChar(text[end]) == charClass && text[end] != '\n')
+                end++;
+        }
+
+        if (start == end) return;
+
+        // Position at last char (inclusive) so PerformEditorYank's cursor+1 extension
+        // produces the correct exclusive end without grabbing a trailing delimiter.
+        state.Cursor.SelectionAnchor = new DocumentOffset(start);
+        state.Cursor.Position = new DocumentOffset(end - 1);
+    }
+
+    /// <summary>
+    /// Selects the inner WORD under the cursor (vim <c>iW</c> semantics).
+    /// A WORD is any contiguous run of non-whitespace characters.
+    /// Newlines are boundaries.
+    /// </summary>
+    /// <param name="state">The editor state to modify.</param>
+    public static void SelectInnerWORD(EditorState state)
+    {
+        if (state.Document.Length == 0) return;
+        var offset = state.Cursor.Position.Value;
+        if (offset >= state.Document.Length) return;
+
+        var text = state.Document.GetText();
+        var ch = text[offset];
+        var isWhitespace = ch != '\n' && char.IsWhiteSpace(ch);
+
+        if (ch == '\n')
+        {
+            // Newline is its own "word" — anchor at offset, position at offset (single char)
+            state.Cursor.SelectionAnchor = new DocumentOffset(offset);
+            state.Cursor.Position = new DocumentOffset(offset);
+            return;
+        }
+
+        var start = offset;
+        var end = offset;
+
+        if (isWhitespace)
+        {
+            // Select contiguous whitespace (same line)
+            while (start > 0 && text[start - 1] != '\n' && char.IsWhiteSpace(text[start - 1]))
+                start--;
+            while (end < text.Length && text[end] != '\n' && char.IsWhiteSpace(text[end]))
+                end++;
+        }
+        else
+        {
+            // Select contiguous non-whitespace (same line)
+            while (start > 0 && text[start - 1] != '\n' && !char.IsWhiteSpace(text[start - 1]))
+                start--;
+            while (end < text.Length && text[end] != '\n' && !char.IsWhiteSpace(text[end]))
+                end++;
+        }
+
+        if (start == end) return;
+
+        state.Cursor.SelectionAnchor = new DocumentOffset(start);
+        state.Cursor.Position = new DocumentOffset(end - 1);
+    }
+
+    /// <summary>
+    /// Configures key, mouse, and drag bindings on a read-only <see cref="EditorWidget"/>
+    /// to support vim text-object sequences (iw, iW, yiw, yiW) with comprehensive
+    /// cancellation on any intervening input.
+    /// </summary>
+    /// <param name="bindings">The editor's input bindings builder.</param>
+    /// <param name="thisEditorState">The <see cref="EditorState"/> of this specific editor.</param>
+    /// <param name="getVimPending">Returns the current <see cref="VimMotionState"/>.</param>
+    /// <param name="getVimPendingEditor">Returns the editor that started the sequence.</param>
+    /// <param name="getVimPendingCursorOffset">Returns the cursor offset when the sequence was armed.</param>
+    /// <param name="getVimPendingTimestamp">Returns the timestamp when the sequence was armed.</param>
+    /// <param name="setVimState">Sets <see cref="VimMotionState"/>, pending editor, and cursor offset.</param>
+    /// <param name="performYank">Called for <c>yiw</c>/<c>yiW</c> to yank the selection.</param>
+    /// <param name="invalidate">Requests a UI refresh.</param>
+    public static void ConfigureReadOnlyEditorBindings(
+        InputBindingsBuilder bindings,
+        EditorState thisEditorState,
+        Func<VimMotionState> getVimPending,
+        Func<EditorState?> getVimPendingEditor,
+        Func<int> getVimPendingCursorOffset,
+        Func<DateTime> getVimPendingTimestamp,
+        Action<VimMotionState, EditorState?, int> setVimState,
+        Action<InputBindingActionContext, EditorNode>? performYank,
+        Action invalidate)
+    {
+        void ResetToIdle() => setVimState(VimMotionState.Idle, null, 0);
+
+        // --- I binding (always registered — starts text object from Idle) ---
+        bindings.Key(Hex1bKey.I).Action(ctx =>
+        {
+            // Timeout check — reset stale state, then fall through to process
+            // this i as a fresh sequence start (don't discard the keypress)
+            if (getVimPending() != VimMotionState.Idle
+                && (DateTime.UtcNow - getVimPendingTimestamp()).TotalSeconds > 1.0)
+            {
+                ResetToIdle();
+            }
+
+            var pending = getVimPending();
+            switch (pending)
+            {
+                case VimMotionState.Idle:
+                    setVimState(
+                        VimMotionState.WaitingForTextObject,
+                        thisEditorState,
+                        thisEditorState.Cursor.Position.Value);
+                    break;
+
+                case VimMotionState.WaitingForYMotion
+                    when thisEditorState == getVimPendingEditor():
+                    setVimState(
+                        VimMotionState.WaitingForYTextObject,
+                        thisEditorState,
+                        thisEditorState.Cursor.Position.Value);
+                    break;
+
+                default:
+                    // Editor mismatch on WaitingForYMotion, or unexpected state
+                    ResetToIdle();
+                    return;
+            }
+
+            invalidate();
+        }, "");
+
+        // --- All other bindings (conditionally registered when pending) ---
+        if (getVimPending() == VimMotionState.Idle) return;
+
+        // W — select inner word (completion)
+        bindings.Key(Hex1bKey.W).Action(ctx =>
+        {
+            CompleteTextObject(ctx, thisEditorState, getVimPending, getVimPendingEditor,
+                getVimPendingCursorOffset, getVimPendingTimestamp, setVimState,
+                performYank, invalidate, isWord: true);
+        }, "");
+
+        // Shift+W — select inner WORD (completion)
+        bindings.Shift().Key(Hex1bKey.W).Action(ctx =>
+        {
+            CompleteTextObject(ctx, thisEditorState, getVimPending, getVimPendingEditor,
+                getVimPendingCursorOffset, getVimPendingTimestamp, setVimState,
+                performYank, invalidate, isWord: false);
+        }, "");
+
+        // --- Cancellation: printable keys ---
+        for (var k = Hex1bKey.A; k <= Hex1bKey.Z; k++)
+        {
+            if (k is Hex1bKey.I or Hex1bKey.W) continue;
+            bindings.Key(k).Action(_ => ResetToIdle(), "");
+        }
+
+        Hex1bKey[] cancelKeys =
+        [
+            Hex1bKey.D0, Hex1bKey.D1, Hex1bKey.D2, Hex1bKey.D3, Hex1bKey.D4,
+            Hex1bKey.D5, Hex1bKey.D6, Hex1bKey.D7, Hex1bKey.D8, Hex1bKey.D9,
+            Hex1bKey.Spacebar, Hex1bKey.None,
+            Hex1bKey.OemComma, Hex1bKey.OemPeriod, Hex1bKey.OemMinus,
+            Hex1bKey.OemPlus, Hex1bKey.OemQuestion, Hex1bKey.Oem1,
+            Hex1bKey.Oem4, Hex1bKey.Oem5, Hex1bKey.Oem6, Hex1bKey.Oem7,
+            Hex1bKey.OemTilde,
+            // Non-navigation EditorNode bindings (no-ops on read-only)
+            Hex1bKey.Backspace, Hex1bKey.Delete, Hex1bKey.Enter, Hex1bKey.Tab,
+            Hex1bKey.Escape, Hex1bKey.F4, Hex1bKey.F12
+        ];
+
+        foreach (var k in cancelKeys)
+            bindings.Key(k).Action(_ => ResetToIdle(), "");
+
+        // Ctrl+key cancellation
+        bindings.Ctrl().Key(Hex1bKey.Backspace).Action(_ => ResetToIdle(), "");
+        bindings.Ctrl().Key(Hex1bKey.Delete).Action(_ => ResetToIdle(), "");
+        bindings.Ctrl().Key(Hex1bKey.A).Action(_ => ResetToIdle(), "");
+        bindings.Ctrl().Key(Hex1bKey.D).Action(_ => ResetToIdle(), "");
+        bindings.Ctrl().Key(Hex1bKey.Z).Action(_ => ResetToIdle(), "");
+        bindings.Ctrl().Key(Hex1bKey.Y).Action(_ => ResetToIdle(), "");
+        bindings.Ctrl().Key(Hex1bKey.Spacebar).Action(_ => ResetToIdle(), "");
+        bindings.Ctrl().Key(Hex1bKey.K).Action(_ => ResetToIdle(), "");
+        bindings.Shift().Key(Hex1bKey.F12).Action(_ => ResetToIdle(), "");
+
+        // --- Cancellation: navigation keys ---
+        Hex1bKey[] navKeys =
+        [
+            Hex1bKey.LeftArrow, Hex1bKey.RightArrow, Hex1bKey.UpArrow, Hex1bKey.DownArrow,
+            Hex1bKey.Home, Hex1bKey.End, Hex1bKey.PageUp, Hex1bKey.PageDown
+        ];
+
+        foreach (var k in navKeys)
+        {
+            bindings.Key(k).Action(_ => ResetToIdle(), "");
+            bindings.Shift().Key(k).Action(_ => ResetToIdle(), "");
+            bindings.Ctrl().Key(k).Action(_ => ResetToIdle(), "");
+        }
+
+        // Note: Ctrl+Shift combos cannot be registered via the fluent builder (Ctrl and Shift
+        // are mutually exclusive in hex1b's KeyStepBuilder). These are covered by the Ctrl-only
+        // and Shift-only navigation cancellation bindings above — the cursor-affinity check
+        // catches any movement regardless.
+
+        // --- Cancellation: mouse bindings ---
+        bindings.Mouse(MouseButton.Left).Action(() => ResetToIdle(), "");
+        bindings.Mouse(MouseButton.Left).Ctrl().Action(() => ResetToIdle(), "");
+        bindings.Mouse(MouseButton.Left).DoubleClick().Action(() => ResetToIdle(), "");
+        bindings.Mouse(MouseButton.Left).TripleClick().Action(() => ResetToIdle(), "");
+        bindings.Drag(MouseButton.Left).Action((_, _) =>
+        {
+            ResetToIdle();
+            return new DragHandler(); // empty → rejected
+        });
+    }
+
+    private static void CompleteTextObject(
+        InputBindingActionContext ctx,
+        EditorState thisEditorState,
+        Func<VimMotionState> getVimPending,
+        Func<EditorState?> getVimPendingEditor,
+        Func<int> getVimPendingCursorOffset,
+        Func<DateTime> getVimPendingTimestamp,
+        Action<VimMotionState, EditorState?, int> setVimState,
+        Action<InputBindingActionContext, EditorNode>? performYank,
+        Action invalidate,
+        bool isWord)
+    {
+        void ResetToIdle() => setVimState(VimMotionState.Idle, null, 0);
+
+        // Timeout check
+        if (getVimPending() != VimMotionState.Idle
+            && (DateTime.UtcNow - getVimPendingTimestamp()).TotalSeconds > 1.0)
+        {
+            ResetToIdle();
+            return;
+        }
+
+        var pending = getVimPending();
+
+        // State check: must be waiting for text object completion
+        if (pending is not (VimMotionState.WaitingForTextObject or VimMotionState.WaitingForYTextObject))
+        {
+            ResetToIdle();
+            return;
+        }
+
+        // Editor affinity
+        if (thisEditorState != getVimPendingEditor())
+        {
+            ResetToIdle();
+            return;
+        }
+
+        // Cursor affinity
+        if (thisEditorState.Cursor.Position.Value != getVimPendingCursorOffset())
+        {
+            ResetToIdle();
+            return;
+        }
+
+        // Selection affinity — if something created a selection between I and W, cancel
+        if (thisEditorState.Cursor.HasSelection)
+        {
+            ResetToIdle();
+            return;
+        }
+
+        // Perform the selection
+        if (isWord)
+            SelectInnerWord(thisEditorState);
+        else
+            SelectInnerWORD(thisEditorState);
+
+        // If this was a yiw/yiW sequence, perform the yank
+        if (pending == VimMotionState.WaitingForYTextObject
+            && performYank is not null
+            && ctx.FocusedNode is EditorNode editor)
+        {
+            performYank(ctx, editor);
+        }
+
+        ResetToIdle();
+        invalidate();
+    }
+
+    private enum CharClass { Word, Punctuation, Whitespace, Newline }
+
+    private static CharClass ClassifyChar(char c) => c switch
+    {
+        '\n' => CharClass.Newline,
+        _ when char.IsLetterOrDigit(c) || c == '_' => CharClass.Word,
+        _ when char.IsWhiteSpace(c) => CharClass.Whitespace,
+        _ => CharClass.Punctuation
+    };
+}

--- a/src/Dotsider/VimMotionState.cs
+++ b/src/Dotsider/VimMotionState.cs
@@ -1,0 +1,19 @@
+namespace Dotsider;
+
+/// <summary>
+/// Tracks the state of a pending vim text-object sequence (iw, iW, yiw, yiW).
+/// </summary>
+public enum VimMotionState
+{
+    /// <summary>No pending motion.</summary>
+    Idle,
+
+    /// <summary>Pressed <c>i</c>, expecting <c>w</c> or <c>W</c>.</summary>
+    WaitingForTextObject,
+
+    /// <summary>Pressed <c>y</c> on editor without selection, expecting <c>i</c>.</summary>
+    WaitingForYMotion,
+
+    /// <summary>Pressed <c>y</c> then <c>i</c>, expecting <c>w</c> or <c>W</c>.</summary>
+    WaitingForYTextObject
+}

--- a/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
@@ -1015,4 +1015,206 @@ public class StandardModeYankIntegrationTests(SampleAssemblyFixture samples) : I
         _cts?.Dispose();
         GC.SuppressFinalize(this);
     }
+
+    // --- Vim Text Object Tests ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task General_IwSelectsWordInEditor()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Tab) // Focus editor
+            .WaitUntil(_ => IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.True(IsFocusedOnEditor());
+        Assert.False(_state!.GeneralInfoEditorState!.Cursor.HasSelection);
+
+        // Press i — verify it arms the state machine
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.I)
+            .WaitUntil(_ => _state!.VimPending == VimMotionState.WaitingForTextObject, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Equal(VimMotionState.WaitingForTextObject, _state!.VimPending);
+
+        // Press w — should select inner word
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.W)
+            .WaitUntil(_ => _state!.VimPending == VimMotionState.Idle, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Equal(VimMotionState.Idle, _state.VimPending);
+        Assert.True(_state.GeneralInfoEditorState!.Cursor.HasSelection);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task General_IWSelectsWORDInEditor()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Press i, wait, then Shift+W (iW)
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("i")
+            .WaitUntil(_ => _state!.VimPending == VimMotionState.WaitingForTextObject, TimeSpan.FromSeconds(5))
+            .Type("W") // uppercase W = Shift+W
+            .WaitUntil(_ => _state!.GeneralInfoEditorState!.Cursor.HasSelection, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.True(_state!.GeneralInfoEditorState!.Cursor.HasSelection);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task General_YiwYanksWordFromEditor()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Press y — verify it arms WaitingForYMotion
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Y)
+            .WaitUntil(_ => _state!.VimPending == VimMotionState.WaitingForYMotion, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Equal(VimMotionState.WaitingForYMotion, _state!.VimPending);
+
+        // Press i — advances to WaitingForYTextObject
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.I)
+            .WaitUntil(_ => _state!.VimPending == VimMotionState.WaitingForYTextObject, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Press w — selects + yanks
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.W)
+            .WaitUntil(_ => _state!.YankNotification is not null, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.NotNull(_state!.YankNotification);
+        Assert.True(_clipboardAdapter!.ClipboardWrites.TryDequeue(out var clipboard));
+        Assert.False(string.IsNullOrEmpty(clipboard));
+        Assert.Equal(VimMotionState.Idle, _state.VimPending);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task General_InterruptedByGlobalKey_DoesNotSelect()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Press i, then 2 (tab switch, Global D2 resets VimPending), then w
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("i")
+            .WaitUntil(_ => _state!.VimPending == VimMotionState.WaitingForTextObject, TimeSpan.FromSeconds(5))
+            .Type("2") // tab switch → VimReset
+            .WaitUntil(_ => _state!.VimPending == VimMotionState.Idle, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.Equal(VimMotionState.Idle, _state!.VimPending);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task General_RandomLetterCancels()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Press i then a (random letter cancels), then w
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("i")
+            .WaitUntil(_ => _state!.VimPending == VimMotionState.WaitingForTextObject, TimeSpan.FromSeconds(5))
+            .Type("a") // EditorNode-level A binding resets
+            .WaitUntil(_ => _state!.VimPending == VimMotionState.Idle, TimeSpan.FromSeconds(5))
+            .Type("w") // should NOT select (VimPending is Idle, W not registered)
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(100, ct);
+        Assert.False(_state!.GeneralInfoEditorState!.Cursor.HasSelection);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task HexDump_YDoesNotArmOnHexNormal()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll, initialTab: TabId.HexDump);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Hex Dump"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Press y on hex dump without selection — should NOT arm VimPending
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(100, ct);
+        Assert.Equal(VimMotionState.Idle, _state!.VimPending);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
 }

--- a/tests/Dotsider.Tests/TextObjectHelperTests.cs
+++ b/tests/Dotsider.Tests/TextObjectHelperTests.cs
@@ -1,0 +1,169 @@
+using Dotsider.Views;
+using Hex1b.Documents;
+using Hex1b.Widgets;
+
+namespace Dotsider.Tests;
+
+public class TextObjectHelperTests
+{
+    private static EditorState CreateEditor(string text, int cursorOffset = 0)
+    {
+        var doc = new Hex1bDocument(text);
+        var state = new EditorState(doc) { IsReadOnly = true };
+        state.SetCursorPosition(new DocumentOffset(cursorOffset));
+        return state;
+    }
+
+    private static string? GetSelectedText(EditorState state)
+    {
+        if (!state.Cursor.HasSelection) return null;
+        // Mirror PerformEditorYank: extend to cursor + 1 to include the cursor character
+        var range = state.Cursor.SelectionRange;
+        var yankEnd = new DocumentOffset(Math.Min(
+            Math.Max(range.End.Value, state.Cursor.Position.Value + 1),
+            state.Document.Length));
+        return state.Document.GetText(new DocumentRange(range.Start, yankEnd));
+    }
+
+    // --- SelectInnerWord ---
+
+    [Fact]
+    public void SelectInnerWord_OnWordChars_SelectsContiguousRun()
+    {
+        var state = CreateEditor("hello_world foo", cursorOffset: 3); // cursor on 'l'
+        TextObjectHelper.SelectInnerWord(state);
+        Assert.Equal("hello_world", GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWord_IncludesUnderscores()
+    {
+        var state = CreateEditor("foo_bar", cursorOffset: 3); // cursor on '_'
+        TextObjectHelper.SelectInnerWord(state);
+        Assert.Equal("foo_bar", GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWord_OnPunctuation_SelectsPunctuationRun()
+    {
+        var state = CreateEditor("foo::bar", cursorOffset: 3); // cursor on first ':'
+        TextObjectHelper.SelectInnerWord(state);
+        Assert.Equal("::", GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWord_OnWhitespace_SelectsWhitespaceRun()
+    {
+        var state = CreateEditor("a   b", cursorOffset: 2); // cursor on middle space
+        TextObjectHelper.SelectInnerWord(state);
+        Assert.Equal("   ", GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWord_OnTab_SelectsTabRun()
+    {
+        var state = CreateEditor("a\t\tb", cursorOffset: 1); // cursor on first tab
+        TextObjectHelper.SelectInnerWord(state);
+        Assert.Equal("\t\t", GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWord_DoesNotCrossNewline()
+    {
+        var state = CreateEditor("abc\ndef", cursorOffset: 2); // cursor on 'c'
+        TextObjectHelper.SelectInnerWord(state);
+        Assert.Equal("abc", GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWord_OnNewline_NoSelection()
+    {
+        // Newlines are word boundaries and single-char tokens.
+        // iw on a newline is a no-op — cursor stays put, no selection.
+        var state = CreateEditor("abc\ndef", cursorOffset: 3); // cursor on '\n'
+        TextObjectHelper.SelectInnerWord(state);
+        Assert.Null(GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWord_AtDocumentStart_SelectsFromStart()
+    {
+        var state = CreateEditor("hello world", cursorOffset: 0);
+        TextObjectHelper.SelectInnerWord(state);
+        Assert.Equal("hello", GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWord_AtDocumentEnd_SelectsToEnd()
+    {
+        var state = CreateEditor("hello world", cursorOffset: 10); // cursor on 'd'
+        TextObjectHelper.SelectInnerWord(state);
+        Assert.Equal("world", GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWord_EmptyDocument_NoSelection()
+    {
+        var state = CreateEditor("");
+        TextObjectHelper.SelectInnerWord(state);
+        Assert.Null(GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWord_CursorAtDocumentLength_NoSelection()
+    {
+        var state = CreateEditor("abc", cursorOffset: 3);
+        TextObjectHelper.SelectInnerWord(state);
+        Assert.Null(GetSelectedText(state));
+    }
+
+    // --- SelectInnerWORD ---
+
+    [Fact]
+    public void SelectInnerWORD_OnNonWhitespace_SelectsToWhitespace()
+    {
+        var state = CreateEditor("foo::bar baz", cursorOffset: 4); // cursor on ':'
+        TextObjectHelper.SelectInnerWORD(state);
+        Assert.Equal("foo::bar", GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWORD_QualifiedName_SelectsEntireFQN()
+    {
+        var state = CreateEditor("System.Runtime.CompilerServices.NullableAttribute", cursorOffset: 10);
+        TextObjectHelper.SelectInnerWORD(state);
+        Assert.Equal("System.Runtime.CompilerServices.NullableAttribute", GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWORD_OnWhitespace_SelectsWhitespaceRun()
+    {
+        var state = CreateEditor("a   b", cursorOffset: 2);
+        TextObjectHelper.SelectInnerWORD(state);
+        Assert.Equal("   ", GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWORD_DoesNotCrossNewline()
+    {
+        var state = CreateEditor("foo::bar\nbaz", cursorOffset: 4);
+        TextObjectHelper.SelectInnerWORD(state);
+        Assert.Equal("foo::bar", GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWORD_SingleToken_SelectsAll()
+    {
+        var state = CreateEditor("abc", cursorOffset: 1);
+        TextObjectHelper.SelectInnerWORD(state);
+        Assert.Equal("abc", GetSelectedText(state));
+    }
+
+    [Fact]
+    public void SelectInnerWORD_EmptyDocument_NoSelection()
+    {
+        var state = CreateEditor("");
+        TextObjectHelper.SelectInnerWORD(state);
+        Assert.Null(GetSelectedText(state));
+    }
+}


### PR DESCRIPTION
## Summary

- `iw` selects the word under the cursor, `iW` selects whitespace-delimited WORDs (grabs fully-qualified type names in one keystroke)
- `yiw` / `yiW` select + yank in one motion with flash and notification
- Works across all read-only editors: Assembly Info, PE/CLR headers, IL Inspector, Strings detail popups, Diff summaries, NuGet Package Info
- Hex dump excluded — `i` is already taken by insert mode

Uses an action-body state machine with three cancellation layers: EditorNode-level key/mouse bindings (conditionally registered only during pending state), Global action resets on every bound key, and editor/cursor/selection affinity checks on completion.

## What changed

- New `VimMotionState` enum and `TextObjectHelper` with `SelectInnerWord`, `SelectInnerWORD`, and `ConfigureReadOnlyEditorBindings`
- Y handler in all three apps arms `WaitingForYMotion` on editor without selection (hex dump guarded)
- Every Global binding across DotsiderApp, DiffApp, NuGetApp, DllInspectorBindings, and all view-level handlers resets VimPending
- Each read-only EditorWidget gets WithInputBindings wiring for text object support
- Docs and README updated with iw/iW/yiw/yiW in keyboard shortcuts and usage sections

## Test plan

- [x] 17 unit tests for SelectInnerWord / SelectInnerWORD (word chars, underscores, punctuation, whitespace, tabs, newlines, FQNs, document boundaries)
- [x] 6 integration tests covering iw, iW, yiw, Global key cancellation, random letter cancellation, hex dump guard
- [x] Full suite: 654 passed, 0 failed

Fixes #80