### PR TITLE
Fix StringExtractor crash on assemblies with empty #US heap

### DIFF
--- a/src/Dotsider.Core/Analysis/StringExtractor.cs
+++ b/src/Dotsider.Core/Analysis/StringExtractor.cs
@@ -30,6 +30,9 @@ public sealed class StringExtractor(AssemblyAnalyzer analyzer)
 
         SkippedUserStringCount = 0;
         var results = new List<StringEntry>();
+
+        if (reader.GetHeapSize(HeapIndex.UserString) == 0) return results;
+
         var handle = MetadataTokens.UserStringHandle(1);
 
         while (!handle.IsNil)
@@ -48,7 +51,14 @@ public sealed class StringExtractor(AssemblyAnalyzer analyzer)
                 SkippedUserStringCount++;
             }
 
-            handle = reader.GetNextHandle(handle);
+            try
+            {
+                handle = reader.GetNextHandle(handle);
+            }
+            catch (BadImageFormatException)
+            {
+                break;
+            }
         }
 
         return results;
@@ -66,6 +76,9 @@ public sealed class StringExtractor(AssemblyAnalyzer analyzer)
 
         SkippedMetadataStringCount = 0;
         var results = new List<StringEntry>();
+
+        if (reader.GetHeapSize(HeapIndex.String) == 0) return results;
+
         var handle = MetadataTokens.StringHandle(1);
 
         while (!handle.IsNil)
@@ -84,7 +97,14 @@ public sealed class StringExtractor(AssemblyAnalyzer analyzer)
                 SkippedMetadataStringCount++;
             }
 
-            handle = reader.GetNextHandle(handle);
+            try
+            {
+                handle = reader.GetNextHandle(handle);
+            }
+            catch (BadImageFormatException)
+            {
+                break;
+            }
         }
 
         return results;

--- a/tests/Dotsider.Tests/StringExtractorTests.cs
+++ b/tests/Dotsider.Tests/StringExtractorTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 
@@ -152,5 +153,48 @@ public class StringExtractorTests(SampleAssemblyFixture samples)
         Assert.Equal(0, extractor.SkippedUserStringCount);
         extractor.ExtractMetadataStrings();
         Assert.Equal(0, extractor.SkippedMetadataStringCount);
+    }
+
+    /// <summary>
+    /// Reproduces #82: drilling into System.Runtime and switching to the Strings tab
+    /// crashes with BadImageFormatException because GetNextHandle reads past the
+    /// end of the #US heap.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void RuntimeAssembly_ExtractUserStrings_DoesNotThrow()
+    {
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        var systemRuntime = Path.Combine(runtimeDir, "System.Runtime.dll");
+        Assert.True(File.Exists(systemRuntime), $"System.Runtime.dll not found at {runtimeDir}");
+
+        using var a = new AssemblyAnalyzer(systemRuntime);
+        var extractor = new StringExtractor(a);
+
+        var strings = extractor.ExtractUserStrings();
+
+        // System.Runtime has no user string literals (its #US heap is zero bytes).
+        // Must not crash, and must not report false skips.
+        Assert.NotNull(strings);
+        Assert.Empty(strings);
+        Assert.Equal(0, extractor.SkippedUserStringCount);
+    }
+
+    /// <summary>
+    /// Same as above but for the #Strings metadata heap, which has the same
+    /// unguarded GetNextHandle pattern.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void RuntimeAssembly_ExtractMetadataStrings_DoesNotThrow()
+    {
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        var systemRuntime = Path.Combine(runtimeDir, "System.Runtime.dll");
+        Assert.True(File.Exists(systemRuntime), $"System.Runtime.dll not found at {runtimeDir}");
+
+        using var a = new AssemblyAnalyzer(systemRuntime);
+        var extractor = new StringExtractor(a);
+
+        var strings = extractor.ExtractMetadataStrings();
+
+        Assert.NotNull(strings);
     }
 }


### PR DESCRIPTION
## Problem

Drilling into a runtime assembly like System.Runtime and switching to the Strings tab crashes with `BadImageFormatException: Read out of bounds`.

Repro:
1. `dotsider samples/HelloWorld/bin/Debug/net10.0/HelloWorld.dll`
2. Press Enter on System.Runtime
3. Press `4` for the Strings tab

## Cause

System.Runtime (and other runtime assemblies) have a zero-byte `#US` heap — no user string literals at all. `ExtractUserStrings` unconditionally creates a handle at offset 1 via `MetadataTokens.UserStringHandle(1)`, which points into nothing. `GetNextHandle` then throws trying to read a compressed integer from a non-existent heap.

## Fix

- Check `GetHeapSize` before entering the iteration loop. If the heap is empty, return early.
- Wrap `GetNextHandle` in its own try/catch in both `ExtractUserStrings` and `ExtractMetadataStrings`, so a truncated heap breaks the loop instead of crashing. This is separate from the `GetUserString`/`GetString` catch so skipped counts stay accurate.

## Tests

Two new tests against `System.Runtime.dll`:
- `RuntimeAssembly_ExtractUserStrings_DoesNotThrow` — verifies no crash, empty results, zero skipped count
- `RuntimeAssembly_ExtractMetadataStrings_DoesNotThrow` — verifies no crash on the metadata strings heap

All 17 StringExtractor tests pass.

Fixes #82