### PR TITLE
Preserve table scroll position when detail popup opens

### DIFF
--- a/src/Dotsider/Views/PeMetadataView.cs
+++ b/src/Dotsider/Views/PeMetadataView.cs
@@ -235,16 +235,16 @@ public static class PeMetadataView
                 .Compact()
                 .Fill();
 
-                // Suppress the teal selected-tab highlight when the detail popup
-                // is open so it doesn't bleed through the transparent backdrop.
-                if (state.PeDetailContent is not null)
-                {
-                    metadataTabs = outer.ThemePanel(t => t
-                        .Set(TabBarTheme.SelectedForegroundColor, Hex1bColor.FromRgb(140, 140, 160))
-                        .Set(TabBarTheme.SelectedBackgroundColor, Hex1bColor.Default),
-                        metadataTabs)
-                        .Fill();
-                }
+                // Always wrap in a ThemePanel so the widget tree stays stable when
+                // the detail popup toggles — avoids re-measure that resets scroll.
+                // When the popup is open, suppress the teal tab highlight so it
+                // doesn't bleed through the transparent backdrop.
+                var popupOpen = state.PeDetailContent is not null;
+                metadataTabs = outer.ThemePanel(t => popupOpen
+                    ? t.Set(TabBarTheme.SelectedForegroundColor, Hex1bColor.FromRgb(140, 140, 160))
+                         .Set(TabBarTheme.SelectedBackgroundColor, Hex1bColor.Default)
+                    : t, metadataTabs)
+                .Fill();
 
                 widgets.Add(metadataTabs);
 

--- a/src/Dotsider/Views/StringsView.cs
+++ b/src/Dotsider/Views/StringsView.cs
@@ -102,16 +102,16 @@ public static class StringsView
                 .Compact()
                 .Fill();
 
-                // Suppress the teal selected-tab highlight when the detail popup
-                // is open so it doesn't bleed through the transparent backdrop.
-                if (state.StringsDetailContent is not null)
-                {
-                    stringsTabs = outer.ThemePanel(t => t
-                        .Set(TabBarTheme.SelectedForegroundColor, Hex1bColor.FromRgb(140, 140, 160))
-                        .Set(TabBarTheme.SelectedBackgroundColor, Hex1bColor.Default),
-                        stringsTabs)
-                        .Fill();
-                }
+                // Always wrap in a ThemePanel so the widget tree stays stable when
+                // the detail popup toggles — avoids re-measure that resets scroll.
+                // When the popup is open, suppress the teal tab highlight so it
+                // doesn't bleed through the transparent backdrop.
+                var popupOpen = state.StringsDetailContent is not null;
+                stringsTabs = outer.ThemePanel(t => popupOpen
+                    ? t.Set(TabBarTheme.SelectedForegroundColor, Hex1bColor.FromRgb(140, 140, 160))
+                         .Set(TabBarTheme.SelectedBackgroundColor, Hex1bColor.Default)
+                    : t, stringsTabs)
+                .Fill();
 
                 widgets.Add(stringsTabs);
 

--- a/tests/Dotsider.Tests/TableScrollPopupTests.cs
+++ b/tests/Dotsider.Tests/TableScrollPopupTests.cs
@@ -1,0 +1,111 @@
+using Hex1b;
+using Hex1b.Automation;
+using Hex1b.Input;
+using Hex1b.Widgets;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Reproduces #90: opening a detail popup in PE/Metadata resets the table's
+/// scroll position to the top. The viewport content should stay put.
+/// </summary>
+[Collection("SampleAssemblies")]
+public class TableScrollPopupTests(SampleAssemblyFixture samples) : IDisposable
+{
+    private Hex1bAppWorkloadAdapter? _workload;
+    private Hex1bTerminal? _terminal;
+    private Hex1bApp? _hex1bApp;
+    private DotsiderState? _state;
+
+    private (Hex1bTerminal terminal, Hex1bApp app) CreateDotsiderApp(int startTab, int subTab)
+    {
+        _workload = new Hex1bAppWorkloadAdapter();
+        _terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(_workload)
+            .WithHeadless()
+            .WithDimensions(120, 30)
+            .Build();
+        DotsiderApp? dotsiderApp = null;
+        _hex1bApp = new Hex1bApp(
+            ctx =>
+            {
+                _state ??= new DotsiderState(_hex1bApp!, samples.RichLibraryDll)
+                {
+                    CurrentTab = startTab,
+                    PeSubTab = subTab
+                };
+                dotsiderApp ??= new DotsiderApp(_state);
+                return Task.FromResult<Hex1bWidget>(dotsiderApp.Build(ctx));
+            },
+            new Hex1bAppOptions
+            {
+                WorkloadAdapter = _workload,
+                EnableInputCoalescing = false
+            });
+        return (_terminal, _hex1bApp);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_ScrollPositionPreservedWhenPopupOpens()
+    {
+        // MethodDef sub-tab: RichLibrary has many methods, enough to scroll
+        var (terminal, app) = CreateDotsiderApp(TabId.PeMetadata, PeSubTabId.MethodDef);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+
+        // We use the second row's token as a scroll marker. When we scroll
+        // far enough down, this token leaves the viewport. If the popup
+        // resets scroll to the top, this token reappears.
+        string? secondRowToken = null;
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("MethodDef"), TimeSpan.FromSeconds(10))
+            // Find the second data row's token (MethodDef tokens start with 0x06)
+            .WaitUntil(s =>
+            {
+                var matches = s.FindPattern(@"0x06[0-9A-F]{6}");
+                if (matches.Count >= 2)
+                {
+                    secondRowToken = matches[1].Text;
+                    return true;
+                }
+                return false;
+            }, TimeSpan.FromSeconds(10))
+            // Scroll to the bottom of the table so early rows leave the viewport
+            .Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow).Key(Hex1bKey.DownArrow)
+            .WaitUntil(s => !s.ContainsText(secondRowToken!), TimeSpan.FromSeconds(10))
+            // Open the detail popup on the now-focused (last) row
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.PeDetailContent is not null, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Detail"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        // If scroll reset to top, the second row token would reappear
+        var snapshot = terminal.CreateSnapshot();
+        Assert.False(snapshot.ContainsText(secondRowToken!),
+            $"Table scrolled back to top when popup opened — row {secondRowToken} reappeared");
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    public void Dispose()
+    {
+        _state?.Dispose();
+        _hex1bApp?.Dispose();
+        _terminal?.Dispose();
+        _workload?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
Opening a detail popup in PE/Metadata or Strings caused the table to scroll back to the top while the popup was shown, then snap back to the original position on dismiss.

The ThemePanel wrapper that suppresses the tab highlight color was conditionally added and removed from the widget tree when the popup toggled. This changed the tree structure, triggering a full re-measure that reset the table's scroll offset. Making the ThemePanel always present with conditional styling keeps the tree stable across popup open/close.

Fixes #90