### PR TITLE
Detect apphost .exe and offer to open the managed .dll

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Grab a standalone binary from [Releases](https://github.com/willibrandon/dotside
 
 ## What it does
 
-dotsider opens any .NET DLL or EXE and lets you explore it across 8 tabs:
+dotsider opens any .NET DLL or EXE and lets you explore it across 8 tabs. If you open an apphost `.exe` that has no .NET metadata, dotsider detects the missing metadata and offers to open the companion managed `.dll` instead.
 
 | Tab | What you see |
 |-----|-------------|
@@ -93,15 +93,16 @@ TUI options:
 Run analysis without the TUI — pipe to other tools, write to files, or output JSON for scripting.
 
 ```
-dotsider analyze MyLib.dll                  # assembly info (default)
-dotsider analyze MyLib.dll --types          # list type definitions
-dotsider analyze MyLib.dll --methods        # list method definitions
-dotsider analyze MyLib.dll --il Type.Method # disassemble a method
-dotsider analyze MyLib.dll --deps           # assembly references
-dotsider analyze MyLib.dll --strings        # extract strings
-dotsider analyze MyLib.dll --size           # size breakdown
-dotsider analyze MyLib.dll --json           # any of the above as JSON
-dotsider analyze MyLib.dll --types -o out.txt  # write to file
+dotsider analyze MyLib.dll                      # assembly info (default)
+dotsider analyze MyLib.dll --types              # list type definitions
+dotsider analyze MyLib.dll --methods            # list method definitions
+dotsider analyze MyLib.dll --il Type.Method     # disassemble a method
+dotsider analyze MyLib.dll --deps               # assembly references
+dotsider analyze MyLib.dll --strings            # extract strings
+dotsider analyze MyLib.dll --size               # size breakdown
+dotsider analyze MyLib.dll --json               # any of the above as JSON
+dotsider analyze MyLib.dll --types -o out.txt   # write to file
+dotsider analyze MyApp.exe                      # apphost .exe → auto-redirects to MyApp.dll
 ```
 
 ### CLI: `dotsider sessions`

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-ApphostDetector.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-ApphostDetector.md
@@ -1,0 +1,53 @@
+---
+title: "ApphostDetector"
+description: "Detects .NET apphost executables and locates their companion managed assemblies."
+slug: api/dotsider.core.analysis.apphostdetector
+sidebar:
+  order: 0
+---
+
+**Namespace:** `Dotsider.Core.Analysis`
+
+**Assembly:** Dotsider.Core.dll
+
+Detects .NET apphost executables and locates their companion managed assemblies.
+
+```csharp
+public static class ApphostDetector
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **ApphostDetector**
+
+## Methods
+
+### FindCompanionDll(string)
+
+If exePath ends with `.exe` and the binary is a .NET
+apphost (embeds both the companion DLL name and a `hostfxr` reference),
+returns the path to the companion `.dll` provided it has readable .NET metadata.
+
+**Parameters:**
+
+- `exePath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Path to the executable file.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+The full path to the companion managed `.dll`, or `null` if the file
+is not an apphost, no companion exists, or the companion has no readable .NET
+metadata.
+
+```csharp
+public static string? FindCompanionDll(string exePath)
+```
+
+## Remarks
+
+`dotnet build` produces both a managed `.dll` (the actual assembly with IL and
+metadata) and a native apphost `.exe` (a launcher that bootstraps the runtime).
+The apphost has no CLR metadata, so most analysis tabs are empty. This detector
+verifies the `.exe` is an apphost by requiring two signals: the companion DLL
+name embedded in the binary AND a reference to `hostfxr` (the .NET host
+framework resolver that every apphost imports to bootstrap the runtime).
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis.md
@@ -7,6 +7,14 @@ sidebar:
 
 ## Classes
 
+### [ApphostDetector](/api/dotsider.core.analysis.apphostdetector/)
+
+Detects .NET apphost executables and locates their companion managed assemblies.
+
+```csharp
+public static class ApphostDetector
+```
+
 ### [AssemblyAnalyzer](/api/dotsider.core.analysis.assemblyanalyzer/)
 
 Core analyzer that reads a .NET assembly and extracts PE, metadata, IL, and string information.

--- a/docs/src/content/docs/api/Dotsider-Core-Protocol-DotsiderProtocol.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Protocol-DotsiderProtocol.md
@@ -1,0 +1,35 @@
+---
+title: "DotsiderProtocol"
+description: "Constants for the dotsider diagnostics protocol."
+slug: api/dotsider.core.protocol.dotsiderprotocol
+sidebar:
+  order: 2
+---
+
+**Namespace:** `Dotsider.Core.Protocol`
+
+**Assembly:** Dotsider.Core.dll
+
+Constants for the dotsider diagnostics protocol.
+
+```csharp
+public static class DotsiderProtocol
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **DotsiderProtocol**
+
+## Fields
+
+### Version
+
+Current protocol version. Changing field types or semantics bumps this;
+adding optional fields does not.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public const int Version = 1
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Protocol-DotsiderRequest.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Protocol-DotsiderRequest.md
@@ -172,3 +172,14 @@ Full or partial type name for filtering.
 public string? TypeName { get; set; }
 ```
 
+### V
+
+Protocol version. Must match [Version](/api/dotsider.core.protocol.dotsiderprotocol.version/).
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+[JsonRequired]
+public int V { get; set; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Protocol-DotsiderResponse.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Protocol-DotsiderResponse.md
@@ -52,6 +52,17 @@ Whether the request succeeded.
 public bool Success { get; set; }
 ```
 
+### V
+
+Protocol version echoed in every response.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+[JsonRequired]
+public int V { get; set; }
+```
+
 ## Methods
 
 ### Fail(string)

--- a/docs/src/content/docs/api/Dotsider-Core-Protocol.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Protocol.md
@@ -15,6 +15,14 @@ Shared JSON serialization options for the dotsider diagnostics protocol.
 public static class DotsiderJsonOptions
 ```
 
+### [DotsiderProtocol](/api/dotsider.core.protocol.dotsiderprotocol/)
+
+Constants for the dotsider diagnostics protocol.
+
+```csharp
+public static class DotsiderProtocol
+```
+
 ### [DotsiderRequest](/api/dotsider.core.protocol.dotsiderrequest/)
 
 JSON request sent to a dotsider diagnostics socket.

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -11,7 +11,7 @@ Point dotsider at any .NET DLL or EXE:
 dotsider HelloWorld.dll
 ```
 
-You land on the **General** tab showing assembly identity, target framework, architecture, and the dependency table.
+You land on the **General** tab showing assembly identity, target framework, architecture, and the dependency table. If you open an apphost `.exe` that has no .NET metadata, dotsider offers to open the companion managed `.dll` instead — press `Enter` to switch or `Esc` to stay.
 
 ![dotsider General tab](/demo.gif)
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -38,7 +38,10 @@ dotsider analyze MyLib.dll --strings          # extract strings
 dotsider analyze MyLib.dll --size             # size breakdown
 dotsider analyze MyLib.dll --json             # any of the above as JSON
 dotsider analyze MyLib.dll --types -o out.txt # write to file
+dotsider analyze MyApp.exe                    # apphost .exe → auto-redirects to MyApp.dll
 ```
+
+If the `.exe` is a native apphost with no .NET metadata and a companion managed `.dll` exists, `analyze` auto-redirects and prints a note to stderr.
 
 | Option | Description |
 |--------|-------------|
@@ -60,7 +63,7 @@ dotsider sessions list                            # list running instances
 dotsider sessions info <pid>                      # assembly info + current view
 dotsider sessions view <pid>                      # current tab and view state
 dotsider sessions navigate <pid> <tab>            # switch to tab (1-8)
-dotsider sessions capture <pid>                    # capture screen as text
+dotsider sessions capture <pid>                   # capture screen as text
 dotsider sessions trace start <pid>               # start tracing
 dotsider sessions trace events <pid>              # get JIT, GC, exception events
 dotsider sessions trace counters <pid>            # get performance counters

--- a/src/Dotsider.Core/Analysis/ApphostDetector.cs
+++ b/src/Dotsider.Core/Analysis/ApphostDetector.cs
@@ -1,0 +1,83 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Detects .NET apphost executables and locates their companion managed assemblies.
+/// </summary>
+/// <remarks>
+/// <c>dotnet build</c> produces both a managed <c>.dll</c> (the actual assembly with IL and
+/// metadata) and a native apphost <c>.exe</c> (a launcher that bootstraps the runtime).
+/// The apphost has no CLR metadata, so most analysis tabs are empty. This detector
+/// verifies the <c>.exe</c> is an apphost by requiring two signals: the companion DLL
+/// name embedded in the binary AND a reference to <c>hostfxr</c> (the .NET host
+/// framework resolver that every apphost imports to bootstrap the runtime).
+/// </remarks>
+public static class ApphostDetector
+{
+    /// <summary>
+    /// If <paramref name="exePath"/> ends with <c>.exe</c> and the binary is a .NET
+    /// apphost (embeds both the companion DLL name and a <c>hostfxr</c> reference),
+    /// returns the path to the companion <c>.dll</c> provided it has readable .NET metadata.
+    /// </summary>
+    /// <param name="exePath">Path to the executable file.</param>
+    /// <returns>
+    /// The full path to the companion managed <c>.dll</c>, or <c>null</c> if the file
+    /// is not an apphost, no companion exists, or the companion has no readable .NET
+    /// metadata.
+    /// </returns>
+    public static string? FindCompanionDll(string exePath)
+    {
+        if (!exePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var dllName = Path.GetFileNameWithoutExtension(exePath) + ".dll";
+        var dllPath = Path.Combine(Path.GetDirectoryName(exePath)!, dllName);
+        if (!File.Exists(dllPath))
+            return null;
+
+        // Verify the .exe is actually a .NET apphost by requiring two signals:
+        // 1. The companion DLL name is embedded (apphost bakes it as a UTF-8 string)
+        // 2. A reference to "hostfxr" exists (the .NET host framework resolver that
+        //    every apphost imports to bootstrap the runtime)
+        // Either alone is a weak heuristic; together they rule out unrelated native
+        // executables that happen to reference the same DLL name.
+        try
+        {
+            var exeBytes = File.ReadAllBytes(exePath);
+            if (!ContainsSequence(exeBytes, Encoding.UTF8.GetBytes(dllName))
+                || !ContainsSequence(exeBytes, "hostfxr"u8))
+                return null;
+        }
+        catch
+        {
+            return null;
+        }
+
+        // Verify the companion .dll has readable .NET metadata
+        try
+        {
+            using var stream = new FileStream(dllPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                return null;
+
+            _ = peReader.GetMetadataReader();
+            return dllPath;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool ContainsSequence(ReadOnlySpan<byte> haystack, ReadOnlySpan<byte> needle)
+    {
+        if (needle.Length == 0 || haystack.Length < needle.Length)
+            return false;
+
+        return haystack.IndexOf(needle) >= 0;
+    }
+}

--- a/src/Dotsider/Commands/AnalyzeCommand.cs
+++ b/src/Dotsider/Commands/AnalyzeCommand.cs
@@ -81,19 +81,50 @@ internal static class AnalyzeCommand
 
             try
             {
-                // Validate output path before opening any files
-                if (outputPath is not null &&
-                    string.Equals(
-                        Path.GetFullPath(file.FullName),
-                        Path.GetFullPath(outputPath),
-                        StringComparison.OrdinalIgnoreCase))
+                var filePath = file.FullName;
+                var originalPath = filePath;
+
+                // Detect apphost .exe — only redirect when the .exe has no .NET metadata
+                if (filePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
-                    Console.Error.WriteLine("Error: Output path cannot be the same as the input file");
-                    return Task.FromResult(1);
+                    try
+                    {
+                        using var probe = new AssemblyAnalyzer(filePath);
+                        if (!probe.HasMetadata)
+                        {
+                            var companion = ApphostDetector.FindCompanionDll(filePath);
+                            if (companion is not null)
+                            {
+                                Console.Error.WriteLine(
+                                    $"Note: {file.Name} is a native apphost. "
+                                    + $"Analyzing {Path.GetFileName(companion)} instead.");
+                                filePath = companion;
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        // Fall through to main analyzer which will report the error
+                    }
                 }
 
-                using var analyzer = new AssemblyAnalyzer(file.FullName);
-                var disassembler = new IlDisassembler(analyzer);
+                // Output-path collision check — reject if -o matches EITHER the original
+                // input path OR the resolved analyzed path, so neither can be clobbered
+                if (outputPath is not null)
+                {
+                    var outputFull = Path.GetFullPath(outputPath);
+                    if (string.Equals(Path.GetFullPath(filePath), outputFull,
+                            StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(Path.GetFullPath(originalPath), outputFull,
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        Console.Error.WriteLine("Error: Output path cannot be the same as the input file");
+                        return Task.FromResult(1);
+                    }
+                }
+
+                using var analyzer = new AssemblyAnalyzer(filePath);
+                var disassembler = analyzer.HasMetadata ? new IlDisassembler(analyzer) : null;
 
                 // Defer opening the output file until we know the input is valid
                 using var formatter = new OutputFormatter(outputPath) { JsonMode = json };
@@ -105,7 +136,15 @@ internal static class AnalyzeCommand
                     return Task.FromResult(PrintMethods(analyzer, formatter));
 
                 if (parseResult.GetValue(s_ilOption) is { } ilTarget)
+                {
+                    if (disassembler is null)
+                    {
+                        Console.Error.WriteLine("Error: --il requires a .NET assembly with metadata");
+                        return Task.FromResult(1);
+                    }
+                    
                     return Task.FromResult(PrintIl(analyzer, disassembler, ilTarget, formatter));
+                }
 
                 if (parseResult.GetValue(s_depsOption))
                     return Task.FromResult(PrintDeps(analyzer, formatter));

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -34,12 +34,16 @@ public sealed class DotsiderApp(DotsiderState state)
         while (_state.PendingMutations.TryDequeue(out var mutation))
             mutation(_state);
 
-        // On first render, move focus from the tab bar into the content area
+        // On first render, move focus from the tab bar into the content area.
+        // Defer if the apphost dialog is open — focus will be seeded on dismiss.
         if (!_initialFocusRequested)
         {
             _initialFocusRequested = true;
-            SeedFocusedRowIfNeeded();
-            RequestContentFocus();
+            if (!_state.ApphostDialogOpen)
+            {
+                SeedFocusedRowIfNeeded();
+                RequestContentFocus();
+            }
         }
 
         // Wire up the yank delegate for text object support
@@ -50,7 +54,7 @@ public sealed class DotsiderApp(DotsiderState state)
         }
 
 
-        return ctx.VStack(outer =>
+        var mainContent = ctx.VStack(outer =>
         [
             // Title bar
             outer.InfoBar(bar =>
@@ -120,7 +124,8 @@ public sealed class DotsiderApp(DotsiderState state)
             // Number keys 1-8, s, q suppressed during search editing, jump dialog,
             // or hex insert mode to let EditorNode/TextBox receive character input
             var hexInsertMode = _state.CurrentTab == TabId.HexDump && _state.HexMode == HexEditMode.Insert;
-            if (!isSearchEditing && !_state.HexJumpDialogOpen && !hexInsertMode)
+            if (!isSearchEditing && !_state.HexJumpDialogOpen && !hexInsertMode
+                && !_state.ApphostDialogOpen)
             {
                 for (var i = 0; i < 8; i++)
                 {
@@ -218,7 +223,7 @@ public sealed class DotsiderApp(DotsiderState state)
                 _state.App.Invalidate();
             }
             var detailPopupOpen = _state.PeDetailContent is not null || _state.StringsDetailContent is not null;
-            if (!_state.HexJumpDialogOpen && !detailPopupOpen)
+            if (!_state.HexJumpDialogOpen && !detailPopupOpen && !_state.ApphostDialogOpen)
             {
                 bindings.Key(Hex1bKey.OemQuestion).Global().OverridesCapture().Action(VimReset(_ => SearchToggle()), "Search");
                 if (!isSearchEditing)
@@ -243,8 +248,24 @@ public sealed class DotsiderApp(DotsiderState state)
                 }), "Confirm search");
             }
 
-            // Hex + IL Inspector keybindings (shared with NuGetApp)
-            if (!isSearchEditing)
+            // Apphost dialog Enter — navigate to companion managed .dll.
+            // Registered as Global so it fires regardless of focus position
+            // (the dialog overlay is in a ZStack layer separate from the main content).
+            if (_state.ApphostDialogOpen && _state.ApphostCompanionDllPath is not null)
+            {
+                bindings.Key(Hex1bKey.Enter).Global().OverridesCapture().Action(VimReset(_ =>
+                {
+                    _state.ApphostDialogOpen = false;
+                    _state.PushAssembly(_state.ApphostCompanionDllPath);
+                    SeedFocusedRowIfNeeded();
+                    RequestContentFocus();
+                    _state.App.Invalidate();
+                }), "Open managed DLL");
+            }
+
+            // Hex + IL Inspector keybindings (shared with NuGetApp).
+            // Suppressed while the apphost dialog is open to prevent background shortcuts.
+            if (!isSearchEditing && !_state.ApphostDialogOpen)
                 DllInspectorBindings.Register(bindings, _state, _state.App,
                     resetVimPending: () => _state.VimPending = VimMotionState.Idle);
 
@@ -334,7 +355,7 @@ public sealed class DotsiderApp(DotsiderState state)
                 && _state.DynamicCategoryFilter is not null;
             if (hasBackTarget && !sizeMapUsesEsc && !dynamicFilterActive
                 && !currentSearch.IsActive && !_state.HexJumpDialogOpen && !hexInsertMode
-                && !_state.DynamicEditingArgs
+                && !_state.ApphostDialogOpen && !_state.DynamicEditingArgs
                 && _state.PeDetailContent is null && _state.StringsDetailContent is null
                 && !(_state.CurrentTab == TabId.IlInspector && _state.IlEditorState?.Cursor.HasSelection == true))
             {
@@ -348,6 +369,11 @@ public sealed class DotsiderApp(DotsiderState state)
                     else if (_state.NavigationStack.Count > 0)
                     {
                         _state.PopAssembly();
+
+                        // Re-show the apphost dialog when backing out to an apphost .exe
+                        if (_state.ApphostCompanionDllPath is not null && !_state.Analyzer.HasMetadata)
+                            _state.ApphostDialogOpen = true;
+
                         _state.NavigateToTab(TabId.General);
                         _state.RequestContentFocus();
                         _state.App.Invalidate();
@@ -355,6 +381,51 @@ public sealed class DotsiderApp(DotsiderState state)
                 }), "Back");
             }
         });
+
+        // Apphost dialog overlay
+        if (_state.ApphostDialogOpen && _state.ApphostCompanionDllPath is not null)
+        {
+            var dllName = Path.GetFileName(_state.ApphostCompanionDllPath);
+            return ctx.ZStack(z =>
+            [
+                mainContent,
+                z.Backdrop(
+                    z.Border(
+                        z.VStack(dlg =>
+                        [
+                            dlg.Text(""),
+                            dlg.Text("  This file is a native apphost executable."),
+                            dlg.Text("  It has no .NET metadata to inspect."),
+                            dlg.Text(""),
+                            dlg.Text("  A managed assembly was found:"),
+                            dlg.Text($"  {dllName}"),
+                            dlg.Text(""),
+                            dlg.Text("  Open the managed .dll instead?"),
+                            dlg.Text(""),
+                            dlg.Text("  Enter: Yes | Esc: No, keep .exe")
+                        ])
+                    ).Title(" Apphost Detected ").FixedWidth(55).FixedHeight(12)
+                    .WithInputBindings(bindings =>
+                    {
+                        bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
+                        {
+                            _state.ApphostDialogOpen = false;
+                            SeedFocusedRowIfNeeded();
+                            RequestContentFocus();
+                            _state.App.Invalidate();
+                        }, "Keep .exe");
+                    })
+                ).OnClickAway(() =>
+                {
+                    _state.ApphostDialogOpen = false;
+                    SeedFocusedRowIfNeeded();
+                    RequestContentFocus();
+                    _state.App.Invalidate();
+                })
+            ]).Fill();
+        }
+
+        return mainContent;
     }
 
     private void SelectTab(int tabIndex)

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -27,11 +27,22 @@ public sealed class DotsiderState : IDisposable
         StringExtractor = new StringExtractor(Analyzer);
         if (Analyzer.HasMetadata)
             IlDisassembler = new IlDisassembler(Analyzer);
-        
+
         var hexDoc = new HexRowDocument(new Hex1bDocument(Analyzer.RawBytes.ToArray()));
         HexRowDoc = hexDoc;
         HexEditorState = new EditorState(hexDoc) { IsReadOnly = true };
         HexCleanVersion = hexDoc.Version;
+
+        // Detect apphost .exe with a companion managed .dll
+        if (!Analyzer.HasMetadata)
+        {
+            var companionDll = ApphostDetector.FindCompanionDll(filePath);
+            if (companionDll is not null)
+            {
+                ApphostCompanionDllPath = companionDll;
+                ApphostDialogOpen = true;
+            }
+        }
     }
 
     /// <summary>
@@ -378,6 +389,14 @@ public sealed class DotsiderState : IDisposable
 
     /// <summary>Whether the hex document has unsaved edits.</summary>
     public bool HexIsDirty => HexEditorState.Document.Version != HexCleanVersion;
+
+    // --- Apphost Detection State ---
+
+    /// <summary>Whether the apphost companion DLL dialog is currently shown.</summary>
+    public bool ApphostDialogOpen { get; set; }
+
+    /// <summary>The path to the companion managed .dll, or null if not detected.</summary>
+    public string? ApphostCompanionDllPath { get; set; }
 
     // --- Dynamic Analysis Tab State ---
 

--- a/tests/Dotsider.Tests/ApphostDetectorTests.cs
+++ b/tests/Dotsider.Tests/ApphostDetectorTests.cs
@@ -1,0 +1,103 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using Dotsider.Core.Analysis;
+
+namespace Dotsider.Tests;
+
+[Collection("SampleAssemblies")]
+public class ApphostDetectorTests(SampleAssemblyFixture samples) : IDisposable
+{
+    private readonly List<string> _tempFiles = [];
+    [Fact(Timeout = 30_000)]
+    public void FindCompanionDll_ApphostExe_ReturnsCompanionDllPath()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Apphost .exe is a Windows artifact");
+
+        var result = ApphostDetector.FindCompanionDll(samples.HelloWorldExe);
+
+        Assert.NotNull(result);
+        Assert.EndsWith(".dll", result!, StringComparison.OrdinalIgnoreCase);
+        Assert.True(File.Exists(result));
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void FindCompanionDll_ManagedDll_ReturnsNull()
+    {
+        var result = ApphostDetector.FindCompanionDll(samples.HelloWorldDll);
+
+        Assert.Null(result);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void FindCompanionDll_NativeAotExe_ReturnsNull()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "NativeAOT .exe is a Windows artifact");
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        var result = ApphostDetector.FindCompanionDll(samples.NativeAotConsoleExe!);
+
+        Assert.Null(result);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void FindCompanionDll_NonExeExtension_ReturnsNull()
+    {
+        var result = ApphostDetector.FindCompanionDll(samples.RichLibraryDll);
+
+        Assert.Null(result);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void FindCompanionDll_NonExistentFile_ReturnsNull()
+    {
+        var result = ApphostDetector.FindCompanionDll(
+            Path.Combine(Path.GetTempPath(), "nonexistent-assembly.exe"));
+
+        Assert.Null(result);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void FindCompanionDll_NativeExeWithDllNameButNoHostfxr_ReturnsNull()
+    {
+        // Simulate a native launcher that embeds the DLL name for its own reasons
+        // but is not a .NET apphost (no hostfxr reference).
+        var dir = Path.Combine(Path.GetTempPath(), $"dotsider-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+
+        var fakeDllName = "FakeLauncher.dll";
+        var fakeExePath = Path.Combine(dir, "FakeLauncher.exe");
+        var fakeDllPath = Path.Combine(dir, fakeDllName);
+
+        // Write a fake .exe containing the DLL name but NOT hostfxr
+        var exeContent = new byte[512];
+        Encoding.UTF8.GetBytes(fakeDllName).CopyTo(exeContent, 64);
+        File.WriteAllBytes(fakeExePath, exeContent);
+        _tempFiles.Add(fakeExePath);
+
+        // Copy a real managed .dll so the companion check would pass
+        File.Copy(samples.HelloWorldDll, fakeDllPath);
+        _tempFiles.Add(fakeDllPath);
+        _tempFiles.Add(dir);
+
+        var result = ApphostDetector.FindCompanionDll(fakeExePath);
+
+        Assert.Null(result);
+    }
+
+    public void Dispose()
+    {
+        foreach (var path in _tempFiles)
+        {
+            try
+            {
+                if (File.Exists(path)) File.Delete(path);
+                else if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
+            }
+            catch { /* best effort */ }
+        }
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/Dotsider.Tests/CliTests.cs
+++ b/tests/Dotsider.Tests/CliTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 
@@ -202,6 +203,22 @@ public class CliTests(SampleAssemblyFixture fixture)
 
         Assert.NotEqual(0, exitCode);
         Assert.Contains("Required command was not provided", stderr);
+    }
+
+    // --- Apphost Detection ---
+
+    [Fact]
+    public async Task Analyze_ApphostExe_AutoRedirectsToManagedDll()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Apphost .exe is a Windows artifact");
+
+        var (exitCode, stdout, stderr) = await RunDotsiderAsync(
+            "analyze", fixture.HelloWorldExe);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("apphost", stderr, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("HelloWorld", stdout);
     }
 
     // --- Helpers ---

--- a/tests/Dotsider.Tests/DotsiderStateTests.cs
+++ b/tests/Dotsider.Tests/DotsiderStateTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
 using Hex1b;
 using Hex1b.Widgets;
@@ -537,6 +538,49 @@ public class DotsiderStateTests(SampleAssemblyFixture samples) : IDisposable
         // Back → IL Inspector
         state.NavigateBack();
         Assert.Equal(TabId.IlInspector, state.CurrentTab);
+    }
+
+    // --- Apphost Detection ---
+
+    [Fact(Timeout = 30_000)]
+    public void ConstructFromApphostExe_SetsApphostDialogState()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Apphost .exe is a Windows artifact");
+
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.HelloWorldExe);
+
+        Assert.True(state.ApphostDialogOpen);
+        Assert.NotNull(state.ApphostCompanionDllPath);
+        Assert.EndsWith(".dll", state.ApphostCompanionDllPath!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void ConstructFromManagedDll_NoApphostDialog()
+    {
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.HelloWorldDll);
+
+        Assert.False(state.ApphostDialogOpen);
+        Assert.Null(state.ApphostCompanionDllPath);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void PushAssembly_FromApphostToCompanionDll_Works()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Apphost .exe is a Windows artifact");
+
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.HelloWorldExe);
+        Assert.False(state.Analyzer.HasMetadata);
+
+        Assert.True(state.PushAssembly(state.ApphostCompanionDllPath!));
+
+        Assert.True(state.Analyzer.HasMetadata);
+        Assert.Equal("HelloWorld.dll", state.Analyzer.FileName);
+        Assert.Single(state.NavigationStack);
     }
 
     public void Dispose()

--- a/tests/Dotsider.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Tests/SampleAssemblyFixture.cs
@@ -63,11 +63,11 @@ public class SampleAssemblyFixture : IAsyncLifetime
         var tfm = "net10.0";
 
         HelloWorldDll = SamplePath("HelloWorld", config, tfm, "HelloWorld.dll");
-        HelloWorldExe = SamplePath("HelloWorld", config, tfm, "HelloWorld");
+        HelloWorldExe = SamplePath("HelloWorld", config, tfm, "HelloWorld.exe");
         ComplexAppDll = SamplePath("ComplexApp", config, tfm, "ComplexApp.dll");
-        ComplexAppExe = SamplePath("ComplexApp", config, tfm, "ComplexApp");
+        ComplexAppExe = SamplePath("ComplexApp", config, tfm, "ComplexApp.exe");
         MinimalApiDll = SamplePath("MinimalApi", config, tfm, "MinimalApi.dll");
-        MinimalApiExe = SamplePath("MinimalApi", config, tfm, "MinimalApi");
+        MinimalApiExe = SamplePath("MinimalApi", config, tfm, "MinimalApi.exe");
         RichLibraryDll = SamplePath("RichLibrary", config, tfm, "RichLibrary.dll");
         RichLibraryV2Dll = SamplePath("RichLibraryV2", config, tfm, "RichLibrary.dll");
         NativeLibDll = SamplePath("NativeLib", config, tfm, "NativeLib.dll");
@@ -98,6 +98,12 @@ public class SampleAssemblyFixture : IAsyncLifetime
             Assert.True(File.Exists(NetFxConsoleExe), $"NetFxConsole.exe not found at {NetFxConsoleExe}");
         if (NativeAotConsoleExe is not null)
             Assert.True(File.Exists(NativeAotConsoleExe), $"NativeAotConsole.exe not found at {NativeAotConsoleExe}");
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.True(File.Exists(HelloWorldExe), $"HelloWorld.exe not found at {HelloWorldExe}");
+            Assert.True(File.Exists(ComplexAppExe), $"ComplexApp.exe not found at {ComplexAppExe}");
+            Assert.True(File.Exists(MinimalApiExe), $"MinimalApi.exe not found at {MinimalApiExe}");
+        }
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Views;
 using Hex1b;
@@ -2013,6 +2014,126 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
         Assert.Equal("Format", search.Query);
         Assert.Equal(TabId.Dynamic, _state.CurrentTab);
         Assert.Same(tracer, _state.Tracer);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    // --- Apphost Detection ---
+
+    [Fact(Timeout = 30_000)]
+    public async Task ApphostExe_ShowsDialog()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Apphost .exe is a Windows artifact");
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.HelloWorldExe);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Apphost Detected"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.True(_state!.ApphostDialogOpen);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task ApphostExe_Enter_NavigatesToManagedDll()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Apphost .exe is a Windows artifact");
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.HelloWorldExe);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Apphost Detected"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(s => !s.ContainsText("Apphost Detected"), TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("depth 2"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.False(_state!.ApphostDialogOpen);
+        Assert.True(_state.Analyzer.HasMetadata);
+        Assert.Equal("HelloWorld.dll", _state.Analyzer.FileName);
+        Assert.Single(_state.NavigationStack);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task ApphostExe_Escape_DismissesDialog()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Apphost .exe is a Windows artifact");
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.HelloWorldExe);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Apphost Detected"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(s => !s.ContainsText("Apphost Detected"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.False(_state!.ApphostDialogOpen);
+        Assert.False(_state.Analyzer.HasMetadata);
+        Assert.Empty(_state.NavigationStack);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task ApphostExe_Enter_ThenBack_ReshowsDialog()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Apphost .exe is a Windows artifact");
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.HelloWorldExe);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        // Accept the dialog → navigate into the managed .dll
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Apphost Detected"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(s => !s.ContainsText("Apphost Detected"), TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("depth 2"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.True(_state!.Analyzer.HasMetadata);
+
+        // Back out → should re-show the dialog on the apphost .exe
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(s => s.ContainsText("Apphost Detected"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.True(_state.ApphostDialogOpen);
+        Assert.False(_state.Analyzer.HasMetadata);
+        Assert.NotNull(_state.ApphostCompanionDllPath);
+        Assert.Empty(_state.NavigationStack);
 
         cts.Cancel();
         await runTask;


### PR DESCRIPTION
When you open a Windows apphost .exe in dotsider, most tabs are empty because the apphost is a native PE with no CLR metadata. This PR detects that situation and offers to open the companion managed .dll instead.

ApphostDetector (new, in Dotsider.Core) checks whether an .exe is a .NET apphost by looking for both the companion DLL name and a hostfxr reference in the binary. Returns the companion .dll path if it exists and has readable metadata.

TUI: when the detector finds a companion .dll, a dialog appears on launch asking whether to open it. Enter navigates into the .dll via the existing navigation stack, so Esc returns to the .exe and re-shows the dialog. All global key bindings (tab switching, search, quit, hex/IL shortcuts) are suppressed while the dialog is open.

CLI analyze: auto-redirects apphost .exe to the companion .dll with a note to stderr. Only redirects when the .exe actually has no metadata (managed .exe files are left alone). The output-path collision check protects both the original and resolved paths. IlDisassembler is now guarded on HasMetadata so native .exe inputs no longer crash.

MCP: unchanged; direct-mode tools inspect exactly the path passed.

Fixes #95