### PR TITLE
Fix Tab8 JIT hint tests stuck in Running state

### DIFF
--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -1742,7 +1742,11 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
         await auto.KeyAsync(Hex1bKey.D8, cts.Token);
         await auto.WaitUntilAsync(s => s.ContainsText("EventPipe") || s.ContainsText("Launch"));
         await auto.EnterAsync(cts.Token);
-        await auto.WaitUntilTextAsync("Re-run", timeout: TimeSpan.FromSeconds(30));
+        await auto.WaitUntilAsync(_ => _state!.Tracer?.ProcessState
+            is TraceProcessState.Exited or TraceProcessState.Error,
+            timeout: TimeSpan.FromSeconds(30));
+        Assert.Equal(TraceProcessState.Exited, _state!.Tracer!.ProcessState);
+        await auto.WaitUntilTextAsync("Re-run");
 
         var tracer = _state!.Tracer!;
 
@@ -1805,7 +1809,11 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
         await auto.KeyAsync(Hex1bKey.D8, cts.Token);
         await auto.WaitUntilAsync(s => s.ContainsText("EventPipe") || s.ContainsText("Launch"));
         await auto.EnterAsync(cts.Token);
-        await auto.WaitUntilTextAsync("Re-run", timeout: TimeSpan.FromSeconds(30));
+        await auto.WaitUntilAsync(_ => _state!.Tracer?.ProcessState
+            is TraceProcessState.Exited or TraceProcessState.Error,
+            timeout: TimeSpan.FromSeconds(30));
+        Assert.Equal(TraceProcessState.Exited, _state!.Tracer!.ProcessState);
+        await auto.WaitUntilTextAsync("Re-run");
 
         var tracer = _state!.Tracer!;
 
@@ -1858,7 +1866,11 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
         await auto.KeyAsync(Hex1bKey.D8, cts.Token);
         await auto.WaitUntilAsync(s => s.ContainsText("EventPipe") || s.ContainsText("Launch"));
         await auto.EnterAsync(cts.Token);
-        await auto.WaitUntilTextAsync("Re-run", timeout: TimeSpan.FromSeconds(30));
+        await auto.WaitUntilAsync(_ => _state!.Tracer?.ProcessState
+            is TraceProcessState.Exited or TraceProcessState.Error,
+            timeout: TimeSpan.FromSeconds(30));
+        Assert.Equal(TraceProcessState.Exited, _state!.Tracer!.ProcessState);
+        await auto.WaitUntilTextAsync("Re-run");
 
         var tracer = _state!.Tracer!;
 


### PR DESCRIPTION
The Tab8 JIT hint tests waited for "Re-run" on screen with a 30s timeout. On CI the HelloWorld process sometimes gets stuck in Running state and never exits, so "Re-run" never appears. Changed to a two-phase wait: first wait for internal ProcessState (Exited or Error) which fast-fails on Error, assert Exited, then wait for the "Re-run" screen text. The internal state wait handles the case where EventPipe connection fails (Error) without hanging 30s.