### PR TITLE
Fix triple-click line selection, add V and yy bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Supported `--ai` providers: claude, gemini, copilot, cursor-agent, opencode, cod
 | `Enter` | Drill into selected item (assembly ref, method, DLL in package) |
 | `Esc` | Go back (assembly stack, breadcrumb, or cross-view jump) |
 | `y` | Yank (copy) — selected text in editors, or focused row in tables |
+| `yy` | Yank entire line under cursor |
+| `V` | Select entire line under cursor |
 | `iw` | Select inner word (vim text object) |
 | `iW` | Select inner WORD (whitespace-delimited — grabs fully-qualified names) |
 | `yiw` / `yiW` | Select + yank word/WORD in one motion |
@@ -154,7 +156,7 @@ Supported `--ai` providers: claude, gemini, copilot, cursor-agent, opencode, cod
 | `s` | Toggle human-readable sizes |
 | `q` | Quit |
 
-Info panels (Assembly Info, PE Headers, CLR Header, detail popups, string details) are selectable read-only editors. Click or `Tab` into them, select text with `Shift` + arrow keys, and press `y` to copy. For word-level selection without the mouse, `iw` selects the word under the cursor and `iW` selects the full whitespace-delimited token — `yiw` copies it in one keystroke.
+Info panels (Assembly Info, PE Headers, CLR Header, detail popups, string details) are selectable read-only editors. Click or `Tab` into them, select text with `Shift` + arrow keys, and press `y` to copy. For word-level selection without the mouse, `iw` selects the word under the cursor and `iW` selects the full whitespace-delimited token — `yiw` copies it in one keystroke. `V` selects the entire line and `yy` copies the entire line in one motion.
 
 **Hex Dump tab** uses vi-style modal editing — the editor starts in normal mode (read-only) to prevent accidental writes:
 

--- a/docs/src/content/docs/reference/keyboard.md
+++ b/docs/src/content/docs/reference/keyboard.md
@@ -13,6 +13,8 @@ description: All keyboard shortcuts for navigating dotsider.
 | `/` | Search |
 | `n` / `N` | Next / previous search match |
 | `y` | Yank (copy) — selected text in editors, or focused row in tables |
+| `yy` | Yank entire line under cursor |
+| `V` | Select entire line under cursor |
 | `iw` | Select inner word under cursor (letters, digits, underscores) |
 | `iW` | Select inner WORD under cursor (whitespace-delimited) |
 | `yiw` | Select + yank inner word in one motion |

--- a/docs/src/content/docs/usage/diff-mode.md
+++ b/docs/src/content/docs/usage/diff-mode.md
@@ -28,6 +28,6 @@ This is useful for reviewing breaking changes between library versions, auditing
 
 ## Copy
 
-The Summary tab has selectable info panels and change statistics. Press `Tab` to cycle focus between them, select text, and press `y` to copy. `iw` and `yiw` work in these panels for quick word-level copying.
+The Summary tab has selectable info panels and change statistics. Press `Tab` to cycle focus between them, select text, and press `y` to copy. `iw` and `yiw` work in these panels for quick word-level copying. `V` selects the entire line and `yy` copies it.
 
 On the Types, Methods, and References tabs, focus a row and press `y` to copy it as tab-separated values. A brief flash confirms the yank.

--- a/docs/src/content/docs/usage/general.md
+++ b/docs/src/content/docs/usage/general.md
@@ -16,7 +16,7 @@ The **General** tab (`1`) is the first thing you see when opening an assembly. I
 
 The Assembly Info panel is a read-only editor. Click into it or press `Tab` to move focus there, then select text with click-drag or `Shift` + arrow keys. Press `y` to yank the selection to the clipboard.
 
-You can also use vim-style text objects: `iw` selects the word under the cursor, `iW` selects a whitespace-delimited WORD (handy for grabbing a version string or assembly name in one keystroke). `yiw` and `yiW` select and copy in one motion.
+You can also use vim-style text objects: `iw` selects the word under the cursor, `iW` selects a whitespace-delimited WORD (handy for grabbing a version string or assembly name in one keystroke). `yiw` and `yiW` select and copy in one motion. `V` selects the entire line and `yy` copies it directly.
 
 On the dependency table, focus a row and press `y` to copy it as tab-separated values. Press `Tab` to cycle focus between the info panel and the table.
 

--- a/docs/src/content/docs/usage/il-inspector.md
+++ b/docs/src/content/docs/usage/il-inspector.md
@@ -22,7 +22,7 @@ Each instruction shows:
 
 Select text in the disassembly pane with click-drag or `Shift` + arrow keys, then press `y` to yank it to the clipboard. The cursor collapses to the end of the selection and a brief flash confirms the copied range — matching neovim's yank behavior.
 
-`iw` selects the word under the cursor (an opcode, a token, a label). `yiw` copies it directly. `iW` grabs the full whitespace-delimited token, which is useful for qualified names in operands.
+`iw` selects the word under the cursor (an opcode, a token, a label). `yiw` copies it directly. `iW` grabs the full whitespace-delimited token, which is useful for qualified names in operands. `V` selects the entire instruction line and `yy` copies it directly.
 
 ## Search
 

--- a/docs/src/content/docs/usage/nuget-mode.md
+++ b/docs/src/content/docs/usage/nuget-mode.md
@@ -21,4 +21,4 @@ Press `Tab` to cycle focus between the Package Info panel and the DLL table. Pre
 
 ## Copy
 
-Select text in the Package Info panel and press `y` to copy. `iw` and `yiw` work here for quick word selection. On the DLL table, focus a row and press `y` to copy the file path.
+Select text in the Package Info panel and press `y` to copy. `iw` and `yiw` work here for quick word selection, `V` selects the line, and `yy` copies it. On the DLL table, focus a row and press `y` to copy the file path.

--- a/docs/src/content/docs/usage/pe-metadata.md
+++ b/docs/src/content/docs/usage/pe-metadata.md
@@ -18,7 +18,7 @@ The **PE / Metadata** tab (`2`) exposes the raw structure of the Portable Execut
 
 ## Text selection and copy
 
-The PE Headers and CLR Header panels are selectable editors. Press `Tab` to cycle focus between them and the metadata table. Select text and press `y` to copy. `iw` and `yiw` work here too — quick way to grab a single header value.
+The PE Headers and CLR Header panels are selectable editors. Press `Tab` to cycle focus between them and the metadata table. Select text and press `y` to copy. `iw` and `yiw` work here too — quick way to grab a single header value. `V` and `yy` work for line-level selection and copy.
 
 Press `Enter` on any metadata table row to open a detail popup. The popup is also a selectable editor — select specific values and press `y` to yank them.
 

--- a/docs/src/content/docs/usage/strings.md
+++ b/docs/src/content/docs/usage/strings.md
@@ -13,7 +13,7 @@ The **Strings** tab (`4`) extracts text from three sources:
 
 ## Copy strings
 
-Press `y` on a focused table row to copy the string value to the clipboard. Press `Enter` to open a detail popup where you can select and copy specific portions of longer strings. In the detail popup, `iw` and `yiw` let you grab individual words without reaching for the mouse.
+Press `y` on a focused table row to copy the string value to the clipboard. Press `Enter` to open a detail popup where you can select and copy specific portions of longer strings. In the detail popup, `iw` and `yiw` let you grab individual words without reaching for the mouse. `V` and `yy` work for full-line selection and copy.
 
 ## Minimum length
 

--- a/src/Dotsider/DiffApp.cs
+++ b/src/Dotsider/DiffApp.cs
@@ -154,6 +154,19 @@ public sealed class DiffApp(DiffState state)
                         && (DateTime.UtcNow - _state.VimPendingTimestamp).TotalSeconds > 1.0)
                         _state.VimPending = VimMotionState.Idle;
 
+                    // yy: second y while already armed → yank entire line
+                    if (_state.VimPending == VimMotionState.WaitingForYMotion
+                        && ctx.FocusedNode is EditorNode { State: var yyState } yyEditor
+                        && yyState == _state.VimPendingEditor
+                        && yyState.Cursor.Position.Value == _state.VimPendingCursorOffset)
+                    {
+                        _state.VimPending = VimMotionState.Idle;
+                        TextObjectHelper.SelectLine(yyState);
+                        if (yyState.Cursor.HasSelection)
+                            PerformEditorYank(ctx, yyEditor);
+                        return;
+                    }
+
                     // Editor with selection
                     if (ctx.FocusedNode is EditorNode { State.Cursor.HasSelection: true } editor)
                     {
@@ -162,7 +175,7 @@ public sealed class DiffApp(DiffState state)
                         return;
                     }
 
-                    // Editor without selection → arm operator-pending for yiw/yiW
+                    // Editor without selection → arm operator-pending for yiw/yiW/yy
                     if (ctx.FocusedNode is EditorNode noSelEditor)
                     {
                         _state.VimPending = VimMotionState.WaitingForYMotion;
@@ -266,7 +279,7 @@ public sealed class DiffApp(DiffState state)
             try
             {
                 if (_state.App.FocusedNode is EditorNode)
-                    hints.Add(s.Section("iw: Word | iW: WORD"));
+                    hints.Add(s.Section("V: Line | iw: Word | iW: WORD"));
             }
             catch (NullReferenceException)
             {

--- a/src/Dotsider/DllInspectorBindings.cs
+++ b/src/Dotsider/DllInspectorBindings.cs
@@ -269,20 +269,6 @@ public static class DllInspectorBindings
             }
         }
 
-        // iw/iW hint — show when a read-only editor is focused (not hex dump)
-        if (state.CurrentTab != TabId.HexDump)
-        {
-            try
-            {
-                if (state.App.FocusedNode is EditorNode)
-                    hints.Add(s.Section("iw: Word"));
-            }
-            catch (NullReferenceException)
-            {
-                // Focus ring may not be initialized yet
-            }
-        }
-
         // Cross-view back hint
         if (state.CrossViewBackTarget is not null)
             hints.Add(s.Section("Esc: Back"));

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -165,7 +165,20 @@ public sealed class DotsiderApp(DotsiderState state)
                         && (DateTime.UtcNow - _state.VimPendingTimestamp).TotalSeconds > 1.0)
                         _state.VimPending = VimMotionState.Idle;
 
-                    // 1. Any focused editor with selection
+                    // 1. yy: second y while already armed → yank entire line
+                    if (_state.VimPending == VimMotionState.WaitingForYMotion
+                        && ctx.FocusedNode is EditorNode { State: var yyState } yyEditor
+                        && yyState == _state.VimPendingEditor
+                        && yyState.Cursor.Position.Value == _state.VimPendingCursorOffset)
+                    {
+                        _state.VimPending = VimMotionState.Idle;
+                        TextObjectHelper.SelectLine(yyState);
+                        if (yyState.Cursor.HasSelection)
+                            PerformEditorYank(ctx, yyEditor);
+                        return;
+                    }
+
+                    // 2. Any focused editor with selection
                     if (ctx.FocusedNode is EditorNode { State.Cursor.HasSelection: true } editor)
                     {
                         _state.VimPending = VimMotionState.Idle;
@@ -173,7 +186,7 @@ public sealed class DotsiderApp(DotsiderState state)
                         return;
                     }
 
-                    // 2. Focused editor WITHOUT selection → arm operator-pending for yiw/yiW
+                    // 3. Focused editor WITHOUT selection → arm operator-pending for yiw/yiW/yy
                     if (ctx.FocusedNode is EditorNode noSelEditor)
                     {
                         // Don't arm on hex dump normal mode (I conflicts with Insert)
@@ -585,7 +598,7 @@ public sealed class DotsiderApp(DotsiderState state)
             {
                 if (_state.App.FocusedNode is EditorNode
                     && _state.CurrentTab != TabId.HexDump)
-                    hints.Add(s.Section("iw: Word | iW: WORD"));
+                    hints.Add(s.Section("V: Line | iw: Word | iW: WORD"));
             }
             catch (NullReferenceException)
             {

--- a/src/Dotsider/NuGetApp.cs
+++ b/src/Dotsider/NuGetApp.cs
@@ -95,7 +95,7 @@ public sealed class NuGetApp(NuGetState state)
                     var isHexDump = _state.SelectedDllState is
                         { CurrentTab: TabId.HexDump };
                     if (_state.App.FocusedNode is EditorNode && !isHexDump)
-                        hints.Add(s.Section("iw: Word | iW: WORD"));
+                        hints.Add(s.Section("V: Line | iw: Word | iW: WORD"));
                 }
                 catch (NullReferenceException)
                 {
@@ -298,20 +298,48 @@ public sealed class NuGetApp(NuGetState state)
                 // Universal yank — same behavior as DotsiderApp
                 bindings.Key(Hex1bKey.Y).Global().Action(ctx =>
                 {
-                    // Timeout check
+                    // Timeout check — reset stale state on both stores
                     if (_state.VimPending != VimMotionState.Idle
                         && (DateTime.UtcNow - _state.VimPendingTimestamp).TotalSeconds > 1.0)
                         _state.VimPending = VimMotionState.Idle;
+                    if (_state.SelectedDllState is { VimPending: not VimMotionState.Idle } dllTimeout
+                        && (DateTime.UtcNow - dllTimeout.VimPendingTimestamp).TotalSeconds > 1.0)
+                        dllTimeout.VimPending = VimMotionState.Idle;
 
-                    // 1. Any focused editor with selection
+                    // 1. yy: second y while already armed → yank entire line
+                    // Check both state stores (browser vs DLL inspector)
+                    if (ctx.FocusedNode is EditorNode { State: var yyState } yyEditor)
+                    {
+                        var dllPending = _state.SelectedDllState;
+                        var isDllYY = dllPending is { VimPending: VimMotionState.WaitingForYMotion }
+                            && yyState == dllPending.VimPendingEditor
+                            && yyState.Cursor.Position.Value == dllPending.VimPendingCursorOffset;
+                        var isBrowserYY = _state.VimPending == VimMotionState.WaitingForYMotion
+                            && yyState == _state.VimPendingEditor
+                            && yyState.Cursor.Position.Value == _state.VimPendingCursorOffset;
+
+                        if (isDllYY || isBrowserYY)
+                        {
+                            if (isDllYY) dllPending!.VimPending = VimMotionState.Idle;
+                            if (isBrowserYY) _state.VimPending = VimMotionState.Idle;
+                            TextObjectHelper.SelectLine(yyState);
+                            if (yyState.Cursor.HasSelection)
+                                PerformEditorYank(ctx, yyEditor);
+                            return;
+                        }
+                    }
+
+                    // 2. Any focused editor with selection
                     if (ctx.FocusedNode is EditorNode { State.Cursor.HasSelection: true } editor)
                     {
                         _state.VimPending = VimMotionState.Idle;
+                        if (_state.SelectedDllState is { } dllSel)
+                            dllSel.VimPending = VimMotionState.Idle;
                         PerformEditorYank(ctx, editor);
                         return;
                     }
 
-                    // 2. Focused editor WITHOUT selection → arm operator-pending for yiw/yiW
+                    // 3. Focused editor WITHOUT selection → arm operator-pending for yiw/yiW/yy
                     if (ctx.FocusedNode is EditorNode noSelEditor)
                     {
                         // Don't arm on hex dump normal mode (I conflicts with Insert)
@@ -339,7 +367,7 @@ public sealed class NuGetApp(NuGetState state)
                             _state.VimPendingCursorOffset = noSelEditor.State.Cursor.Position.Value;
                             _state.VimPendingTimestamp = DateTime.UtcNow;
                         }
-                        
+
                         return;
                     }
 

--- a/src/Dotsider/Views/TextObjectHelper.cs
+++ b/src/Dotsider/Views/TextObjectHelper.cs
@@ -167,6 +167,28 @@ public static class TextObjectHelper
             invalidate();
         }, "");
 
+        // --- Triple-click override: select line content only (no trailing newline) ---
+        // The default EditorWidget triple-click uses SelectLineAt which positions the
+        // cursor at the start of the NEXT line (exclusive end convention). PerformEditorYank
+        // adds +1 to cursor.Position (inclusive/neovim convention for iw/iW). These two
+        // conventions clash, causing yank to grab the newline plus the first character of
+        // the next line. Fix: replace the default handler with one that positions the
+        // cursor on the last visible character of the line (inclusive end).
+        bindings.Remove(EditorWidget.TripleClick);
+        bindings.Mouse(MouseButton.Left).TripleClick().Action(_ =>
+        {
+            SelectLine(thisEditorState);
+            invalidate();
+        }, "Triple-click to select line");
+
+        // --- Shift+V: visual line select (vim V) ---
+        bindings.Shift().Key(Hex1bKey.V).Action(_ =>
+        {
+            ResetToIdle();
+            SelectLine(thisEditorState);
+            invalidate();
+        }, "Select line");
+
         // --- All other bindings (conditionally registered when pending) ---
         if (getVimPending() == VimMotionState.Idle) return;
 
@@ -320,6 +342,42 @@ public static class TextObjectHelper
 
         ResetToIdle();
         invalidate();
+    }
+
+    /// <summary>
+    /// Selects the entire visible content of the line at the cursor position.
+    /// Anchor is set to the exclusive end (one past the last visible character)
+    /// and Position to the line start, producing a half-open selection
+    /// <c>[lineStart, lineStart + len)</c> that the renderer highlights correctly.
+    /// <c>PerformEditorYank</c>'s <c>+1</c> adjustment computes
+    /// <c>Math.Max(lineStart + len, lineStart + 1) = lineStart + len</c>,
+    /// extracting exactly the visible content without the trailing newline.
+    /// </summary>
+    /// <param name="state">The editor state to modify.</param>
+    internal static void SelectLine(EditorState state)
+    {
+        if (state.Document.Length == 0) return;
+
+        var pos = state.Document.OffsetToPosition(state.Cursor.Position);
+        var lineStart = state.Document.PositionToOffset(new DocumentPosition(pos.Line, 1));
+        var lineText = state.Document.GetLineText(pos.Line);
+
+        state.Cursors.CollapseToSingle();
+
+        if (lineText.Length == 0)
+        {
+            // Empty line — just position cursor at line start, no selection
+            state.SetCursorPosition(lineStart);
+            return;
+        }
+
+        // Anchor at exclusive end, Position at start. This makes:
+        //   SelectionRange = (lineStart, lineStart + lineText.Length)
+        //   HasSelection = true (even for single-char lines)
+        //   Renderer highlights [lineStart, lineStart + len) — all visible chars
+        //   Yank extracts [lineStart, lineStart + len) — no trailing newline
+        state.Cursor.SelectionAnchor = new DocumentOffset(lineStart.Value + lineText.Length);
+        state.Cursor.Position = lineStart;
     }
 
     private enum CharClass { Word, Punctuation, Whitespace, Newline }

--- a/tests/Dotsider.Tests/DiffModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/DiffModeYankIntegrationTests.cs
@@ -590,6 +590,39 @@ public class DiffModeYankIntegrationTests(SampleAssemblyFixture samples) : IDisp
         try { await runTask; } catch (OperationCanceledException) { }
     }
 
+    [Fact(Timeout = 30_000)]
+    public async Task Summary_YY_YanksCurrentLine()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Change Summary"), TimeSpan.FromSeconds(10))
+            // Tab to focus the left info editor
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => _state!.App.FocusedNode is EditorNode, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // yy to yank the current line
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.True(_clipboardAdapter!.ClipboardWrites.TryDequeue(out var yankedText),
+            "CopyToClipboard should have emitted an OSC 52 sequence");
+
+        Assert.True(yankedText.Length > 0);
+        Assert.DoesNotContain("\n", yankedText);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
     public void Dispose()
     {
         _cts?.Cancel();

--- a/tests/Dotsider.Tests/NuGetModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/NuGetModeYankIntegrationTests.cs
@@ -695,6 +695,39 @@ public class NuGetModeYankIntegrationTests(SampleAssemblyFixture samples) : IDis
         try { await runTask; } catch (OperationCanceledException) { }
     }
 
+    [Fact(Timeout = 30_000)]
+    public async Task PackageInfo_YY_YanksCurrentLine()
+    {
+        var (terminal, app, ct) = Launch();
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary"), TimeSpan.FromSeconds(10))
+            // Tab to focus the Package Info editor
+            .Key(Hex1bKey.Tab)
+            .WaitUntil(_ => _state!.App.FocusedNode is EditorNode, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // yy to yank the current line
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.True(_clipboardAdapter!.ClipboardWrites.TryDequeue(out var yankedText),
+            "CopyToClipboard should have emitted an OSC 52 sequence");
+
+        Assert.True(yankedText.Length > 0);
+        Assert.DoesNotContain("\n", yankedText);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
     public void Dispose()
     {
         _cts?.Cancel();

--- a/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
@@ -1209,4 +1209,179 @@ public class StandardModeYankIntegrationTests(SampleAssemblyFixture samples) : I
         _cts!.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
     }
+
+    // --- Triple-click line selection ---
+
+    [Fact(Timeout = 60_000)]
+    public async Task IlInspector_TripleClickSelectsOnlyCurrentLine()
+    {
+        var (terminal, app, ct) = Launch(samples.HelloWorldDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Navigate to IL Inspector with a method that has IL instructions
+        var method = _state!.Analyzer.MethodDefs
+            .First(m => m.Rva > 0);
+
+        _state.NavigateToIlMethod(method);
+
+        // Wait for IL content to render — look for the first IL instruction
+        List<(int Line, int Column)> matches = [];
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s =>
+            {
+                var found = s.FindText("IL_0000:");
+                if (found.Count == 0) return false;
+                matches = [.. found.Select(m => (m.Line, m.Column))];
+                return true;
+            }, TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var (row, col) = matches[0];
+
+        // Focus the IL editor (status bar shows "l: Focus IL" when tree has focus)
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("l")
+            .WaitUntil(_ => IsFocusedOnEditor(_state.IlEditorState),
+                TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Triple-click to select the line: three rapid clicks at the same position
+        // (matches the pattern used by hex1b's own EditorMouseTests)
+        await new Hex1bTerminalInputSequenceBuilder()
+            .ClickAt(col + 2, row)
+            .ClickAt(col + 2, row)
+            .ClickAt(col + 2, row)
+            .WaitUntil(_ => _state!.IlEditorState?.Cursor.HasSelection == true,
+                TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Verify the editor still has focus after triple-click
+        Assert.True(IsFocusedOnEditor(_state.IlEditorState),
+            "Editor should have focus after triple-click");
+
+        // Yank the selection
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Verify clipboard content
+        Assert.True(_clipboardAdapter!.ClipboardWrites.TryDequeue(out var yankedText),
+            "CopyToClipboard should have emitted an OSC 52 sequence");
+
+        // The yanked text should be exactly the IL_0000 line — no trailing newline
+        // and no character from the next line (e.g. "I" from "IL_0005")
+        Assert.StartsWith("IL_0000:", yankedText);
+        Assert.DoesNotContain("\n", yankedText);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task IlInspector_ShiftV_SelectsCurrentLine()
+    {
+        var (terminal, app, ct) = Launch(samples.HelloWorldDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Navigate to IL Inspector with a method
+        var method = _state!.Analyzer.MethodDefs.First(m => m.Rva > 0);
+        _state.NavigateToIlMethod(method);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.ContainsText("IL_0000:"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Focus the IL editor and position cursor on a line
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("l")
+            .WaitUntil(_ => IsFocusedOnEditor(_state.IlEditorState), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.False(_state.IlEditorState!.Cursor.HasSelection);
+
+        // Shift+V to select the line
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Shift().Key(Hex1bKey.V)
+            .WaitUntil(_ => _state.IlEditorState!.Cursor.HasSelection, TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Verify: selection covers visible line content, no newline
+        var es = _state.IlEditorState!;
+        var selected = es.Document.GetText(es.Cursor.SelectionRange);
+        // SelectLine uses inclusive end, so GetText(range) may miss the last char;
+        // yank adds +1, but for this assertion just check the raw selection is clean
+        Assert.True(selected.Length > 0, "Selection should not be empty");
+        Assert.DoesNotContain("\n", selected);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task IlInspector_YY_YanksCurrentLine()
+    {
+        var (terminal, app, ct) = Launch(samples.HelloWorldDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Navigate to IL Inspector with a method
+        var method = _state!.Analyzer.MethodDefs.First(m => m.Rva > 0);
+        _state.NavigateToIlMethod(method);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.ContainsText("IL_0000:"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Focus the IL editor
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("l")
+            .WaitUntil(_ => IsFocusedOnEditor(_state.IlEditorState), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // yy to yank the current line
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("y")
+            .Type("y")
+            .WaitUntil(s => s.ContainsText("Yanked"), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.True(_clipboardAdapter!.ClipboardWrites.TryDequeue(out var yankedText),
+            "CopyToClipboard should have emitted an OSC 52 sequence");
+
+        // The first line visible is a comment line (// Method: ...)
+        // Verify: no newline, no bleed into next line
+        Assert.True(yankedText.Length > 0);
+        Assert.DoesNotContain("\n", yankedText);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
 }


### PR DESCRIPTION
Triple-clicking a line in any read-only editor (IL Inspector, General, PE/Metadata, etc.) grabbed the trailing newline plus the first character of the next line. Yanking after triple-click on `IL_0001: ldfld ...` produced:

```
IL_0001: ldfld RichLibrary.Services.UserService::_users
I
```

The problem was a convention mismatch between `EditorState.SelectLineAt` (exclusive end — positions cursor at start of next line) and `PerformEditorYank` (adds +1 to cursor position, assuming inclusive end like `iw`/`iW`). The two conventions clash, so yank grabbed one character too many.

The fix overrides the default triple-click in `TextObjectHelper.ConfigureReadOnlyEditorBindings` with `SelectLine`, which uses a half-open selection: anchor at exclusive end, position at line start. The renderer highlights all visible characters correctly, single-character lines work, and yank extracts exactly the visible content with no trailing newline.

This PR also adds `V` (Shift+V) for visual line select and `yy` for yank-entire-line — both were missing from the vim text-object system that already had `iw`/`iW`/`yiw`/`yiW`. The `yy` handler is added to all three app modes (standard, diff, NuGet) with proper state cleanup. NuGet's dual pending-state stores both get timeout resets.

Removes a duplicate `iw: Word` hint from `DllInspectorBindings` that was showing alongside `NuGetApp`'s own editor hint in DLL-inspector mode.

Integration tests cover triple-click yank, Shift+V selection, and yy across all three app modes. README and docs updated.

Fixes #101