### PR TITLE
Fix cross-platform apphost detection for Linux/macOS

### DIFF
--- a/Dotsider.slnx
+++ b/Dotsider.slnx
@@ -17,6 +17,7 @@
     <Project Path="samples/EmptyLib/EmptyLib.csproj" />
     <Project Path="samples/NetFxConsole/NetFxConsole.csproj" />
     <Project Path="samples/NativeAotConsole/NativeAotConsole.csproj" />
+    <Project Path="samples/Dotted.Name.App/Dotted.Name.App.csproj" />
   </Folder>
 
   <Folder Name="/tests/">

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-ApphostDetector.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-ApphostDetector.md
@@ -24,9 +24,10 @@ public static class ApphostDetector
 
 ### FindCompanionDll(string)
 
-If exePath ends with `.exe` and the binary is a .NET
-apphost (embeds both the companion DLL name and a `hostfxr` reference),
-returns the path to the companion `.dll` provided it has readable .NET metadata.
+If the binary at exePath is a .NET apphost (embeds both the
+companion DLL name and a `hostfxr` reference), returns the path to the
+companion `.dll` provided it has readable .NET metadata. Works with Windows
+`.exe` files and extensionless Linux/macOS executables.
 
 **Parameters:**
 
@@ -45,9 +46,11 @@ public static string? FindCompanionDll(string exePath)
 ## Remarks
 
 `dotnet build` produces both a managed `.dll` (the actual assembly with IL and
-metadata) and a native apphost `.exe` (a launcher that bootstraps the runtime).
-The apphost has no CLR metadata, so most analysis tabs are empty. This detector
-verifies the `.exe` is an apphost by requiring two signals: the companion DLL
-name embedded in the binary AND a reference to `hostfxr` (the .NET host
-framework resolver that every apphost imports to bootstrap the runtime).
+metadata) and a native apphost launcher that bootstraps the runtime. On Windows the
+apphost is a `.exe` (PE format); on Linux and macOS it is an extensionless
+executable (ELF or Mach-O). The apphost has no CLR metadata, so most analysis tabs
+are empty. This detector verifies the file is an apphost by requiring two signals:
+the companion DLL name embedded in the binary AND a reference to `hostfxr`
+(the .NET host framework resolver). These signals are platform-invariant — the
+.NET SDK embeds them identically regardless of binary format.
 

--- a/samples/Dotted.Name.App/Dotted.Name.App.csproj
+++ b/samples/Dotted.Name.App/Dotted.Name.App.csproj
@@ -1,0 +1,11 @@
+<!-- FROZEN TEST FIXTURE — do not modify without updating Dotsider.Tests -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/samples/Dotted.Name.App/Program.cs
+++ b/samples/Dotted.Name.App/Program.cs
@@ -1,0 +1,1 @@
+Console.WriteLine("Dotted.Name.App");

--- a/samples/README.md
+++ b/samples/README.md
@@ -13,5 +13,6 @@ Sample .NET projects used as test fixtures for dotsider's analysis, diff, and tr
 | [RichLibraryV2](RichLibraryV2/) | Library | Breaking changes from RichLibrary v1 for assembly diff testing |
 | [NetFxConsole](NetFxConsole/) | Console app (.NET Fx) | .NET Framework 4.8 target for Dynamic tab guard testing |
 | [NativeAotConsole](NativeAotConsole/) | Console app (NativeAOT) | NativeAOT-published binary for Dynamic tab tracing tests |
+| [Dotted.Name.App](Dotted.Name.App/) | Console app | Dotted assembly name for cross-platform apphost detection testing |
 
 All managed samples target .NET 10 with nullable reference types enabled unless noted otherwise.

--- a/src/Dotsider.Core/Analysis/ApphostDetector.cs
+++ b/src/Dotsider.Core/Analysis/ApphostDetector.cs
@@ -9,18 +9,21 @@ namespace Dotsider.Core.Analysis;
 /// </summary>
 /// <remarks>
 /// <c>dotnet build</c> produces both a managed <c>.dll</c> (the actual assembly with IL and
-/// metadata) and a native apphost <c>.exe</c> (a launcher that bootstraps the runtime).
-/// The apphost has no CLR metadata, so most analysis tabs are empty. This detector
-/// verifies the <c>.exe</c> is an apphost by requiring two signals: the companion DLL
-/// name embedded in the binary AND a reference to <c>hostfxr</c> (the .NET host
-/// framework resolver that every apphost imports to bootstrap the runtime).
+/// metadata) and a native apphost launcher that bootstraps the runtime. On Windows the
+/// apphost is a <c>.exe</c> (PE format); on Linux and macOS it is an extensionless
+/// executable (ELF or Mach-O). The apphost has no CLR metadata, so most analysis tabs
+/// are empty. This detector verifies the file is an apphost by requiring two signals:
+/// the companion DLL name embedded in the binary AND a reference to <c>hostfxr</c>
+/// (the .NET host framework resolver). These signals are platform-invariant — the
+/// .NET SDK embeds them identically regardless of binary format.
 /// </remarks>
 public static class ApphostDetector
 {
     /// <summary>
-    /// If <paramref name="exePath"/> ends with <c>.exe</c> and the binary is a .NET
-    /// apphost (embeds both the companion DLL name and a <c>hostfxr</c> reference),
-    /// returns the path to the companion <c>.dll</c> provided it has readable .NET metadata.
+    /// If the binary at <paramref name="exePath"/> is a .NET apphost (embeds both the
+    /// companion DLL name and a <c>hostfxr</c> reference), returns the path to the
+    /// companion <c>.dll</c> provided it has readable .NET metadata. Works with Windows
+    /// <c>.exe</c> files and extensionless Linux/macOS executables.
     /// </summary>
     /// <param name="exePath">Path to the executable file.</param>
     /// <returns>
@@ -30,20 +33,30 @@ public static class ApphostDetector
     /// </returns>
     public static string? FindCompanionDll(string exePath)
     {
-        if (!exePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+        // A .dll is already a managed assembly — never redirect it.
+        if (exePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
             return null;
 
-        var dllName = Path.GetFileNameWithoutExtension(exePath) + ".dll";
+        // For .exe files, strip the extension (Foo.exe → Foo.dll).
+        // For extensionless files (Linux/macOS apphosts), append .dll to the
+        // full filename. GetFileNameWithoutExtension can't be used because it
+        // treats dots in the assembly name as extensions
+        // (e.g., Company.Product.Tool → Company.Product instead of Company.Product.Tool).
+        var fileName = Path.GetFileName(exePath);
+        var dllName = exePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+            ? Path.GetFileNameWithoutExtension(fileName) + ".dll"
+            : fileName + ".dll";
         var dllPath = Path.Combine(Path.GetDirectoryName(exePath)!, dllName);
         if (!File.Exists(dllPath))
             return null;
 
-        // Verify the .exe is actually a .NET apphost by requiring two signals:
+        // Verify the file is actually a .NET apphost by requiring two signals:
         // 1. The companion DLL name is embedded (apphost bakes it as a UTF-8 string)
         // 2. A reference to "hostfxr" exists (the .NET host framework resolver that
         //    every apphost imports to bootstrap the runtime)
         // Either alone is a weak heuristic; together they rule out unrelated native
-        // executables that happen to reference the same DLL name.
+        // executables that happen to reference the same DLL name. These signals are
+        // embedded identically in PE (.exe), ELF, and Mach-O apphost binaries.
         try
         {
             var exeBytes = File.ReadAllBytes(exePath);

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -15,7 +15,7 @@ namespace Dotsider.Core.Analysis;
 public sealed class AssemblyAnalyzer : IDisposable
 {
     private readonly Stream _stream;
-    private readonly PEReader _peReader;
+    private readonly PEReader? _peReader;
     private readonly MetadataReader? _metadataReader;
     private readonly byte[] _rawBytes;
 
@@ -33,7 +33,6 @@ public sealed class AssemblyAnalyzer : IDisposable
     /// </summary>
     /// <param name="filePath">Absolute path to the assembly file.</param>
     /// <exception cref="FileNotFoundException">The file does not exist.</exception>
-    /// <exception cref="BadImageFormatException">The file is not a valid PE image.</exception>
     public AssemblyAnalyzer(string filePath)
     {
         FilePath = filePath;
@@ -61,6 +60,14 @@ public sealed class AssemblyAnalyzer : IDisposable
 
             ReadPeHeaders();
             ReadClrHeader();
+        }
+        catch (BadImageFormatException) when (IsNativeExecutable(_rawBytes))
+        {
+            // Non-PE native binary (ELF or Mach-O on Linux/macOS), such as a
+            // .NET apphost or NativeAOT output. Raw bytes are already loaded
+            // for hex dump; PE-specific analysis will be empty.
+            _peReader?.Dispose();
+            _peReader = null;
         }
         catch
         {
@@ -99,6 +106,11 @@ public sealed class AssemblyAnalyzer : IDisposable
 
             ReadPeHeaders();
             ReadClrHeader();
+        }
+        catch (BadImageFormatException) when (IsNativeExecutable(_rawBytes))
+        {
+            _peReader?.Dispose();
+            _peReader = null;
         }
         catch
         {
@@ -188,7 +200,7 @@ public sealed class AssemblyAnalyzer : IDisposable
     /// <returns>The method body block, or null.</returns>
     public MethodBodyBlock? GetMethodBody(MethodDefInfo method)
     {
-        if (method.Rva == 0) return null;
+        if (method.Rva == 0 || _peReader is null) return null;
         return _peReader.GetMethodBody(method.Rva);
     }
 
@@ -231,8 +243,26 @@ public sealed class AssemblyAnalyzer : IDisposable
     /// <inheritdoc/>
     public void Dispose()
     {
-        _peReader.Dispose();
+        _peReader?.Dispose();
         _stream.Dispose();
+    }
+
+    /// <summary>
+    /// Returns true if the raw bytes start with a recognized native executable
+    /// magic (ELF or Mach-O). Used to distinguish legitimate non-PE binaries
+    /// from corrupted or junk files.
+    /// </summary>
+    private static bool IsNativeExecutable(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < 4) return false;
+
+        // ELF: \x7fELF
+        if (bytes[0] == 0x7F && bytes[1] == 0x45 && bytes[2] == 0x4C && bytes[3] == 0x46)
+            return true;
+
+        // Mach-O: four known magic values (big/little endian, 32/64-bit)
+        uint magic = (uint)(bytes[0] << 24 | bytes[1] << 16 | bytes[2] << 8 | bytes[3]);
+        return magic is 0xFEEDFACE or 0xFEEDFACF or 0xCEFAEDFE or 0xCFFAEDFE;
     }
 
     private void ReadAssemblyIdentity()
@@ -275,6 +305,7 @@ public sealed class AssemblyAnalyzer : IDisposable
 
     private void ReadPeHeaders()
     {
+        if (_peReader is null) return;
         var coffHeader = _peReader.PEHeaders.CoffHeader;
         var optionalHeader = _peReader.PEHeaders.PEHeader;
 
@@ -312,6 +343,7 @@ public sealed class AssemblyAnalyzer : IDisposable
 
     private void ReadClrHeader()
     {
+        if (_peReader is null) return;
         var corHeader = _peReader.PEHeaders.CorHeader;
         if (corHeader is null) return;
 
@@ -330,6 +362,7 @@ public sealed class AssemblyAnalyzer : IDisposable
 
     private List<SectionInfo> ReadSections()
     {
+        if (_peReader is null) return [];
         return [.. _peReader.PEHeaders.SectionHeaders
             .Select(s => new SectionInfo(
                 Name: s.Name,
@@ -513,7 +546,7 @@ public sealed class AssemblyAnalyzer : IDisposable
                 try
                 {
                     var resourcesRva = ClrHeader.ResourcesRva;
-                    var sectionData = _peReader.GetSectionData(resourcesRva);
+                    var sectionData = _peReader!.GetSectionData(resourcesRva);
                     if (sectionData.Length > 0)
                     {
                         var reader = sectionData.GetReader();

--- a/src/Dotsider/Commands/AnalyzeCommand.cs
+++ b/src/Dotsider/Commands/AnalyzeCommand.cs
@@ -84,28 +84,15 @@ internal static class AnalyzeCommand
                 var filePath = file.FullName;
                 var originalPath = filePath;
 
-                // Detect apphost .exe — only redirect when the .exe has no .NET metadata
-                if (filePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                // Detect apphost (Windows .exe or extensionless Linux/macOS binary)
+                // and redirect to the companion managed .dll.
+                var companion = ApphostDetector.FindCompanionDll(filePath);
+                if (companion is not null)
                 {
-                    try
-                    {
-                        using var probe = new AssemblyAnalyzer(filePath);
-                        if (!probe.HasMetadata)
-                        {
-                            var companion = ApphostDetector.FindCompanionDll(filePath);
-                            if (companion is not null)
-                            {
-                                Console.Error.WriteLine(
-                                    $"Note: {file.Name} is a native apphost. "
-                                    + $"Analyzing {Path.GetFileName(companion)} instead.");
-                                filePath = companion;
-                            }
-                        }
-                    }
-                    catch
-                    {
-                        // Fall through to main analyzer which will report the error
-                    }
+                    Console.Error.WriteLine(
+                        $"Note: {file.Name} is a native apphost. "
+                        + $"Analyzing {Path.GetFileName(companion)} instead.");
+                    filePath = companion;
                 }
 
                 // Output-path collision check — reject if -o matches EITHER the original

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -641,8 +641,13 @@ public sealed class DotsiderApp(DotsiderState state)
             return hints;
         }).WithDefaultSeparator(" | ");
 
-    private static void SaveHexChanges(DotsiderState state)
+    /// <summary>Delegate for the reopen-or-fallback step, injectable for testing.</summary>
+    internal delegate (AssemblyAnalyzer Analyzer, string? ResolvedPath) ReopenFunc(
+        string[] candidatePaths, byte[] recoveryBytes, string filePath);
+
+    internal static void SaveHexChanges(DotsiderState state, ReopenFunc? reopener = null)
     {
+        reopener ??= ReopenOrFallback;
         var filePath = state.Analyzer.FilePath;
         var tempPath = filePath + ".tmp";
 
@@ -689,31 +694,48 @@ public sealed class DotsiderApp(DotsiderState state)
             filePath + ".recovery"
         ];
 
-        foreach (var path in candidates)
+        var (analyzer, resolvedPath) = reopener(candidates, newBytes, filePath);
+        CommitAnalyzer(state, analyzer);
+
+        if (resolvedPath is null)
+        {
+            state.HexNotification = "Saved (working from memory — file may be locked)";
+        }
+        else
+        {
+            savedPath = resolvedPath;
+            var fileName = Path.GetFileName(savedPath);
+            var size = new FileInfo(savedPath).Length;
+            state.HexNotification = savedPath == filePath
+                ? $"\"{fileName}\" {size}B written"
+                : $"Saved to {fileName} (could not overwrite original)";
+        }
+    }
+
+    /// <summary>
+    /// Tries each candidate path in order. If all fail, falls back to an
+    /// in-memory analyzer constructed from <paramref name="recoveryBytes"/>.
+    /// </summary>
+    /// <returns>
+    /// The opened analyzer and the resolved path, or <c>null</c> path if
+    /// the in-memory fallback was used.
+    /// </returns>
+    internal static (AssemblyAnalyzer Analyzer, string? ResolvedPath) ReopenOrFallback(
+        string[] candidatePaths, byte[] recoveryBytes, string filePath)
+    {
+        foreach (var path in candidatePaths)
         {
             try
             {
-                // Recovery path needs the bytes written first
                 if (path.EndsWith(".recovery") && !File.Exists(path))
-                    File.WriteAllBytes(path, newBytes);
+                    File.WriteAllBytes(path, recoveryBytes);
 
-                CommitAnalyzer(state, new AssemblyAnalyzer(path));
-                savedPath = path;
-
-                var fileName = Path.GetFileName(savedPath);
-                var size = new FileInfo(savedPath).Length;
-                state.HexNotification = savedPath == filePath
-                    ? $"\"{fileName}\" {size}B written"
-                    : $"Saved to {fileName} (could not overwrite original)";
-                return;
+                return (new AssemblyAnalyzer(path), path);
             }
             catch { /* try next candidate */ }
         }
 
-        // All disk candidates exhausted. Fall back to in-memory analyzer
-        // constructed from the validated bytes — no filesystem I/O required.
-        CommitAnalyzer(state, new AssemblyAnalyzer(newBytes, filePath));
-        state.HexNotification = "Saved (working from memory — file may be locked)";
+        return (new AssemblyAnalyzer(recoveryBytes, filePath), null);
     }
 
     /// <summary>

--- a/src/Dotsider/Program.cs
+++ b/src/Dotsider/Program.cs
@@ -3,6 +3,7 @@ using System.CommandLine;
 using System.Text;
 using Dotsider;
 using Dotsider.Commands;
+using Dotsider.Core.Analysis;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
@@ -94,6 +95,28 @@ diffCommand.SetAction(async (parseResult, ct) =>
         return 1;
     }
 
+    // Redirect apphost binaries to their companion managed .dll
+    var leftPath = left.FullName;
+    var rightPath = right.FullName;
+
+    var leftCompanion = ApphostDetector.FindCompanionDll(leftPath);
+    if (leftCompanion is not null)
+    {
+        Console.Error.WriteLine(
+            $"Note: {left.Name} is a native apphost. "
+            + $"Analyzing {Path.GetFileName(leftCompanion)} instead.");
+        leftPath = leftCompanion;
+    }
+
+    var rightCompanion = ApphostDetector.FindCompanionDll(rightPath);
+    if (rightCompanion is not null)
+    {
+        Console.Error.WriteLine(
+            $"Note: {right.Name} is a native apphost. "
+            + $"Analyzing {Path.GetFileName(rightCompanion)} instead.");
+        rightPath = rightCompanion;
+    }
+
     DiffState? capturedDiffState = null;
 
     await using var diagnosticsListener = new DotsiderDiagnosticsListener(
@@ -167,7 +190,7 @@ diffCommand.SetAction(async (parseResult, ct) =>
     {
         if (capturedDiffState is null)
         {
-            var diffState = new DiffState(diffHex1bApp!, left.FullName, right.FullName);
+            var diffState = new DiffState(diffHex1bApp!, leftPath, rightPath);
             capturedDiffState = diffState;
             diffApp = new DiffApp(diffState);
         }

--- a/tests/Dotsider.Tests/ApphostDetectorTests.cs
+++ b/tests/Dotsider.Tests/ApphostDetectorTests.cs
@@ -9,11 +9,8 @@ public class ApphostDetectorTests(SampleAssemblyFixture samples) : IDisposable
 {
     private readonly List<string> _tempFiles = [];
     [Fact(Timeout = 30_000)]
-    public void FindCompanionDll_ApphostExe_ReturnsCompanionDllPath()
+    public void FindCompanionDll_Apphost_ReturnsCompanionDllPath()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Apphost .exe is a Windows artifact");
-
         var result = ApphostDetector.FindCompanionDll(samples.HelloWorldExe);
 
         Assert.NotNull(result);
@@ -32,8 +29,6 @@ public class ApphostDetectorTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public void FindCompanionDll_NativeAotExe_ReturnsNull()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "NativeAOT .exe is a Windows artifact");
         Assert.SkipWhen(samples.NativeAotConsoleExe is null,
             "NativeAOT sample was not built");
 
@@ -85,6 +80,16 @@ public class ApphostDetectorTests(SampleAssemblyFixture samples) : IDisposable
         var result = ApphostDetector.FindCompanionDll(fakeExePath);
 
         Assert.Null(result);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void FindCompanionDll_DottedNameApphost_ReturnsCompanionDllPath()
+    {
+        var result = ApphostDetector.FindCompanionDll(samples.DottedNameAppExe);
+
+        Assert.NotNull(result);
+        Assert.EndsWith("Dotted.Name.App.dll", result!, StringComparison.OrdinalIgnoreCase);
+        Assert.True(File.Exists(result));
     }
 
     public void Dispose()

--- a/tests/Dotsider.Tests/AssemblyAnalyzerTests.cs
+++ b/tests/Dotsider.Tests/AssemblyAnalyzerTests.cs
@@ -291,6 +291,40 @@ public class AssemblyAnalyzerTests(SampleAssemblyFixture samples)
     }
 
     [Fact(Timeout = 30_000)]
+    public void NativeApphost_FileConstructor_ToleratesNonPeBinary()
+    {
+        using var a = new AssemblyAnalyzer(samples.HelloWorldExe);
+
+        Assert.False(a.HasMetadata);
+        Assert.True(a.FileSize > 0);
+        Assert.False(a.RawBytes.IsEmpty);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void NativeApphost_ByteArrayConstructor_ToleratesNonPeBinary()
+    {
+        var bytes = File.ReadAllBytes(samples.HelloWorldExe);
+        using var a = new AssemblyAnalyzer(bytes, samples.HelloWorldExe);
+
+        Assert.False(a.HasMetadata);
+        Assert.Equal(bytes.Length, a.FileSize);
+        Assert.False(a.RawBytes.IsEmpty);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void NativeAot_ByteArrayConstructor_ToleratesNonPeBinary()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        var bytes = File.ReadAllBytes(samples.NativeAotConsoleExe!);
+        using var a = new AssemblyAnalyzer(bytes, samples.NativeAotConsoleExe!);
+
+        Assert.False(a.HasMetadata);
+        Assert.Equal(bytes.Length, a.FileSize);
+    }
+
+    [Fact(Timeout = 30_000)]
     public void ResolveToken_ReturnsString()
     {
         using var a = new AssemblyAnalyzer(samples.RichLibraryDll);

--- a/tests/Dotsider.Tests/CliTests.cs
+++ b/tests/Dotsider.Tests/CliTests.cs
@@ -208,11 +208,8 @@ public class CliTests(SampleAssemblyFixture fixture)
     // --- Apphost Detection ---
 
     [Fact]
-    public async Task Analyze_ApphostExe_AutoRedirectsToManagedDll()
+    public async Task Analyze_Apphost_AutoRedirectsToManagedDll()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Apphost .exe is a Windows artifact");
-
         var (exitCode, stdout, stderr) = await RunDotsiderAsync(
             "analyze", fixture.HelloWorldExe);
 

--- a/tests/Dotsider.Tests/DotsiderStateTests.cs
+++ b/tests/Dotsider.Tests/DotsiderStateTests.cs
@@ -545,8 +545,6 @@ public class DotsiderStateTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public void ConstructFromApphostExe_SetsApphostDialogState()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Apphost .exe is a Windows artifact");
 
         var app = CreateApp();
         using var state = new DotsiderState(app, samples.HelloWorldExe);
@@ -569,8 +567,6 @@ public class DotsiderStateTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public void PushAssembly_FromApphostToCompanionDll_Works()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Apphost .exe is a Windows artifact");
 
         var app = CreateApp();
         using var state = new DotsiderState(app, samples.HelloWorldExe);

--- a/tests/Dotsider.Tests/DynamicTabGuardTests.cs
+++ b/tests/Dotsider.Tests/DynamicTabGuardTests.cs
@@ -87,8 +87,6 @@ public class DynamicTabGuardTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public void IsNativeAot_TrueForNativeAotConsole()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "NativeAOT produces ELF/Mach-O on non-Windows; dotsider requires PE");
         var app = CreateApp();
         using var state = new DotsiderState(app, samples.NativeAotConsoleExe!);
         Assert.True(state.IsNativeAot);
@@ -128,8 +126,6 @@ public class DynamicTabGuardTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public async Task Tab8_NativeAot_ShowsIdleViewNotGuard()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "NativeAOT produces ELF/Mach-O on non-Windows; dotsider requires PE");
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var (terminal, app) = CreateDotsiderApp(samples.NativeAotConsoleExe!);
         var runTask = app.RunAsync(cts.Token);
@@ -157,8 +153,6 @@ public class DynamicTabGuardTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public async Task NativeAot_NavigateAllTabs_NoCrash()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "NativeAOT produces ELF/Mach-O on non-Windows; dotsider requires PE");
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var (terminal, app) = CreateDotsiderApp(samples.NativeAotConsoleExe!);
         var runTask = app.RunAsync(cts.Token);

--- a/tests/Dotsider.Tests/HexSaveStressTests.cs
+++ b/tests/Dotsider.Tests/HexSaveStressTests.cs
@@ -1,6 +1,7 @@
 using Dotsider.Core.Analysis;
 using Hex1b;
 using Hex1b.Automation;
+using Hex1b.Documents;
 using Hex1b.Input;
 using Hex1b.Widgets;
 
@@ -230,6 +231,53 @@ public class HexSaveStressTests(SampleAssemblyFixture samples) : IDisposable
         }
     }
 
+    [Fact(Timeout = 30_000)]
+    public async Task NativeBinary_HexSave_Succeeds()
+    {
+        // Copy ONLY the apphost (no companion DLL) so there's no apphost
+        // dialog — the file opens as a plain native binary without metadata.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dotsider-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var tempFile = Path.Combine(tempDir, "HelloWorld");
+        File.Copy(samples.HelloWorldExe, tempFile);
+
+        try
+        {
+            var (terminal, app) = CreateDotsiderApp(tempFile);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            var runTask = app.RunAsync(cts.Token);
+            await Task.Delay(100, cts.Token);
+
+            // Navigate to hex tab, edit a byte, save
+            await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+                .Key(Hex1bKey.D5)
+                .WaitUntil(s => s.ContainsText("i: Edit"), TimeSpan.FromSeconds(10))
+                .Key(Hex1bKey.I)
+                .WaitUntil(s => s.ContainsText("INSERT"), TimeSpan.FromSeconds(10))
+                .Key(Hex1bKey.RightArrow).Key(Hex1bKey.RightArrow)
+                .Key(Hex1bKey.RightArrow).Key(Hex1bKey.RightArrow)
+                .Key(Hex1bKey.F).Key(Hex1bKey.F)
+                .WaitUntil(_ => _state!.HexIsDirty, TimeSpan.FromSeconds(10))
+                .Key(Hex1bKey.Escape)
+                .WaitUntil(s => s.ContainsText("i: Edit"), TimeSpan.FromSeconds(10))
+                .Ctrl().Key(Hex1bKey.S)
+                .WaitUntil(_ => _state!.HexNotification != null, TimeSpan.FromSeconds(10))
+                .Build()
+                .ApplyAsync(terminal, cts.Token);
+
+            Assert.Contains("written", _state!.HexNotification);
+            Assert.False(_state.HexIsDirty);
+
+            cts.Cancel();
+            await runTask;
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
     [Fact]
     public void InMemoryAnalyzer_FunctionsWithoutDisk()
     {
@@ -246,6 +294,102 @@ public class HexSaveStressTests(SampleAssemblyFixture samples) : IDisposable
         Assert.True(analyzer.HasMetadata);
         Assert.NotNull(analyzer.AssemblyName);
         Assert.True(analyzer.RawBytes.Length > 0);
+    }
+
+    [Fact]
+    public void InMemoryAnalyzer_NativeBinary_SaveRecoveryPath()
+    {
+        // Simulates the byte-array fallback in SaveHexChanges: after a hex
+        // edit on a native binary (apphost/NativeAOT), all disk candidates
+        // are exhausted and the analyzer is reconstructed from memory.
+        var originalBytes = File.ReadAllBytes(samples.HelloWorldExe);
+
+        // Simulate a hex edit: modify a byte in the native binary
+        var editedBytes = originalBytes.ToArray();
+        editedBytes[4] = 0xFF;
+
+        using var analyzer = new AssemblyAnalyzer(editedBytes, samples.HelloWorldExe);
+
+        Assert.Equal(samples.HelloWorldExe, analyzer.FilePath);
+        Assert.Equal(editedBytes.Length, analyzer.FileSize);
+        Assert.False(analyzer.HasMetadata);
+        Assert.False(analyzer.RawBytes.IsEmpty);
+        Assert.Equal(0xFF, analyzer.RawBytes.Span[4]);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void ReopenOrFallback_AllCandidatesFail_ReturnsInMemoryAnalyzer()
+    {
+        // Exercises the candidate loop + byte-array fallback with all
+        // non-existent paths so the in-memory branch triggers.
+        var originalBytes = File.ReadAllBytes(samples.HelloWorldExe);
+        var editedBytes = originalBytes.ToArray();
+        editedBytes[4] = 0xFF;
+
+        string[] bogusPath =
+        [
+            "/nonexistent/dir/HelloWorld",
+            "/nonexistent/dir/HelloWorld.tmp",
+            "/nonexistent/dir/HelloWorld.recovery"
+        ];
+
+        var (analyzer, resolvedPath) = DotsiderApp.ReopenOrFallback(
+            bogusPath, editedBytes, samples.HelloWorldExe);
+
+        using (analyzer)
+        {
+            Assert.Null(resolvedPath);
+            Assert.Equal(samples.HelloWorldExe, analyzer.FilePath);
+            Assert.False(analyzer.HasMetadata);
+            Assert.Equal(editedBytes.Length, analyzer.FileSize);
+            Assert.Equal(0xFF, analyzer.RawBytes.Span[4]);
+        }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public void SaveHexChanges_NativeBinary_MemoryFallbackSetsNotification()
+    {
+        // Drives SaveHexChanges through the resolvedPath == null branch by
+        // injecting a reopener that always returns the in-memory fallback.
+        // Verifies the caller correctly sets the "working from memory" notification.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dotsider-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var tempFile = Path.Combine(tempDir, "HelloWorld");
+        File.Copy(samples.HelloWorldExe, tempFile);
+
+        try
+        {
+            _workload = new Hex1bAppWorkloadAdapter();
+            _terminal = Hex1bTerminal.CreateBuilder()
+                .WithWorkload(_workload)
+                .WithHeadless()
+                .WithDimensions(80, 24)
+                .Build();
+            _hex1bApp = new Hex1bApp(
+                _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+                new Hex1bAppOptions { WorkloadAdapter = _workload });
+            _state = new DotsiderState(_hex1bApp, tempFile);
+
+            // Make the document dirty
+            _state.HexEditorState.IsReadOnly = false;
+            _state.HexEditorState.Document.ApplyBytes(
+                new ByteReplaceOperation(4, 1, [0xFF]));
+            _state.HexEditorState.IsReadOnly = true;
+            Assert.True(_state.HexIsDirty);
+
+            // Inject a reopener that simulates all disk candidates failing
+            DotsiderApp.SaveHexChanges(_state,
+                reopener: (_, bytes, path) => (new AssemblyAnalyzer(bytes, path), null));
+
+            Assert.Equal("Saved (working from memory — file may be locked)", _state.HexNotification);
+            Assert.False(_state.HexIsDirty);
+            Assert.False(_state.Analyzer.HasMetadata);
+            Assert.Equal(0xFF, _state.Analyzer.RawBytes.Span[4]);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
     }
 
     public void Dispose()

--- a/tests/Dotsider.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Tests/SampleAssemblyFixture.cs
@@ -27,7 +27,11 @@ public class SampleAssemblyFixture : IAsyncLifetime
     // .NET Framework sample (Windows only — net48 requires Windows)
     public string? NetFxConsoleExe { get; private set; }
 
-    // NativeAOT sample (Windows-only — ELF/Mach-O outputs aren't PE files)
+    // Dotted assembly name sample (e.g., Company.Product.Tool)
+    public string DottedNameAppDll { get; private set; } = null!;
+    public string DottedNameAppExe { get; private set; } = null!;
+
+    // NativeAOT sample
     public string? NativeAotConsoleExe { get; private set; }
 
     // Non-.NET binary for error case testing
@@ -47,41 +51,43 @@ public class SampleAssemblyFixture : IAsyncLifetime
             BuildProject("samples/MinimalApi"),
             BuildProject("samples/NativeLib"),
             BuildProject("samples/EmptyLib"),
+            BuildProject("samples/Dotted.Name.App"),
         };
 
-        // Both samples are Windows-only: net48 needs Windows, and NativeAOT
-        // outputs ELF/Mach-O on Linux/macOS which aren't PE files.
+        // net48 needs Windows; NativeAOT builds on all platforms.
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
             builds.Add(BuildProject("samples/NetFxConsole"));
-            builds.Add(PublishNativeAotProject("samples/NativeAotConsole"));
-        }
+
+        builds.Add(PublishNativeAotProject("samples/NativeAotConsole"));
 
         await Task.WhenAll(builds);
 
         var config = "Debug";
         var tfm = "net10.0";
+        var apphostExt = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
 
         HelloWorldDll = SamplePath("HelloWorld", config, tfm, "HelloWorld.dll");
-        HelloWorldExe = SamplePath("HelloWorld", config, tfm, "HelloWorld.exe");
+        HelloWorldExe = SamplePath("HelloWorld", config, tfm, $"HelloWorld{apphostExt}");
         ComplexAppDll = SamplePath("ComplexApp", config, tfm, "ComplexApp.dll");
-        ComplexAppExe = SamplePath("ComplexApp", config, tfm, "ComplexApp.exe");
+        ComplexAppExe = SamplePath("ComplexApp", config, tfm, $"ComplexApp{apphostExt}");
         MinimalApiDll = SamplePath("MinimalApi", config, tfm, "MinimalApi.dll");
-        MinimalApiExe = SamplePath("MinimalApi", config, tfm, "MinimalApi.exe");
+        MinimalApiExe = SamplePath("MinimalApi", config, tfm, $"MinimalApi{apphostExt}");
         RichLibraryDll = SamplePath("RichLibrary", config, tfm, "RichLibrary.dll");
         RichLibraryV2Dll = SamplePath("RichLibraryV2", config, tfm, "RichLibrary.dll");
         NativeLibDll = SamplePath("NativeLib", config, tfm, "NativeLib.dll");
         EmptyLibDll = SamplePath("EmptyLib", config, tfm, "EmptyLib.dll");
+        DottedNameAppDll = SamplePath("Dotted.Name.App", config, tfm, "Dotted.Name.App.dll");
+        DottedNameAppExe = SamplePath("Dotted.Name.App", config, tfm, $"Dotted.Name.App{apphostExt}");
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             NetFxConsoleExe = Path.Combine(_repoRoot, "samples", "NetFxConsole",
                 "bin", config, "net48", "NetFxConsole.exe");
-
-            var rid = RuntimeInformation.RuntimeIdentifier;
-            NativeAotConsoleExe = Path.Combine(_repoRoot, "samples", "NativeAotConsole",
-                "bin", "Release", tfm, rid, "publish", "NativeAotConsole.exe");
         }
+
+        var rid = RuntimeInformation.RuntimeIdentifier;
+        NativeAotConsoleExe = Path.Combine(_repoRoot, "samples", "NativeAotConsole",
+            "bin", "Release", tfm, rid, "publish", $"NativeAotConsole{apphostExt}");
 
         RichLibraryNupkg = Path.Combine(_repoRoot, "samples", "RichLibrary",
             "bin", config, "RichLibrary.2.5.1.nupkg");
@@ -98,12 +104,11 @@ public class SampleAssemblyFixture : IAsyncLifetime
             Assert.True(File.Exists(NetFxConsoleExe), $"NetFxConsole.exe not found at {NetFxConsoleExe}");
         if (NativeAotConsoleExe is not null)
             Assert.True(File.Exists(NativeAotConsoleExe), $"NativeAotConsole.exe not found at {NativeAotConsoleExe}");
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            Assert.True(File.Exists(HelloWorldExe), $"HelloWorld.exe not found at {HelloWorldExe}");
-            Assert.True(File.Exists(ComplexAppExe), $"ComplexApp.exe not found at {ComplexAppExe}");
-            Assert.True(File.Exists(MinimalApiExe), $"MinimalApi.exe not found at {MinimalApiExe}");
-        }
+        Assert.True(File.Exists(HelloWorldExe), $"HelloWorld apphost not found at {HelloWorldExe}");
+        Assert.True(File.Exists(ComplexAppExe), $"ComplexApp apphost not found at {ComplexAppExe}");
+        Assert.True(File.Exists(MinimalApiExe), $"MinimalApi apphost not found at {MinimalApiExe}");
+        Assert.True(File.Exists(DottedNameAppDll), $"Dotted.Name.App.dll not found at {DottedNameAppDll}");
+        Assert.True(File.Exists(DottedNameAppExe), $"Dotted.Name.App apphost not found at {DottedNameAppExe}");
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -1920,8 +1920,6 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public async Task ApphostExe_ShowsDialog()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Apphost .exe is a Windows artifact");
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var (terminal, app) = CreateDotsiderApp(samples.HelloWorldExe);
@@ -1943,8 +1941,6 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public async Task ApphostExe_Enter_NavigatesToManagedDll()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Apphost .exe is a Windows artifact");
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var (terminal, app) = CreateDotsiderApp(samples.HelloWorldExe);
@@ -1972,8 +1968,6 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public async Task ApphostExe_Escape_DismissesDialog()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Apphost .exe is a Windows artifact");
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var (terminal, app) = CreateDotsiderApp(samples.HelloWorldExe);
@@ -1999,8 +1993,6 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public async Task ApphostExe_Enter_ThenBack_ReshowsDialog()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Apphost .exe is a Windows artifact");
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var (terminal, app) = CreateDotsiderApp(samples.HelloWorldExe);


### PR DESCRIPTION
Running dotsider against a Linux/macOS apphost (extensionless ELF/Mach-O binary) crashed with BadImageFormatException because ApphostDetector.FindCompanionDll bailed on anything without a .exe extension, and AssemblyAnalyzer couldn't parse non-PE files.

The apphost byte-scanning logic (embedded DLL name + hostfxr) was already platform-agnostic — it was just gated on the wrong file extension.

What changed:

ApphostDetector now accepts extensionless files (skips .dll instead of requiring .exe). Dotted assembly names like Company.Product.Tool are handled correctly — GetFileNameWithoutExtension was stripping the last segment on extensionless files.

AssemblyAnalyzer tolerates ELF and Mach-O binaries by checking magic bytes in a catch filter. This means the TUI opens native binaries the same way on all platforms — hex dump works, apphost dialog appears, user can accept or dismiss. The byte-array constructor used by SaveHexChanges recovery also got the same treatment.

AnalyzeCommand and the diff path in Program.cs now detect apphosts regardless of extension.

SaveHexChanges has a new ReopenOrFallback helper extracted for testability, with an injectable reopener delegate so the in-memory fallback branch can be tested at the caller level.

NativeAOT sample now builds on all platforms (was Windows-only). New Dotted.Name.App sample covers the dotted-name regression.

12 previously-skipped tests now run cross-platform. Only 2 remain skipped (net48, Windows-only by nature). 726 total, 724 passed.

Fixes #105