### PR TITLE
Highlight all labels on multi-value counter lines

### DIFF
--- a/src/Dotsider/Views/InfoLabelDecorationProvider.cs
+++ b/src/Dotsider/Views/InfoLabelDecorationProvider.cs
@@ -5,8 +5,9 @@ namespace Dotsider.Views;
 
 /// <summary>
 /// Provides label coloring for read-only info editors.
-/// Colors text from the start of each line up to and including the colon
-/// with a dimmed label color, matching the original InfoLine styling.
+/// Colors all label:value patterns on each line with a dimmed label color.
+/// Labels are identified by walking backwards from each colon to find
+/// letters/digits, stopping at double-space boundaries between values.
 /// </summary>
 public sealed class InfoLabelDecorationProvider : ITextDecorationProvider
 {
@@ -27,32 +28,84 @@ public sealed class InfoLabelDecorationProvider : ITextDecorationProvider
             if (string.IsNullOrEmpty(text))
                 continue;
 
-            // Only match label patterns: optional leading spaces, then letters/spaces, then colon.
-            // The colon must appear within the first 25 characters to avoid false positives
-            // on content lines that happen to contain colons.
-            var colonIdx = text.IndexOf(':');
-            if (colonIdx < 0 || colonIdx > 25)
-                continue;
+            var searchStart = 0;
+            var isFirstOnLine = true;
 
-            // Verify everything before the colon is whitespace or letters (a label)
-            var isLabel = true;
-            for (var i = 0; i < colonIdx; i++)
+            while (searchStart < text.Length)
             {
-                if (!char.IsLetterOrDigit(text[i]) && text[i] is not ' ' and not '-')
-                {
-                    isLabel = false;
+                var colonIdx = text.IndexOf(':', searchStart);
+                if (colonIdx < 0)
                     break;
+
+                // Walk backwards from the colon to find the label start.
+                var labelStart = colonIdx - 1;
+                while (labelStart >= searchStart
+                    && (char.IsLetterOrDigit(text[labelStart]) || text[labelStart] is ' ' or '-'))
+                {
+                    // Stop at double-space (gap between previous value and this label)
+                    if (text[labelStart] == ' ' && labelStart > 0 && text[labelStart - 1] == ' ')
+                    {
+                        labelStart++;
+                        break;
+                    }
+                    labelStart--;
                 }
+                if (labelStart < 0) labelStart = 0;
+
+                // Skip leading spaces within the label
+                while (labelStart < colonIdx && text[labelStart] == ' ')
+                    labelStart++;
+
+                // Validate: at least one letter before the colon (avoids matching
+                // version numbers like "1.0.0.0") and the colon must be close to
+                // the label start to avoid false positives on content colons.
+                var hasLetter = false;
+                for (var i = labelStart; i < colonIdx; i++)
+                {
+                    if (char.IsLetter(text[i]))
+                    {
+                        hasLetter = true;
+                        break;
+                    }
+                }
+
+                if (hasLetter && labelStart < colonIdx && (colonIdx - labelStart) <= 25)
+                {
+                    // First label on the line includes leading whitespace (column 1)
+                    var spanCol = isFirstOnLine ? 1 : labelStart + 1;
+                    spans.Add(new TextDecorationSpan(
+                        new DocumentPosition(line, spanCol),
+                        new DocumentPosition(line, colonIdx + 2),
+                        LabelDecoration,
+                        5));
+                    isFirstOnLine = false;
+                }
+
+                // Skip past the value to the next multi-label separator.
+                // First skip the padding between the label's colon and its value,
+                // then look for 4+ consecutive spaces which indicate a real
+                // value→label boundary ("Gen 0: 4    Gen 1: 4").
+                var next = colonIdx + 1;
+                // Skip immediate padding after colon
+                while (next < text.Length && text[next] == ' ')
+                    next++;
+                // Skip through value content until a 4+ space gap.
+                // If no gap is found, stop scanning this line entirely.
+                var foundSeparator = false;
+                while (next < text.Length - 3)
+                {
+                    if (text[next] == ' ' && text[next + 1] == ' '
+                        && text[next + 2] == ' ' && text[next + 3] == ' ')
+                    {
+                        while (next < text.Length && text[next] == ' ')
+                            next++;
+                        foundSeparator = true;
+                        break;
+                    }
+                    next++;
+                }
+                searchStart = foundSeparator ? next : text.Length;
             }
-
-            if (!isLabel)
-                continue;
-
-            spans.Add(new TextDecorationSpan(
-                new DocumentPosition(line, 1),
-                new DocumentPosition(line, colonIdx + 2),
-                LabelDecoration,
-                5));
         }
 
         return spans;

--- a/tests/Dotsider.Tests/InfoDecorationProviderTests.cs
+++ b/tests/Dotsider.Tests/InfoDecorationProviderTests.cs
@@ -119,4 +119,70 @@ public class InfoDecorationProviderTests
         Assert.Single(spans);
     }
 
+    [Fact]
+    public void InfoLabel_IgnoresColonsInsideValues()
+    {
+        var provider = new InfoLabelDecorationProvider();
+        var doc = new Hex1bDocument("  Description:  Visit https://example.com for details");
+
+        var spans = provider.GetDecorations(1, 1, doc);
+
+        // Only "Description:" should be colored, not "https:"
+        Assert.Single(spans);
+    }
+
+    [Fact]
+    public void InfoLabel_IgnoresTrailingColonInValue()
+    {
+        var provider = new InfoLabelDecorationProvider();
+        var doc = new Hex1bDocument("  Description:  abc:");
+
+        var spans = provider.GetDecorations(1, 1, doc);
+
+        Assert.Single(spans);
+    }
+
+    [Fact]
+    public void InfoLabel_IgnoresColonAfterDoubleSpaceInValue()
+    {
+        var provider = new InfoLabelDecorationProvider();
+        var doc = new Hex1bDocument("  Description:  Value  with: colon");
+
+        var spans = provider.GetDecorations(1, 1, doc);
+
+        Assert.Single(spans);
+    }
+
+    [Fact]
+    public void InfoLabel_IgnoresDoubleColonInValues()
+    {
+        var provider = new InfoLabelDecorationProvider();
+        var doc = new Hex1bDocument("  MethodDef:    Namespace.Type::Method");
+
+        var spans = provider.GetDecorations(1, 1, doc);
+
+        Assert.Single(spans);
+    }
+
+    [Fact]
+    public void InfoLabel_ColorsMultipleLabelsPerLine()
+    {
+        var provider = new InfoLabelDecorationProvider();
+        var doc = new Hex1bDocument("  Gen 0: 4    Gen 1: 4    Gen 2: 4");
+
+        var spans = provider.GetDecorations(1, 1, doc);
+
+        Assert.Equal(3, spans.Count);
+    }
+
+    [Fact]
+    public void InfoLabel_ColorsThreadingLabels()
+    {
+        var provider = new InfoLabelDecorationProvider();
+        var doc = new Hex1bDocument("  Threads: 2    Queue: 0    Exceptions: 0    Timers: 1");
+
+        var spans = provider.GetDecorations(1, 1, doc);
+
+        Assert.Equal(4, spans.Count);
+    }
 }


### PR DESCRIPTION
The GC Collections and Threading panels in the Dynamic Counters subtab put multiple label:value pairs on the same line ("Gen 0: 4    Gen 1: 4    Gen 2: 4"). InfoLabelDecorationProvider only found the first colon per line, so "Gen 1:", "Gen 2:", "Queue:", "Exceptions:", and "Timers:" were not getting the blue-gray highlight.

The provider now scans for all colons per line, walking backwards from each to find the label start. After matching a label, it skips past the colon's padding and value content, only resuming at a 4+ space gap which indicates a real value-to-label separator. If no gap is found, scanning stops for that line to avoid miscoloring colons inside values like URLs, Type::Method signatures, or trailing colons in descriptions.

Fixes #115