### PR TITLE
Fix Escape from dep graph returning to wrong tab

### DIFF
--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -383,13 +383,13 @@ public sealed class DotsiderApp(DotsiderState state)
                     }
                     else if (_state.NavigationStack.Count > 0)
                     {
-                        _state.PopAssembly();
+                        var backTab = _state.PopAssembly();
 
                         // Re-show the apphost dialog when backing out to an apphost .exe
                         if (_state.ApphostCompanionDllPath is not null && !_state.Analyzer.HasMetadata)
                             _state.ApphostDialogOpen = true;
 
-                        _state.NavigateToTab(TabId.General);
+                        _state.NavigateToTab(backTab);
                         _state.RequestContentFocus();
                         _state.App.Invalidate();
                     }

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -96,6 +96,9 @@ public sealed class DotsiderState : IDisposable
     /// <summary>Saved focused dep keys matching the navigation stack for restore on back.</summary>
     private readonly Stack<object?> _focusedDepStack = new();
 
+    /// <summary>Saved tab IDs matching the navigation stack for restore on back.</summary>
+    private readonly Stack<int> _tabStack = new();
+
     /// <summary>Maximum navigation depth for assembly drill-down.</summary>
     public const int MaxNavigationDepth = 10;
 
@@ -682,6 +685,7 @@ public sealed class DotsiderState : IDisposable
 
         NavigationError = null;
         _focusedDepStack.Push(GeneralFocusedDep);
+        _tabStack.Push(CurrentTab);
         NavigationStack.Push(Analyzer);
         Analyzer = newAnalyzer;
         StringExtractor = new StringExtractor(Analyzer);
@@ -696,10 +700,12 @@ public sealed class DotsiderState : IDisposable
 
     /// <summary>
     /// Pops the top of the navigation stack and restores the previous analyzer.
+    /// Returns the tab that was active when the assembly was pushed, or
+    /// <see cref="TabId.General"/> if nothing was saved.
     /// </summary>
-    public bool PopAssembly()
+    public int PopAssembly()
     {
-        if (NavigationStack.Count == 0) return false;
+        if (NavigationStack.Count == 0) return TabId.General;
         NavigationError = null;
         Analyzer.Dispose();
         Analyzer = NavigationStack.Pop();
@@ -709,10 +715,11 @@ public sealed class DotsiderState : IDisposable
         HexRowDoc = hexDoc;
         HexEditorState = new EditorState(hexDoc) { IsReadOnly = true };
         HexCleanVersion = hexDoc.Version;
+        var savedTab = _tabStack.Count > 0 ? _tabStack.Pop() : TabId.General;
         var savedFocus = _focusedDepStack.Count > 0 ? _focusedDepStack.Pop() : null;
         ResetViewState();
         GeneralFocusedDep = savedFocus;
-        return true;
+        return savedTab;
     }
 
     private void ResetViewState()

--- a/tests/Dotsider.Tests/DotsiderStateTests.cs
+++ b/tests/Dotsider.Tests/DotsiderStateTests.cs
@@ -104,7 +104,7 @@ public class DotsiderStateTests(SampleAssemblyFixture samples) : IDisposable
         var app = CreateApp();
         using var state = new DotsiderState(app, samples.HelloWorldDll);
         Assert.True(state.PushAssembly(samples.RichLibraryDll));
-        Assert.True(state.PopAssembly());
+        state.PopAssembly();
         Assert.Equal("HelloWorld.dll", state.Analyzer.FileName);
         Assert.Empty(state.NavigationStack);
     }
@@ -158,7 +158,7 @@ public class DotsiderStateTests(SampleAssemblyFixture samples) : IDisposable
         // Set an error, then pop
         state.PushAssembly("/nonexistent/fake.dll");
         Assert.NotNull(state.NavigationError);
-        Assert.True(state.PopAssembly());
+        state.PopAssembly();
         Assert.Null(state.NavigationError);
     }
 
@@ -186,11 +186,13 @@ public class DotsiderStateTests(SampleAssemblyFixture samples) : IDisposable
     }
 
     [Fact(Timeout = 30_000)]
-    public void PopAssembly_EmptyStack_ReturnsFalse()
+    public void PopAssembly_EmptyStack_IsNoOp()
     {
         var app = CreateApp();
         using var state = new DotsiderState(app, samples.HelloWorldDll);
-        Assert.False(state.PopAssembly());
+        state.PopAssembly();
+        Assert.Equal("HelloWorld.dll", state.Analyzer.FileName);
+        Assert.Empty(state.NavigationStack);
     }
 
     [Fact(Timeout = 30_000)]


### PR DESCRIPTION
When drilling into a dependency from the Dependency Graph tab (Enter), then pressing Escape to go back, the app always returned to the General tab instead of the Dependency Graph tab.

The root cause was two-fold: DependencyGraphView's Enter handler calls NavigateToTab(TabId.General) after pushing an assembly, but nothing tracked which tab the user was on before the push. The Escape handler in DotsiderApp then hardcoded NavigateToTab(TabId.General) after popping.

Added a parallel _tabStack (same pattern as the existing _focusedDepStack) that saves CurrentTab in PushAssembly and returns it from PopAssembly. The back handler now navigates to the returned tab instead of always going to General.

Fixes #117