### PR TITLE
fix(il-inspector): land cursor on first IL instruction for fresh method opens

### DIFF
--- a/src/Dotsider/Views/IlInspectorView.cs
+++ b/src/Dotsider/Views/IlInspectorView.cs
@@ -414,6 +414,22 @@ public static class IlInspectorView
             state.IlNavigationProvider.HeaderLineCount = state.IlHeaderLineCount;
             state.IlEditorKey = state.GetOrCreateEditorKey(state.Analyzer, method.Token);
             state.IlCachedEditors.Remove(state.IlEditorKey);
+
+            if (state.IlHeaderLineCount > 0)
+            {
+                var offset = 0;
+                var newlines = 0;
+                for (var i = 0; i < disassembly.Length && newlines < state.IlHeaderLineCount; i++)
+                {
+                    if (disassembly[i] == '\n')
+                    {
+                        newlines++;
+                        offset = i + 1;
+                    }
+                }
+                
+                state.IlEditorState.SetCursorPosition(new DocumentOffset(offset));
+            }
         }
 
         // Consume pending cursor match (from search n/N navigation)

--- a/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
+++ b/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
@@ -67,11 +67,12 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         await auto.WaitUntilTextAsync("// Method: RichLibrary.IlNavigationFixture::CallLocalMethod");
         await auto.WaitUntilTextAsync("call RichLibrary.IlNavigationFixture::LocalTarget");
 
-        // Focus editor with 'l', then navigate down to the call line
+        // Focus editor with 'l', then navigate down to the call line.
+        // Cursor starts on the first IL instruction (IL_0000: nop), so 8 downs
+        // lands on IL_0010: call — independent of header line count.
         await auto.KeyAsync(Hex1bKey.L, ct);
         await Task.Delay(200, ct);
-        // 15 downs: 7 header lines + 8 instructions to reach IL_0010 call
-        for (var i = 0; i < 15; i++) await auto.DownAsync(ct);
+        for (var i = 0; i < 8; i++) await auto.DownAsync(ct);
         await Task.Delay(200, ct);
 
         return _state!.IlEditorState?.Cursor.Position.Value ?? -1;


### PR DESCRIPTION
Opening a method in the IL inspector used to drop the cursor at offset 0, which is the first `// Method:` header line. That meant gd, word motions, and vertical navigation all started from metadata prose rather than executable IL, and users had to skip past the 6–7 header lines first.

With this change, a fresh editor (tree click, search, or go-to-def) seeks past `HeaderLineCount` newlines and positions the cursor at the start of the first `IL_` instruction. The header is still visible above. Cached editors and back-stack restores are untouched, so returning to a previously visited method still lands exactly where you left off.

Test helper `NavigateToCallLocalMethodAndFocusCallLine` no longer has to account for header length — eight DownArrows from the first instruction always reaches `IL_0010: call`, regardless of whether the method has a locals signature.

Fixes: #137