### PR TITLE
fix(il-inspector): follow generic method instantiations on go-to-definition

### DIFF
--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-IlNavigationTarget-GenericInstantiation.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-IlNavigationTarget-GenericInstantiation.md
@@ -1,6 +1,6 @@
 ---
 title: "IlNavigationTarget.GenericInstantiation"
-description: "A generic instantiation (TypeSpec or MethodSpec) that cannot be navigated directly."
+description: "A MethodSpec whose metadata could not be decoded into a navigable target."
 slug: api/dotsider.core.analysis.models.ilnavigationtarget.genericinstantiation
 sidebar:
   order: 1
@@ -10,7 +10,7 @@ sidebar:
 
 **Assembly:** Dotsider.Core.dll
 
-A generic instantiation (TypeSpec or MethodSpec) that cannot be navigated directly.
+A MethodSpec whose metadata could not be decoded into a navigable target.
 
 ```csharp
 public sealed record IlNavigationTarget.GenericInstantiation : IlNavigationTarget, IEquatable<IlNavigationTarget>, IEquatable<IlNavigationTarget.GenericInstantiation>
@@ -29,25 +29,25 @@ public sealed record IlNavigationTarget.GenericInstantiation : IlNavigationTarge
 
 ### GenericInstantiation(int, string)
 
-A generic instantiation (TypeSpec or MethodSpec) that cannot be navigated directly.
+A MethodSpec whose metadata could not be decoded into a navigable target.
 
 **Parameters:**
 
 - `Token` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): 
-- `DisplayName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): 
+- `Reason` ([String](https://learn.microsoft.com/dotnet/api/system.string)): 
 
 ```csharp
-public GenericInstantiation(int Token, string DisplayName)
+public GenericInstantiation(int Token, string Reason)
 ```
 
 ## Properties
 
-### DisplayName
+### Reason
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 
 ```csharp
-public string DisplayName { get; init; }
+public string Reason { get; init; }
 ```
 
 ### Token

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models.md
@@ -182,7 +182,7 @@ public sealed record IlNavigationTarget.ExternalType : IlNavigationTarget, IEqua
 
 ### [IlNavigationTarget.GenericInstantiation](/api/dotsider.core.analysis.models.ilnavigationtarget.genericinstantiation/)
 
-A generic instantiation (TypeSpec or MethodSpec) that cannot be navigated directly.
+A MethodSpec whose metadata could not be decoded into a navigable target.
 
 ```csharp
 public sealed record IlNavigationTarget.GenericInstantiation : IlNavigationTarget, IEquatable<IlNavigationTarget>, IEquatable<IlNavigationTarget.GenericInstantiation>

--- a/src/Dotsider.Core/Analysis/IlNavigationResolver.cs
+++ b/src/Dotsider.Core/Analysis/IlNavigationResolver.cs
@@ -267,15 +267,18 @@ public static class IlNavigationResolver
     private static IlNavigationTarget ResolveMethodSpec(
         AssemblyAnalyzer analyzer, MetadataReader reader, MethodSpecificationHandle handle, int token)
     {
+        int methodToken;
         try
         {
             var ms = reader.GetMethodSpecification(handle);
-            var methodToken = MetadataTokens.GetToken(ms.Method);
-            var underlying = Resolve(analyzer, methodToken);
-            if (underlying is IlNavigationTarget.LocalMethod) return underlying;
-            return new IlNavigationTarget.GenericInstantiation(token, analyzer.ResolveToken(token));
+            methodToken = MetadataTokens.GetToken(ms.Method);
         }
-        catch { return new IlNavigationTarget.GenericInstantiation(token, analyzer.ResolveToken(token)); }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return new IlNavigationTarget.GenericInstantiation(token, ex.Message);
+        }
+
+        return Resolve(analyzer, methodToken);
     }
 
     private static string GetAssemblyNameFromTypeRef(MetadataReader reader, TypeReferenceHandle handle)

--- a/src/Dotsider.Core/Analysis/Models/IlNavigationTarget.cs
+++ b/src/Dotsider.Core/Analysis/Models/IlNavigationTarget.cs
@@ -25,8 +25,8 @@ public abstract record IlNavigationTarget
     public sealed record ExternalField(
         string FieldName, string DeclaringType, string AssemblyName) : IlNavigationTarget;
 
-    /// <summary>A generic instantiation (TypeSpec or MethodSpec) that cannot be navigated directly.</summary>
-    public sealed record GenericInstantiation(int Token, string DisplayName) : IlNavigationTarget;
+    /// <summary>A MethodSpec whose metadata could not be decoded into a navigable target.</summary>
+    public sealed record GenericInstantiation(int Token, string Reason) : IlNavigationTarget;
 
     /// <summary>A token kind that is recognized but not supported for navigation.</summary>
     public sealed record Unsupported(int Token, string Reason) : IlNavigationTarget;

--- a/src/Dotsider.DocGenerator/Dotsider.DocGenerator.csproj
+++ b/src/Dotsider.DocGenerator/Dotsider.DocGenerator.csproj
@@ -17,6 +17,8 @@
     <!-- Must match the Roslyn version Docfx.App was built against -->
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <!-- Temporary direct reference to resolve vulnerability in System.Security.Cryptography.Xml < 9.0.15 -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.15" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -713,8 +713,8 @@ public sealed class DotsiderState : IDisposable
             case IlNavigationTarget.ExternalField(var fieldName, var extFieldDeclType, var assemblyName):
                 return NavigateToExternalField(assemblyName, fieldName, extFieldDeclType);
 
-            case IlNavigationTarget.GenericInstantiation:
-                ShowTransientNotice("Generic instantiation — navigation not yet supported");
+            case IlNavigationTarget.GenericInstantiation(_, var reason):
+                ShowTransientNotice($"Cannot decode generic instantiation: {reason}");
                 return false;
 
             case IlNavigationTarget.Unsupported(_, var reason):

--- a/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
+++ b/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
@@ -680,5 +682,98 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         state.RestoreFromIlBackEntry(entry);
         Assert.Equal("GetStringEmpty", state.IlSelectedMethod?.Name);
         Assert.Null(state.IlSelectedField);
+    }
+
+    /// <summary>
+    /// Resolves a MethodSpec token (call to Enumerable.Where&lt;User&gt; from
+    /// UserService.FindByRole) and expects the underlying ExternalMethod target —
+    /// not a GenericInstantiation fallback.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Resolve_MethodSpec_ReturnsUnderlyingExternalMethod()
+    {
+        using var analyzer = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var dis = new IlDisassembler(analyzer);
+        var method = analyzer.MethodDefs.First(m =>
+            m.Name == "FindByRole" && m.DeclaringType.Contains("UserService"));
+        var callInst = dis.Disassemble(method).First(i =>
+            i.OpCode == "call" && i.MetadataToken is not null
+            && MetadataTokens.EntityHandle(i.MetadataToken.Value).Kind
+                == HandleKind.MethodSpecification);
+
+        var target = IlNavigationResolver.Resolve(analyzer, callInst.MetadataToken!.Value);
+
+        var ext = Assert.IsType<IlNavigationTarget.ExternalMethod>(target);
+        Assert.Equal("Where", ext.MemberName);
+        Assert.Equal("System.Linq.Enumerable", ext.DeclaringType);
+        // Signature should encode the method generic parameter as !!0, proving
+        // we resolved the open-generic definition rather than coincidental match.
+        Assert.Contains("!!0", ext.Signature);
+    }
+
+    /// <summary>
+    /// Navigates from a MethodSpec call site to the open-generic definition in System.Linq.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NavigateToIlDefinition_MethodSpec_LandsOnOpenGenericDefinition()
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+        state.CurrentTab = TabId.IlInspector;
+
+        var method = state.Analyzer.MethodDefs.First(m =>
+            m.Name == "FindByRole" && m.DeclaringType.Contains("UserService"));
+        state.IlSelectedMethod = method;
+        var result = state.IlDisassembler!.DisassembleWithText(method);
+        Assert.NotNull(result);
+        state.IlEditorState = new EditorState(
+            new Hex1b.Documents.Hex1bDocument(result.Value.Text)) { IsReadOnly = true };
+        state.IlEditorMethod = method;
+        state.IlEditorAnalyzer = state.Analyzer;
+
+        var callInst = result.Value.Instructions.First(i =>
+            i.OpCode == "call" && i.MetadataToken is not null
+            && MetadataTokens.EntityHandle(i.MetadataToken.Value).Kind
+                == HandleKind.MethodSpecification);
+
+        var navigated = state.NavigateToIlDefinition(callInst.MetadataToken!.Value);
+
+        Assert.True(navigated, "MethodSpec navigation must succeed for Enumerable.Where");
+        Assert.True(state.NavigationStack.Count > 0, "Should have pushed System.Linq");
+        Assert.NotNull(state.IlSelectedMethod);
+        Assert.Equal("Where", state.IlSelectedMethod.Name);
+        Assert.Equal("System.Linq.Enumerable", state.IlSelectedMethod.DeclaringType);
+        Assert.Contains("!!0", state.IlSelectedMethod.Signature);
+        Assert.Equal(TabId.IlInspector, state.CurrentTab);
+    }
+
+    /// <summary>
+    /// A malformed MethodSpec token must surface as GenericInstantiation with a
+    /// non-empty Reason, and the DotsiderState arm must report it via TransientNotice.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Resolve_InvalidMethodSpecToken_ReturnsGenericInstantiationWithReason()
+    {
+        using var analyzer = new AssemblyAnalyzer(samples.RichLibraryDll);
+        // HandleKind.MethodSpecification = 0x2B. Row 0xFFFFFF is well past any real row,
+        // so reader.GetMethodSpecification will throw BadImageFormatException.
+        var invalidToken = unchecked((int)0x2BFFFFFF);
+
+        var target = IlNavigationResolver.Resolve(analyzer, invalidToken);
+
+        var gi = Assert.IsType<IlNavigationTarget.GenericInstantiation>(target);
+        Assert.Equal(invalidToken, gi.Token);
+        Assert.False(string.IsNullOrEmpty(gi.Reason));
+
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+        var navigated = state.NavigateToIlDefinition(invalidToken);
+        Assert.False(navigated);
+        Assert.NotNull(state.TransientNotice);
+        Assert.Contains("generic instantiation", state.TransientNotice, StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
Calling go-to-definition on a MethodSpec token (Enumerable.Where, ToList, and friends) used to bail out with "Generic instantiation — navigation not yet supported." The cause was in ResolveMethodSpec: it short-circuited only on LocalMethod and collapsed every other underlying outcome — ExternalMethod, Unsupported, Unresolved — into a single GenericInstantiation target that DotsiderState had no information to act on.

ResolveMethodSpec now forwards whatever the recursive Resolve returns. GenericInstantiation is reserved for the narrow case where the MethodSpec row itself can't be decoded, and it carries the underlying exception message as Reason so users see the real reason rather than a misleading hex token. Signature matching in NavigateToExternalMethod is untouched — MethodDef and MemberRef signatures both round-trip through SignatureTypeProvider with generic parameters normalized to !!0, so exact matching already works.

Coverage: a resolver test pinning UserService.FindByRole's MethodSpec to Enumerable.Where, an end-to-end navigation test that asserts the open-generic definition is reached (no skip-on-failure guard), and a fallback test using a fabricated invalid MethodSpec token to exercise the GenericInstantiation path.

Fixes: #139