### PR TITLE
AssemblyDiffer: detect IL body changes with normalized instruction comparison

### DIFF
--- a/benchmarks/Dotsider.Benchmarks/AssemblyDifferBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/AssemblyDifferBenchmarks.cs
@@ -13,27 +13,43 @@ namespace Dotsider.Benchmarks;
 public class AssemblyDifferBenchmarks
 {
     private AssemblyAnalyzer _coreLibAnalyzer = null!;
+    private AssemblyAnalyzer _coreLibAnalyzer2 = null!;
     private AssemblyAnalyzer _xmlAnalyzer = null!;
+    private AssemblyAnalyzer _richV1Analyzer = null!;
+    private AssemblyAnalyzer _richV2Analyzer = null!;
 
     /// <summary>
-    /// Opens CoreLib and Xml analyzers so comparisons have two fully-initialized assemblies on hand.
+    /// Opens all analyzers for benchmarking. Creates two distinct CoreLib instances
+    /// to measure real body comparison cost with separate PEReader instances.
     /// </summary>
     [GlobalSetup]
     public void Setup()
     {
         var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
-        _coreLibAnalyzer = new AssemblyAnalyzer(Path.Combine(runtimeDir, "System.Private.CoreLib.dll"));
+        var coreLibPath = Path.Combine(runtimeDir, "System.Private.CoreLib.dll");
+        _coreLibAnalyzer = new AssemblyAnalyzer(coreLibPath);
+        _coreLibAnalyzer2 = new AssemblyAnalyzer(coreLibPath);
         _xmlAnalyzer = new AssemblyAnalyzer(Path.Combine(runtimeDir, "System.Private.Xml.dll"));
+
+        BenchmarkHelpers.BuildSample("samples/RichLibrary");
+        BenchmarkHelpers.BuildSample("samples/RichLibraryV2");
+        _richV1Analyzer = new AssemblyAnalyzer(
+            BenchmarkHelpers.GetBuildPath("samples/RichLibrary", "RichLibrary.dll"));
+        _richV2Analyzer = new AssemblyAnalyzer(
+            BenchmarkHelpers.GetBuildPath("samples/RichLibraryV2", "RichLibrary.dll"));
     }
 
     /// <summary>
-    /// Disposes the shared analyzers.
+    /// Disposes all shared analyzers.
     /// </summary>
     [GlobalCleanup]
     public void Cleanup()
     {
         _coreLibAnalyzer.Dispose();
+        _coreLibAnalyzer2.Dispose();
         _xmlAnalyzer.Dispose();
+        _richV1Analyzer.Dispose();
+        _richV2Analyzer.Dispose();
     }
 
     /// <summary>
@@ -44,9 +60,27 @@ public class AssemblyDifferBenchmarks
         => AssemblyDiffer.Compare(_coreLibAnalyzer, _xmlAnalyzer);
 
     /// <summary>
-    /// Compares an assembly against itself to characterize the identity-diff fast path.
+    /// Compares an assembly against itself to characterize the identity-diff fast path
+    /// where both sides share the same analyzer instance.
     /// </summary>
     [Benchmark(Description = "CoreLib vs CoreLib (identity)")]
     public AssemblyDiffResult Compare_Identity()
         => AssemblyDiffer.Compare(_coreLibAnalyzer, _coreLibAnalyzer);
+
+    /// <summary>
+    /// Compares two distinct analyzer instances for the same CoreLib file.
+    /// Measures the real cost of body comparison with separate PEReader instances
+    /// and normalized token resolution.
+    /// </summary>
+    [Benchmark(Description = "CoreLib vs CoreLib (distinct)")]
+    public AssemblyDiffResult Compare_DistinctAnalyzers()
+        => AssemblyDiffer.Compare(_coreLibAnalyzer, _coreLibAnalyzer2);
+
+    /// <summary>
+    /// Compares RichLibrary v1 vs v2 — a realistic diff with body changes,
+    /// token churn, exception region differences, and local signature changes.
+    /// </summary>
+    [Benchmark(Description = "RichLibrary v1 vs v2 (body diff)")]
+    public AssemblyDiffResult Compare_RichLibraryVersions()
+        => AssemblyDiffer.Compare(_richV1Analyzer, _richV2Analyzer);
 }

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -34,7 +34,7 @@ dotnet run --project benchmarks/Dotsider.Benchmarks -c Release -- --list flat
 |---|---|
 | `ApphostDetectorBenchmarks` | Apphost companion-DLL detection (real apphost, dotted-name, fake exe, early exit) and bundled-entry extraction |
 | `AssemblyAnalyzerBenchmarks` | Constructor (file and byte[]), lazy metadata properties (TypeDefs, MethodDefs, AssemblyRefs, TypeRefs, MemberRefs, FieldDefs, CustomAttributes, Resources, Sections), token resolution, and 6-step assembly resolution chain |
-| `AssemblyDifferBenchmarks` | Dictionary-based O(n) diff of two assemblies by type, method, and reference |
+| `AssemblyDifferBenchmarks` | Dictionary-based O(n) diff of two assemblies by type, method, and reference with normalized IL body comparison |
 | `DependencyGraphBuilderBenchmarks` | Positioned dependency graph construction from assembly refs and type ref counts |
 | `DotNetRuntimeLocatorColdBenchmarks` | Cold-path .NET runtime discovery: base path + shared framework resolution with cache cleared |
 | `DotNetRuntimeLocatorWarmBenchmarks` | Warm-cache ConcurrentDictionary hit for shared framework lookup |
@@ -105,8 +105,12 @@ Benchmarks that require real .NET executables (apphost, single-file bundle, runt
 
 | Benchmark | Mean | Allocated |
 |---|---|---|
-| CoreLib vs Xml (max diff) | 38.57 ms | 8.81 MB |
-| CoreLib vs CoreLib (identity) | 32.78 ms | 8.58 MB |
+| CoreLib vs Xml (max diff) | 40.25 ms | 9.03 MB |
+| CoreLib vs CoreLib (identity) | 151.03 ms | 293.56 MB |
+| CoreLib vs CoreLib (distinct) | 155.46 ms | 293.56 MB |
+| RichLibrary v1 vs v2 (body diff) | 149.9 μs | 358 KB |
+
+Identity and distinct benchmarks are worst-case: every method matches, forcing normalized token resolution across 12K+ bodies. Cross-assembly is flat because few methods share keys. RichLibrary is a realistic version diff.
 
 #### DependencyGraphBuilder
 

--- a/docs/src/content/docs/usage/diff-mode.md
+++ b/docs/src/content/docs/usage/diff-mode.md
@@ -26,6 +26,20 @@ Press `f` to cycle through diff filters:
 
 This is useful for reviewing breaking changes between library versions, auditing what changed in a new build, or understanding the impact of a refactoring.
 
+## What gets compared
+
+Types are matched by fully qualified name. Methods are matched by declaring type, name, and signature. Assembly references are matched by name.
+
+For matched methods, the diff detects changes across several layers:
+
+- **Attributes** — visibility, vtable layout, sealed/abstract flags
+- **Implementation attributes** — IL vs native, managed vs unmanaged
+- **Local variable signatures** — local types decoded and compared element-by-element
+- **Exception regions** — try/catch structure, handler offsets, catch types resolved by name
+- **IL instructions** — a normalized walk that resolves metadata token operands (method calls, field accesses, type references, string literals, standalone signatures) to their semantic names before comparing, so metadata table reordering between builds does not produce false positives
+
+The Change column on the Methods tab shows which layers differ: `attributes`, `impl`, `body`, or a combination.
+
 ## Copy
 
 The Summary tab has selectable info panels and change statistics. Press `Tab` to cycle focus between them, select text, and press `y` to copy. `iw` and `yiw` work in these panels for quick word-level copying. `V` selects the entire line and `yy` copies it.

--- a/samples/RichLibrary/RichLibrary.csproj
+++ b/samples/RichLibrary/RichLibrary.csproj
@@ -14,6 +14,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />

--- a/samples/RichLibrary/Services/FunctionPointerHelpers.cs
+++ b/samples/RichLibrary/Services/FunctionPointerHelpers.cs
@@ -1,0 +1,20 @@
+namespace RichLibrary.Services;
+
+/// <summary>
+/// Helpers that exercise function-pointer IL patterns for diff testing.
+/// </summary>
+public static class FunctionPointerHelpers
+{
+    /// <summary>Invokes a function pointer with managed calling convention.</summary>
+    public static unsafe int InvokeCallback(nint fp, int x)
+    {
+        return ((delegate* managed<int, int>)fp)(x);
+    }
+
+    /// <summary>Checks whether a managed function pointer is non-null.</summary>
+    public static unsafe bool HasCallback(nint fp)
+    {
+        delegate* managed<int, int> callback = (delegate* managed<int, int>)fp;
+        return callback != null;
+    }
+}

--- a/samples/RichLibrary/Services/UserService.cs
+++ b/samples/RichLibrary/Services/UserService.cs
@@ -39,4 +39,18 @@ public sealed class UserService : IRepository<User>
     public User? FindByEmail(string email) =>
         _users.Values.FirstOrDefault(u =>
             string.Equals(u.Email, email, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>Tries to find a user by ID, returning null on error.</summary>
+    public User? TryFindById(int id)
+    {
+        try { return GetById(id); }
+        catch (Exception) { return null; }
+    }
+
+    /// <summary>Returns a summary of the user store.</summary>
+    public string SummarizeUsers()
+    {
+        int count = _users.Count;
+        return $"Total users: {count}";
+    }
 }

--- a/samples/RichLibraryV2/RichLibraryV2.csproj
+++ b/samples/RichLibraryV2/RichLibraryV2.csproj
@@ -13,6 +13,7 @@
     <Company>Dotsider</Company>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/samples/RichLibraryV2/Services/FunctionPointerHelpers.cs
+++ b/samples/RichLibraryV2/Services/FunctionPointerHelpers.cs
@@ -1,0 +1,20 @@
+namespace RichLibrary.Services;
+
+/// <summary>
+/// Helpers that exercise function-pointer IL patterns for diff testing.
+/// </summary>
+public static class FunctionPointerHelpers
+{
+    /// <summary>Invokes a function pointer with unmanaged Cdecl calling convention.</summary>
+    public static unsafe int InvokeCallback(nint fp, int x)
+    {
+        return ((delegate* unmanaged[Cdecl]<int, int>)fp)(x);
+    }
+
+    /// <summary>Checks whether an unmanaged Cdecl function pointer is non-null.</summary>
+    public static unsafe bool HasCallback(nint fp)
+    {
+        delegate* unmanaged[Cdecl]<int, int> callback = (delegate* unmanaged[Cdecl]<int, int>)fp;
+        return callback != null;
+    }
+}

--- a/samples/RichLibraryV2/Services/UserService.cs
+++ b/samples/RichLibraryV2/Services/UserService.cs
@@ -44,4 +44,19 @@ public sealed class UserService
     /// <summary>Finds all users that have the specified tag.</summary>
     public IEnumerable<User> FindByTag(string tag) =>
         _users.Values.Where(u => u.Tags.Contains(tag));
+
+    /// <summary>Tries to find a user by ID, returning null on error.</summary>
+    public User? TryFindById(int id)
+    {
+        try { return GetById(id); }
+        catch (InvalidOperationException) { return null; }
+    }
+
+    /// <summary>Returns a summary of the user store.</summary>
+    public string SummarizeUsers()
+    {
+        int count = _users.Count;
+        int active = _users.Values.Count(u => u.Role != UserRole.Viewer);
+        return $"Total users: {count}, Active: {active}";
+    }
 }

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -362,9 +362,146 @@ public sealed class AssemblyAnalyzer : IDisposable
                 _ => $"0x{token:X8}"
             };
         }
-        catch (ArgumentException)
+        catch (Exception ex) when (ex is ArgumentException or BadImageFormatException)
         {
             return $"0x{token:X8}";
+        }
+    }
+
+    /// <summary>
+    /// Resolves a metadata token to a comparison-safe name that includes method/member
+    /// signatures, handles MethodSpec/TypeSpec, decodes StandaloneSig blobs, and returns
+    /// full untruncated user strings. Unlike <see cref="ResolveToken"/>, this produces
+    /// names suitable for semantic cross-assembly comparison.
+    /// </summary>
+    /// <param name="token">The metadata token to resolve.</param>
+    /// <returns>A comparison-safe string for the token.</returns>
+    internal string ResolveTokenForComparison(int token)
+    {
+        if (_metadataReader is null) return $"0x{token:X8}";
+
+        try
+        {
+            var handle = MetadataTokens.EntityHandle(token);
+            return handle.Kind switch
+            {
+                HandleKind.TypeReference => GetTypeRefName((TypeReferenceHandle)handle),
+                HandleKind.TypeDefinition => GetTypeDefName((TypeDefinitionHandle)handle),
+                HandleKind.TypeSpecification => DecodeTypeSpec((TypeSpecificationHandle)handle),
+                HandleKind.MethodDefinition => ResolveMethodDefForComparison((MethodDefinitionHandle)handle),
+                HandleKind.MemberReference => ResolveMemberRefForComparison((MemberReferenceHandle)handle),
+                HandleKind.MethodSpecification => ResolveMethodSpecForComparison((MethodSpecificationHandle)handle),
+                HandleKind.FieldDefinition => GetFieldDefName((FieldDefinitionHandle)handle),
+                HandleKind.StandaloneSignature => ResolveStandaloneSigForComparison((StandaloneSignatureHandle)handle),
+                HandleKind.UserString => GetFullUserString(MetadataTokens.UserStringHandle(token & 0x00FFFFFF)),
+                _ => $"0x{token:X8}"
+            };
+        }
+        catch (Exception ex) when (ex is ArgumentException or BadImageFormatException)
+        {
+            return $"0x{token:X8}";
+        }
+    }
+
+    private string ResolveMethodDefForComparison(MethodDefinitionHandle handle)
+    {
+        var md = _metadataReader!.GetMethodDefinition(handle);
+        var typeName = GetTypeDefName(md.GetDeclaringType());
+        var name = _metadataReader.GetString(md.Name);
+        var sig = DecodeMethodSignature(md);
+        return $"{typeName}::{name} {sig}";
+    }
+
+    private string ResolveMemberRefForComparison(MemberReferenceHandle handle)
+    {
+        var mr = _metadataReader!.GetMemberReference(handle);
+        var name = _metadataReader.GetString(mr.Name);
+        var parent = mr.Parent.Kind switch
+        {
+            HandleKind.TypeReference => GetTypeRefName((TypeReferenceHandle)mr.Parent),
+            HandleKind.TypeDefinition => GetTypeDefName((TypeDefinitionHandle)mr.Parent),
+            HandleKind.TypeSpecification => DecodeTypeSpec((TypeSpecificationHandle)mr.Parent),
+            _ => "?"
+        };
+
+        try
+        {
+            var sig = mr.DecodeMethodSignature(new SignatureTypeProvider(), genericContext: default);
+            var paramTypes = string.Join(", ", sig.ParameterTypes);
+            return $"{parent}::{name} {sig.ReturnType}({paramTypes})";
+        }
+        catch
+        {
+            // Field reference — no method signature to decode
+            return $"{parent}::{name}";
+        }
+    }
+
+    private string ResolveMethodSpecForComparison(MethodSpecificationHandle handle)
+    {
+        var ms = _metadataReader!.GetMethodSpecification(handle);
+        var baseMethod = ResolveTokenForComparison(MetadataTokens.GetToken(ms.Method));
+        try
+        {
+            var typeArgs = ms.DecodeSignature(new SignatureTypeProvider(), genericContext: default);
+            return $"{baseMethod}<{string.Join(", ", typeArgs)}>";
+        }
+        catch
+        {
+            return baseMethod;
+        }
+    }
+
+    private string ResolveStandaloneSigForComparison(StandaloneSignatureHandle handle)
+    {
+        var sig = _metadataReader!.GetStandaloneSignature(handle);
+        try
+        {
+            var methodSig = sig.DecodeMethodSignature(new SignatureTypeProvider(), genericContext: default);
+            var paramTypes = string.Join(", ", methodSig.ParameterTypes);
+            var conv = FormatCallingConvention(methodSig.Header);
+            return $"method({conv}) {methodSig.ReturnType}({paramTypes})";
+        }
+        catch
+        {
+            try
+            {
+                var localTypes = sig.DecodeLocalSignature(new SignatureTypeProvider(), genericContext: default);
+                return $"locals({string.Join(", ", localTypes)})";
+            }
+            catch
+            {
+                return $"StandaloneSig(0x{MetadataTokens.GetToken(handle):X8})";
+            }
+        }
+    }
+
+    private static string FormatCallingConvention(SignatureHeader header)
+    {
+        var conv = header.CallingConvention switch
+        {
+            SignatureCallingConvention.Default => "default",
+            SignatureCallingConvention.CDecl => "cdecl",
+            SignatureCallingConvention.StdCall => "stdcall",
+            SignatureCallingConvention.ThisCall => "thiscall",
+            SignatureCallingConvention.FastCall => "fastcall",
+            SignatureCallingConvention.Unmanaged => "unmanaged",
+            _ => $"0x{(byte)header.CallingConvention:X2}"
+        };
+        if (header.IsInstance) conv = "instance " + conv;
+        if (header.HasExplicitThis) conv = "explicit " + conv;
+        return conv;
+    }
+
+    private string GetFullUserString(UserStringHandle handle)
+    {
+        try
+        {
+            return $"\"{_metadataReader!.GetUserString(handle)}\"";
+        }
+        catch
+        {
+            return $"0x{MetadataTokens.GetToken(handle):X8}";
         }
     }
 
@@ -985,12 +1122,25 @@ public sealed class AssemblyAnalyzer : IDisposable
         }
 
         /// <inheritdoc/>
-        public string GetFunctionPointerType(MethodSignature<string> signature) =>
-            "delegate*";
+        public string GetFunctionPointerType(MethodSignature<string> signature)
+        {
+            var conv = signature.Header.CallingConvention switch
+            {
+                SignatureCallingConvention.Default => "managed",
+                SignatureCallingConvention.CDecl => "unmanaged[Cdecl]",
+                SignatureCallingConvention.StdCall => "unmanaged[Stdcall]",
+                SignatureCallingConvention.ThisCall => "unmanaged[Thiscall]",
+                SignatureCallingConvention.FastCall => "unmanaged[Fastcall]",
+                SignatureCallingConvention.Unmanaged => "unmanaged",
+                _ => "managed"
+            };
+            var paramTypes = string.Join(", ", signature.ParameterTypes);
+            return $"delegate* {conv} {signature.ReturnType}({paramTypes})";
+        }
 
         /// <inheritdoc/>
         public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) =>
-            unmodifiedType;
+            isRequired ? $"modreq({modifier}) {unmodifiedType}" : $"modopt({modifier}) {unmodifiedType}";
     }
 
     /// <summary>

--- a/src/Dotsider.Core/Analysis/AssemblyDiffer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyDiffer.cs
@@ -1,3 +1,6 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
@@ -17,7 +20,7 @@ public static class AssemblyDiffer
     public static AssemblyDiffResult Compare(AssemblyAnalyzer left, AssemblyAnalyzer right)
     {
         var typeDiffs = CompareTypes(left.TypeDefs, right.TypeDefs);
-        var methodDiffs = CompareMethods(left.MethodDefs, right.MethodDefs);
+        var methodDiffs = CompareMethods(left.MethodDefs, right.MethodDefs, left, right);
         var refDiffs = CompareRefs(left.AssemblyRefs, right.AssemblyRefs);
 
         var summary = new DiffSummary(
@@ -80,7 +83,8 @@ public static class AssemblyDiffer
     }
 
     private static IReadOnlyList<DiffEntry<MethodDefInfo>> CompareMethods(
-        IReadOnlyList<MethodDefInfo> left, IReadOnlyList<MethodDefInfo> right)
+        IReadOnlyList<MethodDefInfo> left, IReadOnlyList<MethodDefInfo> right,
+        AssemblyAnalyzer leftAnalyzer, AssemblyAnalyzer rightAnalyzer)
     {
         // Tuple key avoids 60K+ string allocations from interpolation on large assemblies
         var leftByKey = new Dictionary<(string DeclaringType, string Name, string Signature), MethodDefInfo>(left.Count);
@@ -97,18 +101,23 @@ public static class AssemblyDiffer
         {
             if (rightByKey.TryGetValue(key, out var rm))
             {
-                string? detail = null;
-                if (lm.Attributes != rm.Attributes || lm.ImplAttributes != rm.ImplAttributes)
-                {
-                    var changes = new List<string>(2);
-                    if (lm.Attributes != rm.Attributes) changes.Add("attributes changed");
-                    if (lm.ImplAttributes != rm.ImplAttributes) changes.Add("impl changed");
-                    detail = string.Join(", ", changes);
-                }
+                bool attrsChanged = lm.Attributes != rm.Attributes;
+                bool implChanged = lm.ImplAttributes != rm.ImplAttributes;
+                bool bodyChanged = BodiesDiffer(lm, rm, leftAnalyzer, rightAnalyzer);
 
-                result.Add(detail is not null
-                    ? new DiffEntry<MethodDefInfo>(DiffKind.Changed, lm, rm, detail)
-                    : new DiffEntry<MethodDefInfo>(DiffKind.Unchanged, lm, rm, null));
+                if (attrsChanged || implChanged || bodyChanged)
+                {
+                    var changes = new List<string>(3);
+                    if (attrsChanged) changes.Add("attributes");
+                    if (implChanged) changes.Add("impl");
+                    if (bodyChanged) changes.Add("body");
+                    result.Add(new DiffEntry<MethodDefInfo>(
+                        DiffKind.Changed, lm, rm, string.Join(", ", changes)));
+                }
+                else
+                {
+                    result.Add(new DiffEntry<MethodDefInfo>(DiffKind.Unchanged, lm, rm, null));
+                }
             }
             else
             {
@@ -164,5 +173,258 @@ public static class AssemblyDiffer
         }
 
         return [.. result.OrderBy(d => d.Kind).ThenBy(d => (d.Left ?? d.Right)!.Name)];
+    }
+
+    private static bool BodiesDiffer(
+        MethodDefInfo leftMethod, MethodDefInfo rightMethod,
+        AssemblyAnalyzer leftAnalyzer, AssemblyAnalyzer rightAnalyzer)
+    {
+        // Tier 0: Both abstract/extern — no bodies to compare
+        if (leftMethod.Rva == 0 && rightMethod.Rva == 0)
+            return false;
+        if (leftMethod.Rva == 0 || rightMethod.Rva == 0)
+            return true;
+
+        // Tier 1: Retrieve method bodies
+        MethodBodyBlock? leftBody, rightBody;
+        try { leftBody = leftAnalyzer.GetMethodBody(leftMethod); }
+        catch (BadImageFormatException) { leftBody = null; }
+        try { rightBody = rightAnalyzer.GetMethodBody(rightMethod); }
+        catch (BadImageFormatException) { rightBody = null; }
+
+        if (leftBody is null && rightBody is null) return false;
+        if (leftBody is null || rightBody is null) return true;
+
+        // Tier 2: Structural checks
+        if (leftBody.MaxStack != rightBody.MaxStack) return true;
+        if (leftBody.LocalVariablesInitialized != rightBody.LocalVariablesInitialized) return true;
+
+        // Tier 3: Local variable signature comparison
+        if (LocalSignaturesDiffer(
+            leftAnalyzer.GetMetadataReader(), leftBody,
+            rightAnalyzer.GetMetadataReader(), rightBody))
+            return true;
+
+        // Tier 4: Exception region comparison
+        var leftRegions = leftBody.ExceptionRegions;
+        var rightRegions = rightBody.ExceptionRegions;
+        if (leftRegions.Length != rightRegions.Length) return true;
+
+        for (int i = 0; i < leftRegions.Length; i++)
+        {
+            var lr = leftRegions[i];
+            var rr = rightRegions[i];
+            if (lr.Kind != rr.Kind
+                || lr.TryOffset != rr.TryOffset
+                || lr.TryLength != rr.TryLength
+                || lr.HandlerOffset != rr.HandlerOffset
+                || lr.HandlerLength != rr.HandlerLength
+                || lr.FilterOffset != rr.FilterOffset)
+                return true;
+
+            if (!lr.CatchType.IsNil || !rr.CatchType.IsNil)
+            {
+                if (lr.CatchType.IsNil != rr.CatchType.IsNil) return true;
+                var leftCatch = leftAnalyzer.ResolveTokenForComparison(MetadataTokens.GetToken(lr.CatchType));
+                var rightCatch = rightAnalyzer.ResolveTokenForComparison(MetadataTokens.GetToken(rr.CatchType));
+                if (leftCatch != rightCatch) return true;
+            }
+        }
+
+        // Tier 5: Normalized IL instruction walk
+        var leftIl = leftBody.GetILBytes();
+        var rightIl = rightBody.GetILBytes();
+        if (leftIl is null && rightIl is null) return false;
+        if (leftIl is null || rightIl is null) return true;
+
+        return NormalizedIlDiffers(leftIl, rightIl, leftAnalyzer, rightAnalyzer);
+    }
+
+    /// <summary>
+    /// Compares local variable signatures by decoding both sides to type name arrays.
+    /// </summary>
+    /// <param name="leftReader">The metadata reader for the left assembly.</param>
+    /// <param name="leftBody">The left method body.</param>
+    /// <param name="rightReader">The metadata reader for the right assembly.</param>
+    /// <param name="rightBody">The right method body.</param>
+    /// <returns><see langword="true"/> if the local variable signatures differ.</returns>
+    internal static bool LocalSignaturesDiffer(
+        MetadataReader? leftReader, MethodBodyBlock leftBody,
+        MetadataReader? rightReader, MethodBodyBlock rightBody)
+    {
+        if (leftBody.LocalSignature.IsNil && rightBody.LocalSignature.IsNil)
+            return false;
+        if (leftBody.LocalSignature.IsNil != rightBody.LocalSignature.IsNil)
+            return true;
+
+        if (leftReader is null || rightReader is null)
+            return false;
+
+        ImmutableArray<string> leftLocals, rightLocals;
+        try
+        {
+            var leftSig = leftReader.GetStandaloneSignature(leftBody.LocalSignature);
+            leftLocals = leftSig.DecodeLocalSignature(
+                new AssemblyAnalyzer.SignatureTypeProvider(), genericContext: default);
+        }
+        catch { return false; }
+
+        try
+        {
+            var rightSig = rightReader.GetStandaloneSignature(rightBody.LocalSignature);
+            rightLocals = rightSig.DecodeLocalSignature(
+                new AssemblyAnalyzer.SignatureTypeProvider(), genericContext: default);
+        }
+        catch { return false; }
+
+        if (leftLocals.Length != rightLocals.Length) return true;
+
+        for (int i = 0; i < leftLocals.Length; i++)
+        {
+            if (leftLocals[i] != rightLocals[i]) return true;
+        }
+
+        return false;
+    }
+
+    private static bool NormalizedIlDiffers(
+        byte[] leftIl, byte[] rightIl,
+        AssemblyAnalyzer leftAnalyzer, AssemblyAnalyzer rightAnalyzer)
+    {
+        int leftOffset = 0, rightOffset = 0;
+
+        while (leftOffset < leftIl.Length && rightOffset < rightIl.Length)
+        {
+            // Read opcodes
+            var leftOpByte = leftIl[leftOffset++];
+            var rightOpByte = rightIl[rightOffset++];
+
+            ILOpCode leftOp, rightOp;
+            if (leftOpByte == 0xFE)
+            {
+                if (leftOffset >= leftIl.Length) return true;
+                leftOp = (ILOpCode)(0xFE00 | leftIl[leftOffset++]);
+            }
+            else
+            {
+                leftOp = (ILOpCode)leftOpByte;
+            }
+
+            if (rightOpByte == 0xFE)
+            {
+                if (rightOffset >= rightIl.Length) return true;
+                rightOp = (ILOpCode)(0xFE00 | rightIl[rightOffset++]);
+            }
+            else
+            {
+                rightOp = (ILOpCode)rightOpByte;
+            }
+
+            if (leftOp != rightOp) return true;
+
+            var operandKind = IlDisassembler.GetOperandType(leftOp);
+            switch (operandKind)
+            {
+                case IlDisassembler.OperandKind.None:
+                    break;
+
+                case IlDisassembler.OperandKind.ShortBranchTarget:
+                case IlDisassembler.OperandKind.ShortInlineI:
+                case IlDisassembler.OperandKind.ShortInlineVar:
+                    if (leftIl[leftOffset] != rightIl[rightOffset]) return true;
+                    leftOffset++;
+                    rightOffset++;
+                    break;
+
+                case IlDisassembler.OperandKind.InlineVar:
+                    if (leftIl[leftOffset] != rightIl[rightOffset]
+                        || leftIl[leftOffset + 1] != rightIl[rightOffset + 1])
+                        return true;
+                    leftOffset += 2;
+                    rightOffset += 2;
+                    break;
+
+                case IlDisassembler.OperandKind.BranchTarget:
+                case IlDisassembler.OperandKind.InlineI:
+                case IlDisassembler.OperandKind.ShortInlineR:
+                    if (!leftIl.AsSpan(leftOffset, 4).SequenceEqual(rightIl.AsSpan(rightOffset, 4)))
+                        return true;
+                    leftOffset += 4;
+                    rightOffset += 4;
+                    break;
+
+                case IlDisassembler.OperandKind.InlineI8:
+                case IlDisassembler.OperandKind.InlineR:
+                    if (!leftIl.AsSpan(leftOffset, 8).SequenceEqual(rightIl.AsSpan(rightOffset, 8)))
+                        return true;
+                    leftOffset += 8;
+                    rightOffset += 8;
+                    break;
+
+                case IlDisassembler.OperandKind.InlineMethod:
+                case IlDisassembler.OperandKind.InlineField:
+                case IlDisassembler.OperandKind.InlineType:
+                case IlDisassembler.OperandKind.InlineTok:
+                {
+                    var leftToken = IlDisassembler.ReadInt32(leftIl, ref leftOffset);
+                    var rightToken = IlDisassembler.ReadInt32(rightIl, ref rightOffset);
+                    var leftResolved = leftAnalyzer.ResolveTokenForComparison(leftToken);
+                    var rightResolved = rightAnalyzer.ResolveTokenForComparison(rightToken);
+                    if (leftResolved != rightResolved) return true;
+                    break;
+                }
+
+                case IlDisassembler.OperandKind.InlineString:
+                {
+                    var leftToken = IlDisassembler.ReadInt32(leftIl, ref leftOffset);
+                    var rightToken = IlDisassembler.ReadInt32(rightIl, ref rightOffset);
+                    var leftReader = leftAnalyzer.GetMetadataReader();
+                    var rightReader = rightAnalyzer.GetMetadataReader();
+                    if (leftReader is null || rightReader is null) return leftToken != rightToken;
+                    try
+                    {
+                        var leftStr = leftReader.GetUserString(
+                            MetadataTokens.UserStringHandle(leftToken & 0x00FFFFFF));
+                        var rightStr = rightReader.GetUserString(
+                            MetadataTokens.UserStringHandle(rightToken & 0x00FFFFFF));
+                        if (leftStr != rightStr) return true;
+                    }
+                    catch
+                    {
+                        if (leftToken != rightToken) return true;
+                    }
+                    break;
+                }
+
+                case IlDisassembler.OperandKind.InlineSig:
+                {
+                    var leftToken = IlDisassembler.ReadInt32(leftIl, ref leftOffset);
+                    var rightToken = IlDisassembler.ReadInt32(rightIl, ref rightOffset);
+                    var leftResolved = leftAnalyzer.ResolveTokenForComparison(leftToken);
+                    var rightResolved = rightAnalyzer.ResolveTokenForComparison(rightToken);
+                    if (leftResolved != rightResolved) return true;
+                    break;
+                }
+
+                case IlDisassembler.OperandKind.InlineSwitch:
+                {
+                    var leftCount = IlDisassembler.ReadInt32(leftIl, ref leftOffset);
+                    var rightCount = IlDisassembler.ReadInt32(rightIl, ref rightOffset);
+                    if (leftCount != rightCount) return true;
+                    var targetBytes = leftCount * 4;
+                    if (!leftIl.AsSpan(leftOffset, targetBytes)
+                        .SequenceEqual(rightIl.AsSpan(rightOffset, targetBytes)))
+                        return true;
+                    leftOffset += targetBytes;
+                    rightOffset += targetBytes;
+                    break;
+                }
+
+                default:
+                    break;
+            }
+        }
+
+        return leftOffset != leftIl.Length || rightOffset != rightIl.Length;
     }
 }

--- a/src/Dotsider.Core/Analysis/IlDisassembler.cs
+++ b/src/Dotsider.Core/Analysis/IlDisassembler.cs
@@ -210,40 +210,40 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
     private static string FormatBranchTarget(int target) => $"IL_{target:X4}";
     private static string FormatOpCode(ILOpCode opCode) => opCode.ToString().ToLowerInvariant().Replace('_', '.');
 
-    private static sbyte ReadSByte(byte[] il, ref int offset) => (sbyte)il[offset++];
-    private static byte ReadByte(byte[] il, ref int offset) => il[offset++];
-    private static ushort ReadUInt16(byte[] il, ref int offset)
+    internal static sbyte ReadSByte(byte[] il, ref int offset) => (sbyte)il[offset++];
+    internal static byte ReadByte(byte[] il, ref int offset) => il[offset++];
+    internal static ushort ReadUInt16(byte[] il, ref int offset)
     {
         var v = BitConverter.ToUInt16(il, offset);
         offset += 2;
         return v;
     }
-    private static int ReadInt32(byte[] il, ref int offset)
+    internal static int ReadInt32(byte[] il, ref int offset)
     {
         var v = BitConverter.ToInt32(il, offset);
         offset += 4;
         return v;
     }
-    private static long ReadInt64(byte[] il, ref int offset)
+    internal static long ReadInt64(byte[] il, ref int offset)
     {
         var v = BitConverter.ToInt64(il, offset);
         offset += 8;
         return v;
     }
-    private static float ReadSingle(byte[] il, ref int offset)
+    internal static float ReadSingle(byte[] il, ref int offset)
     {
         var v = BitConverter.ToSingle(il, offset);
         offset += 4;
         return v;
     }
-    private static double ReadDouble(byte[] il, ref int offset)
+    internal static double ReadDouble(byte[] il, ref int offset)
     {
         var v = BitConverter.ToDouble(il, offset);
         offset += 8;
         return v;
     }
 
-    private enum OperandKind
+    internal enum OperandKind
     {
         None,
         ShortBranchTarget,
@@ -264,7 +264,7 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
         InlineSwitch
     }
 
-    private static OperandKind GetOperandType(ILOpCode opCode) => opCode switch
+    internal static OperandKind GetOperandType(ILOpCode opCode) => opCode switch
     {
         ILOpCode.Nop or ILOpCode.Break or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3
             or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
@@ -334,7 +334,8 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
         ILOpCode.Ldfld or ILOpCode.Ldflda or ILOpCode.Stfld or ILOpCode.Ldsfld or ILOpCode.Ldsflda or ILOpCode.Stsfld
             => OperandKind.InlineField,
         ILOpCode.Castclass or ILOpCode.Isinst or ILOpCode.Newarr or ILOpCode.Box or ILOpCode.Unbox
-            or ILOpCode.Unbox_any or ILOpCode.Ldelem or ILOpCode.Stelem or ILOpCode.Ldobj or ILOpCode.Stobj
+            or ILOpCode.Unbox_any or ILOpCode.Ldelema or ILOpCode.Ldelem or ILOpCode.Stelem
+            or ILOpCode.Ldobj or ILOpCode.Stobj
             or ILOpCode.Cpobj or ILOpCode.Initobj or ILOpCode.Constrained or ILOpCode.Sizeof
             or ILOpCode.Mkrefany or ILOpCode.Refanyval
             => OperandKind.InlineType,

--- a/src/Dotsider.Core/README.md
+++ b/src/Dotsider.Core/README.md
@@ -11,7 +11,7 @@ Core library for .NET assembly analysis. Provides analyzers, models, and the dia
 | `StringExtractor` | Extracts user strings, metadata strings, and raw binary strings from an assembly |
 | `SizeAnalyzer` | Builds a hierarchical size tree (namespace → type → method) by IL byte size |
 | `DependencyGraphBuilder` | Generates a dependency graph (nodes and edges) from assembly references |
-| `AssemblyDiffer` | Compares two assemblies and reports added, removed, and changed types, methods, and references |
+| `AssemblyDiffer` | Compares two assemblies and reports added, removed, and changed types, methods, and references. Method body comparison uses normalized IL instruction walks with semantic token resolution, deep local signature decoding, and exception region analysis |
 | `RuntimeTracer` | Launches a .NET process with EventPipe tracing for JIT, GC, exception, and counter events |
 | `NuGetPackageAnalyzer` | Reads `.nupkg` files for package metadata and DLL listing |
 | `SingleFileBundleReader` | Detects and reads .NET single-file bundles — parses the manifest and extracts individual entries |

--- a/src/Dotsider/Views/DiffMethodsView.cs
+++ b/src/Dotsider/Views/DiffMethodsView.cs
@@ -86,7 +86,7 @@ public static class DiffMethodsView
                     h.Cell("Declaring Type").Width(SizeHint.Fixed(30)),
                     h.Cell("Method").Width(SizeHint.Fixed(25)),
                     h.Cell("Signature").Width(SizeHint.Fill),
-                    h.Cell("Change").Width(SizeHint.Fixed(30))
+                    h.Cell("Change").Width(SizeHint.Fixed(35))
                 ])
                 .Row((r, entry, rowState) =>
                 {

--- a/tests/Dotsider.Tests/AssemblyDifferTests.cs
+++ b/tests/Dotsider.Tests/AssemblyDifferTests.cs
@@ -158,4 +158,209 @@ public class AssemblyDifferTests(SampleAssemblyFixture samples)
         Assert.Contains(result.TypeDiffs, d =>
             d.Kind == DiffKind.Added && d.Right!.Name == "AuditLog");
     }
+
+    /// <summary>
+    /// Verifies methods with different IL bodies are reported as changed.
+    /// Product.PrintMembers has same signature in v1/v2 but different IL because
+    /// the Product record shape changed (StockCount→Quantity, added Sku).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void V1vsV2_MethodDiffs_BodyChangesDetected()
+    {
+        using var left = new AssemblyAnalyzer(samples.RichLibraryDll);
+        using var right = new AssemblyAnalyzer(samples.RichLibraryV2Dll);
+        var result = AssemblyDiffer.Compare(left, right);
+
+        var printMembers = result.MethodDiffs.FirstOrDefault(d =>
+            (d.Left ?? d.Right)!.Name == "PrintMembers"
+            && (d.Left ?? d.Right)!.DeclaringType.Contains("Product"));
+
+        Assert.NotNull(printMembers);
+        Assert.Equal(DiffKind.Changed, printMembers.Kind);
+        Assert.Contains("body", printMembers.ChangeDescription!);
+    }
+
+    /// <summary>
+    /// Verifies source-identical methods survive token renumbering without false positives.
+    /// CountActive is source-identical in v1/v2 but Product changed shape, causing token churn.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void V1vsV2_MethodDiffs_SourceIdenticalMethodStaysUnchanged()
+    {
+        using var left = new AssemblyAnalyzer(samples.RichLibraryDll);
+        using var right = new AssemblyAnalyzer(samples.RichLibraryV2Dll);
+        var result = AssemblyDiffer.Compare(left, right);
+
+        var countActive = result.MethodDiffs.FirstOrDefault(d =>
+            (d.Left ?? d.Right)!.Name == "CountActive"
+            && (d.Left ?? d.Right)!.DeclaringType.Contains("ProductCatalog"));
+
+        Assert.NotNull(countActive);
+        Assert.Equal(DiffKind.Unchanged, countActive.Kind);
+    }
+
+    /// <summary>
+    /// Verifies exception region changes are detected.
+    /// TryFindById catches Exception (v1) vs InvalidOperationException (v2).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void V1vsV2_MethodDiffs_ExceptionRegionChangeDetected()
+    {
+        using var left = new AssemblyAnalyzer(samples.RichLibraryDll);
+        using var right = new AssemblyAnalyzer(samples.RichLibraryV2Dll);
+        var result = AssemblyDiffer.Compare(left, right);
+
+        var tryFindById = result.MethodDiffs.FirstOrDefault(d =>
+            (d.Left ?? d.Right)!.Name == "TryFindById"
+            && (d.Left ?? d.Right)!.DeclaringType.Contains("UserService"));
+
+        Assert.NotNull(tryFindById);
+        Assert.Equal(DiffKind.Changed, tryFindById.Kind);
+        Assert.Contains("body", tryFindById.ChangeDescription!);
+    }
+
+    /// <summary>
+    /// Verifies local signature changes are detected.
+    /// SummarizeUsers has 1 local (v1) vs 2+ locals (v2).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void V1vsV2_MethodDiffs_LocalSignatureChangeDetected()
+    {
+        using var left = new AssemblyAnalyzer(samples.RichLibraryDll);
+        using var right = new AssemblyAnalyzer(samples.RichLibraryV2Dll);
+        var result = AssemblyDiffer.Compare(left, right);
+
+        var summarize = result.MethodDiffs.FirstOrDefault(d =>
+            (d.Left ?? d.Right)!.Name == "SummarizeUsers"
+            && (d.Left ?? d.Right)!.DeclaringType.Contains("UserService"));
+
+        Assert.NotNull(summarize);
+        Assert.Equal(DiffKind.Changed, summarize.Kind);
+        Assert.Contains("body", summarize.ChangeDescription!);
+    }
+
+    /// <summary>
+    /// Isolated test: LocalSignaturesDiffer returns true for two methods with
+    /// different non-empty local signatures, exercising the element-by-element path.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void LocalSignaturesDiffer_DifferentLocals_ReturnsTrue()
+    {
+        using var analyzer = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var reader = analyzer.GetMetadataReader()!;
+
+        // Add has locals (int id, User user); SummarizeUsers has local (int count)
+        var addMethod = analyzer.MethodDefs.First(m =>
+            m.Name == "Add" && m.DeclaringType.Contains("UserService"));
+        var summarizeMethod = analyzer.MethodDefs.First(m =>
+            m.Name == "SummarizeUsers" && m.DeclaringType.Contains("UserService"));
+
+        var addBody = analyzer.GetMethodBody(addMethod)!;
+        var summarizeBody = analyzer.GetMethodBody(summarizeMethod)!;
+
+        Assert.True(AssemblyDiffer.LocalSignaturesDiffer(reader, addBody, reader, summarizeBody));
+    }
+
+    /// <summary>
+    /// Isolated test: LocalSignaturesDiffer returns false for the same method body.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void LocalSignaturesDiffer_SameMethod_ReturnsFalse()
+    {
+        using var analyzer = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var reader = analyzer.GetMetadataReader()!;
+
+        var addMethod = analyzer.MethodDefs.First(m =>
+            m.Name == "Add" && m.DeclaringType.Contains("UserService"));
+        var addBody = analyzer.GetMethodBody(addMethod)!;
+
+        Assert.False(AssemblyDiffer.LocalSignaturesDiffer(reader, addBody, reader, addBody));
+    }
+
+    /// <summary>
+    /// Verifies comparing an assembly against itself produces no body changes.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void SameAssembly_NoBodyChanges()
+    {
+        using var left = new AssemblyAnalyzer(samples.RichLibraryDll);
+        using var right = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var result = AssemblyDiffer.Compare(left, right);
+
+        Assert.DoesNotContain(result.MethodDiffs, d =>
+            d.ChangeDescription?.Contains("body") == true);
+    }
+
+    /// <summary>
+    /// Verifies abstract methods (Rva == 0) are not incorrectly flagged as body-changed.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void SameAssembly_AbstractMethods_NoBodyChange()
+    {
+        using var left = new AssemblyAnalyzer(samples.RichLibraryDll);
+        using var right = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var result = AssemblyDiffer.Compare(left, right);
+
+        var abstractMethods = result.MethodDiffs.Where(d =>
+            (d.Left ?? d.Right)!.Rva == 0);
+
+        Assert.All(abstractMethods, m => Assert.Equal(DiffKind.Unchanged, m.Kind));
+    }
+
+    /// <summary>
+    /// Verifies that body differences increase the MethodsChanged count in the summary.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void V1vsV2_Summary_MethodsChangedIncludesBodyChanges()
+    {
+        using var left = new AssemblyAnalyzer(samples.RichLibraryDll);
+        using var right = new AssemblyAnalyzer(samples.RichLibraryV2Dll);
+        var result = AssemblyDiffer.Compare(left, right);
+
+        var bodyChangedCount = result.MethodDiffs.Count(d =>
+            d.ChangeDescription?.Contains("body") == true);
+
+        Assert.True(bodyChangedCount > 0, "Should detect at least one body change");
+        Assert.True(result.MetadataSummary.MethodsChanged >= bodyChangedCount);
+    }
+
+    /// <summary>
+    /// Verifies that calli instructions with different calling conventions are detected.
+    /// InvokeCallback uses managed (v1) vs unmanaged[Cdecl] (v2) — different StandaloneSig tokens.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void V1vsV2_MethodDiffs_CalliCallingConventionChangeDetected()
+    {
+        using var left = new AssemblyAnalyzer(samples.RichLibraryDll);
+        using var right = new AssemblyAnalyzer(samples.RichLibraryV2Dll);
+        var result = AssemblyDiffer.Compare(left, right);
+
+        var invokeCallback = result.MethodDiffs.FirstOrDefault(d =>
+            (d.Left ?? d.Right)!.Name == "InvokeCallback"
+            && (d.Left ?? d.Right)!.DeclaringType.Contains("FunctionPointerHelpers"));
+
+        Assert.NotNull(invokeCallback);
+        Assert.Equal(DiffKind.Changed, invokeCallback.Kind);
+        Assert.Contains("body", invokeCallback.ChangeDescription!);
+    }
+
+    /// <summary>
+    /// Verifies that local variables with different function-pointer types are detected.
+    /// HasCallback has a managed function-pointer local (v1) vs unmanaged[Cdecl] (v2).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void V1vsV2_MethodDiffs_FunctionPointerLocalChangeDetected()
+    {
+        using var left = new AssemblyAnalyzer(samples.RichLibraryDll);
+        using var right = new AssemblyAnalyzer(samples.RichLibraryV2Dll);
+        var result = AssemblyDiffer.Compare(left, right);
+
+        var hasCallback = result.MethodDiffs.FirstOrDefault(d =>
+            (d.Left ?? d.Right)!.Name == "HasCallback"
+            && (d.Left ?? d.Right)!.DeclaringType.Contains("FunctionPointerHelpers"));
+
+        Assert.NotNull(hasCallback);
+        Assert.Equal(DiffKind.Changed, hasCallback.Kind);
+        Assert.Contains("body", hasCallback.ChangeDescription!);
+    }
 }

--- a/tests/Dotsider.Tests/RootCauseInvestigation.cs
+++ b/tests/Dotsider.Tests/RootCauseInvestigation.cs
@@ -1,0 +1,183 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Runtime.InteropServices;
+using Dotsider.Core.Analysis;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Regression tests for the ldelema operand table bug that caused IL walk desync.
+/// </summary>
+public class IlWalkRegressionTests
+{
+    /// <summary>
+    /// Zero-fallback invariant: walking all token-bearing operands in CoreLib must produce
+    /// zero resolver failures. Any failure indicates an operand table bug causing offset desync.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public void CoreLib_AllTokenOperands_ResolveWithoutFallback()
+    {
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        var coreLibPath = Path.Combine(runtimeDir, "System.Private.CoreLib.dll");
+        using var analyzer = new AssemblyAnalyzer(coreLibPath);
+        var reader = analyzer.GetMetadataReader()!;
+
+        var failures = new List<string>();
+        int tokensChecked = 0;
+
+        foreach (var method in analyzer.MethodDefs)
+        {
+            if (method.Rva == 0) continue;
+            MethodBodyBlock? body;
+            try { body = analyzer.GetMethodBody(method); }
+            catch (BadImageFormatException) { continue; }
+            if (body is null) continue;
+
+            var il = body.GetILBytes();
+            if (il is null) continue;
+
+            int offset = 0;
+            while (offset < il.Length)
+            {
+                int instrOffset = offset;
+                var opByte = il[offset++];
+                ILOpCode op;
+                if (opByte == 0xFE)
+                {
+                    if (offset >= il.Length) break;
+                    op = (ILOpCode)(0xFE00 | il[offset++]);
+                }
+                else op = (ILOpCode)opByte;
+
+                var kind = IlDisassembler.GetOperandType(op);
+
+                bool isTokenOp = kind is
+                    IlDisassembler.OperandKind.InlineMethod or
+                    IlDisassembler.OperandKind.InlineField or
+                    IlDisassembler.OperandKind.InlineType or
+                    IlDisassembler.OperandKind.InlineTok or
+                    IlDisassembler.OperandKind.InlineSig;
+
+                if (kind == IlDisassembler.OperandKind.InlineSwitch)
+                {
+                    if (offset + 4 > il.Length) break;
+                    var count = BitConverter.ToInt32(il, offset);
+                    offset += 4 + count * 4;
+                    continue;
+                }
+
+                if (isTokenOp)
+                {
+                    if (offset + 4 > il.Length) break;
+                    var token = BitConverter.ToInt32(il, offset);
+                    offset += 4;
+                    tokensChecked++;
+
+                    EntityHandle handle;
+                    try { handle = MetadataTokens.EntityHandle(token); }
+                    catch
+                    {
+                        failures.Add($"{method.DeclaringType}::{method.Name} @ IL_{instrOffset:X4}: " +
+                            $"invalid token 0x{token:X8} after {op}");
+                        continue;
+                    }
+
+                    int row = MetadataTokens.GetRowNumber(handle);
+                    try
+                    {
+                        // Validate the handle resolves — this is the path that was crashing
+                        switch (handle.Kind)
+                        {
+                            case HandleKind.MethodDefinition:
+                                _ = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+                                break;
+                            case HandleKind.MemberReference:
+                                _ = reader.GetMemberReference((MemberReferenceHandle)handle);
+                                break;
+                            case HandleKind.FieldDefinition:
+                                _ = reader.GetFieldDefinition((FieldDefinitionHandle)handle);
+                                break;
+                            case HandleKind.TypeDefinition:
+                                _ = reader.GetTypeDefinition((TypeDefinitionHandle)handle);
+                                break;
+                            case HandleKind.TypeReference:
+                                _ = reader.GetTypeReference((TypeReferenceHandle)handle);
+                                break;
+                            case HandleKind.MethodSpecification:
+                                _ = reader.GetMethodSpecification((MethodSpecificationHandle)handle);
+                                break;
+                            case HandleKind.TypeSpecification:
+                                _ = reader.GetTypeSpecification((TypeSpecificationHandle)handle);
+                                break;
+                            case HandleKind.StandaloneSignature:
+                                _ = reader.GetStandaloneSignature((StandaloneSignatureHandle)handle);
+                                break;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        failures.Add($"{method.DeclaringType}::{method.Name} @ IL_{instrOffset:X4}: " +
+                            $"0x{token:X8} ({handle.Kind} row {row}) after {op} — " +
+                            $"{ex.GetType().Name}: {ex.Message}");
+                    }
+                }
+                else
+                {
+                    int size = kind switch
+                    {
+                        IlDisassembler.OperandKind.None => 0,
+                        IlDisassembler.OperandKind.ShortBranchTarget or
+                        IlDisassembler.OperandKind.ShortInlineI or
+                        IlDisassembler.OperandKind.ShortInlineVar => 1,
+                        IlDisassembler.OperandKind.InlineVar => 2,
+                        IlDisassembler.OperandKind.BranchTarget or
+                        IlDisassembler.OperandKind.InlineI or
+                        IlDisassembler.OperandKind.ShortInlineR or
+                        IlDisassembler.OperandKind.InlineString => 4,
+                        IlDisassembler.OperandKind.InlineI8 or
+                        IlDisassembler.OperandKind.InlineR => 8,
+                        _ => 0
+                    };
+                    offset += size;
+                }
+            }
+        }
+
+        Assert.True(failures.Count == 0,
+            $"Found {failures.Count} resolver fallbacks in {tokensChecked} tokens " +
+            $"(first 5):\n" + string.Join("\n", failures.Take(5)));
+    }
+
+    /// <summary>
+    /// Regression test: ldelema must be decoded with InlineType (4-byte operand).
+    /// Before the fix, it mapped to None (0 bytes), causing a 4-byte offset desync.
+    /// </summary>
+    [Fact]
+    public void GetOperandType_Ldelema_ReturnsInlineType()
+    {
+        Assert.Equal(
+            IlDisassembler.OperandKind.InlineType,
+            IlDisassembler.GetOperandType(ILOpCode.Ldelema));
+    }
+
+    /// <summary>
+    /// Regression test: CoreLib distinct-analyzer diff completes without hitting
+    /// the BadImageFormatException fallback in ResolveTokenForComparison.
+    /// The original crash was a desync from the missing ldelema operand entry.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public void CoreLib_DistinctAnalyzerDiff_NoResolverFallbacks()
+    {
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        var coreLibPath = Path.Combine(runtimeDir, "System.Private.CoreLib.dll");
+        using var left = new AssemblyAnalyzer(coreLibPath);
+        using var right = new AssemblyAnalyzer(coreLibPath);
+
+        // This was the exact path that crashed before the fix
+        var result = AssemblyDiffer.Compare(left, right);
+
+        // With correct operand table, identity diff should have zero body changes
+        Assert.DoesNotContain(result.MethodDiffs, d =>
+            d.ChangeDescription?.Contains("body") == true);
+    }
+}


### PR DESCRIPTION
AssemblyDiffer.CompareMethods previously only compared Attributes and ImplAttributes for matched methods. If a method's implementation changed without touching its signature or attributes, the differ reported it as Unchanged.

The differ now compares method bodies through a tiered approach. Structural checks come first (MaxStack, locals-init flag), followed by decoded local variable signatures compared element-by-element, exception regions with catch types resolved to names, and finally a normalized IL instruction walk. The IL walk resolves every metadata token operand to its semantic name before comparing, so metadata table reordering between builds does not produce false positives.

Token resolution uses a new comparison-oriented resolver that includes method signatures (disambiguates overloads), handles MethodSpec/TypeSpec, decodes StandaloneSig blobs with calling convention headers, preserves function-pointer shapes in local signatures, and returns full untruncated user strings.

Also fixes a missing `ldelema` entry in `IlDisassembler.GetOperandType`. Since `ldelema` mapped to `OperandKind.None` (0 bytes consumed instead of 4), every occurrence caused a 4-byte offset desync that corrupted all subsequent token reads. This affected both the differ and the existing IL disassembler display. The fix is one line — adding `ILOpCode.Ldelema` to the `InlineType` case — but the impact was the single largest source of bad tokens when diffing CoreLib-scale assemblies.

The zero-fallback invariant test walks all 173K+ token operands in CoreLib and asserts that every one resolves without hitting the defensive catch. The CountActive negative regression test confirms source-identical methods survive token renumbering without false positives.

Fixes #141