### PR TITLE
Fix go-to-definition for MemberRef with generic TypeSpec parent

### DIFF
--- a/src/Dotsider.Core/Analysis/IlNavigationResolver.cs
+++ b/src/Dotsider.Core/Analysis/IlNavigationResolver.cs
@@ -252,7 +252,13 @@ public static class IlNavigationResolver
         var angleBracket = typeName.IndexOf('<');
         if (angleBracket < 0) return typeName;
         var baseName = typeName[..angleBracket];
-        // Count generic args to reconstruct the arity suffix
+        // If the base name already has a backtick+arity suffix from metadata
+        // (e.g., "Dictionary`2"), return it as-is to avoid a double suffix.
+        var lastBacktick = baseName.LastIndexOf('`');
+        if (lastBacktick >= 0 && lastBacktick < baseName.Length - 1
+            && int.TryParse(baseName[(lastBacktick + 1)..], out _))
+            return baseName;
+        // Otherwise, count generic args to reconstruct the arity suffix.
         var depth = 0;
         var count = 1;
         for (var i = angleBracket; i < typeName.Length; i++)

--- a/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
+++ b/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
@@ -750,6 +750,31 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
     }
 
     /// <summary>
+    /// Resolves a MemberRef with a TypeSpec parent (generic type instantiation).
+    /// UserService.Update calls ConcurrentDictionary&lt;int, User&gt;.set_Item —
+    /// the parent is a TypeSpec, not a TypeRef. The resolver must still identify it as
+    /// an ExternalMethod, not return Unsupported.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Resolve_MemberRefWithTypeSpecParent_ReturnsExternalMethod()
+    {
+        using var analyzer = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var dis = new IlDisassembler(analyzer);
+
+        var method = analyzer.MethodDefs.First(m =>
+            m.Name == "Update" && m.DeclaringType.Contains("UserService"));
+        var callInst = dis.Disassemble(method).First(i =>
+            i.OpCode == "callvirt" && i.MetadataToken is not null
+            && i.Operand.Contains("set_Item"));
+
+        var target = IlNavigationResolver.Resolve(analyzer, callInst.MetadataToken!.Value);
+
+        var ext = Assert.IsType<IlNavigationTarget.ExternalMethod>(target);
+        Assert.Equal("set_Item", ext.MemberName);
+        Assert.Contains("ConcurrentDictionary", ext.DeclaringType);
+    }
+
+    /// <summary>
     /// A malformed MethodSpec token must surface as GenericInstantiation with a
     /// non-empty Reason, and the DotsiderState arm must report it via TransientNotice.
     /// </summary>


### PR DESCRIPTION
StripGenericArgs in IlNavigationResolver.cs unconditionally appends a backtick+arity suffix when stripping generic arguments from a decoded type name. But metadata type names already carry the arity suffix — <code>ConcurrentDictionary&#96;2</code>, for example. The result was a double suffix like <code>ConcurrentDictionary&#96;2&#96;2</code> that matched nothing in the TypeRef table, so go-to-definition silently failed for any callvirt/call targeting a method on a generic type instantiation where the parent is a TypeSpec.

The fix checks whether the base name (everything before the first `<`) already ends with a backtick followed by digits. If so, it returns the base name as-is instead of appending a duplicate arity.

`UserService.Update` calling <code>ConcurrentDictionary&lt;int, User&gt;::set_Item</code> is the simplest reproduction case — the new test asserts that the resolver returns ExternalMethod instead of Unsupported.

Fixes #143