### PR TITLE
Follow type forwarders through partial-facade BCL assemblies

### DIFF
--- a/samples/RichLibrary/IlNavigationFixture.cs
+++ b/samples/RichLibrary/IlNavigationFixture.cs
@@ -42,4 +42,7 @@ public class IlNavigationFixture
 
     /// <summary>Accesses System.String.Empty (produces ldsfld MemberRef to external field).</summary>
     public string GetStringEmpty() { _counter++; return string.Empty; }
+
+    /// <summary>Constructs a type locally owned in the partial-facade System.Collections.dll.</summary>
+    public LinkedList<int> CreateLinkedList() { _counter++; return new LinkedList<int>(); }
 }

--- a/src/Dotsider.Core/Analysis/ImplementationAssemblyResolver.cs
+++ b/src/Dotsider.Core/Analysis/ImplementationAssemblyResolver.cs
@@ -61,6 +61,32 @@ public static class ImplementationAssemblyResolver
     {
         var directResult = AssemblyAnalyzer.ResolveAssembly(
             referencingAssemblyPath, assemblyName, targetFramework, preferredRuntimePack, sourceBundlePath);
+
+        // Partial facades (e.g. System.Collections.dll) ship real IL for some types
+        // and forward others, so a whole-assembly signal like HasUsableMetadata
+        // cannot tell "owned here" from "forwarded elsewhere". When the declaring
+        // type is known, walk forwarders to the assembly that actually owns it.
+        if (directResult is not null && declaringType is not null)
+        {
+            var (outcome, home) = ResolveDeclaringTypeHome(
+                referencingAssemblyPath, assemblyName, directResult, declaringType,
+                targetFramework, preferredRuntimePack, sourceBundlePath);
+            switch (outcome)
+            {
+                case HomeOutcome.Found:
+                    return home;
+                case HomeOutcome.ChaseBroken:
+                    // directResult *did* reference the type (as a forwarder) but the
+                    // chain broke before hitting an owning TypeDef. Falling through
+                    // to HasUsableMetadata/KnownMappings here would hand callers a
+                    // non-owning facade and recreate the original "method not found"
+                    // failure downstream. Signal the miss explicitly instead.
+                    return null;
+                case HomeOutcome.NotFound:
+                    break; // type never referenced by directResult — fall through
+            }
+        }
+
         if (directResult is not null && HasUsableMetadata(directResult))
             return directResult;
 
@@ -71,67 +97,137 @@ public static class ImplementationAssemblyResolver
             if (implResult is not null) return implResult;
         }
 
-        // mscorlib is monolithic in .NET Framework but its types are spread across
-        // many assemblies in .NET Core. The stub mscorlib.dll in the runtime directory
-        // contains type forwarders that point each type to its real implementation
-        // assembly — read those to resolve the exact assembly for the declaring type.
-        if (directResult is not null && declaringType is not null)
-        {
-            var forwarded = ResolveViaTypeForwarders(
-                referencingAssemblyPath, directResult, declaringType,
-                targetFramework, preferredRuntimePack, sourceBundlePath);
-            if (forwarded is not null) return forwarded;
-        }
-
         return directResult;
     }
 
-    private static ResolvedAssembly? ResolveViaTypeForwarders(string referencingAssemblyPath,
-        ResolvedAssembly stubAssembly, string declaringType,
-        string? targetFramework, string? preferredRuntimePack, string? sourceBundlePath)
+    private enum HomeOutcome
     {
-        try
+        /// <summary>An assembly owning <c>declaringType</c> as a TypeDef was reached.</summary>
+        Found,
+
+        /// <summary>
+        /// <c>declaringType</c> is not referenced by the starting assembly at all —
+        /// neither as a TypeDef nor as an ExportedType forwarder. Safe to fall back
+        /// to other resolution strategies.
+        /// </summary>
+        NotFound,
+
+        /// <summary>
+        /// A forwarder for <c>declaringType</c> was found somewhere in the chain but
+        /// the target could not be reached (cycle, unresolvable assembly, or chain
+        /// terminated without a TypeDef match). Falling back would return a
+        /// non-owning assembly, so callers must treat this as a hard miss.
+        /// </summary>
+        ChaseBroken,
+    }
+
+    /// <summary>
+    /// Walks type forwarders starting at <paramref name="start"/> until we reach the
+    /// assembly that owns <paramref name="declaringType"/> as a TypeDef.
+    /// </summary>
+    /// <returns>
+    /// A tuple describing the outcome. <see cref="HomeOutcome.Found"/> returns the
+    /// owning assembly; <see cref="HomeOutcome.NotFound"/> and
+    /// <see cref="HomeOutcome.ChaseBroken"/> return <c>null</c> but carry different
+    /// semantics for <see cref="ResolveCore"/>.
+    /// </returns>
+    private static (HomeOutcome Outcome, ResolvedAssembly? Assembly) ResolveDeclaringTypeHome(
+        string referencingAssemblyPath, string startAssemblyName, ResolvedAssembly start,
+        string declaringType, string? targetFramework, string? preferredRuntimePack,
+        string? sourceBundlePath)
+    {
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { startAssemblyName };
+        var current = start;
+        var chasing = false;
+
+        while (true)
         {
-            PEReader pe;
-            Stream? stream = null;
-            switch (stubAssembly)
+            bool ownsType;
+            string? nextAsmName;
+            try
             {
-                case ResolvedAssembly.FromFile(var path):
-                    stream = File.OpenRead(path);
-                    pe = new PEReader(stream);
-                    break;
-                case ResolvedAssembly.FromBundle(var bytes, _, _):
-                    stream = new MemoryStream(bytes, writable: false);
-                    pe = new PEReader(stream);
-                    break;
-                default:
-                    return null;
+                (ownsType, nextAsmName) = InspectForDeclaringType(current, declaringType);
+            }
+            catch
+            {
+                return (chasing ? HomeOutcome.ChaseBroken : HomeOutcome.NotFound, null);
             }
 
-            using (stream)
-            using (pe)
+            if (ownsType) return (HomeOutcome.Found, current);
+
+            if (nextAsmName is null)
+                return (chasing ? HomeOutcome.ChaseBroken : HomeOutcome.NotFound, null);
+
+            if (!visited.Add(nextAsmName))
+                return (HomeOutcome.ChaseBroken, null);
+
+            var next = AssemblyAnalyzer.ResolveAssembly(
+                referencingAssemblyPath, nextAsmName,
+                targetFramework, preferredRuntimePack, sourceBundlePath);
+                
+            if (next is null) return (HomeOutcome.ChaseBroken, null);
+
+            current = next;
+            chasing = true;
+        }
+    }
+
+    /// <summary>
+    /// Opens the assembly once and reports either "owns the type as a TypeDef" or
+    /// "forwards it to N" (or neither).
+    /// </summary>
+    private static (bool OwnsType, string? ForwardedTo) InspectForDeclaringType(
+        ResolvedAssembly resolved, string declaringType)
+    {
+        Stream stream = resolved switch
+        {
+            ResolvedAssembly.FromFile(var path) => File.OpenRead(path),
+            ResolvedAssembly.FromBundle(var bytes, _, _) => new MemoryStream(bytes, writable: false),
+            _ => null!
+        };
+
+        if (stream is null) return (false, null);
+
+        using (stream)
+        using (var pe = new PEReader(stream))
+        {
+            if (!pe.HasMetadata) return (false, null);
+            var reader = pe.GetMetadataReader();
+
+            foreach (var h in reader.TypeDefinitions)
             {
-                if (!pe.HasMetadata) return null;
-                var reader = pe.GetMetadataReader();
+                if (GetTypeDefFullName(reader, h) == declaringType)
+                    return (true, null);
+            }
 
-                foreach (var handle in reader.ExportedTypes)
-                {
-                    var fullName = GetExportedTypeFullName(reader, handle);
-                    if (fullName != declaringType) continue;
-
-                    var asmName = GetForwardedAssemblyName(reader, handle);
-                    if (asmName is null) continue;
-                    return AssemblyAnalyzer.ResolveAssembly(
-                        referencingAssemblyPath, asmName,
-                        targetFramework, preferredRuntimePack, sourceBundlePath);
-                }
+            foreach (var h in reader.ExportedTypes)
+            {
+                if (GetExportedTypeFullName(reader, h) != declaringType) continue;
+                var asmName = GetForwardedAssemblyName(reader, h);
+                if (asmName is not null) return (false, asmName);
             }
         }
-        catch
+
+        return (false, null);
+    }
+
+    /// <summary>
+    /// Builds the full name for a TypeDef, walking <see cref="TypeDefinition.GetDeclaringType"/>
+    /// for nested types. Uses '/' as the nesting separator to match the convention
+    /// produced by <see cref="GetExportedTypeFullName"/>.
+    /// </summary>
+    private static string GetTypeDefFullName(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        var td = reader.GetTypeDefinition(handle);
+        var name = reader.GetString(td.Name);
+        if (td.IsNested)
         {
-            // Stub might not be readable — fall through
+            var parent = GetTypeDefFullName(reader, td.GetDeclaringType());
+            return $"{parent}/{name}";
         }
-        return null;
+
+        var ns = reader.GetString(td.Namespace);
+        return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
     }
 
     /// <summary>

--- a/tests/Dotsider.Tests/AssemblyResolutionTests.cs
+++ b/tests/Dotsider.Tests/AssemblyResolutionTests.cs
@@ -1,3 +1,7 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 
@@ -80,5 +84,151 @@ public sealed class AssemblyResolutionTests(SampleAssemblyFixture samples) : IDi
             samples.RichLibraryDll, "System.Runtime",
             ".NETCoreApp,Version=v10.0", "Microsoft.NETCore.App");
         Assert.NotNull(resolved);
+    }
+
+    /// <summary>
+    /// System.Collections.dll is a partial facade: it ships real IL for some types
+    /// (LinkedList`1, BitArray, …) and forwards others to System.Private.CoreLib.
+    /// Resolving a forwarded type must follow the ExportedType to the implementation,
+    /// not stop at the facade just because it happens to carry usable metadata.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ImplementationAssemblyResolver_PartialFacade_ForwardedType_LandsInImplementationAssembly()
+    {
+        var resolved = ImplementationAssemblyResolver.Resolve(
+            samples.HelloWorldDll, "System.Collections",
+            "System.Collections.Generic.List`1",
+            ".NETCoreApp,Version=v10.0", "Microsoft.NETCore.App");
+        var fromFile = Assert.IsType<ResolvedAssembly.FromFile>(resolved);
+        Assert.Equal("System.Private.CoreLib.dll", Path.GetFileName(fromFile.Path));
+    }
+
+    /// <summary>
+    /// Guardrail for the same partial facade: a type the facade actually owns as a
+    /// TypeDef must stay in the facade, not be over-chased into CoreLib.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ImplementationAssemblyResolver_PartialFacade_LocallyOwnedType_StaysInFacade()
+    {
+        var resolved = ImplementationAssemblyResolver.Resolve(
+            samples.HelloWorldDll, "System.Collections",
+            "System.Collections.Generic.LinkedList`1",
+            ".NETCoreApp,Version=v10.0", "Microsoft.NETCore.App");
+        var fromFile = Assert.IsType<ResolvedAssembly.FromFile>(resolved);
+        Assert.Equal("System.Collections.dll", Path.GetFileName(fromFile.Path));
+    }
+
+    /// <summary>
+    /// When a forwarder names the declaring type but the chain cannot be completed
+    /// (target assembly absent, cycle, or chain ends without an owning TypeDef),
+    /// the resolver must return null rather than falling back to the facade itself.
+    /// Handing a callers a non-owning assembly recreates the "method not found"
+    /// failure downstream — the whole point of the type-aware probe is to avoid it.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ImplementationAssemblyResolver_ForwarderChaseBroken_ReturnsNullNotFacade()
+    {
+        // Build a synthetic facade that forwards "Sample.Forwarded" to an assembly
+        // that does not exist anywhere on the probe path. Place it in an isolated
+        // temp directory so AssemblyAnalyzer.ResolveAssembly finds it app-local
+        // (step 1 of probing) but cannot find "NonExistent.Target".
+        var dir = Path.Combine(Path.GetTempPath(), "dotsider-chase-broken-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var referencingPath = Path.Combine(dir, "Ref.dll");
+            var facadePath = Path.Combine(dir, "SyntheticFacade.dll");
+            // The referencing path only needs to exist on disk for Path.GetDirectoryName;
+            // its contents are never read by this code path.
+            File.WriteAllBytes(referencingPath, []);
+            File.WriteAllBytes(facadePath, BuildSyntheticFacade(
+                moduleName: "SyntheticFacade",
+                forwarderTypeFullName: "Sample.Forwarded",
+                targetAssemblyName: "NonExistent.Target"));
+
+            var result = ImplementationAssemblyResolver.Resolve(
+                referencingPath, "SyntheticFacade", "Sample.Forwarded");
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Emits a minimal PE with exactly one ExportedType forwarder pointing at the
+    /// named target assembly. Used by the chase-broken regression to construct a
+    /// forwarder whose target cannot be resolved.
+    /// </summary>
+    private static byte[] BuildSyntheticFacade(
+        string moduleName, string forwarderTypeFullName, string targetAssemblyName)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddAssembly(
+            metadata.GetOrAddString(moduleName),
+            new Version(1, 0, 0, 0),
+            default, default,
+            0, AssemblyHashAlgorithm.None);
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString(moduleName + ".dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default, default);
+        metadata.AddTypeDefinition(
+            default, default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var asmRef = metadata.AddAssemblyReference(
+            metadata.GetOrAddString(targetAssemblyName),
+            new Version(1, 0, 0, 0),
+            default, default, 0, default);
+
+        var dot = forwarderTypeFullName.LastIndexOf('.');
+        var ns = dot >= 0 ? forwarderTypeFullName[..dot] : string.Empty;
+        var name = dot >= 0 ? forwarderTypeFullName[(dot + 1)..] : forwarderTypeFullName;
+
+        metadata.AddExportedType(
+            TypeAttributes.Public | (TypeAttributes)0x00200000, // IsForwarder
+            metadata.GetOrAddString(ns),
+            metadata.GetOrAddString(name),
+            implementation: asmRef,
+            typeDefinitionId: 0);
+
+        var pe = new ManagedPEBuilder(
+            new PEHeaderBuilder(imageCharacteristics: Characteristics.Dll),
+            new MetadataRootBuilder(metadata),
+            ilStream: new BlobBuilder());
+        var blob = new BlobBuilder();
+        pe.Serialize(blob);
+        return blob.ToArray();
+    }
+
+    /// <summary>
+    /// Partial-facade forwarder resolution must also work through the bundle context
+    /// path. Drives TryResolveFromBundle explicitly by passing sourceBundlePath.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ImplementationAssemblyResolver_PartialFacade_Bundle_ForwardedType_LandsInImplementationAssembly()
+    {
+        Assert.NotNull(samples.SelfContainedConsoleExe);
+        var resolved = ImplementationAssemblyResolver.Resolve(
+            "SelfContainedConsole.dll",
+            "System.Collections",
+            "System.Collections.Generic.List`1",
+            ".NETCoreApp,Version=v10.0", "Microsoft.NETCore.App",
+            samples.SelfContainedConsoleExe);
+        Assert.NotNull(resolved);
+        var name = resolved switch
+        {
+            ResolvedAssembly.FromFile f => Path.GetFileName(f.Path),
+            ResolvedAssembly.FromBundle b => b.Name,
+            _ => null
+        };
+        Assert.Equal("System.Private.CoreLib.dll", name);
     }
 }

--- a/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
+++ b/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
@@ -85,6 +85,8 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
     {
         _state?.Dispose();
         _terminal?.Dispose();
+        ImplementationAssemblyResolver.ClearCache();
+        DotNetRuntimeLocator.ClearCache();
     }
 
     // --- Resolver unit tests ---
@@ -800,5 +802,110 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         Assert.False(navigated);
         Assert.NotNull(state.TransientNotice);
         Assert.Contains("generic instantiation", state.TransientNotice, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Navigates to the ctor of a generic type forwarded through a partial-facade
+    /// BCL assembly. HelloWorld's MoveNext calls newobj List&lt;byte[]&gt;::.ctor —
+    /// the TypeRef scope is System.Collections (a partial facade), which forwards
+    /// List`1 to System.Private.CoreLib. The resolver must land there, not inside
+    /// the facade.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ExternalMethod_ForwardedFromPartialFacade_Ctor_LandsInCoreLib()
+        => AssertForwardedListMemberLandsInCoreLib("newobj", ".ctor");
+
+    /// <summary>
+    /// Same partial-facade chase, but for the callvirt on List&lt;byte[]&gt;::Add.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ExternalMethod_ForwardedFromPartialFacade_Add_LandsInCoreLib()
+        => AssertForwardedListMemberLandsInCoreLib("callvirt", "Add");
+
+    /// <summary>
+    /// Same partial-facade chase, but for the callvirt on List&lt;byte[]&gt;::Clear.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ExternalMethod_ForwardedFromPartialFacade_Clear_LandsInCoreLib()
+        => AssertForwardedListMemberLandsInCoreLib("callvirt", "Clear");
+
+    private void AssertForwardedListMemberLandsInCoreLib(string opCode, string memberName)
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.HelloWorldDll);
+        state.CurrentTab = TabId.IlInspector;
+
+        var moveNext = state.Analyzer.MethodDefs.First(m =>
+            m.Name == "MoveNext" && m.DeclaringType.Contains("<Main>$"));
+        state.IlSelectedMethod = moveNext;
+        var result = state.IlDisassembler!.DisassembleWithText(moveNext);
+        Assert.NotNull(result);
+        state.IlEditorState = new EditorState(
+            new Hex1b.Documents.Hex1bDocument(result.Value.Text)) { IsReadOnly = true };
+        state.IlEditorMethod = moveNext;
+        state.IlEditorAnalyzer = state.Analyzer;
+
+        var target = result.Value.Instructions
+            .Where(i => i.OpCode == opCode && i.MetadataToken is not null)
+            .Select(i => (inst: i, nav: IlNavigationResolver.Resolve(
+                state.Analyzer, i.MetadataToken!.Value)))
+            .First(x => x.nav is IlNavigationTarget.ExternalMethod em
+                && em.MemberName == memberName
+                && em.DeclaringType == "System.Collections.Generic.List`1");
+
+        var navigated = state.NavigateToIlDefinition(target.inst.MetadataToken!.Value);
+
+        Assert.True(navigated, $"Navigation must succeed for List`1::{memberName}");
+        Assert.Null(state.TransientNotice);
+        Assert.True(state.NavigationStack.Count > 0, "Should have pushed assembly");
+        Assert.NotNull(state.IlSelectedMethod);
+        Assert.Equal(memberName, state.IlSelectedMethod.Name);
+        Assert.Equal("System.Collections.Generic.List`1", state.IlSelectedMethod.DeclaringType);
+        Assert.Equal("System.Private.CoreLib.dll",
+            Path.GetFileName(state.Analyzer.FilePath));
+    }
+
+    /// <summary>
+    /// Navigates to a type locally owned in the partial facade. LinkedList`1 is one
+    /// of System.Collections.dll's real TypeDefs, not a forwarder — the resolver
+    /// must stay in the facade rather than over-chasing into CoreLib.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ExternalMethod_LocallyOwnedInPartialFacade_StaysInFacade()
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+        state.CurrentTab = TabId.IlInspector;
+
+        var method = state.Analyzer.MethodDefs.First(m =>
+            m.Name == "CreateLinkedList" && m.DeclaringType.Contains("IlNavigationFixture"));
+        state.IlSelectedMethod = method;
+        var result = state.IlDisassembler!.DisassembleWithText(method);
+        Assert.NotNull(result);
+        state.IlEditorState = new EditorState(
+            new Hex1b.Documents.Hex1bDocument(result.Value.Text)) { IsReadOnly = true };
+        state.IlEditorMethod = method;
+        state.IlEditorAnalyzer = state.Analyzer;
+
+        var target = result.Value.Instructions
+            .Where(i => i.OpCode == "newobj" && i.MetadataToken is not null)
+            .Select(i => (inst: i, nav: IlNavigationResolver.Resolve(
+                state.Analyzer, i.MetadataToken!.Value)))
+            .First(x => x.nav is IlNavigationTarget.ExternalMethod em
+                && em.MemberName == ".ctor"
+                && em.DeclaringType == "System.Collections.Generic.LinkedList`1");
+
+        var navigated = state.NavigateToIlDefinition(target.inst.MetadataToken!.Value);
+
+        Assert.True(navigated, "Navigation must succeed for LinkedList`1::.ctor");
+        Assert.Null(state.TransientNotice);
+        Assert.NotNull(state.IlSelectedMethod);
+        Assert.Equal("System.Collections.Generic.LinkedList`1", state.IlSelectedMethod.DeclaringType);
+        Assert.Equal("System.Collections.dll",
+            Path.GetFileName(state.Analyzer.FilePath));
     }
 }


### PR DESCRIPTION
`System.Collections.dll` in the shared framework is a partial facade: 71 real TypeDefs (``LinkedList`1``, ``SortedList`2``, `BitArray`, …) alongside 20 `ExportedType` forwarders, one of which redirects ``List`1`` to `System.Private.CoreLib`. `ImplementationAssemblyResolver.ResolveCore` was gated on `HasUsableMetadata` — a whole-assembly signal that returns true for these facades on the strength of the real IL — so a forwarded type like ``List`1`` stopped at the facade and the downstream probe came up empty.

Rewritten as a type-aware walk: when the declaring type is known, `TypeDefinitions` and `ExportedTypes` are read in one pass; forwarders are chased under a visited-set cycle guard. A broken chain (cycle, unresolvable target, or end-without-owner) is kept distinct from "type never referenced here" via a `HomeOutcome` tri-state, so the resolver returns null rather than fall back to a non-owning facade and recreate the failure deeper in navigation.

Pure shims (`mscorlib.dll`, `System.Runtime.dll`), nested-type forwarders (`System.Environment/SpecialFolder`), locally-owned types in the facade (``LinkedList`1``), bundle-backed resolution, and a synthetic chase-broken case are all covered by existing and new tests.

Fixes #145