### PR TITLE
Resolve go-to-definition on bare generic-parameter TypeSpecs

### DIFF
--- a/samples/RichLibrary/GenericParamFixture.cs
+++ b/samples/RichLibrary/GenericParamFixture.cs
@@ -1,0 +1,24 @@
+namespace RichLibrary;
+
+/// <summary>
+/// Generic-parameter fixture. Emits bare ELEMENT_TYPE_VAR / ELEMENT_TYPE_MVAR
+/// TypeSpecs so navigation on them can be exercised.
+/// </summary>
+/// <typeparam name="TKey">Exercises ELEMENT_TYPE_VAR at index 0.</typeparam>
+/// <typeparam name="TValue">Exercises ELEMENT_TYPE_VAR at index 1.</typeparam>
+public class GenericParamFixture<TKey, TValue>
+{
+    /// <summary>Emits initobj !1 — zero-initializing a TValue local.</summary>
+    public TValue DefaultValue()
+    {
+        TValue v = default!;
+        return v;
+    }
+
+    /// <summary>Emits initobj !!0 — zero-initializing a method-level generic parameter.</summary>
+    public T DefaultMethodParam<T>()
+    {
+        T v = default!;
+        return v;
+    }
+}

--- a/src/Dotsider.Core/Analysis/IlNavigationResolver.cs
+++ b/src/Dotsider.Core/Analysis/IlNavigationResolver.cs
@@ -15,8 +15,14 @@ public static class IlNavigationResolver
     /// </summary>
     /// <param name="analyzer">The assembly analyzer containing the metadata.</param>
     /// <param name="token">The raw metadata token from an IL instruction operand.</param>
+    /// <param name="contextMethod">
+    /// The method whose IL body produced the token, when known. Needed to resolve
+    /// bare generic-parameter TypeSpecs (<c>ELEMENT_TYPE_VAR</c>/<c>ELEMENT_TYPE_MVAR</c>),
+    /// which do not encode their generic owner on their own.
+    /// </param>
     /// <returns>The resolved navigation target.</returns>
-    public static IlNavigationTarget Resolve(AssemblyAnalyzer analyzer, int token)
+    public static IlNavigationTarget Resolve(
+        AssemblyAnalyzer analyzer, int token, MethodDefInfo? contextMethod = null)
     {
         var reader = analyzer.GetMetadataReader();
         if (reader is null)
@@ -31,10 +37,10 @@ public static class IlNavigationResolver
             HandleKind.MethodDefinition => ResolveMethodDef(analyzer, token),
             HandleKind.TypeDefinition => ResolveTypeDef(analyzer, token),
             HandleKind.FieldDefinition => ResolveFieldDef(analyzer, token),
-            HandleKind.MemberReference => ResolveMemberRef(analyzer, reader, (MemberReferenceHandle)handle, token),
+            HandleKind.MemberReference => ResolveMemberRef(analyzer, reader, (MemberReferenceHandle)handle, token, contextMethod),
             HandleKind.TypeReference => ResolveTypeRef(analyzer, reader, (TypeReferenceHandle)handle, token),
-            HandleKind.TypeSpecification => ResolveTypeSpec(analyzer, reader, (TypeSpecificationHandle)handle, token),
-            HandleKind.MethodSpecification => ResolveMethodSpec(analyzer, reader, (MethodSpecificationHandle)handle, token),
+            HandleKind.TypeSpecification => ResolveTypeSpec(analyzer, reader, (TypeSpecificationHandle)handle, token, contextMethod),
+            HandleKind.MethodSpecification => ResolveMethodSpec(analyzer, reader, (MethodSpecificationHandle)handle, token, contextMethod),
             _ => new IlNavigationTarget.Unsupported(token, $"Unsupported handle kind: {handle.Kind}")
         };
     }
@@ -67,7 +73,8 @@ public static class IlNavigationResolver
     }
 
     private static IlNavigationTarget ResolveMemberRef(
-        AssemblyAnalyzer analyzer, MetadataReader reader, MemberReferenceHandle handle, int token)
+        AssemblyAnalyzer analyzer, MetadataReader reader, MemberReferenceHandle handle, int token,
+        MethodDefInfo? contextMethod)
     {
         MemberReference mr;
         try { mr = reader.GetMemberReference(handle); }
@@ -102,7 +109,7 @@ public static class IlNavigationResolver
             HandleKind.TypeReference => ResolveMemberRefExternalParent(
                 reader, (TypeReferenceHandle)mr.Parent, name, signature, kind),
             HandleKind.TypeSpecification => ResolveMemberRefWithTypeSpecParent(
-                analyzer, reader, (TypeSpecificationHandle)mr.Parent, name, signature, kind, token),
+                analyzer, reader, (TypeSpecificationHandle)mr.Parent, name, signature, kind, token, contextMethod),
             _ => new IlNavigationTarget.Unsupported(token, $"MemberRef parent kind: {mr.Parent.Kind}")
         };
     }
@@ -156,8 +163,19 @@ public static class IlNavigationResolver
     }
 
     private static IlNavigationTarget ResolveTypeSpec(
-        AssemblyAnalyzer analyzer, MetadataReader reader, TypeSpecificationHandle handle, int token)
+        AssemblyAnalyzer analyzer, MetadataReader reader, TypeSpecificationHandle handle, int token,
+        MethodDefInfo? contextMethod)
     {
+        // A bare ELEMENT_TYPE_VAR / ELEMENT_TYPE_MVAR TypeSpec names a generic
+        // parameter but does not encode its generic owner. Route through the
+        // enclosing method's context before trying to match TypeDefs/TypeRefs,
+        // since the decoded string ("!N"/"!!N") will not match anything.
+        var genericParam = TryReadGenericParameter(reader, handle);
+        if (genericParam is { } gp)
+        {
+            return ResolveGenericParameter(analyzer, gp.Kind, gp.Index, token, contextMethod);
+        }
+
         // Decode the TypeSpec to a string, then find the underlying open generic type
         // by matching the name prefix (before the generic arguments) against TypeDefs/TypeRefs.
         string decoded;
@@ -189,10 +207,102 @@ public static class IlNavigationResolver
         return new IlNavigationTarget.Unsupported(token, $"Cannot resolve TypeSpec: {decoded}");
     }
 
+    /// <summary>
+    /// Maps a bare generic-parameter TypeSpec to the closest navigable definition —
+    /// for <c>ELEMENT_TYPE_VAR</c> the enclosing type, for <c>ELEMENT_TYPE_MVAR</c>
+    /// the enclosing method.
+    /// </summary>
+    private static IlNavigationTarget ResolveGenericParameter(
+        AssemblyAnalyzer analyzer, GenericParamKind kind, int index, int token,
+        MethodDefInfo? contextMethod)
+    {
+        var label = kind == GenericParamKind.TypeParam ? $"!{index}" : $"!!{index}";
+        if (contextMethod is null)
+        {
+            return new IlNavigationTarget.Unsupported(token,
+                $"Generic parameter {label} requires method context for navigation");
+        }
+
+        if (kind == GenericParamKind.MethodParam)
+        {
+            // A method-level generic parameter's only definition site is the method
+            // signature the user is already reading. Routing to LocalMethod(self)
+            // would hit the "already selected" short-circuit in NavigateToIlDefinition
+            // and silently no-op, so surface an explicit transient notice instead.
+            return new IlNavigationTarget.Unsupported(token,
+                $"Generic method parameter {label} of {contextMethod.Name} — defined by this method's signature");
+        }
+
+        // ELEMENT_TYPE_VAR: navigate to the enclosing type. It is the one whose
+        // GenericParam rows define this index, so it's the only place the parameter
+        // exists as a definition in metadata.
+        var declaringTypeName = contextMethod.DeclaringType;
+        var localType = analyzer.TypeDefs.FirstOrDefault(t => t.FullName == declaringTypeName);
+        if (localType is not null)
+            return new IlNavigationTarget.LocalType(localType);
+
+        return new IlNavigationTarget.Unresolved(token,
+            $"Generic parameter {label} declaring type not found: {declaringTypeName}");
+    }
+
+    private enum GenericParamKind { TypeParam, MethodParam }
+
+    /// <summary>
+    /// Attempts to identify a TypeSpec whose signature is just a generic parameter
+    /// reference (<c>ELEMENT_TYPE_VAR</c> or <c>ELEMENT_TYPE_MVAR</c>), skipping any
+    /// leading CustomMod prefixes. Returns null for any other signature shape.
+    /// </summary>
+    private static (GenericParamKind Kind, int Index)? TryReadGenericParameter(
+        MetadataReader reader, TypeSpecificationHandle handle)
+    {
+        try
+        {
+            var ts = reader.GetTypeSpecification(handle);
+            var blob = reader.GetBlobReader(ts.Signature);
+            SignatureTypeCode code;
+            while (true)
+            {
+                if (blob.RemainingBytes <= 0) return null;
+                code = blob.ReadSignatureTypeCode();
+                if (code != SignatureTypeCode.OptionalModifier
+                    && code != SignatureTypeCode.RequiredModifier)
+                    break;
+                // Skip the coded TypeDefOrRefOrSpec index that follows a CMOD.
+                blob.ReadTypeHandle();
+            }
+            return code switch
+            {
+                SignatureTypeCode.GenericTypeParameter =>
+                    (GenericParamKind.TypeParam, blob.ReadCompressedInteger()),
+                SignatureTypeCode.GenericMethodParameter =>
+                    (GenericParamKind.MethodParam, blob.ReadCompressedInteger()),
+                _ => null,
+            };
+        }
+        catch { return null; }
+    }
+
     private static IlNavigationTarget ResolveMemberRefWithTypeSpecParent(
         AssemblyAnalyzer analyzer, MetadataReader reader, TypeSpecificationHandle typeSpecHandle,
-        string name, string signature, MemberRefKind kind, int token)
+        string name, string signature, MemberRefKind kind, int token,
+        MethodDefInfo? contextMethod)
     {
+        // MemberRef parent is a TypeSpec naming a generic parameter on its own —
+        // route through the context's declaring type so we don't try to match "!N"
+        // against TypeDefs/TypeRefs below.
+        var genericParam = TryReadGenericParameter(reader, typeSpecHandle);
+        if (genericParam is { } gp && contextMethod is not null
+            && gp.Kind == GenericParamKind.TypeParam)
+        {
+            var declType = analyzer.TypeDefs.FirstOrDefault(
+                t => t.FullName == contextMethod.DeclaringType);
+            if (declType is not null)
+            {
+                var localHandle = MetadataTokens.TypeDefinitionHandle(
+                    MetadataTokens.GetRowNumber(MetadataTokens.EntityHandle(declType.Token)));
+                return ResolveMemberRefLocalParent(analyzer, localHandle, name, signature, kind, token);
+            }
+        }
         // Decode the TypeSpec to find the underlying type name, then resolve the member.
         string decoded;
         try
@@ -271,7 +381,8 @@ public static class IlNavigationResolver
     }
 
     private static IlNavigationTarget ResolveMethodSpec(
-        AssemblyAnalyzer analyzer, MetadataReader reader, MethodSpecificationHandle handle, int token)
+        AssemblyAnalyzer analyzer, MetadataReader reader, MethodSpecificationHandle handle, int token,
+        MethodDefInfo? contextMethod)
     {
         int methodToken;
         try
@@ -284,7 +395,7 @@ public static class IlNavigationResolver
             return new IlNavigationTarget.GenericInstantiation(token, ex.Message);
         }
 
-        return Resolve(analyzer, methodToken);
+        return Resolve(analyzer, methodToken, contextMethod);
     }
 
     private static string GetAssemblyNameFromTypeRef(MetadataReader reader, TypeReferenceHandle handle)

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -668,7 +668,11 @@ public sealed class DotsiderState : IDisposable
     /// <returns>True if navigation occurred.</returns>
     public bool NavigateToIlDefinition(int token)
     {
-        var target = IlNavigationResolver.Resolve(Analyzer, token);
+        // IlEditorMethod reflects the currently-open method body; fall back to the
+        // list selection when the editor hasn't loaded yet. The resolver needs this
+        // to tie bare generic-parameter TypeSpecs ("!N"/"!!N") back to their owner.
+        var target = IlNavigationResolver.Resolve(
+            Analyzer, token, IlEditorMethod ?? IlSelectedMethod);
         switch (target)
         {
             case IlNavigationTarget.LocalMethod(var method):
@@ -684,6 +688,15 @@ public sealed class DotsiderState : IDisposable
 
             case IlNavigationTarget.LocalType(var type):
                 PushIlBackEntry(false);
+                // Clear the method/editor selection so the right pane stops showing
+                // the IL we just left — otherwise tree focus moves but the editor
+                // still renders the previous method and the nav looks half-applied.
+                IlSelectedMethod = null;
+                IlSelectedField = null;
+                IlEditorState = null;
+                IlEditorMethod = null;
+                IlEditorAnalyzer = null;
+                IlEditorField = null;
                 IlTreeExpansionState[$"ns:{(!string.IsNullOrEmpty(type.Namespace) ? type.Namespace : "(global)")}"] = true;
                 SetIlFocusedTreeKey($"type:{type.FullName}");
                 App.RequestFocus(node => node is ListNode);

--- a/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
+++ b/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
@@ -58,8 +58,9 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         await auto.WaitUntilAlternateScreenAsync();
         await auto.WaitUntilTextAsync("Select a method");
 
-        // Navigate tree: 6 downs to IlNavigationFixture, expand, down to CallLocalMethod, select
-        for (var i = 0; i < 6; i++) await auto.DownAsync(ct);
+        // Navigate tree: 7 downs to IlNavigationFixture, expand, down to CallLocalMethod, select.
+        // GenericParamFixture`2 sorts before IlNavigationFixture under the RichLibrary namespace.
+        for (var i = 0; i < 7; i++) await auto.DownAsync(ct);
         await auto.EnterAsync(ct); // expand IlNavigationFixture
         await auto.WaitUntilTextAsync("CallLocalMethod");
         await auto.DownAsync(ct); // move to CallLocalMethod
@@ -907,5 +908,150 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         Assert.Equal("System.Collections.Generic.LinkedList`1", state.IlSelectedMethod.DeclaringType);
         Assert.Equal("System.Collections.dll",
             Path.GetFileName(state.Analyzer.FilePath));
+    }
+
+    /// <summary>
+    /// A TypeSpec whose signature is a bare ELEMENT_TYPE_VAR names a generic
+    /// parameter of the enclosing type. The resolver needs the current method
+    /// context to know which owner "!N" refers to; with that context it routes
+    /// to the enclosing type definition (where the GenericParam row lives).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Resolve_TypeSpecGenericTypeParam_WithContext_ReturnsEnclosingType()
+    {
+        using var analyzer = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var dis = new IlDisassembler(analyzer);
+        var method = analyzer.MethodDefs.First(m =>
+            m.Name == "DefaultValue" && m.DeclaringType.Contains("GenericParamFixture"));
+        var initobj = dis.Disassemble(method).First(i =>
+            i.OpCode == "initobj" && i.MetadataToken is not null);
+
+        var target = IlNavigationResolver.Resolve(analyzer, initobj.MetadataToken!.Value, method);
+
+        var local = Assert.IsType<IlNavigationTarget.LocalType>(target);
+        Assert.Equal("RichLibrary.GenericParamFixture`2", local.Type.FullName);
+    }
+
+    /// <summary>
+    /// A TypeSpec whose signature is a bare ELEMENT_TYPE_MVAR names a method-
+    /// level generic parameter. The only definition site is the current method's
+    /// signature, so the resolver reports it via Unsupported (a transient notice)
+    /// rather than a self-navigation that the UI would silently swallow.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Resolve_TypeSpecGenericMethodParam_WithContext_ReportsDefinedBySignature()
+    {
+        using var analyzer = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var dis = new IlDisassembler(analyzer);
+        var method = analyzer.MethodDefs.First(m =>
+            m.Name == "DefaultMethodParam" && m.DeclaringType.Contains("GenericParamFixture"));
+        var initobj = dis.Disassemble(method).First(i =>
+            i.OpCode == "initobj" && i.MetadataToken is not null);
+
+        var target = IlNavigationResolver.Resolve(analyzer, initobj.MetadataToken!.Value, method);
+
+        var unsupported = Assert.IsType<IlNavigationTarget.Unsupported>(target);
+        Assert.Contains("!!0", unsupported.Reason);
+        Assert.Contains("DefaultMethodParam", unsupported.Reason);
+    }
+
+    /// <summary>
+    /// End-to-end: pressing go-to-definition on initobj !!0 inside the method
+    /// raises a transient notice and does not change the selected method. The
+    /// UI gets a clear "there's nothing to navigate to" signal instead of a
+    /// silent no-op.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NavigateToIlDefinition_TypeSpecGenericMethodParam_RaisesNotice()
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+        state.CurrentTab = TabId.IlInspector;
+
+        var method = state.Analyzer.MethodDefs.First(m =>
+            m.Name == "DefaultMethodParam" && m.DeclaringType.Contains("GenericParamFixture"));
+        state.IlSelectedMethod = method;
+        var result = state.IlDisassembler!.DisassembleWithText(method);
+        Assert.NotNull(result);
+        state.IlEditorState = new EditorState(
+            new Hex1b.Documents.Hex1bDocument(result.Value.Text)) { IsReadOnly = true };
+        state.IlEditorMethod = method;
+        state.IlEditorAnalyzer = state.Analyzer;
+
+        var initobj = result.Value.Instructions.First(i =>
+            i.OpCode == "initobj" && i.MetadataToken is not null);
+
+        var navigated = state.NavigateToIlDefinition(initobj.MetadataToken!.Value);
+
+        Assert.False(navigated);
+        Assert.NotNull(state.TransientNotice);
+        Assert.Contains("!!0", state.TransientNotice);
+        Assert.Same(method, state.IlSelectedMethod);
+    }
+
+    /// <summary>
+    /// Without a method context, a bare generic-parameter TypeSpec is not
+    /// resolvable. The resolver should surface a message that explains what's
+    /// missing rather than the opaque "Cannot resolve TypeSpec: !1".
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Resolve_TypeSpecGenericTypeParam_WithoutContext_ReportsMissingContext()
+    {
+        using var analyzer = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var dis = new IlDisassembler(analyzer);
+        var method = analyzer.MethodDefs.First(m =>
+            m.Name == "DefaultValue" && m.DeclaringType.Contains("GenericParamFixture"));
+        var initobj = dis.Disassemble(method).First(i =>
+            i.OpCode == "initobj" && i.MetadataToken is not null);
+
+        var target = IlNavigationResolver.Resolve(analyzer, initobj.MetadataToken!.Value);
+
+        var unsupported = Assert.IsType<IlNavigationTarget.Unsupported>(target);
+        Assert.Contains("!1", unsupported.Reason);
+        Assert.Contains("context", unsupported.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// End-to-end: pressing go-to-definition on initobj !1 in a generic method
+    /// lands on the enclosing type, clears the selected method, and raises no
+    /// transient notice.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NavigateToIlDefinition_TypeSpecGenericTypeParam_LandsOnEnclosingType()
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+        state.CurrentTab = TabId.IlInspector;
+
+        var method = state.Analyzer.MethodDefs.First(m =>
+            m.Name == "DefaultValue" && m.DeclaringType.Contains("GenericParamFixture"));
+        state.IlSelectedMethod = method;
+        var result = state.IlDisassembler!.DisassembleWithText(method);
+        Assert.NotNull(result);
+        state.IlEditorState = new EditorState(
+            new Hex1b.Documents.Hex1bDocument(result.Value.Text)) { IsReadOnly = true };
+        state.IlEditorMethod = method;
+        state.IlEditorAnalyzer = state.Analyzer;
+
+        var initobj = result.Value.Instructions.First(i =>
+            i.OpCode == "initobj" && i.MetadataToken is not null);
+
+        var navigated = state.NavigateToIlDefinition(initobj.MetadataToken!.Value);
+
+        Assert.True(navigated, "Navigation to generic type parameter's owner must succeed");
+        Assert.Null(state.TransientNotice);
+        Assert.Equal(
+            "type:RichLibrary.GenericParamFixture`2",
+            state.IlFocusedTreeKey as string);
+        // Method/editor selection must be cleared so the right pane stops showing
+        // DefaultValue's IL. Without that the navigation only half-applies.
+        Assert.Null(state.IlSelectedMethod);
+        Assert.Null(state.IlEditorMethod);
+        Assert.Null(state.IlEditorState);
+        Assert.Null(state.IlEditorAnalyzer);
     }
 }


### PR DESCRIPTION
A TypeSpec whose signature is a bare `ELEMENT_TYPE_VAR` (`!N`) or `ELEMENT_TYPE_MVAR` (`!!N`) names a generic parameter without encoding its owner. The decoder could only produce the index string, so the resolver fell through to "Cannot resolve TypeSpec: !1" on instructions like `IL_0013: initobj 0x1B000022` inside ``ConcurrentDictionary`2::TryRemove``.

`IlNavigationResolver.Resolve` now takes an optional `contextMethod`, which `DotsiderState.NavigateToIlDefinition` feeds from the currently-open IL body. `TryReadGenericParameter` inspects the signature bytes (skipping any leading CustomMods) to recognise the bare VAR / MVAR shape.

For VAR the resolver routes to the enclosing type's TypeDef. The `LocalType` arm in `NavigateToIlDefinition` now clears the method and editor selection so the right pane actually lands on the type instead of still rendering the method we left. For MVAR the only definition site is the signature the user is already reading, so routing to `LocalMethod(self)` would trip the "already selected" short-circuit and silently no-op — the resolver returns `Unsupported` with a message naming the parameter and method, which surfaces in the hints bar.

Fixes #147