### PR TITLE
Full transitive dependency graph with scope + filter controls

### DIFF
--- a/benchmarks/Dotsider.Benchmarks/DependencyGraphBuilderBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/DependencyGraphBuilderBenchmarks.cs
@@ -37,16 +37,16 @@ public class DependencyGraphBuilderBenchmarks
     }
 
     /// <summary>
-    /// Builds the positioned dependency graph for CoreLib — the widest typical graph shape.
+    /// Builds the transitive dependency graph rooted at CoreLib — the widest typical shape.
     /// </summary>
     [Benchmark(Description = "CoreLib graph")]
-    public (IReadOnlyList<GraphNode> Nodes, IReadOnlyList<GraphEdge> Edges) Build_CoreLib()
+    public DependencyGraphResult Build_CoreLib()
         => DependencyGraphBuilder.Build(_coreLibAnalyzer);
 
     /// <summary>
-    /// Builds the dependency graph for Xml, which has a smaller AssemblyRef count than CoreLib.
+    /// Builds the transitive dependency graph rooted at Xml.
     /// </summary>
     [Benchmark(Description = "Xml graph")]
-    public (IReadOnlyList<GraphNode> Nodes, IReadOnlyList<GraphEdge> Edges) Build_Xml()
+    public DependencyGraphResult Build_Xml()
         => DependencyGraphBuilder.Build(_xmlAnalyzer);
 }

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -33,9 +33,9 @@ dotnet run --project benchmarks/Dotsider.Benchmarks -c Release -- --list flat
 | Class | What it measures |
 |---|---|
 | `ApphostDetectorBenchmarks` | Apphost companion-DLL detection (real apphost, dotted-name, fake exe, early exit) and bundled-entry extraction |
-| `AssemblyAnalyzerBenchmarks` | Constructor (file and byte[]), lazy metadata properties (TypeDefs, MethodDefs, AssemblyRefs, TypeRefs, MemberRefs, FieldDefs, CustomAttributes, Resources, Sections), token resolution, and 6-step assembly resolution chain |
+| `AssemblyAnalyzerBenchmarks` | Constructor (file and byte[]), lazy metadata properties (TypeDefs, MethodDefs, AssemblyRefs, TypeRefs, MemberRefs, FieldDefs, CustomAttributes, Resources, Sections), token resolution, and 7-step assembly resolution chain (app-local, NuGet deps.json, runtime directory, source bundle, host bundle, adjacent bundles, shared framework) |
 | `AssemblyDifferBenchmarks` | Dictionary-based O(n) diff of two assemblies by type, method, and reference with normalized IL body comparison |
-| `DependencyGraphBuilderBenchmarks` | Positioned dependency graph construction from assembly refs and type ref counts |
+| `DependencyGraphBuilderBenchmarks` | Full transitive assembly dependency closure — BFS walk that resolves each AssemblyRef by full identity, opens it, and recurses (CoreLib has no outbound refs so this is pure builder overhead; Xml walks its full BCL/runtime-pack closure) |
 | `DotNetRuntimeLocatorColdBenchmarks` | Cold-path .NET runtime discovery: base path + shared framework resolution with cache cleared |
 | `DotNetRuntimeLocatorWarmBenchmarks` | Warm-cache ConcurrentDictionary hit for shared framework lookup |
 | `HexSearchBenchmarks` | `FindBytePattern` with short, long, and no-match patterns against real assemblies |
@@ -83,23 +83,25 @@ Benchmarks that require real .NET executables (apphost, single-file bundle, runt
 | Benchmark | Mean | Allocated |
 |---|---|---|
 | CoreLib Construction | 1.57 ms | 16.29 MB |
-| Xml Construction | 0.77 ms | 8.60 MB |
-| CoreLib from byte[] (bundle model) | 68.83 μs | 12.56 KB |
-| CoreLib TypeDefs | 2.50 ms | 17.90 MB |
-| Xml TypeDefs | 1.26 ms | 9.65 MB |
-| CoreLib MethodDefs | 25.51 ms | 61.22 MB |
-| Xml MethodDefs | 11.08 ms | 21.49 MB |
+| Xml Construction | 0.82 ms | 8.60 MB |
+| CoreLib from byte[] (bundle model) | 66.24 μs | 12.56 KB |
+| CoreLib TypeDefs | 2.57 ms | 17.90 MB |
+| Xml TypeDefs | 1.24 ms | 9.65 MB |
+| CoreLib MethodDefs | 25.50 ms | 61.25 MB |
+| Xml MethodDefs | 11.23 ms | 21.49 MB |
 | CoreLib AssemblyRefs | 1.55 ms | 16.29 MB |
-| CoreLib TypeRefs | 1.55 ms | 16.29 MB |
-| CoreLib MemberRefs (signature decoding) | 5.43 ms | 20.78 MB |
-| CoreLib FieldDefs (signature decoding) | 3.76 ms | 19.83 MB |
-| CoreLib CustomAttributes | 16.23 ms | 37.65 MB |
-| CoreLib Resources | 1.56 ms | 16.29 MB |
-| CoreLib Sections | 1.76 ms | 16.29 MB |
-| ResolveToken (MethodDef → name) | 1.70 ms | 16.29 MB |
-| ResolveAssembly step 2 (runtime dir) | 5.67 μs | 1.48 KB |
-| ResolveAssembly step 6 (shared framework) | 90.49 μs | 141 KB |
-| ResolveAssembly miss (all 6 steps) | 92.08 μs | 141 KB |
+| CoreLib TypeRefs | 1.52 ms | 16.29 MB |
+| CoreLib MemberRefs (signature decoding) | 5.23 ms | 20.80 MB |
+| CoreLib FieldDefs (signature decoding) | 3.45 ms | 19.85 MB |
+| CoreLib CustomAttributes | 17.11 ms | 37.65 MB |
+| CoreLib Resources | 1.43 ms | 16.29 MB |
+| CoreLib Sections | 1.37 ms | 16.29 MB |
+| ResolveToken (MethodDef → name) | 1.40 ms | 16.29 MB |
+| ResolveAssembly step 3 (runtime dir) | 28.84 μs | 3.53 KB |
+| ResolveAssembly step 7 (shared framework) | 203.30 μs | 5.28 KB |
+| ResolveAssembly miss (all 7 steps) | 203.79 μs | 5.40 KB |
+
+ResolveAssembly now includes a NuGet `.deps.json` probe between app-local and runtime-dir so library projects (RichLibrary, etc.) find their NuGet dependencies. The direct base-name lookup is a single `File.Exists` per resolve; when no manifest sits next to the referencing assembly the probe returns in microseconds. The ~23 μs delta vs. the prior baseline is the cost of that check on every resolve.
 
 #### AssemblyDiffer
 
@@ -116,8 +118,10 @@ Identity and distinct benchmarks are worst-case: every method matches, forcing n
 
 | Benchmark | Mean | Allocated |
 |---|---|---|
-| CoreLib graph | 25.58 ns | 264 B |
-| Xml graph | 8,355.35 ns | 5,608 B |
+| CoreLib graph | 229.9 ns | 2 KB |
+| Xml graph | 20.24 ms | 78.60 MB |
+
+The builder now produces a full transitive closure: every AssemblyRef is resolved by full identity, opened, and recursed into. CoreLib has no outbound refs so its graph is a single root node (the baseline reflects pure BFS + layout overhead). Xml refs most of the BCL, so its closure walks ~dozens of additional assemblies — each one opened via `AssemblyAnalyzer`, which dominates both time and allocation. The prior 8 μs baseline measured only the root's direct-ref star without any resolution or traversal; the new number is the cost of doing the thing the name actually claims.
 
 #### DotNetRuntimeLocator
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
@@ -417,6 +417,32 @@ The method body block, or null.
 public MethodBodyBlock? GetMethodBody(MethodDefInfo method)
 ```
 
+### IsFrameworkAssembly(AssemblyProvenance, AssemblyRefInfo, string?, string?)
+
+Classifies whether an assembly belongs to the .NET framework surface regardless of
+deployment model. Returns true when the node was located through the
+shared framework or runtime directory, or when its identity matches a well-known
+Microsoft framework public key token, or when the shared-framework locator recognizes
+its simple name for the supplied target framework. This classification is used by the
+TUI framework-filter toggle so framework assemblies shipped inside a self-contained
+publish or single-file bundle are filtered consistently with framework assemblies
+loaded from the shared runtime.
+
+**Parameters:**
+
+- `provenance` ([AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)): How the node was located.
+- `identity` ([AssemblyRefInfo](/api/dotsider.core.analysis.models.assemblyrefinfo/)): The resolved assembly's identity.
+- `targetFramework` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The referencing assembly's target framework moniker.
+- `preferredRuntimePack` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The referencing assembly's preferred runtime pack.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+true if the node represents a framework assembly.
+
+```csharp
+public static bool IsFrameworkAssembly(AssemblyProvenance provenance, AssemblyRefInfo identity, string? targetFramework, string? preferredRuntimePack)
+```
+
 ### ResolveAssembly(string, string, string?, string?, string?)
 
 Resolves a referenced assembly name to a file on disk or bytes from a bundle.
@@ -437,6 +463,33 @@ The resolved assembly, or `null` if not found.
 
 ```csharp
 public static ResolvedAssembly? ResolveAssembly(string referencingAssemblyPath, string assemblyName, string? targetFramework = null, string? preferredRuntimePack = null, string? sourceBundlePath = null)
+```
+
+### ResolveAssemblyByIdentity(string, AssemblyRefInfo, string?, string?, string?)
+
+Resolves a referenced assembly by full identity (name, version, culture, public key token).
+Probes every stage of String) and accepts only candidates whose
+manifest identity matches the requested identity exactly. If no probe produces a full
+match but at least one probe produces a simple-name match whose identity differs,
+returns [IdentityMismatch](/api/dotsider.core.analysis.models.assemblyprovenance.identitymismatch/) with the path of that candidate —
+the graph does not expand from mismatched files.
+
+**Parameters:**
+
+- `referencingAssemblyPath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Path of the assembly that references the target.
+- `identity` ([AssemblyRefInfo](/api/dotsider.core.analysis.models.assemblyrefinfo/)): The full identity the caller expects to resolve.
+- `targetFramework` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Target framework moniker for shared-framework probing.
+- `preferredRuntimePack` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Preferred runtime pack name.
+- `sourceBundlePath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Bundle path, when the referencing assembly came from a bundle.
+
+**Returns:** [ValueTuple\<ResolvedAssembly, AssemblyProvenance, String\>](https://learn.microsoft.com/dotnet/api/system.valuetuple-3)
+
+A tuple of the resolved assembly (or null), the provenance classifying
+how the node was located, and the path of a simple-name match whose identity did not
+match (populated only when provenance is [IdentityMismatch](/api/dotsider.core.analysis.models.assemblyprovenance.identitymismatch/)).
+
+```csharp
+public static (ResolvedAssembly? Resolved, AssemblyProvenance Provenance, string? CandidateProbePath) ResolveAssemblyByIdentity(string referencingAssemblyPath, AssemblyRefInfo identity, string? targetFramework = null, string? preferredRuntimePack = null, string? sourceBundlePath = null)
 ```
 
 ### ResolveAssemblyPath(string, string)

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyIdentityFormat.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyIdentityFormat.md
@@ -1,0 +1,51 @@
+---
+title: "AssemblyIdentityFormat"
+description: "Formats an assembly's full identity into a stable opaque string used as a graph node identifier and as a key for grouping TypeRefInfo entries by the full identity of their resolution scope."
+slug: api/dotsider.core.analysis.assemblyidentityformat
+sidebar:
+  order: 0
+---
+
+**Namespace:** `Dotsider.Core.Analysis`
+
+**Assembly:** Dotsider.Core.dll
+
+Formats an assembly's full identity into a stable opaque string used as a graph node
+identifier and as a key for grouping [TypeRefInfo](/api/dotsider.core.analysis.models.typerefinfo/) entries by the
+full identity of their resolution scope.
+
+```csharp
+public static class AssemblyIdentityFormat
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **AssemblyIdentityFormat**
+
+## Methods
+
+### Format(string, string?, string?, string?)
+
+Formats an assembly identity into its canonical identifier string.
+
+**Parameters:**
+
+- `name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The assembly simple name.
+- `version` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The assembly version, or null.
+- `culture` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The assembly culture, or null/empty for culture-neutral.
+- `publicKeyToken` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The public key token hex, or null.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+A stable opaque identifier derived from the four identity fields.
+
+```csharp
+public static string Format(string name, string? version, string? culture, string? publicKeyToken)
+```
+
+## Remarks
+
+The format is `"{Name}|{Version}|{Culture}|{PublicKeyToken}"`. Null or empty culture
+is normalized to `"neutral"` so two nodes only differ by culture when they truly do.
+The identifier is treated as opaque by consumers; it is never parsed.
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-DependencyGraphBuilder.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-DependencyGraphBuilder.md
@@ -1,6 +1,6 @@
 ---
 title: "DependencyGraphBuilder"
-description: "Builds a dependency graph from an assembly's references and type refs. Uses a hierarchical tree layout with the root assembly at top center."
+description: "Builds the full transitive assembly dependency graph rooted at an analyzed assembly. Performs a breadth-first walk through each assembly's AssemblyRefs, resolving children by full identity, deduping on Id, preserving edges for cycles and diamonds, and classifying unresolvable and identity-mismatched references as non-expanding leaf nodes. Produces a DependencyGraphResult containing the public topology plus internal navigation metadata consumed only by the TUI."
 slug: api/dotsider.core.analysis.dependencygraphbuilder
 sidebar:
   order: 0
@@ -10,8 +10,12 @@ sidebar:
 
 **Assembly:** Dotsider.Core.dll
 
-Builds a dependency graph from an assembly's references and type refs.
-Uses a hierarchical tree layout with the root assembly at top center.
+Builds the full transitive assembly dependency graph rooted at an analyzed assembly.
+Performs a breadth-first walk through each assembly's [AssemblyRefs](/api/dotsider.core.analysis.assemblyanalyzer.assemblyrefs/),
+resolving children by full identity, deduping on [Id](/api/dotsider.core.analysis.models.graphnode.id/), preserving edges
+for cycles and diamonds, and classifying unresolvable and identity-mismatched references as
+non-expanding leaf nodes. Produces a [DependencyGraphResult](/api/dotsider.core.analysis.models.dependencygraphresult/) containing the
+public topology plus internal navigation metadata consumed only by the TUI.
 
 ```csharp
 public static class DependencyGraphBuilder
@@ -25,17 +29,18 @@ public static class DependencyGraphBuilder
 
 ### Build(AssemblyAnalyzer)
 
-Builds a graph of assembly references with positioned nodes and weighted edges.
+Builds the transitive dependency graph rooted at analyzer.
 
 **Parameters:**
 
-- `analyzer` ([AssemblyAnalyzer](/api/dotsider.core.analysis.assemblyanalyzer/)): The assembly analyzer to read references from.
+- `analyzer` ([AssemblyAnalyzer](/api/dotsider.core.analysis.assemblyanalyzer/)): The root assembly analyzer. The caller retains ownership and disposal
+    responsibility; the builder does not dispose it.
 
-**Returns:** [ValueTuple\<GraphNode\>, GraphEdge\>\>](https://learn.microsoft.com/dotnet/api/system.valuetuple-2)
+**Returns:** [DependencyGraphResult](/api/dotsider.core.analysis.models.dependencygraphresult/)
 
-The graph nodes and edges for rendering.
+The computed nodes, edges, and per-node navigation metadata.
 
 ```csharp
-public static (IReadOnlyList<GraphNode> Nodes, IReadOnlyList<GraphEdge> Edges) Build(AssemblyAnalyzer analyzer)
+public static DependencyGraphResult Build(AssemblyAnalyzer analyzer)
 ```
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-IlNavigationResolver.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-IlNavigationResolver.md
@@ -23,7 +23,7 @@ public static class IlNavigationResolver
 
 ## Methods
 
-### Resolve(AssemblyAnalyzer, int)
+### Resolve(AssemblyAnalyzer, int, MethodDefInfo?)
 
 Resolves the given metadata token against the analyzer's metadata tables.
 
@@ -31,12 +31,15 @@ Resolves the given metadata token against the analyzer's metadata tables.
 
 - `analyzer` ([AssemblyAnalyzer](/api/dotsider.core.analysis.assemblyanalyzer/)): The assembly analyzer containing the metadata.
 - `token` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The raw metadata token from an IL instruction operand.
+- `contextMethod` ([MethodDefInfo](/api/dotsider.core.analysis.models.methoddefinfo/)): The method whose IL body produced the token, when known. Needed to resolve
+bare generic-parameter TypeSpecs (`ELEMENT_TYPE_VAR`/`ELEMENT_TYPE_MVAR`),
+which do not encode their generic owner on their own.
 
 **Returns:** [IlNavigationTarget](/api/dotsider.core.analysis.models.ilnavigationtarget/)
 
 The resolved navigation target.
 
 ```csharp
-public static IlNavigationTarget Resolve(AssemblyAnalyzer analyzer, int token)
+public static IlNavigationTarget Resolve(AssemblyAnalyzer analyzer, int token, MethodDefInfo? contextMethod = null)
 ```
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-AssemblyProvenance.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-AssemblyProvenance.md
@@ -1,0 +1,128 @@
+---
+title: "AssemblyProvenance"
+description: "Describes how an assembly in the dependency graph was located — or why it could not be."
+slug: api/dotsider.core.analysis.models.assemblyprovenance
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+Describes how an assembly in the dependency graph was located — or why it could not be.
+
+```csharp
+public enum AssemblyProvenance
+```
+
+## Fields
+
+### AdjacentBundle
+
+Extracted from a single-file bundle adjacent to the referencing assembly.
+
+**Returns:** [AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)
+
+```csharp
+AdjacentBundle = 7
+```
+
+### AppLocal
+
+Resolved from the referencing assembly's directory on disk.
+
+**Returns:** [AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)
+
+```csharp
+AppLocal = 1
+```
+
+### HostBundle
+
+Extracted from the host process bundle (when dotsider itself is bundled).
+
+**Returns:** [AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)
+
+```csharp
+HostBundle = 6
+```
+
+### IdentityMismatch
+
+A probe produced a file whose simple name matched, but whose manifest identity
+(version, culture, or public key token) did not match the requested reference.
+The graph does not expand from such candidates — the node is left as an unresolved leaf.
+
+**Returns:** [AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)
+
+```csharp
+IdentityMismatch = 9
+```
+
+### NuGetPackageCache
+
+Resolved from the NuGet global packages folder by consulting the referencing
+assembly's `.deps.json` manifest for the exact resolved package version and
+runtime asset path.
+
+**Returns:** [AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)
+
+```csharp
+NuGetPackageCache = 3
+```
+
+### Root
+
+The analyzed assembly itself (the graph root).
+
+**Returns:** [AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)
+
+```csharp
+Root = 0
+```
+
+### RuntimeDirectory
+
+Resolved from the active .NET runtime directory.
+
+**Returns:** [AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)
+
+```csharp
+RuntimeDirectory = 2
+```
+
+### SharedFramework
+
+Resolved through the shared-framework discovery for the target framework.
+
+**Returns:** [AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)
+
+```csharp
+SharedFramework = 4
+```
+
+### SourceBundle
+
+Extracted from the single-file bundle that produced the referencing assembly.
+
+**Returns:** [AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)
+
+```csharp
+SourceBundle = 5
+```
+
+### Unresolved
+
+No probe produced any candidate file for the referenced simple name.
+
+**Returns:** [AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)
+
+```csharp
+Unresolved = 8
+```
+
+## Remarks
+
+The order of enum members is not significant; callers should compare by member name.
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-DependencyGraphResult.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-DependencyGraphResult.md
@@ -1,0 +1,88 @@
+---
+title: "DependencyGraphResult"
+description: "The result of building a transitive assembly dependency graph. Contains the public topology consumed by serializers (Nodes, Edges) and the internal navigation metadata consumed by the TUI (NavigationById)."
+slug: api/dotsider.core.analysis.models.dependencygraphresult
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+The result of building a transitive assembly dependency graph. Contains the public topology
+consumed by serializers ([Nodes](/api/dotsider.core.analysis.models.dependencygraphresult.nodes/), [Edges](/api/dotsider.core.analysis.models.dependencygraphresult.edges/)) and the internal navigation
+metadata consumed by the TUI ([NavigationById](/api/dotsider.core.analysis.models.dependencygraphresult.navigationbyid/)).
+
+```csharp
+public sealed record DependencyGraphResult : IEquatable<DependencyGraphResult>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **DependencyGraphResult**
+
+## Implements
+
+- [IEquatable\<DependencyGraphResult\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### DependencyGraphResult(IReadOnlyList\<GraphNode\>, IReadOnlyList\<GraphEdge\>, IReadOnlyDictionary\<string, GraphNavigationContext\>)
+
+The result of building a transitive assembly dependency graph. Contains the public topology
+consumed by serializers ([Nodes](/api/dotsider.core.analysis.models.dependencygraphresult.nodes/), [Edges](/api/dotsider.core.analysis.models.dependencygraphresult.edges/)) and the internal navigation
+metadata consumed by the TUI ([NavigationById](/api/dotsider.core.analysis.models.dependencygraphresult.navigationbyid/)).
+
+**Parameters:**
+
+- `Nodes` ([IReadOnlyList\<GraphNode\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): All nodes in the graph including the root and any unresolved or identity-mismatched leaves,
+each carrying its computed layout coordinates and depth.
+- `Edges` ([IReadOnlyList\<GraphEdge\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Directed edges from each referencing assembly to every assembly it references. Edges for
+cycles and diamonds are preserved; a child identity revisited through a second parent emits
+a new edge but does not re-expand the subtree.
+- `NavigationById` ([IReadOnlyDictionary\<String, GraphNavigationContext\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlydictionary-2)): Per-node navigation metadata keyed by [Id](/api/dotsider.core.analysis.models.graphnode.id/). Intended for in-process TUI
+use only — consumers that serialize graph topology (CLI JSON, diagnostics UDS, MCP tools) must
+ignore this dictionary to avoid leaking machine-local paths through their public contracts.
+
+```csharp
+public DependencyGraphResult(IReadOnlyList<GraphNode> Nodes, IReadOnlyList<GraphEdge> Edges, IReadOnlyDictionary<string, GraphNavigationContext> NavigationById)
+```
+
+## Properties
+
+### Edges
+
+Directed edges from each referencing assembly to every assembly it references. Edges for
+cycles and diamonds are preserved; a child identity revisited through a second parent emits
+a new edge but does not re-expand the subtree.
+
+**Returns:** [IReadOnlyList\<GraphEdge\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<GraphEdge> Edges { get; init; }
+```
+
+### NavigationById
+
+Per-node navigation metadata keyed by [Id](/api/dotsider.core.analysis.models.graphnode.id/). Intended for in-process TUI
+use only — consumers that serialize graph topology (CLI JSON, diagnostics UDS, MCP tools) must
+ignore this dictionary to avoid leaking machine-local paths through their public contracts.
+
+**Returns:** [IReadOnlyDictionary\<String, GraphNavigationContext\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlydictionary-2)
+
+```csharp
+public IReadOnlyDictionary<string, GraphNavigationContext> NavigationById { get; init; }
+```
+
+### Nodes
+
+All nodes in the graph including the root and any unresolved or identity-mismatched leaves,
+each carrying its computed layout coordinates and depth.
+
+**Returns:** [IReadOnlyList\<GraphNode\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<GraphNode> Nodes { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-GraphEdge.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-GraphEdge.md
@@ -1,6 +1,6 @@
 ---
 title: "GraphEdge"
-description: "An edge connecting two nodes in the dependency graph."
+description: "A directed edge from a referencing assembly to a referenced assembly in the transitive dependency graph. Edges are retained for cycles and diamonds: revisiting an already-seen target identity emits a new edge but does not re-expand the target's subtree."
 slug: api/dotsider.core.analysis.models.graphedge
 sidebar:
   order: 1
@@ -10,7 +10,9 @@ sidebar:
 
 **Assembly:** Dotsider.Core.dll
 
-An edge connecting two nodes in the dependency graph.
+A directed edge from a referencing assembly to a referenced assembly in the transitive
+dependency graph. Edges are retained for cycles and diamonds: revisiting an already-seen
+target identity emits a new edge but does not re-expand the target's subtree.
 
 ```csharp
 public sealed record GraphEdge : IEquatable<GraphEdge>
@@ -28,43 +30,49 @@ public sealed record GraphEdge : IEquatable<GraphEdge>
 
 ### GraphEdge(string, string, int)
 
-An edge connecting two nodes in the dependency graph.
+A directed edge from a referencing assembly to a referenced assembly in the transitive
+dependency graph. Edges are retained for cycles and diamonds: revisiting an already-seen
+target identity emits a new edge but does not re-expand the target's subtree.
 
 **Parameters:**
 
-- `SourceName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Name of the assembly that holds the reference.
-- `TargetName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Name of the referenced assembly.
-- `TypeRefCount` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): Number of type references from source to target.
+- `SourceId` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The [Id](/api/dotsider.core.analysis.models.graphnode.id/) of the referencing assembly.
+- `TargetId` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The [Id](/api/dotsider.core.analysis.models.graphnode.id/) of the referenced assembly.
+- `TypeRefCount` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The number of TypeRef entries in the referencing assembly whose resolution scope resolves
+to the exact full identity of the target (not merely its simple name). Zero when the target
+is referenced by the AssemblyRef table but no TypeRefs are scoped to it.
 
 ```csharp
-public GraphEdge(string SourceName, string TargetName, int TypeRefCount)
+public GraphEdge(string SourceId, string TargetId, int TypeRefCount)
 ```
 
 ## Properties
 
-### SourceName
+### SourceId
 
-Name of the assembly that holds the reference.
+The [Id](/api/dotsider.core.analysis.models.graphnode.id/) of the referencing assembly.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 
 ```csharp
-public string SourceName { get; init; }
+public string SourceId { get; init; }
 ```
 
-### TargetName
+### TargetId
 
-Name of the referenced assembly.
+The [Id](/api/dotsider.core.analysis.models.graphnode.id/) of the referenced assembly.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 
 ```csharp
-public string TargetName { get; init; }
+public string TargetId { get; init; }
 ```
 
 ### TypeRefCount
 
-Number of type references from source to target.
+The number of TypeRef entries in the referencing assembly whose resolution scope resolves
+to the exact full identity of the target (not merely its simple name). Zero when the target
+is referenced by the AssemblyRef table but no TypeRefs are scoped to it.
 
 **Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-GraphNavigationContext.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-GraphNavigationContext.md
@@ -1,0 +1,143 @@
+---
+title: "GraphNavigationContext"
+description: "Internal per-node metadata describing how a dependency graph node was resolved and the context under which it was reached. Used by the TUI for Enter-to-open navigation and framework filtering. Never serialized — this data must not leak through CLI, diagnostics, or MCP surfaces that publish graph topology."
+slug: api/dotsider.core.analysis.models.graphnavigationcontext
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+Internal per-node metadata describing how a dependency graph node was resolved and the
+context under which it was reached. Used by the TUI for Enter-to-open navigation and
+framework filtering. Never serialized — this data must not leak through CLI, diagnostics,
+or MCP surfaces that publish graph topology.
+
+```csharp
+public sealed record GraphNavigationContext : IEquatable<GraphNavigationContext>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **GraphNavigationContext**
+
+## Implements
+
+- [IEquatable\<GraphNavigationContext\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### GraphNavigationContext(ResolvedAssembly?, string?, string?, string?, string?, AssemblyProvenance, bool, string?)
+
+Internal per-node metadata describing how a dependency graph node was resolved and the
+context under which it was reached. Used by the TUI for Enter-to-open navigation and
+framework filtering. Never serialized — this data must not leak through CLI, diagnostics,
+or MCP surfaces that publish graph topology.
+
+**Parameters:**
+
+- `Resolved` ([ResolvedAssembly](/api/dotsider.core.analysis.models.resolvedassembly/)): The resolved assembly location, or null when the node is unresolved or
+the provenance is [IdentityMismatch](/api/dotsider.core.analysis.models.assemblyprovenance.identitymismatch/).
+- `ReferencingFilePath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The file path of the analyzer that first caused this node to be visited.
+- `ReferencingBundlePath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The bundle path associated with the referencing analyzer, when applicable.
+- `ReferencingTargetFramework` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The target framework of the referencing analyzer, used for shared-framework probing.
+- `ReferencingPreferredRuntimePack` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The preferred runtime pack of the referencing analyzer.
+- `Provenance` ([AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)): Classification of how the node was located.
+- `IsFrameworkAssembly` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether the node represents a .NET framework assembly, classified independently of its
+provenance so that framework assemblies shipped inside a self-contained publish or single-file
+bundle are still identified correctly.
+- `CandidateProbePath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The file path of a simple-name match whose identity did not match the requested reference,
+populated only when [Provenance](/api/dotsider.core.analysis.models.graphnavigationcontext.provenance/) is [IdentityMismatch](/api/dotsider.core.analysis.models.assemblyprovenance.identitymismatch/).
+
+```csharp
+public GraphNavigationContext(ResolvedAssembly? Resolved, string? ReferencingFilePath, string? ReferencingBundlePath, string? ReferencingTargetFramework, string? ReferencingPreferredRuntimePack, AssemblyProvenance Provenance, bool IsFrameworkAssembly, string? CandidateProbePath)
+```
+
+## Properties
+
+### CandidateProbePath
+
+The file path of a simple-name match whose identity did not match the requested reference,
+populated only when [Provenance](/api/dotsider.core.analysis.models.graphnavigationcontext.provenance/) is [IdentityMismatch](/api/dotsider.core.analysis.models.assemblyprovenance.identitymismatch/).
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? CandidateProbePath { get; init; }
+```
+
+### IsFrameworkAssembly
+
+Whether the node represents a .NET framework assembly, classified independently of its
+provenance so that framework assemblies shipped inside a self-contained publish or single-file
+bundle are still identified correctly.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool IsFrameworkAssembly { get; init; }
+```
+
+### Provenance
+
+Classification of how the node was located.
+
+**Returns:** [AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)
+
+```csharp
+public AssemblyProvenance Provenance { get; init; }
+```
+
+### ReferencingBundlePath
+
+The bundle path associated with the referencing analyzer, when applicable.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? ReferencingBundlePath { get; init; }
+```
+
+### ReferencingFilePath
+
+The file path of the analyzer that first caused this node to be visited.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? ReferencingFilePath { get; init; }
+```
+
+### ReferencingPreferredRuntimePack
+
+The preferred runtime pack of the referencing analyzer.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? ReferencingPreferredRuntimePack { get; init; }
+```
+
+### ReferencingTargetFramework
+
+The target framework of the referencing analyzer, used for shared-framework probing.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? ReferencingTargetFramework { get; init; }
+```
+
+### Resolved
+
+The resolved assembly location, or null when the node is unresolved or
+the provenance is [IdentityMismatch](/api/dotsider.core.analysis.models.assemblyprovenance.identitymismatch/).
+
+**Returns:** [ResolvedAssembly](/api/dotsider.core.analysis.models.resolvedassembly/)
+
+```csharp
+public ResolvedAssembly? Resolved { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-GraphNode.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-GraphNode.md
@@ -1,6 +1,6 @@
 ---
 title: "GraphNode"
-description: "A node in the assembly dependency graph."
+description: "A node in the transitive assembly dependency graph. Topology only — layout coordinates and rendered labels are the responsibility of the view layer, which projects the visible subgraph into a separate render model so filters and viewport changes rebalance without perturbing this record."
 slug: api/dotsider.core.analysis.models.graphnode
 sidebar:
   order: 1
@@ -10,7 +10,10 @@ sidebar:
 
 **Assembly:** Dotsider.Core.dll
 
-A node in the assembly dependency graph.
+A node in the transitive assembly dependency graph. Topology only — layout coordinates
+and rendered labels are the responsibility of the view layer, which projects the visible
+subgraph into a separate render model so filters and viewport changes rebalance without
+perturbing this record.
 
 ```csharp
 public sealed record GraphNode : IEquatable<GraphNode>
@@ -26,28 +29,74 @@ public sealed record GraphNode : IEquatable<GraphNode>
 
 ## Constructors
 
-### GraphNode(string, string?, string?, bool, double, double)
+### GraphNode(string, string, string?, string, string?, bool, int, bool)
 
-A node in the assembly dependency graph.
+A node in the transitive assembly dependency graph. Topology only — layout coordinates
+and rendered labels are the responsibility of the view layer, which projects the visible
+subgraph into a separate render model so filters and viewport changes rebalance without
+perturbing this record.
 
 **Parameters:**
 
-- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Assembly name.
-- `Version` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Assembly version string, or null if unavailable.
+- `Id` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Stable opaque identifier for this node, derived from the full assembly identity
+([Name](/api/dotsider.core.analysis.models.graphnode.name/), [Version](/api/dotsider.core.analysis.models.graphnode.version/), [Culture](/api/dotsider.core.analysis.models.graphnode.culture/), [PublicKeyToken](/api/dotsider.core.analysis.models.graphnode.publickeytoken/))
+via String). Two
+assemblies that share a simple name but differ in any identity field produce distinct ids.
+- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Assembly simple name.
+- `Version` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Assembly version string, or null when unavailable.
+- `Culture` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Assembly culture, or `"neutral"` for culture-neutral assemblies. Never empty.
 - `PublicKeyToken` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Public key token hex string, or null.
-- `IsRoot` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether this is the root (analyzed) assembly.
-- `X` ([Double](https://learn.microsoft.com/dotnet/api/system.double)): X coordinate for graph layout rendering.
-- `Y` ([Double](https://learn.microsoft.com/dotnet/api/system.double)): Y coordinate for graph layout rendering.
+- `IsRoot` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether this is the analyzed assembly (the root of the graph).
+- `Depth` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The minimum number of AssemblyRef hops from the root to this node as discovered by BFS.
+Zero for the root; one for direct references; greater for transitive references.
+- `Unresolved` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether this node is a leaf that could not be resolved. Includes both the case where no
+probe produced any candidate and the case where a probe produced a simple-name match whose
+manifest identity did not match — the latter is further distinguished by the node's
+navigation-context provenance.
 
 ```csharp
-public GraphNode(string Name, string? Version, string? PublicKeyToken, bool IsRoot, double X, double Y)
+public GraphNode(string Id, string Name, string? Version, string Culture, string? PublicKeyToken, bool IsRoot, int Depth, bool Unresolved)
 ```
 
 ## Properties
 
+### Culture
+
+Assembly culture, or `"neutral"` for culture-neutral assemblies. Never empty.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Culture { get; init; }
+```
+
+### Depth
+
+The minimum number of AssemblyRef hops from the root to this node as discovered by BFS.
+Zero for the root; one for direct references; greater for transitive references.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int Depth { get; init; }
+```
+
+### Id
+
+Stable opaque identifier for this node, derived from the full assembly identity
+([Name](/api/dotsider.core.analysis.models.graphnode.name/), [Version](/api/dotsider.core.analysis.models.graphnode.version/), [Culture](/api/dotsider.core.analysis.models.graphnode.culture/), [PublicKeyToken](/api/dotsider.core.analysis.models.graphnode.publickeytoken/))
+via String). Two
+assemblies that share a simple name but differ in any identity field produce distinct ids.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Id { get; init; }
+```
+
 ### IsRoot
 
-Whether this is the root (analyzed) assembly.
+Whether this is the analyzed assembly (the root of the graph).
 
 **Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
 
@@ -57,7 +106,7 @@ public bool IsRoot { get; init; }
 
 ### Name
 
-Assembly name.
+Assembly simple name.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 
@@ -75,33 +124,26 @@ Public key token hex string, or null.
 public string? PublicKeyToken { get; init; }
 ```
 
+### Unresolved
+
+Whether this node is a leaf that could not be resolved. Includes both the case where no
+probe produced any candidate and the case where a probe produced a simple-name match whose
+manifest identity did not match — the latter is further distinguished by the node's
+navigation-context provenance.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool Unresolved { get; init; }
+```
+
 ### Version
 
-Assembly version string, or null if unavailable.
+Assembly version string, or null when unavailable.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 
 ```csharp
 public string? Version { get; init; }
-```
-
-### X
-
-X coordinate for graph layout rendering.
-
-**Returns:** [Double](https://learn.microsoft.com/dotnet/api/system.double)
-
-```csharp
-public double X { get; init; }
-```
-
-### Y
-
-Y coordinate for graph layout rendering.
-
-**Returns:** [Double](https://learn.microsoft.com/dotnet/api/system.double)
-
-```csharp
-public double Y { get; init; }
 ```
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-TypeRefInfo.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-TypeRefInfo.md
@@ -26,7 +26,7 @@ public sealed record TypeRefInfo : IEquatable<TypeRefInfo>
 
 ## Constructors
 
-### TypeRefInfo(int, string, string, string, string)
+### TypeRefInfo(int, string, string, string, string, string)
 
 Information about a referenced type from the TypeRef metadata table.
 
@@ -36,10 +36,18 @@ Information about a referenced type from the TypeRef metadata table.
 - `Namespace` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The namespace of the referenced type.
 - `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The simple name of the referenced type.
 - `FullName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The fully qualified name (Namespace.Name).
-- `ResolutionScope` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The scope in which the type is defined (assembly name or module).
+- `ResolutionScope` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The scope in which the type is defined, rendered as a human-readable string — the
+referenced assembly's simple name, the enclosing type's full name, or the scope kind
+for module and module-reference scopes.
+- `ResolutionScopeId` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The full-identity identifier of the referenced assembly, when the resolution scope ultimately
+derives from an `AssemblyReference`. For TypeRefs whose scope is another TypeRef
+(nested-type scopes) this carries the enclosing type's resolution-scope id by walking the
+nested chain to its root. Empty for module or module-reference scopes, where no referenced
+assembly is involved. Used by the dependency-graph builder to group TypeRefs by full
+identity so per-edge counts are correct even when two references share a simple name.
 
 ```csharp
-public TypeRefInfo(int Token, string Namespace, string Name, string FullName, string ResolutionScope)
+public TypeRefInfo(int Token, string Namespace, string Name, string FullName, string ResolutionScope, string ResolutionScopeId)
 ```
 
 ## Properties
@@ -76,12 +84,29 @@ public string Namespace { get; init; }
 
 ### ResolutionScope
 
-The scope in which the type is defined (assembly name or module).
+The scope in which the type is defined, rendered as a human-readable string — the
+referenced assembly's simple name, the enclosing type's full name, or the scope kind
+for module and module-reference scopes.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 
 ```csharp
 public string ResolutionScope { get; init; }
+```
+
+### ResolutionScopeId
+
+The full-identity identifier of the referenced assembly, when the resolution scope ultimately
+derives from an `AssemblyReference`. For TypeRefs whose scope is another TypeRef
+(nested-type scopes) this carries the enclosing type's resolution-scope id by walking the
+nested chain to its root. Empty for module or module-reference scopes, where no referenced
+assembly is involved. Used by the dependency-graph builder to group TypeRefs by full
+identity so per-edge counts are correct even when two references share a simple name.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string ResolutionScopeId { get; init; }
 ```
 
 ### Token

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models.md
@@ -100,6 +100,16 @@ Information about a custom attribute applied to a metadata entity.
 public sealed record CustomAttributeInfo : IEquatable<CustomAttributeInfo>
 ```
 
+### [DependencyGraphResult](/api/dotsider.core.analysis.models.dependencygraphresult/)
+
+The result of building a transitive assembly dependency graph. Contains the public topology
+consumed by serializers ([Nodes](/api/dotsider.core.analysis.models.dependencygraphresult.nodes/), [Edges](/api/dotsider.core.analysis.models.dependencygraphresult.edges/)) and the internal navigation
+metadata consumed by the TUI ([NavigationById](/api/dotsider.core.analysis.models.dependencygraphresult.navigationbyid/)).
+
+```csharp
+public sealed record DependencyGraphResult : IEquatable<DependencyGraphResult>
+```
+
 ### [DiffEntry\<T\>](/api/dotsider.core.analysis.models.diffentry-1/)
 
 A single diff entry wrapping an item from either side.
@@ -126,15 +136,31 @@ public sealed record FieldDefInfo : IEquatable<FieldDefInfo>
 
 ### [GraphEdge](/api/dotsider.core.analysis.models.graphedge/)
 
-An edge connecting two nodes in the dependency graph.
+A directed edge from a referencing assembly to a referenced assembly in the transitive
+dependency graph. Edges are retained for cycles and diamonds: revisiting an already-seen
+target identity emits a new edge but does not re-expand the target's subtree.
 
 ```csharp
 public sealed record GraphEdge : IEquatable<GraphEdge>
 ```
 
+### [GraphNavigationContext](/api/dotsider.core.analysis.models.graphnavigationcontext/)
+
+Internal per-node metadata describing how a dependency graph node was resolved and the
+context under which it was reached. Used by the TUI for Enter-to-open navigation and
+framework filtering. Never serialized — this data must not leak through CLI, diagnostics,
+or MCP surfaces that publish graph topology.
+
+```csharp
+public sealed record GraphNavigationContext : IEquatable<GraphNavigationContext>
+```
+
 ### [GraphNode](/api/dotsider.core.analysis.models.graphnode/)
 
-A node in the assembly dependency graph.
+A node in the transitive assembly dependency graph. Topology only — layout coordinates
+and rendered labels are the responsibility of the view layer, which projects the visible
+subgraph into a separate render model so filters and viewport changes rebalance without
+perturbing this record.
 
 ```csharp
 public sealed record GraphNode : IEquatable<GraphNode>
@@ -357,6 +383,14 @@ public sealed record TypeRefInfo : IEquatable<TypeRefInfo>
 ```
 
 ## Enums
+
+### [AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)
+
+Describes how an assembly in the dependency graph was located — or why it could not be.
+
+```csharp
+public enum AssemblyProvenance
+```
 
 ### [BundleFileType](/api/dotsider.core.analysis.models.bundlefiletype/)
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-NuGetDepsJsonResolver.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-NuGetDepsJsonResolver.md
@@ -1,0 +1,47 @@
+---
+title: "NuGetDepsJsonResolver"
+description: "Resolves assembly references by consulting the referencing assembly's .deps.json file to locate its NuGet dependencies in the NuGet global packages folder. This is the probe step that makes library projects work — dotnet build does not copy NuGet package assemblies next to a library's bin output, but the .deps.json manifest records the exact resolved package version and runtime asset path, matching what the .NET host uses at runtime."
+slug: api/dotsider.core.analysis.nugetdepsjsonresolver
+sidebar:
+  order: 0
+---
+
+**Namespace:** `Dotsider.Core.Analysis`
+
+**Assembly:** Dotsider.Core.dll
+
+Resolves assembly references by consulting the referencing assembly's `.deps.json`
+file to locate its NuGet dependencies in the NuGet global packages folder. This is the
+probe step that makes library projects work — `dotnet build` does not copy NuGet
+package assemblies next to a library's `bin` output, but the `.deps.json`
+manifest records the exact resolved package version and runtime asset path, matching
+what the .NET host uses at runtime.
+
+```csharp
+public static class NuGetDepsJsonResolver
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **NuGetDepsJsonResolver**
+
+## Methods
+
+### TryResolve(string, string)
+
+Attempts to locate assemblyName in the referencing assembly's
+`.deps.json` manifest and resolve it against the NuGet global packages folder.
+
+**Parameters:**
+
+- `referencingAssemblyPath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Path of the assembly whose `.deps.json` is consulted.
+- `assemblyName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Simple name of the assembly to locate (e.g. `Newtonsoft.Json`).
+
+**Returns:** [ResolvedAssembly](/api/dotsider.core.analysis.models.resolvedassembly/)
+
+A [FromFile](/api/dotsider.core.analysis.models.resolvedassembly.fromfile/) pointing at the packaged dll, or null.
+
+```csharp
+public static ResolvedAssembly? TryResolve(string referencingAssemblyPath, string assemblyName)
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis.md
@@ -33,6 +33,16 @@ Uses dictionary-based O(n) matching by name.
 public static class AssemblyDiffer
 ```
 
+### [AssemblyIdentityFormat](/api/dotsider.core.analysis.assemblyidentityformat/)
+
+Formats an assembly's full identity into a stable opaque string used as a graph node
+identifier and as a key for grouping [TypeRefInfo](/api/dotsider.core.analysis.models.typerefinfo/) entries by the
+full identity of their resolution scope.
+
+```csharp
+public static class AssemblyIdentityFormat
+```
+
 ### [AssemblyLoader](/api/dotsider.core.analysis.assemblyloader/)
 
 Shared factory for opening assembly files. Handles apphosts (companion .dll redirect),
@@ -46,8 +56,12 @@ public static class AssemblyLoader
 
 ### [DependencyGraphBuilder](/api/dotsider.core.analysis.dependencygraphbuilder/)
 
-Builds a dependency graph from an assembly's references and type refs.
-Uses a hierarchical tree layout with the root assembly at top center.
+Builds the full transitive assembly dependency graph rooted at an analyzed assembly.
+Performs a breadth-first walk through each assembly's [AssemblyRefs](/api/dotsider.core.analysis.assemblyanalyzer.assemblyrefs/),
+resolving children by full identity, deduping on [Id](/api/dotsider.core.analysis.models.graphnode.id/), preserving edges
+for cycles and diamonds, and classifying unresolvable and identity-mismatched references as
+non-expanding leaf nodes. Produces a [DependencyGraphResult](/api/dotsider.core.analysis.models.dependencygraphresult/) containing the
+public topology plus internal navigation metadata consumed only by the TUI.
 
 ```csharp
 public static class DependencyGraphBuilder
@@ -85,6 +99,19 @@ assemblies (e.g., System.Private.CoreLib) by probing for type forwarding.
 
 ```csharp
 public static class ImplementationAssemblyResolver
+```
+
+### [NuGetDepsJsonResolver](/api/dotsider.core.analysis.nugetdepsjsonresolver/)
+
+Resolves assembly references by consulting the referencing assembly's `.deps.json`
+file to locate its NuGet dependencies in the NuGet global packages folder. This is the
+probe step that makes library projects work — `dotnet build` does not copy NuGet
+package assemblies next to a library's `bin` output, but the `.deps.json`
+manifest records the exact resolved package version and runtime asset path, matching
+what the .NET host uses at runtime.
+
+```csharp
+public static class NuGetDepsJsonResolver
 ```
 
 ### [NuGetPackageAnalyzer](/api/dotsider.core.analysis.nugetpackageanalyzer/)

--- a/docs/src/content/docs/usage/dep-graph.md
+++ b/docs/src/content/docs/usage/dep-graph.md
@@ -1,18 +1,42 @@
 ---
 title: Dep Graph
-description: Visual dependency graph with edge weights by TypeRef count.
+description: Full transitive assembly dependency graph with TypeRef-weighted edges.
 ---
 
 ![Dep Graph tab](../../../assets/screenshots/dep-graph.png)
 
-The **Dep Graph** tab (`6`) renders a visual dependency graph:
+The **Dep Graph** tab (`6`) renders the full transitive closure of assembly references rooted at the analyzed assembly:
 
-- Your assembly sits at the root
-- Each referenced assembly appears as a node
-- Edge weights show how many TypeRefs point to that dependency
+- Your assembly sits at the root at depth 0
+- Every referenced assembly appears as a node, positioned by BFS depth
+- Edge weights show how many TypeRefs in the referencing assembly resolve to the exact full identity of the target
+- Framework assemblies (BCL, runtime pack) are included by default
+
+Identity is keyed on the full `(name, version, culture, public key token)` tuple, so two assemblies that share a simple name but differ in any identity field appear as two distinct nodes. When a simple name collides, labels show only the identity fields that actually differ — for example `TargetLib v2.0.0.0` when only versions differ, or `TargetLib v1.0.0.0 (b77a5c56)` when only public key tokens differ.
+
+## Unresolved and identity-mismatched nodes
+
+References that cannot be located on disk or inside a bundle render as leaf nodes prefixed with `?`. When a probe produces a file whose simple name matches but whose manifest identity does not, the node renders with a `!` prefix and the graph does not expand from the mismatched file — the closure stays honest about what it actually contains.
+
+## Scope and filter
+
+Two independent controls narrow what you see. Both default to off so the full transitive closure is the starting view.
+
+- `d`: toggle **scope**. `all` (default) shows every node in the closure; `direct` shows only the root and its direct references — depth 1 — plus the edges between them. `direct` is the .NET-native way to think about a project's own package dependencies without the transitive expansion.
+- `f`: toggle **framework filtering**. Assemblies classified as part of the .NET framework (shared runtime, runtime pack, or well-known Microsoft public key tokens) are hidden along with any edges that touch them. Deployment-model-agnostic — framework assemblies shipped inside a self-contained publish or single-file bundle are classified consistently with framework assemblies loaded from the shared runtime.
+
+The controls compose. `scope: direct` with framework filtering on shows the root plus only the non-framework direct references, which is typically the clearest view of what a project actually brings into its dependency graph. The root is always visible regardless of either control. The status line reports visible counts versus totals and which controls are active.
+
+Transitive-only is intentionally not an option — hiding direct parents would produce disconnected islands and remove the explanation path that shows why deeper nodes are in the closure.
 
 ## Navigation
 
-Press `Enter` on any dependency node to open that assembly in a new analysis context (if the file is found on disk). Press `Esc` to return.
+- `←` / `→`: move the keyboard selection across visible nodes. Selection auto-scrolls the viewport to keep the selected box in view.
+- `↑` / `↓`: scroll the viewport up or down one row at a time.
+- `PageUp` / `PageDown`: scroll by one viewport height.
+- `Home` / `End`: jump to the top or bottom of the graph.
+- `Enter`: open the selected node's resolved assembly in a new analysis context. Uses the resolution location recorded at traversal time, not a fresh probe from the root, so transitive nodes open correctly. Enter on the root is a no-op; Enter on an unresolved or identity-mismatched leaf surfaces an explanatory status message.
+- `Esc`: return to the prior analysis context.
+- `/`: search by name; `n` and `p` cycle through matches. Search always operates on the visible model, so hidden nodes (by scope or filter) are never matched or selected.
 
-This gives you a quick sense of which dependencies are most heavily used and lets you drill into any of them.
+When the graph fits the viewport, depth bands spread through the available height. When it doesn't, bands pack tightly from the top and scroll reveals the rest.

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -749,11 +749,42 @@ public sealed class AssemblyAnalyzer : IDisposable
                 _ => tr.ResolutionScope.Kind.ToString()
             };
 
+            var scopeId = ResolveScopeAssemblyIdentityId(tr.ResolutionScope);
+
             result.Add(new TypeRefInfo(
-                MetadataTokens.GetToken(handle), ns, name, fullName, scope));
+                MetadataTokens.GetToken(handle), ns, name, fullName, scope, scopeId));
         }
 
         return result;
+    }
+
+    private string ResolveScopeAssemblyIdentityId(EntityHandle scopeHandle)
+    {
+        if (_metadataReader is null) return string.Empty;
+
+        var current = scopeHandle;
+        while (current.Kind == HandleKind.TypeReference)
+        {
+            var parent = _metadataReader.GetTypeReference((TypeReferenceHandle)current);
+            current = parent.ResolutionScope;
+        }
+
+        if (current.Kind != HandleKind.AssemblyReference)
+            return string.Empty;
+
+        var ar = _metadataReader.GetAssemblyReference((AssemblyReferenceHandle)current);
+        var refName = _metadataReader.GetString(ar.Name);
+        var refVersion = ar.Version.ToString();
+        var refCulture = _metadataReader.GetString(ar.Culture);
+
+        string? refPkt = null;
+        var pktBytes = _metadataReader.GetBlobBytes(ar.PublicKeyOrToken);
+        if (pktBytes.Length > 0)
+        {
+            refPkt = Convert.ToHexStringLower(pktBytes);
+        }
+
+        return AssemblyIdentityFormat.Format(refName, refVersion, refCulture, refPkt);
     }
 
     private List<MemberRefInfo> ReadMemberRefs()
@@ -1174,7 +1205,12 @@ public sealed class AssemblyAnalyzer : IDisposable
         local = Path.Combine(directory, $"{assemblyName}.exe");
         if (File.Exists(local)) return new ResolvedAssembly.FromFile(local);
 
-        // 2. .NET runtime directory (BCL assemblies)
+        // 2. NuGet global packages folder via .deps.json — library projects do not copy
+        // NuGet dependencies into bin, so deps.json is the authoritative mapping.
+        var fromNuGet = NuGetDepsJsonResolver.TryResolve(referencingAssemblyPath, assemblyName);
+        if (fromNuGet is not null) return fromNuGet;
+
+        // 3. .NET runtime directory (BCL assemblies)
         var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
         var runtimeDll = Path.Combine(runtimeDir, $"{assemblyName}.dll");
         if (File.Exists(runtimeDll)) return new ResolvedAssembly.FromFile(runtimeDll);
@@ -1207,6 +1243,227 @@ public sealed class AssemblyAnalyzer : IDisposable
     {
         var resolved = ResolveAssembly(referencingAssemblyPath, assemblyName);
         return resolved is ResolvedAssembly.FromFile(var path) ? path : null;
+    }
+
+    /// <summary>
+    /// Resolves a referenced assembly by full identity (name, version, culture, public key token).
+    /// Probes every stage of <see cref="ResolveAssembly"/> and accepts only candidates whose
+    /// manifest identity matches the requested identity exactly. If no probe produces a full
+    /// match but at least one probe produces a simple-name match whose identity differs,
+    /// returns <see cref="AssemblyProvenance.IdentityMismatch"/> with the path of that candidate —
+    /// the graph does not expand from mismatched files.
+    /// </summary>
+    /// <param name="referencingAssemblyPath">Path of the assembly that references the target.</param>
+    /// <param name="identity">The full identity the caller expects to resolve.</param>
+    /// <param name="targetFramework">Target framework moniker for shared-framework probing.</param>
+    /// <param name="preferredRuntimePack">Preferred runtime pack name.</param>
+    /// <param name="sourceBundlePath">Bundle path, when the referencing assembly came from a bundle.</param>
+    /// <returns>
+    /// A tuple of the resolved assembly (or <see langword="null"/>), the provenance classifying
+    /// how the node was located, and the path of a simple-name match whose identity did not
+    /// match (populated only when provenance is <see cref="AssemblyProvenance.IdentityMismatch"/>).
+    /// </returns>
+    public static (ResolvedAssembly? Resolved, AssemblyProvenance Provenance, string? CandidateProbePath)
+        ResolveAssemblyByIdentity(
+            string referencingAssemblyPath,
+            AssemblyRefInfo identity,
+            string? targetFramework = null,
+            string? preferredRuntimePack = null,
+            string? sourceBundlePath = null)
+    {
+        var directory = sourceBundlePath is not null
+            ? Path.GetDirectoryName(sourceBundlePath)!
+            : Path.GetDirectoryName(referencingAssemblyPath)!;
+
+        string? mismatchPath = null;
+
+        (ResolvedAssembly?, AssemblyProvenance)? TryFile(string path, AssemblyProvenance provenance)
+        {
+            if (!File.Exists(path)) return null;
+            var actual = TryReadFileIdentity(path);
+            if (actual is null) return null;
+            if (IdentityEquals(identity, actual.Value))
+                return (new ResolvedAssembly.FromFile(path), provenance);
+            if (IsFrameworkRollForwardMatch(identity, actual.Value, provenance))
+                return (new ResolvedAssembly.FromFile(path), provenance);
+            mismatchPath ??= path;
+            return null;
+        }
+
+        (ResolvedAssembly?, AssemblyProvenance)? TryBundle(
+            ResolvedAssembly.FromBundle? candidate, AssemblyProvenance provenance)
+        {
+            if (candidate is null) return null;
+            var actual = TryReadBundleIdentity(candidate.Bytes);
+            if (actual is null) return null;
+            if (IdentityEquals(identity, actual.Value))
+                return (candidate, provenance);
+            if (IsFrameworkRollForwardMatch(identity, actual.Value, provenance))
+                return (candidate, provenance);
+            mismatchPath ??= $"{candidate.BundlePath}:{candidate.Name}";
+            return null;
+        }
+
+        (ResolvedAssembly?, AssemblyProvenance)? TryNuGet()
+        {
+            var resolved = NuGetDepsJsonResolver.TryResolve(referencingAssemblyPath, identity.Name);
+            if (resolved is ResolvedAssembly.FromFile f)
+                return TryFile(f.Path, AssemblyProvenance.NuGetPackageCache);
+            return null;
+        }
+
+        var hit = TryFile(Path.Combine(directory, $"{identity.Name}.dll"), AssemblyProvenance.AppLocal)
+                  ?? TryFile(Path.Combine(directory, $"{identity.Name}.exe"), AssemblyProvenance.AppLocal)
+                  ?? TryNuGet()
+                  ?? TryFile(Path.Combine(RuntimeEnvironment.GetRuntimeDirectory(), $"{identity.Name}.dll"),
+                             AssemblyProvenance.RuntimeDirectory)
+                  ?? TryBundle(TryResolveFromBundle(sourceBundlePath, identity.Name),
+                               AssemblyProvenance.SourceBundle)
+                  ?? TryBundle(TryResolveFromBundle(Environment.ProcessPath, identity.Name),
+                               AssemblyProvenance.HostBundle)
+                  ?? TryBundle(TryResolveFromAdjacentBundles(directory, identity.Name),
+                               AssemblyProvenance.AdjacentBundle);
+
+        if (hit is null)
+        {
+            var shared = DotNetRuntimeLocator.FindAssemblyInSharedFramework(
+                identity.Name, targetFramework, preferredRuntimePack);
+            if (shared is not null)
+                hit = TryFile(shared.Path, AssemblyProvenance.SharedFramework);
+        }
+
+        if (hit is { } h)
+            return (h.Item1, h.Item2, null);
+
+        return mismatchPath is not null
+            ? (null, AssemblyProvenance.IdentityMismatch, mismatchPath)
+            : (null, AssemblyProvenance.Unresolved, null);
+    }
+
+    /// <summary>
+    /// Classifies whether an assembly belongs to the .NET framework surface regardless of
+    /// deployment model. Returns <see langword="true"/> when the node was located through the
+    /// shared framework or runtime directory, or when its identity matches a well-known
+    /// Microsoft framework public key token, or when the shared-framework locator recognizes
+    /// its simple name for the supplied target framework. This classification is used by the
+    /// TUI framework-filter toggle so framework assemblies shipped inside a self-contained
+    /// publish or single-file bundle are filtered consistently with framework assemblies
+    /// loaded from the shared runtime.
+    /// </summary>
+    /// <param name="provenance">How the node was located.</param>
+    /// <param name="identity">The resolved assembly's identity.</param>
+    /// <param name="targetFramework">The referencing assembly's target framework moniker.</param>
+    /// <param name="preferredRuntimePack">The referencing assembly's preferred runtime pack.</param>
+    /// <returns><see langword="true"/> if the node represents a framework assembly.</returns>
+    public static bool IsFrameworkAssembly(
+        AssemblyProvenance provenance,
+        AssemblyRefInfo identity,
+        string? targetFramework,
+        string? preferredRuntimePack)
+    {
+        if (provenance is AssemblyProvenance.SharedFramework or AssemblyProvenance.RuntimeDirectory)
+            return true;
+
+        if (identity.PublicKeyToken is string pkt && WellKnownFrameworkPublicKeyTokens.Contains(pkt))
+            return true;
+
+        var shared = DotNetRuntimeLocator.FindAssemblyInSharedFramework(
+            identity.Name, targetFramework, preferredRuntimePack);
+        return shared is not null;
+    }
+
+    private static readonly HashSet<string> WellKnownFrameworkPublicKeyTokens = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "b77a5c561934e089",
+        "b03f5f7f11d50a3a",
+        "31bf3856ad364e35",
+        "7cec85d7bea7798e",
+        "cc7b13ffcd2ddd51",
+        "adb9793829ddae60",
+    };
+
+    private static (string Name, string Version, string Culture, string? PublicKeyToken)? TryReadFileIdentity(string path)
+    {
+        try
+        {
+            using var analyzer = new AssemblyAnalyzer(path);
+            if (!analyzer.HasMetadata || analyzer.AssemblyName is null)
+                return null;
+            return (analyzer.AssemblyName,
+                    analyzer.AssemblyVersion ?? string.Empty,
+                    analyzer.Culture ?? "neutral",
+                    analyzer.PublicKeyToken);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static (string Name, string Version, string Culture, string? PublicKeyToken)? TryReadBundleIdentity(byte[] bytes)
+    {
+        try
+        {
+            using var analyzer = new AssemblyAnalyzer(bytes, filePath: "<bundle>");
+            if (!analyzer.HasMetadata || analyzer.AssemblyName is null)
+                return null;
+            return (analyzer.AssemblyName,
+                    analyzer.AssemblyVersion ?? string.Empty,
+                    analyzer.Culture ?? "neutral",
+                    analyzer.PublicKeyToken);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Whether a probe candidate qualifies as a .NET host-style framework roll-forward of the
+    /// requested reference. Matches the binding behavior the .NET host applies when a binary
+    /// compiled against an older framework version runs against a newer shared framework:
+    /// if the candidate came from the shared framework, runtime directory, or NuGet package
+    /// cache, shares the simple name and public key token, and carries a well-known Microsoft
+    /// framework public key token, accept the version difference. Without this, every
+    /// framework-referencing package (net6-targeted third-party libraries running on net10)
+    /// would fill the graph with identity-mismatched leaves even though the .NET host itself
+    /// binds them happily.
+    /// </summary>
+    private static bool IsFrameworkRollForwardMatch(
+        AssemblyRefInfo requested,
+        (string Name, string Version, string Culture, string? PublicKeyToken) actual,
+        AssemblyProvenance provenance)
+    {
+        if (provenance is not (AssemblyProvenance.SharedFramework
+                              or AssemblyProvenance.RuntimeDirectory
+                              or AssemblyProvenance.NuGetPackageCache))
+            return false;
+        if (!string.Equals(requested.Name, actual.Name, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (string.IsNullOrEmpty(requested.PublicKeyToken) || string.IsNullOrEmpty(actual.PublicKeyToken))
+            return false;
+        if (!string.Equals(requested.PublicKeyToken, actual.PublicKeyToken, StringComparison.OrdinalIgnoreCase))
+            return false;
+        return WellKnownFrameworkPublicKeyTokens.Contains(requested.PublicKeyToken);
+    }
+
+    private static bool IdentityEquals(
+        AssemblyRefInfo requested,
+        (string Name, string Version, string Culture, string? PublicKeyToken) actual)
+    {
+        if (!string.Equals(requested.Name, actual.Name, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (!string.Equals(requested.Version, actual.Version, StringComparison.Ordinal))
+            return false;
+
+        var requestedCulture = string.IsNullOrEmpty(requested.Culture) ? "neutral" : requested.Culture;
+        var actualCulture = string.IsNullOrEmpty(actual.Culture) ? "neutral" : actual.Culture;
+        if (!string.Equals(requestedCulture, actualCulture, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var requestedPkt = requested.PublicKeyToken ?? string.Empty;
+        var actualPkt = actual.PublicKeyToken ?? string.Empty;
+        return string.Equals(requestedPkt, actualPkt, StringComparison.OrdinalIgnoreCase);
     }
 
     private static ResolvedAssembly.FromBundle? TryResolveFromBundle(string? bundlePath, string assemblyName)

--- a/src/Dotsider.Core/Analysis/AssemblyIdentityFormat.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyIdentityFormat.cs
@@ -1,0 +1,28 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Formats an assembly's full identity into a stable opaque string used as a graph node
+/// identifier and as a key for grouping <see cref="Models.TypeRefInfo"/> entries by the
+/// full identity of their resolution scope.
+/// </summary>
+/// <remarks>
+/// The format is <c>"{Name}|{Version}|{Culture}|{PublicKeyToken}"</c>. Null or empty culture
+/// is normalized to <c>"neutral"</c> so two nodes only differ by culture when they truly do.
+/// The identifier is treated as opaque by consumers; it is never parsed.
+/// </remarks>
+public static class AssemblyIdentityFormat
+{
+    /// <summary>
+    /// Formats an assembly identity into its canonical identifier string.
+    /// </summary>
+    /// <param name="name">The assembly simple name.</param>
+    /// <param name="version">The assembly version, or <see langword="null"/>.</param>
+    /// <param name="culture">The assembly culture, or <see langword="null"/>/empty for culture-neutral.</param>
+    /// <param name="publicKeyToken">The public key token hex, or <see langword="null"/>.</param>
+    /// <returns>A stable opaque identifier derived from the four identity fields.</returns>
+    public static string Format(string name, string? version, string? culture, string? publicKeyToken)
+    {
+        var normalizedCulture = string.IsNullOrEmpty(culture) ? "neutral" : culture;
+        return $"{name}|{version ?? string.Empty}|{normalizedCulture}|{publicKeyToken ?? string.Empty}";
+    }
+}

--- a/src/Dotsider.Core/Analysis/DependencyGraphBuilder.cs
+++ b/src/Dotsider.Core/Analysis/DependencyGraphBuilder.cs
@@ -3,77 +3,238 @@ using Dotsider.Core.Analysis.Models;
 namespace Dotsider.Core.Analysis;
 
 /// <summary>
-/// Builds a dependency graph from an assembly's references and type refs.
-/// Uses a hierarchical tree layout with the root assembly at top center.
+/// Builds the full transitive assembly dependency graph rooted at an analyzed assembly.
+/// Performs a breadth-first walk through each assembly's <see cref="AssemblyAnalyzer.AssemblyRefs"/>,
+/// resolving children by full identity, deduping on <see cref="GraphNode.Id"/>, preserving edges
+/// for cycles and diamonds, and classifying unresolvable and identity-mismatched references as
+/// non-expanding leaf nodes. Produces a <see cref="DependencyGraphResult"/> containing the
+/// public topology plus internal navigation metadata consumed only by the TUI.
 /// </summary>
 public static class DependencyGraphBuilder
 {
     /// <summary>
-    /// Builds a graph of assembly references with positioned nodes and weighted edges.
+    /// Builds the transitive dependency graph rooted at <paramref name="analyzer"/>.
     /// </summary>
-    /// <param name="analyzer">The assembly analyzer to read references from.</param>
-    /// <returns>The graph nodes and edges for rendering.</returns>
-    public static (IReadOnlyList<GraphNode> Nodes, IReadOnlyList<GraphEdge> Edges) Build(
-        AssemblyAnalyzer analyzer)
+    /// <param name="analyzer">The root assembly analyzer. The caller retains ownership and disposal
+    /// responsibility; the builder does not dispose it.</param>
+    /// <returns>The computed nodes, edges, and per-node navigation metadata.</returns>
+    public static DependencyGraphResult Build(AssemblyAnalyzer analyzer)
     {
-        var nodes = new List<GraphNode>();
+        var byId = new Dictionary<string, GraphNode>(StringComparer.Ordinal);
         var edges = new List<GraphEdge>();
+        var navById = new Dictionary<string, GraphNavigationContext>(StringComparer.Ordinal);
+        var depthById = new Dictionary<string, int>(StringComparer.Ordinal);
+        var parentOrderById = new Dictionary<string, int>(StringComparer.Ordinal);
+        var resolutionCache = new Dictionary<(string ParentId, string ChildId),
+            (ResolvedAssembly? Resolved, AssemblyProvenance Provenance, string? CandidateProbePath)>();
 
-        // Count type refs per assembly for edge weights
-        var typeRefCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        foreach (var typeRef in analyzer.TypeRefs)
-        {
-            var scope = typeRef.ResolutionScope;
-            if (!string.IsNullOrEmpty(scope))
-            {
-                typeRefCounts.TryGetValue(scope, out var count);
-                typeRefCounts[scope] = count + 1;
-            }
-        }
+        var rootIdentity = IdentityFromAnalyzer(analyzer);
+        var rootId = AssemblyIdentityFormat.Format(
+            rootIdentity.Name, rootIdentity.Version, rootIdentity.Culture, rootIdentity.PublicKeyToken);
 
-        var refs = analyzer.AssemblyRefs;
-
-        // Root node at top center
-        nodes.Add(new GraphNode(
-            analyzer.AssemblyName ?? analyzer.FileName,
-            analyzer.AssemblyVersion,
-            analyzer.PublicKeyToken,
+        depthById[rootId] = 0;
+        parentOrderById[rootId] = 0;
+        byId[rootId] = new GraphNode(
+            Id: rootId,
+            Name: rootIdentity.Name,
+            Version: NullIfEmpty(rootIdentity.Version),
+            Culture: rootIdentity.Culture,
+            PublicKeyToken: rootIdentity.PublicKeyToken,
             IsRoot: true,
-            X: 0.5,
-            Y: 0.1));
+            Depth: 0,
+            Unresolved: false);
+        navById[rootId] = new GraphNavigationContext(
+            Resolved: null,
+            ReferencingFilePath: null,
+            ReferencingBundlePath: null,
+            ReferencingTargetFramework: null,
+            ReferencingPreferredRuntimePack: null,
+            Provenance: AssemblyProvenance.Root,
+            IsFrameworkAssembly: false,
+            CandidateProbePath: null);
 
-        // Child nodes evenly spaced below
-        for (var i = 0; i < refs.Count; i++)
+        var queue = new Queue<(AssemblyAnalyzer Analyzer, string NodeId, bool OwnsDispose)>();
+        queue.Enqueue((analyzer, rootId, OwnsDispose: false));
+
+        var parentCounter = 1;
+
+        while (queue.Count > 0)
         {
-            var asmRef = refs[i];
-            double x;
-            // Multiple rows if many refs
-            var row = i / 8;
-            var col = i % 8;
-            var colCount = Math.Min(8, refs.Count - row * 8);
+            var (current, currentId, ownsDispose) = queue.Dequeue();
+            var currentDepth = depthById[currentId];
 
-            if (refs.Count <= 8)
+            try
             {
-                x = refs.Count == 1 ? 0.5 : (double)i / (refs.Count - 1);
-                nodes.Add(new GraphNode(
-                    asmRef.Name, asmRef.Version, asmRef.PublicKeyToken,
-                    IsRoot: false, X: 0.05 + x * 0.9, Y: 0.5));
-            }
-            else
-            {
-                x = colCount == 1 ? 0.5 : (double)col / (colCount - 1);
-                nodes.Add(new GraphNode(
-                    asmRef.Name, asmRef.Version, asmRef.PublicKeyToken,
-                    IsRoot: false,
-                    X: 0.05 + x * 0.9,
-                    Y: 0.4 + row * 0.2));
-            }
+                var refs = current.HasMetadata ? current.AssemblyRefs : [];
+                var typeRefs = current.HasMetadata ? current.TypeRefs : [];
 
-            typeRefCounts.TryGetValue(asmRef.Name, out var refCount);
-            edges.Add(new GraphEdge(
-                nodes[0].Name, asmRef.Name, refCount));
+                var counts = CountTypeRefsByScopeId(typeRefs);
+
+                foreach (var asmRef in refs)
+                {
+                    var childId = AssemblyIdentityFormat.Format(
+                        asmRef.Name, asmRef.Version, asmRef.Culture, asmRef.PublicKeyToken);
+
+                    counts.TryGetValue(childId, out var count);
+
+                    if (byId.TryGetValue(childId, out var existing))
+                    {
+                        edges.Add(new GraphEdge(currentId, childId, count));
+
+                        if (existing.Unresolved)
+                        {
+                            var retry = ResolveAndQueueNew(
+                                current, currentId, asmRef, childId,
+                                resolutionCache, byId, navById, depthById, parentOrderById,
+                                queue, ref parentCounter, currentDepth, upgrade: existing);
+                            _ = retry;
+                        }
+
+                        continue;
+                    }
+
+                    edges.Add(new GraphEdge(currentId, childId, count));
+
+                    ResolveAndQueueNew(
+                        current, currentId, asmRef, childId,
+                        resolutionCache, byId, navById, depthById, parentOrderById,
+                        queue, ref parentCounter, currentDepth, upgrade: null);
+                }
+            }
+            finally
+            {
+                if (ownsDispose)
+                    current.Dispose();
+            }
         }
 
-        return (nodes, edges);
+        // Preserve sibling order from traversal so toggling view-layer filters does not
+        // cause jitter in the rendered graph — the view layer keys its row packing off
+        // this stable ordering.
+        var orderedNodes = byId.Values
+            .OrderBy(n => n.Depth)
+            .ThenBy(n => parentOrderById.TryGetValue(n.Id, out var o) ? o : int.MaxValue)
+            .ThenBy(n => n.Id, StringComparer.Ordinal)
+            .ToList();
+
+        return new DependencyGraphResult(orderedNodes, edges, navById);
     }
+
+    private static bool ResolveAndQueueNew(
+        AssemblyAnalyzer parent,
+        string parentId,
+        AssemblyRefInfo asmRef,
+        string childId,
+        Dictionary<(string ParentId, string ChildId),
+            (ResolvedAssembly? Resolved, AssemblyProvenance Provenance, string? CandidateProbePath)> cache,
+        Dictionary<string, GraphNode> byId,
+        Dictionary<string, GraphNavigationContext> navById,
+        Dictionary<string, int> depthById,
+        Dictionary<string, int> parentOrderById,
+        Queue<(AssemblyAnalyzer Analyzer, string NodeId, bool OwnsDispose)> queue,
+        ref int parentCounter,
+        int parentDepth,
+        GraphNode? upgrade)
+    {
+        if (!cache.TryGetValue((parentId, childId), out var resolution))
+        {
+            resolution = AssemblyAnalyzer.ResolveAssemblyByIdentity(
+                parent.FilePath, asmRef,
+                parent.TargetFramework, parent.PreferredRuntimePack, parent.SourceBundlePath);
+            cache[(parentId, childId)] = resolution;
+        }
+
+        // Classify from the requested AssemblyRef identity so unresolved and identity-mismatched
+        // framework refs (common when a net6-targeted package runs against net10) are still
+        // filtered by the framework toggle — otherwise the filter leaves a pile of BCL leaves
+        // visible and defeats its purpose on real package graphs.
+        var isFramework = AssemblyAnalyzer.IsFrameworkAssembly(
+            resolution.Provenance, asmRef, parent.TargetFramework, parent.PreferredRuntimePack);
+
+        var childNav = new GraphNavigationContext(
+            Resolved: resolution.Resolved,
+            ReferencingFilePath: parent.FilePath,
+            ReferencingBundlePath: parent.SourceBundlePath,
+            ReferencingTargetFramework: parent.TargetFramework,
+            ReferencingPreferredRuntimePack: parent.PreferredRuntimePack,
+            Provenance: resolution.Provenance,
+            IsFrameworkAssembly: isFramework,
+            CandidateProbePath: resolution.CandidateProbePath);
+
+        var childDepth = parentDepth + 1;
+
+        if (upgrade is null)
+        {
+            depthById[childId] = childDepth;
+            parentOrderById[childId] = parentCounter++;
+            byId[childId] = new GraphNode(
+                Id: childId,
+                Name: asmRef.Name,
+                Version: NullIfEmpty(asmRef.Version),
+                Culture: string.IsNullOrEmpty(asmRef.Culture) ? "neutral" : asmRef.Culture,
+                PublicKeyToken: asmRef.PublicKeyToken,
+                IsRoot: false,
+                Depth: childDepth,
+                Unresolved: resolution.Resolved is null);
+            navById[childId] = childNav;
+        }
+        else if (resolution.Resolved is not null)
+        {
+            byId[childId] = upgrade with { Unresolved = false };
+            navById[childId] = childNav;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (resolution.Resolved is null)
+            return false;
+
+        try
+        {
+            AssemblyAnalyzer childAnalyzer = resolution.Resolved switch
+            {
+                ResolvedAssembly.FromFile f => new AssemblyAnalyzer(f.Path),
+                ResolvedAssembly.FromBundle b => new AssemblyAnalyzer(
+                    b.Bytes, filePath: b.Name, sourceBundlePath: b.BundlePath, displayName: b.Name),
+                _ => throw new InvalidOperationException("Unknown ResolvedAssembly variant."),
+            };
+            queue.Enqueue((childAnalyzer, childId, OwnsDispose: true));
+            return true;
+        }
+        catch
+        {
+            byId[childId] = byId[childId] with { Unresolved = true };
+            navById[childId] = childNav with
+            {
+                Resolved = null,
+                Provenance = AssemblyProvenance.Unresolved,
+            };
+            return false;
+        }
+    }
+
+    private static Dictionary<string, int> CountTypeRefsByScopeId(IReadOnlyList<TypeRefInfo> typeRefs)
+    {
+        var result = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var t in typeRefs)
+        {
+            if (string.IsNullOrEmpty(t.ResolutionScopeId)) continue;
+            result.TryGetValue(t.ResolutionScopeId, out var n);
+            result[t.ResolutionScopeId] = n + 1;
+        }
+        return result;
+    }
+
+    private static AssemblyRefInfo IdentityFromAnalyzer(AssemblyAnalyzer analyzer)
+    {
+        var name = analyzer.AssemblyName ?? analyzer.FileName;
+        var version = analyzer.AssemblyVersion ?? string.Empty;
+        var culture = string.IsNullOrEmpty(analyzer.Culture) ? "neutral" : analyzer.Culture!;
+        return new AssemblyRefInfo(name, version, culture, analyzer.PublicKeyToken);
+    }
+
+    private static string? NullIfEmpty(string value) => string.IsNullOrEmpty(value) ? null : value;
+
 }

--- a/src/Dotsider.Core/Analysis/Models/AssemblyProvenance.cs
+++ b/src/Dotsider.Core/Analysis/Models/AssemblyProvenance.cs
@@ -1,0 +1,48 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// Describes how an assembly in the dependency graph was located — or why it could not be.
+/// </summary>
+/// <remarks>
+/// The order of enum members is not significant; callers should compare by member name.
+/// </remarks>
+public enum AssemblyProvenance
+{
+    /// <summary>The analyzed assembly itself (the graph root).</summary>
+    Root,
+
+    /// <summary>Resolved from the referencing assembly's directory on disk.</summary>
+    AppLocal,
+
+    /// <summary>Resolved from the active .NET runtime directory.</summary>
+    RuntimeDirectory,
+
+    /// <summary>
+    /// Resolved from the NuGet global packages folder by consulting the referencing
+    /// assembly's <c>.deps.json</c> manifest for the exact resolved package version and
+    /// runtime asset path.
+    /// </summary>
+    NuGetPackageCache,
+
+    /// <summary>Resolved through the shared-framework discovery for the target framework.</summary>
+    SharedFramework,
+
+    /// <summary>Extracted from the single-file bundle that produced the referencing assembly.</summary>
+    SourceBundle,
+
+    /// <summary>Extracted from the host process bundle (when dotsider itself is bundled).</summary>
+    HostBundle,
+
+    /// <summary>Extracted from a single-file bundle adjacent to the referencing assembly.</summary>
+    AdjacentBundle,
+
+    /// <summary>No probe produced any candidate file for the referenced simple name.</summary>
+    Unresolved,
+
+    /// <summary>
+    /// A probe produced a file whose simple name matched, but whose manifest identity
+    /// (version, culture, or public key token) did not match the requested reference.
+    /// The graph does not expand from such candidates — the node is left as an unresolved leaf.
+    /// </summary>
+    IdentityMismatch,
+}

--- a/src/Dotsider.Core/Analysis/Models/DependencyGraphResult.cs
+++ b/src/Dotsider.Core/Analysis/Models/DependencyGraphResult.cs
@@ -1,0 +1,25 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// The result of building a transitive assembly dependency graph. Contains the public topology
+/// consumed by serializers (<see cref="Nodes"/>, <see cref="Edges"/>) and the internal navigation
+/// metadata consumed by the TUI (<see cref="NavigationById"/>).
+/// </summary>
+/// <param name="Nodes">
+/// All nodes in the graph including the root and any unresolved or identity-mismatched leaves,
+/// each carrying its computed layout coordinates and depth.
+/// </param>
+/// <param name="Edges">
+/// Directed edges from each referencing assembly to every assembly it references. Edges for
+/// cycles and diamonds are preserved; a child identity revisited through a second parent emits
+/// a new edge but does not re-expand the subtree.
+/// </param>
+/// <param name="NavigationById">
+/// Per-node navigation metadata keyed by <see cref="GraphNode.Id"/>. Intended for in-process TUI
+/// use only — consumers that serialize graph topology (CLI JSON, diagnostics UDS, MCP tools) must
+/// ignore this dictionary to avoid leaking machine-local paths through their public contracts.
+/// </param>
+public sealed record DependencyGraphResult(
+    IReadOnlyList<GraphNode> Nodes,
+    IReadOnlyList<GraphEdge> Edges,
+    IReadOnlyDictionary<string, GraphNavigationContext> NavigationById);

--- a/src/Dotsider.Core/Analysis/Models/GraphEdge.cs
+++ b/src/Dotsider.Core/Analysis/Models/GraphEdge.cs
@@ -1,12 +1,22 @@
 namespace Dotsider.Core.Analysis.Models;
 
 /// <summary>
-/// An edge connecting two nodes in the dependency graph.
+/// A directed edge from a referencing assembly to a referenced assembly in the transitive
+/// dependency graph. Edges are retained for cycles and diamonds: revisiting an already-seen
+/// target identity emits a new edge but does not re-expand the target's subtree.
 /// </summary>
-/// <param name="SourceName">Name of the assembly that holds the reference.</param>
-/// <param name="TargetName">Name of the referenced assembly.</param>
-/// <param name="TypeRefCount">Number of type references from source to target.</param>
+/// <param name="SourceId">
+/// The <see cref="GraphNode.Id"/> of the referencing assembly.
+/// </param>
+/// <param name="TargetId">
+/// The <see cref="GraphNode.Id"/> of the referenced assembly.
+/// </param>
+/// <param name="TypeRefCount">
+/// The number of TypeRef entries in the referencing assembly whose resolution scope resolves
+/// to the exact full identity of the target (not merely its simple name). Zero when the target
+/// is referenced by the AssemblyRef table but no TypeRefs are scoped to it.
+/// </param>
 public sealed record GraphEdge(
-    string SourceName,
-    string TargetName,
+    string SourceId,
+    string TargetId,
     int TypeRefCount);

--- a/src/Dotsider.Core/Analysis/Models/GraphNavigationContext.cs
+++ b/src/Dotsider.Core/Analysis/Models/GraphNavigationContext.cs
@@ -1,0 +1,43 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// Internal per-node metadata describing how a dependency graph node was resolved and the
+/// context under which it was reached. Used by the TUI for Enter-to-open navigation and
+/// framework filtering. Never serialized — this data must not leak through CLI, diagnostics,
+/// or MCP surfaces that publish graph topology.
+/// </summary>
+/// <param name="Resolved">
+/// The resolved assembly location, or <see langword="null"/> when the node is unresolved or
+/// the provenance is <see cref="AssemblyProvenance.IdentityMismatch"/>.
+/// </param>
+/// <param name="ReferencingFilePath">
+/// The file path of the analyzer that first caused this node to be visited.
+/// </param>
+/// <param name="ReferencingBundlePath">
+/// The bundle path associated with the referencing analyzer, when applicable.
+/// </param>
+/// <param name="ReferencingTargetFramework">
+/// The target framework of the referencing analyzer, used for shared-framework probing.
+/// </param>
+/// <param name="ReferencingPreferredRuntimePack">
+/// The preferred runtime pack of the referencing analyzer.
+/// </param>
+/// <param name="Provenance">Classification of how the node was located.</param>
+/// <param name="IsFrameworkAssembly">
+/// Whether the node represents a .NET framework assembly, classified independently of its
+/// provenance so that framework assemblies shipped inside a self-contained publish or single-file
+/// bundle are still identified correctly.
+/// </param>
+/// <param name="CandidateProbePath">
+/// The file path of a simple-name match whose identity did not match the requested reference,
+/// populated only when <see cref="Provenance"/> is <see cref="AssemblyProvenance.IdentityMismatch"/>.
+/// </param>
+public sealed record GraphNavigationContext(
+    ResolvedAssembly? Resolved,
+    string? ReferencingFilePath,
+    string? ReferencingBundlePath,
+    string? ReferencingTargetFramework,
+    string? ReferencingPreferredRuntimePack,
+    AssemblyProvenance Provenance,
+    bool IsFrameworkAssembly,
+    string? CandidateProbePath);

--- a/src/Dotsider.Core/Analysis/Models/GraphNode.cs
+++ b/src/Dotsider.Core/Analysis/Models/GraphNode.cs
@@ -1,18 +1,40 @@
 namespace Dotsider.Core.Analysis.Models;
 
 /// <summary>
-/// A node in the assembly dependency graph.
+/// A node in the transitive assembly dependency graph. Topology only — layout coordinates
+/// and rendered labels are the responsibility of the view layer, which projects the visible
+/// subgraph into a separate render model so filters and viewport changes rebalance without
+/// perturbing this record.
 /// </summary>
-/// <param name="Name">Assembly name.</param>
-/// <param name="Version">Assembly version string, or <see langword="null"/> if unavailable.</param>
+/// <param name="Id">
+/// Stable opaque identifier for this node, derived from the full assembly identity
+/// (<see cref="Name"/>, <see cref="Version"/>, <see cref="Culture"/>, <see cref="PublicKeyToken"/>)
+/// via <see cref="AssemblyIdentityFormat.Format(string, string?, string?, string?)"/>. Two
+/// assemblies that share a simple name but differ in any identity field produce distinct ids.
+/// </param>
+/// <param name="Name">Assembly simple name.</param>
+/// <param name="Version">Assembly version string, or <see langword="null"/> when unavailable.</param>
+/// <param name="Culture">
+/// Assembly culture, or <c>"neutral"</c> for culture-neutral assemblies. Never empty.
+/// </param>
 /// <param name="PublicKeyToken">Public key token hex string, or <see langword="null"/>.</param>
-/// <param name="IsRoot">Whether this is the root (analyzed) assembly.</param>
-/// <param name="X">X coordinate for graph layout rendering.</param>
-/// <param name="Y">Y coordinate for graph layout rendering.</param>
+/// <param name="IsRoot">Whether this is the analyzed assembly (the root of the graph).</param>
+/// <param name="Depth">
+/// The minimum number of AssemblyRef hops from the root to this node as discovered by BFS.
+/// Zero for the root; one for direct references; greater for transitive references.
+/// </param>
+/// <param name="Unresolved">
+/// Whether this node is a leaf that could not be resolved. Includes both the case where no
+/// probe produced any candidate and the case where a probe produced a simple-name match whose
+/// manifest identity did not match — the latter is further distinguished by the node's
+/// navigation-context provenance.
+/// </param>
 public sealed record GraphNode(
+    string Id,
     string Name,
     string? Version,
+    string Culture,
     string? PublicKeyToken,
     bool IsRoot,
-    double X,
-    double Y);
+    int Depth,
+    bool Unresolved);

--- a/src/Dotsider.Core/Analysis/Models/TypeRefInfo.cs
+++ b/src/Dotsider.Core/Analysis/Models/TypeRefInfo.cs
@@ -7,10 +7,23 @@ namespace Dotsider.Core.Analysis.Models;
 /// <param name="Namespace">The namespace of the referenced type.</param>
 /// <param name="Name">The simple name of the referenced type.</param>
 /// <param name="FullName">The fully qualified name (Namespace.Name).</param>
-/// <param name="ResolutionScope">The scope in which the type is defined (assembly name or module).</param>
+/// <param name="ResolutionScope">
+/// The scope in which the type is defined, rendered as a human-readable string — the
+/// referenced assembly's simple name, the enclosing type's full name, or the scope kind
+/// for module and module-reference scopes.
+/// </param>
+/// <param name="ResolutionScopeId">
+/// The full-identity identifier of the referenced assembly, when the resolution scope ultimately
+/// derives from an <c>AssemblyReference</c>. For TypeRefs whose scope is another TypeRef
+/// (nested-type scopes) this carries the enclosing type's resolution-scope id by walking the
+/// nested chain to its root. Empty for module or module-reference scopes, where no referenced
+/// assembly is involved. Used by the dependency-graph builder to group TypeRefs by full
+/// identity so per-edge counts are correct even when two references share a simple name.
+/// </param>
 public sealed record TypeRefInfo(
     int Token,
     string Namespace,
     string Name,
     string FullName,
-    string ResolutionScope);
+    string ResolutionScope,
+    string ResolutionScopeId);

--- a/src/Dotsider.Core/Analysis/NuGetDepsJsonResolver.cs
+++ b/src/Dotsider.Core/Analysis/NuGetDepsJsonResolver.cs
@@ -1,0 +1,152 @@
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Resolves assembly references by consulting the referencing assembly's <c>.deps.json</c>
+/// file to locate its NuGet dependencies in the NuGet global packages folder. This is the
+/// probe step that makes library projects work — <c>dotnet build</c> does not copy NuGet
+/// package assemblies next to a library's <c>bin</c> output, but the <c>.deps.json</c>
+/// manifest records the exact resolved package version and runtime asset path, matching
+/// what the .NET host uses at runtime.
+/// </summary>
+public static class NuGetDepsJsonResolver
+{
+    /// <summary>
+    /// Attempts to locate <paramref name="assemblyName"/> in the referencing assembly's
+    /// <c>.deps.json</c> manifest and resolve it against the NuGet global packages folder.
+    /// </summary>
+    /// <param name="referencingAssemblyPath">Path of the assembly whose <c>.deps.json</c> is consulted.</param>
+    /// <param name="assemblyName">Simple name of the assembly to locate (e.g. <c>Newtonsoft.Json</c>).</param>
+    /// <returns>A <see cref="ResolvedAssembly.FromFile"/> pointing at the packaged dll, or <see langword="null"/>.</returns>
+    public static ResolvedAssembly? TryResolve(string referencingAssemblyPath, string assemblyName)
+    {
+        var depsJsonPath = FindDepsJsonFor(referencingAssemblyPath);
+        if (depsJsonPath is null) return null;
+
+        string? libraryKey;
+        string? runtimeRelative;
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllBytes(depsJsonPath));
+            if (!TryFindRuntimeAsset(doc.RootElement, assemblyName, out libraryKey, out runtimeRelative))
+                return null;
+        }
+        catch (IOException) { return null; }
+        catch (JsonException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+
+        if (libraryKey is null || runtimeRelative is null) return null;
+
+        var packagePath = ReadLibraryPath(depsJsonPath, libraryKey);
+        if (packagePath is null) return null;
+
+        foreach (var root in GetNuGetPackagesRoots())
+        {
+            var candidate = Path.Combine(root, packagePath.Replace('/', Path.DirectorySeparatorChar),
+                runtimeRelative.Replace('/', Path.DirectorySeparatorChar));
+            if (File.Exists(candidate))
+                return new ResolvedAssembly.FromFile(candidate);
+        }
+
+        return null;
+    }
+
+    private static string? FindDepsJsonFor(string referencingAssemblyPath)
+    {
+        // Match only on the referencing assembly's own base name. The .NET SDK publishes
+        // the deps manifest alongside the primary output as <AssemblyName>.deps.json, so a
+        // direct base-name check covers every normal library and application layout. The
+        // previous glob-scan fallback ran a Directory.GetFiles on every resolve call even
+        // when no manifest existed (the common case for runtime-dir assemblies) and
+        // added tens of microseconds of overhead per probe — a measurable slowdown on the
+        // hot path of transitive graph traversal.
+        var dir = Path.GetDirectoryName(referencingAssemblyPath);
+        if (dir is null) return null;
+
+        var baseName = Path.GetFileNameWithoutExtension(referencingAssemblyPath);
+        var direct = Path.Combine(dir, $"{baseName}.deps.json");
+        return File.Exists(direct) ? direct : null;
+    }
+
+    private static bool TryFindRuntimeAsset(
+        JsonElement root, string assemblyName,
+        out string? libraryKey, out string? runtimeRelative)
+    {
+        libraryKey = null;
+        runtimeRelative = null;
+
+        if (!root.TryGetProperty("targets", out var targets) || targets.ValueKind != JsonValueKind.Object)
+            return false;
+
+        foreach (var target in targets.EnumerateObject())
+        {
+            if (target.Value.ValueKind != JsonValueKind.Object) continue;
+
+            foreach (var lib in target.Value.EnumerateObject())
+            {
+                if (lib.Value.ValueKind != JsonValueKind.Object) continue;
+                if (!lib.Value.TryGetProperty("runtime", out var runtime) || runtime.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                foreach (var asset in runtime.EnumerateObject())
+                {
+                    var fileName = Path.GetFileNameWithoutExtension(asset.Name);
+                    if (string.Equals(fileName, assemblyName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        libraryKey = lib.Name;
+                        runtimeRelative = asset.Name;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static string? ReadLibraryPath(string depsJsonPath, string libraryKey)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllBytes(depsJsonPath));
+            if (!doc.RootElement.TryGetProperty("libraries", out var libs)
+                || libs.ValueKind != JsonValueKind.Object)
+                return null;
+
+            if (!libs.TryGetProperty(libraryKey, out var entry) || entry.ValueKind != JsonValueKind.Object)
+                return null;
+
+            if (!entry.TryGetProperty("type", out var type) || type.GetString() != "package")
+                return null;
+
+            if (entry.TryGetProperty("path", out var pathProp) && pathProp.ValueKind == JsonValueKind.String)
+                return pathProp.GetString();
+
+            var slash = libraryKey.IndexOf('/');
+            return slash > 0
+                ? $"{libraryKey[..slash].ToLowerInvariant()}/{libraryKey[(slash + 1)..]}"
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static IEnumerable<string> GetNuGetPackagesRoots()
+    {
+        var fromEnv = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (!string.IsNullOrEmpty(fromEnv))
+            yield return fromEnv;
+
+        var home = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? Environment.GetEnvironmentVariable("USERPROFILE")
+            : Environment.GetEnvironmentVariable("HOME");
+
+        if (!string.IsNullOrEmpty(home))
+            yield return Path.Combine(home, ".nuget", "packages");
+    }
+}

--- a/src/Dotsider.Mcp/Prompts/DependencyHealthPrompt.cs
+++ b/src/Dotsider.Mcp/Prompts/DependencyHealthPrompt.cs
@@ -28,10 +28,11 @@ public sealed partial class DependencyHealthPrompt
                - Note the version and whether it's a framework or third-party assembly
                - Flag any very old versions that may have known vulnerabilities
 
-            3. **Dependency Graph**: Use get_dependency_graph to visualize the full dependency tree:
+            3. **Dependency Graph**: Use get_dependency_graph to visualize the full transitive closure of references:
                - Identify diamond dependencies (same assembly referenced via multiple paths)
                - Look for circular references
                - Count total transitive dependency depth
+               - Framework assemblies (BCL, runtime pack) are included; ignore them client-side if the analysis is focused on third-party surface
 
             4. **Type References**: Use get_type_refs to understand which types are actually used from each dependency:
                - Identify dependencies with very few type usages (candidates for removal)

--- a/src/Dotsider.Mcp/README.md
+++ b/src/Dotsider.Mcp/README.md
@@ -66,7 +66,7 @@ Most tools accept either parameter. Session-only tools (navigation, tracing) req
 | Tool | Description |
 |------|-------------|
 | `get_assembly_refs` | Assembly references with version and public key token |
-| `get_dependency_graph` | Nodes and edges for visualization |
+| `get_dependency_graph` | Full transitive closure of assembly references with per-edge TypeRef counts |
 | `get_type_refs` | Types imported from other assemblies |
 
 ### Diff

--- a/src/Dotsider.Mcp/Tools/DependencyTools.cs
+++ b/src/Dotsider.Mcp/Tools/DependencyTools.cs
@@ -41,7 +41,11 @@ public sealed partial class DependencyTools(DotsiderSessionManager sessionManage
     }
 
     /// <summary>
-    /// Builds the full dependency graph with nodes and edges for visualization.
+    /// Builds the full closure of direct and transitive assembly references, with per-edge
+    /// TypeRef counts grouped by full identity. Each node carries a stable opaque id, a depth
+    /// (zero for the root), and an unresolved flag for references that could not be located
+    /// or whose identity did not match any probe. Framework assemblies are included by default;
+    /// clients can filter them out by name or public key token.
     /// </summary>
     /// <param name="assemblyPath">Path to assembly file.</param>
     /// <param name="sessionId">PID of a running dotsider instance.</param>
@@ -57,8 +61,8 @@ public sealed partial class DependencyTools(DotsiderSessionManager sessionManage
         {
             ToolHelpers.ValidateAssemblyPath(assemblyPath);
             using var analyzer = ToolHelpers.OpenAnalyzer(assemblyPath);
-            var (nodes, edges) = DependencyGraphBuilder.Build(analyzer);
-            return JsonSerializer.Serialize(new { Nodes = nodes, Edges = edges },
+            var graph = DependencyGraphBuilder.Build(analyzer);
+            return JsonSerializer.Serialize(new { graph.Nodes, graph.Edges },
                 DotsiderJsonOptions.Default);
         }
 

--- a/src/Dotsider/Commands/AnalyzeCommand.cs
+++ b/src/Dotsider/Commands/AnalyzeCommand.cs
@@ -339,8 +339,8 @@ internal static class AnalyzeCommand
     {
         if (fmt.JsonMode)
         {
-            var (nodes, edges) = DependencyGraphBuilder.Build(a);
-            fmt.WriteJson(new { a.AssemblyRefs, Graph = new { nodes, edges } });
+            var graph = DependencyGraphBuilder.Build(a);
+            fmt.WriteJson(new { a.AssemblyRefs, Graph = new { graph.Nodes, graph.Edges } });
             return 0;
         }
 

--- a/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
+++ b/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
@@ -544,8 +544,8 @@ internal sealed class DotsiderDiagnosticsListener(
     private DotsiderResponse HandleGetDependencyGraph()
     {
         var analyzer = RequireAnalyzer();
-        var (nodes, edges) = DependencyGraphBuilder.Build(analyzer);
-        return DotsiderResponse.Ok(new { Nodes = nodes, Edges = edges });
+        var graph = DependencyGraphBuilder.Build(analyzer);
+        return DotsiderResponse.Ok(new { graph.Nodes, graph.Edges });
     }
 
     private DotsiderResponse HandleGetTypeRefs() =>

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -449,8 +449,55 @@ public sealed class DotsiderState : IDisposable
 
     // --- Dependency Graph Tab State ---
 
-    /// <summary>Cached dependency graph (nodes + edges).</summary>
+    /// <summary>Cached dependency graph (nodes + edges) for the current analyzer.</summary>
     public (IReadOnlyList<GraphNode> Nodes, IReadOnlyList<GraphEdge> Edges)? CachedGraph { get; set; }
+
+    /// <summary>
+    /// Per-node navigation metadata for the cached graph, keyed by <see cref="GraphNode.Id"/>.
+    /// Populated alongside <see cref="CachedGraph"/>. Never serialized; TUI-only.
+    /// </summary>
+    public IReadOnlyDictionary<string, GraphNavigationContext>? GraphNavigation { get; set; }
+
+    /// <summary>
+    /// Whether the Dep Graph view currently hides framework assemblies. Toggled by the
+    /// <c>f</c> key. Applies to rendering, search, selection, yank, and Enter — not to
+    /// the underlying cached graph.
+    /// </summary>
+    public bool DepGraphHideFramework { get; set; }
+
+    /// <summary>
+    /// The dependency-scope narrowing currently applied to the Dep Graph view. Toggled by the
+    /// <c>d</c> key, separate from the framework filter. In <see cref="DependencyGraphScope.DirectOnly"/>
+    /// the view shows only the root and its depth-1 references; in <see cref="DependencyGraphScope.All"/>
+    /// the full transitive closure is visible.
+    /// </summary>
+    public DependencyGraphScope DepGraphScope { get; set; } = DependencyGraphScope.All;
+
+    /// <summary>
+    /// Cached render layout for the Dep Graph view, populated by the view each frame when
+    /// the underlying inputs are unchanged. Internal — view-layer geometry must not leak
+    /// across the public graph contract.
+    /// </summary>
+    internal GraphRenderLayout? CachedGraphRenderLayout { get; set; }
+
+    /// <summary>
+    /// Invalidation key for <see cref="CachedGraphRenderLayout"/>. When this key differs
+    /// from the current frame's computed key the layout is rebuilt; mouse moves alone do
+    /// not invalidate.
+    /// </summary>
+    internal GraphRenderLayoutKey? CachedGraphRenderLayoutKey { get; set; }
+
+    /// <summary>
+    /// True while the transitive dependency-graph build is in flight on a background task.
+    /// The view shows a status message while this is set.
+    /// </summary>
+    public bool GraphBuildInProgress { get; set; }
+
+    /// <summary>
+    /// Error message produced by the most recent Enter-to-open attempt on the Dep Graph,
+    /// or <see langword="null"/> when the last attempt succeeded or none has been made.
+    /// </summary>
+    public string? GraphNavigationError { get; set; }
 
     /// <summary>The currently hovered/selected node name in the graph view.</summary>
     public string? GraphSelectedNode { get; set; }
@@ -460,6 +507,14 @@ public sealed class DotsiderState : IDisposable
 
     /// <summary>Keyboard-selected node index in the dependency graph, or -1 for none.</summary>
     public int GraphSelectedIndex { get; set; } = -1;
+
+    /// <summary>
+    /// Vertical scroll offset of the Dep Graph viewport, in character rows. The graph is
+    /// rendered with every Y shifted by this amount. Clamped each frame to the current
+    /// render-layout content height minus viewport height, so resizing or filter changes
+    /// can only shrink the valid scroll range, never strand the viewport off-content.
+    /// </summary>
+    public int DepGraphScrollY { get; set; }
 
     // --- Size Treemap Tab State ---
 
@@ -1288,9 +1343,17 @@ public sealed class DotsiderState : IDisposable
         CachedMetadataStrings = null;
         CachedRawStrings = null;
         CachedGraph = null;
+        GraphNavigation = null;
+        GraphBuildInProgress = false;
+        GraphNavigationError = null;
         GraphSelectedNode = null;
         GraphMatchIndex = -1;
         GraphSelectedIndex = -1;
+        DepGraphScope = DependencyGraphScope.All;
+        DepGraphHideFramework = false;
+        DepGraphScrollY = 0;
+        CachedGraphRenderLayout = null;
+        CachedGraphRenderLayoutKey = null;
         CachedSizeTree = null;
         TreemapCurrentLevel = null;
         TreemapBreadcrumb.Clear();
@@ -1391,5 +1454,42 @@ public sealed class DotsiderState : IDisposable
         }
 
         return CachedRawStrings;
+    }
+
+    /// <summary>
+    /// Kicks off a background build of the transitive dependency graph when the Dep Graph
+    /// view is first rendered for the current analyzer. While the build runs, the view
+    /// displays a placeholder message; when the build completes, the result is published
+    /// to <see cref="CachedGraph"/> and <see cref="GraphNavigation"/> and the UI is
+    /// invalidated to trigger a re-render. Calls made while a build is already in flight
+    /// or after the graph is cached are no-ops. If the analyzer changes before the build
+    /// completes, the stale result is discarded.
+    /// </summary>
+    public void EnsureCachedGraphAsync()
+    {
+        if (CachedGraph is not null || GraphBuildInProgress)
+            return;
+
+        GraphBuildInProgress = true;
+        var capturedAnalyzer = Analyzer;
+
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                var result = DependencyGraphBuilder.Build(capturedAnalyzer);
+
+                if (!ReferenceEquals(Analyzer, capturedAnalyzer))
+                    return;
+
+                GraphNavigation = result.NavigationById;
+                CachedGraph = (result.Nodes, result.Edges);
+            }
+            finally
+            {
+                GraphBuildInProgress = false;
+                App.Invalidate();
+            }
+        });
     }
 }

--- a/src/Dotsider/Views/DependencyGraphScope.cs
+++ b/src/Dotsider/Views/DependencyGraphScope.cs
@@ -1,0 +1,17 @@
+namespace Dotsider.Views;
+
+/// <summary>
+/// The scope control on the Dep Graph tab that narrows the graph by dependency relationship.
+/// Separate from the framework filter — scope decides which nodes are in the graph at all,
+/// framework filter hides well-known framework assemblies within that scope. Transitive-only
+/// is intentionally not an option: hiding direct parents would produce disconnected islands
+/// and remove the explanation path that justifies why deeper nodes are in the closure.
+/// </summary>
+public enum DependencyGraphScope
+{
+    /// <summary>Show the full transitive closure. Default.</summary>
+    All,
+
+    /// <summary>Show only the root and its depth-1 references plus the edges between them.</summary>
+    DirectOnly,
+}

--- a/src/Dotsider/Views/DependencyGraphView.cs
+++ b/src/Dotsider/Views/DependencyGraphView.cs
@@ -1,4 +1,4 @@
-using Dotsider.Core.Analysis;
+using System.Text;
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
 using Hex1b.Input;
@@ -9,13 +9,16 @@ using Hex1b.Widgets;
 namespace Dotsider.Views;
 
 /// <summary>
-/// Builds the Dependency Graph tab (Tab 6), rendering an interactive
-/// assembly reference graph using SurfaceWidget with search highlighting.
+/// Builds the Dependency Graph tab (Tab 6). Renders the full transitive dependency closure
+/// rooted at the analyzed assembly with id-based edge lookup, provenance-based framework
+/// filtering, per-node Enter navigation through stored resolution context, and label
+/// disambiguation for simple-name collisions.
 /// </summary>
 public static class DependencyGraphView
 {
     private static readonly Hex1bColor RootColor = Hex1bColor.FromRgb(0, 200, 180);
     private static readonly Hex1bColor RefColor = Hex1bColor.FromRgb(100, 130, 180);
+    private static readonly Hex1bColor UnresolvedColor = Hex1bColor.FromRgb(120, 100, 100);
     private static readonly Hex1bColor EdgeColor = Hex1bColor.FromRgb(80, 80, 100);
     private static readonly Hex1bColor HighlightColor = Hex1bColor.FromRgb(255, 220, 100);
     private static readonly Hex1bColor SelectionBorder = Hex1bColor.FromRgb(255, 255, 255);
@@ -28,11 +31,31 @@ public static class DependencyGraphView
     /// <returns>The root widget for the Dependency Graph tab.</returns>
     public static Hex1bWidget Build(WidgetContext<VStackWidget> ctx, DotsiderState state)
     {
-        var (nodes, edges) = state.CachedGraph ??= DependencyGraphBuilder.Build(state.Analyzer);
+        // Kick off (or no-op on) a background build so opening tab 6 on a large assembly
+        // does not stall the render loop. The Interactable tree below is always rendered
+        // — even while the build runs — so keyboard focus works from the first frame and
+        // existing startup-focus tests still land on the graph surface.
+        state.EnsureCachedGraphAsync();
+
+        var ready = state.CachedGraph is not null;
+        IReadOnlyList<GraphNode> allNodes = ready ? state.CachedGraph!.Value.Nodes : [];
+        IReadOnlyList<GraphEdge> allEdges = ready ? state.CachedGraph!.Value.Edges : [];
+        var nav = state.GraphNavigation;
+        var visible = BuildVisibleModel(
+            allNodes, allEdges, nav, state.DepGraphScope, state.DepGraphHideFramework);
+        var nodes = visible.Nodes;
+        var edges = visible.Edges;
+        var indexById = visible.IndexById;
+        var disambig = ComputeDisambiguation(nodes);
+
+        // Clamp selection index to current visible size. Preserve -1 (no selection) so
+        // arrow keys advance from "none" to the first node, matching existing behavior.
+        if (state.GraphSelectedIndex >= nodes.Count)
+            state.GraphSelectedIndex = nodes.Count > 0 ? 0 : -1;
+
         var search = state.Search[TabId.DepGraph];
         var query = search.Query;
 
-        // Find matching node indices for navigation
         var matchingNodes = new List<int>();
         if (!string.IsNullOrEmpty(query))
         {
@@ -44,11 +67,9 @@ public static class DependencyGraphView
             search.SetMatchCount(matchingNodes.Count);
         }
 
-        // Clamp match index to current results
         if (state.GraphMatchIndex >= matchingNodes.Count)
             state.GraphMatchIndex = matchingNodes.Count > 0 ? 0 : -1;
 
-        // Set up match navigation using stable index
         if (state.CurrentTab == TabId.DepGraph)
         {
             state.NavigateNextMatch = matchingNodes.Count > 0 ? () =>
@@ -64,43 +85,77 @@ public static class DependencyGraphView
             : null;
         }
 
+        var totalNodes = allNodes.Count;
+        var totalEdges = allEdges.Count;
+        var hiddenNodes = totalNodes - nodes.Count;
+
         return ctx.VStack(outer =>
         {
             var widgets = new List<Hex1bWidget>();
 
-            // Display: hover > keyboard selection > search match > default
             var displayNode = state.GraphSelectedNode;
             if (displayNode is null && state.GraphSelectedIndex >= 0
                 && state.GraphSelectedIndex < nodes.Count)
             {
-                var node = nodes[state.GraphSelectedIndex];
-                var version = node.Version is not null ? $" v{node.Version}" : "";
-                displayNode = $"{node.Name}{version}";
+                displayNode = FormatLabel(nodes[state.GraphSelectedIndex], disambig);
             }
             if (displayNode is null && state.GraphMatchIndex >= 0
                 && state.GraphMatchIndex < matchingNodes.Count)
             {
-                var node = nodes[matchingNodes[state.GraphMatchIndex]];
-                var version = node.Version is not null ? $" v{node.Version}" : "";
-                displayNode = $"{node.Name}{version}";
+                displayNode = FormatLabel(nodes[matchingNodes[state.GraphMatchIndex]], disambig);
+            }
+
+            string baseCounts = hiddenNodes > 0
+                ? $"Nodes: {nodes.Count}/{totalNodes}  Edges: {edges.Count}/{totalEdges}  Hidden: {hiddenNodes}"
+                : $"Nodes: {nodes.Count}  Edges: {edges.Count}";
+
+            string scrollSuffix = string.Empty;
+            if (ready && state.CachedGraphRenderLayout is { } laidOut
+                && state.CachedGraphRenderLayoutKey is { } laidOutKey)
+            {
+                var maxScroll = Math.Max(0, laidOut.ContentHeight - laidOutKey.Height);
+                if (maxScroll > 0)
+                    scrollSuffix = $"  Scroll: {Math.Clamp(state.DepGraphScrollY, 0, maxScroll)}/{maxScroll}";
+            }
+
+            var statusLeft = !ready
+                ? " Building dependency graph..."
+                : $" {baseCounts}{scrollSuffix}";
+
+            string scopeSuffix, filterSuffix;
+            if (!ready)
+            {
+                scopeSuffix = string.Empty;
+                filterSuffix = string.Empty;
+            }
+            else
+            {
+                scopeSuffix = state.DepGraphScope == DependencyGraphScope.DirectOnly
+                    ? "  [scope: direct]"
+                    : "  [d: scope all]";
+                filterSuffix = state.DepGraphHideFramework
+                    ? "  [filter: f]"
+                    : "  [f: hide framework]";
             }
 
             widgets.Add(outer.HStack(row =>
             [
-                row.Text($" Nodes: {nodes.Count}  Edges: {edges.Count}"),
+                row.Text(statusLeft + scopeSuffix + filterSuffix),
                 row.Text(displayNode is not null
                     ? $"  | {displayNode}"
                     : "  | Hover over a node for details").Fill()
             ]).FixedHeight(1));
 
-            // Search bar
+            if (state.GraphNavigationError is not null)
+                widgets.Add(outer.Text($" {state.GraphNavigationError}").FixedHeight(1));
+
             SearchBarHelper.AddSearchBar(widgets, outer, search, state.App);
 
-            // Graph surface wrapped in Interactable for keyboard/click support
             widgets.Add(outer.Interactable(ic =>
                 ic.Surface(s =>
                 [
-                    s.Layer(surface => DrawGraph(surface, nodes, edges, state, s.MouseX, s.MouseY, query))
+                    s.Layer(surface => DrawGraph(surface, visible, nav, disambig,
+                        state, s.MouseX, s.MouseY, query))
                 ]).Fill()
             ).WithInputBindings(bindings =>
             {
@@ -109,6 +164,7 @@ public static class DependencyGraphView
                     if (nodes.Count > 0)
                     {
                         state.GraphSelectedIndex = (state.GraphSelectedIndex + 1) % nodes.Count;
+                        ScrollSelectionIntoView(state);
                         state.App.Invalidate();
                     }
                 }, "Next node");
@@ -120,27 +176,104 @@ public static class DependencyGraphView
                         state.GraphSelectedIndex = state.GraphSelectedIndex <= 0
                             ? nodes.Count - 1
                             : state.GraphSelectedIndex - 1;
+                        ScrollSelectionIntoView(state);
                         state.App.Invalidate();
                     }
                 }, "Previous node");
 
+                bindings.Key(Hex1bKey.UpArrow).Action(_ =>
+                {
+                    state.DepGraphScrollY = Math.Max(0, state.DepGraphScrollY - 1);
+                    state.App.Invalidate();
+                }, "Scroll up");
+
+                bindings.Key(Hex1bKey.DownArrow).Action(_ =>
+                {
+                    state.DepGraphScrollY += 1;
+                    state.App.Invalidate();
+                }, "Scroll down");
+
+                bindings.Key(Hex1bKey.PageUp).Action(_ =>
+                {
+                    var page = Math.Max(1, state.CachedGraphRenderLayoutKey?.Height ?? 20);
+                    state.DepGraphScrollY = Math.Max(0, state.DepGraphScrollY - page);
+                    state.App.Invalidate();
+                }, "Scroll up one page");
+
+                bindings.Key(Hex1bKey.PageDown).Action(_ =>
+                {
+                    var page = Math.Max(1, state.CachedGraphRenderLayoutKey?.Height ?? 20);
+                    state.DepGraphScrollY += page;
+                    state.App.Invalidate();
+                }, "Scroll down one page");
+
+                bindings.Key(Hex1bKey.Home).Action(_ =>
+                {
+                    state.DepGraphScrollY = 0;
+                    state.App.Invalidate();
+                }, "Scroll to top");
+
+                bindings.Key(Hex1bKey.End).Action(_ =>
+                {
+                    state.DepGraphScrollY = int.MaxValue;
+                    state.App.Invalidate();
+                }, "Scroll to bottom");
+
+                bindings.Key(Hex1bKey.F).Action(_ =>
+                {
+                    state.DepGraphHideFramework = !state.DepGraphHideFramework;
+                    state.GraphSelectedIndex = -1;
+                    state.GraphMatchIndex = -1;
+                    state.GraphNavigationError = null;
+                    state.DepGraphScrollY = 0;
+                    state.App.Invalidate();
+                }, "Toggle framework filter");
+
+                bindings.Key(Hex1bKey.D).Action(_ =>
+                {
+                    state.DepGraphScope = state.DepGraphScope == DependencyGraphScope.DirectOnly
+                        ? DependencyGraphScope.All
+                        : DependencyGraphScope.DirectOnly;
+                    state.GraphSelectedIndex = -1;
+                    state.GraphMatchIndex = -1;
+                    state.GraphNavigationError = null;
+                    state.DepGraphScrollY = 0;
+                    state.App.Invalidate();
+                }, "Toggle scope (all / direct)");
+
                 bindings.Key(Hex1bKey.Enter).Action(_ =>
                 {
-                    if (state.GraphSelectedIndex >= 0 && state.GraphSelectedIndex < nodes.Count)
+                    if (state.GraphSelectedIndex < 0 || state.GraphSelectedIndex >= nodes.Count)
+                        return;
+
+                    var node = nodes[state.GraphSelectedIndex];
+
+                    if (node.IsRoot)
+                        return;
+
+                    if (nav is null || !nav.TryGetValue(node.Id, out var nctx))
                     {
-                        var node = nodes[state.GraphSelectedIndex];
-                        var resolved = AssemblyAnalyzer.ResolveAssembly(
-                            state.Analyzer.FilePath, node.Name,
-                            state.Analyzer.TargetFramework,
-                            state.Analyzer.PreferredRuntimePack,
-                            state.Analyzer.SourceBundlePath);
-                        if (resolved is not null && state.PushAssembly(resolved))
-                        {
-                            state.NavigateToTab(TabId.General);
-                            state.App.RequestFocus(n =>
-                                n.GetType().Name.StartsWith("TableNode"));
-                            state.App.Invalidate();
-                        }
+                        state.GraphNavigationError = $"{node.Name}: navigation context missing";
+                        state.App.Invalidate();
+                        return;
+                    }
+
+                    if (nctx.Resolved is null)
+                    {
+                        state.GraphNavigationError = nctx.Provenance == AssemblyProvenance.IdentityMismatch
+                            ? $"{node.Name}: identity mismatch against {nctx.CandidateProbePath ?? "(unknown)"}"
+                            : $"{node.Name}: not resolvable";
+                        state.App.Invalidate();
+                        return;
+                    }
+
+                    if (state.PushAssembly(nctx.Resolved))
+                    {
+                        state.GraphNavigationError = null;
+                        state.NavigateToTab(TabId.General);
+                        state.App.RequestFocus(n =>
+                            n.GetType().Name.StartsWith("TableNode"));
+                        state.App.Invalidate();
                     }
                 }, "Open assembly");
             }).Fill());
@@ -161,100 +294,547 @@ public static class DependencyGraphView
         .Fill();
     }
 
-    private static void DrawGraph(Surface surface, IReadOnlyList<GraphNode> nodes,
-        IReadOnlyList<GraphEdge> edges, DotsiderState state, int mouseX, int mouseY, string? query)
+    private static void DrawGraph(
+        Surface surface,
+        VisibleGraphModel visible,
+        IReadOnlyDictionary<string, GraphNavigationContext>? nav,
+        IReadOnlyDictionary<string, IdentityDiscriminator> disambig,
+        DotsiderState state,
+        int mouseX,
+        int mouseY,
+        string? query)
     {
         var w = surface.Width;
         var h = surface.Height;
         if (w < 10 || h < 5) return;
 
-        var hasQuery = !string.IsNullOrEmpty(query);
+        var layout = GetOrBuildRenderLayout(state, visible, nav, disambig, w, h);
+        var renderNodes = layout.Nodes;
+        if (renderNodes.Count == 0) return;
+
+        var maxScroll = Math.Max(0, layout.ContentHeight - h);
         var selectedIndex = state.GraphSelectedIndex;
 
-        // Draw edges first (underneath nodes)
-        foreach (var edge in edges)
+        // Clamp but do not force-follow the selection. Forcing every frame would fight user
+        // scroll: pressing End or PageDown while a node is selected would snap scroll back
+        // to the selected node's Y and never actually reach the bottom. Selection-follow
+        // runs only when the user moves the selection, inside the Left/Right arrow handlers.
+        state.DepGraphScrollY = Math.Clamp(state.DepGraphScrollY, 0, maxScroll);
+        var scrollY = state.DepGraphScrollY;
+
+        // Hover resolution works in layout space, so translate the mouse's surface Y back up
+        // into layout coordinates. Skip hover entirely when the mouse is outside the surface.
+        var layoutMouseY = mouseY + scrollY;
+        var hoverWinner = ResolveHoverWinner(renderNodes, mouseX, layoutMouseY);
+
+        var hasQuery = !string.IsNullOrEmpty(query);
+
+        foreach (var edge in layout.Edges)
         {
-            var src = nodes.FirstOrDefault(n => n.Name == edge.SourceName);
-            var tgt = nodes.FirstOrDefault(n => n.Name == edge.TargetName);
-            if (src is null || tgt is null) continue;
+            if (!layout.IndexById.TryGetValue(edge.SourceId, out var srcIdx)) continue;
+            if (!layout.IndexById.TryGetValue(edge.TargetId, out var tgtIdx)) continue;
 
-            var x1 = (int)(src.X * (w - 1));
-            var y1 = (int)(src.Y * (h - 1)) + 1;
-            var x2 = (int)(tgt.X * (w - 1));
-            var y2 = (int)(tgt.Y * (h - 1)) - 1;
+            var src = renderNodes[srcIdx];
+            var tgt = renderNodes[tgtIdx];
 
-            // Simple vertical-first routing
+            // Skip back-edges (cycles and same-level references). Their natural routing has
+            // to go through the source's bottom row, which scatters stray `│` fragments at
+            // the last visible row of the canvas and reads as phantom content beyond the
+            // viewport — indistinguishable from "scroll isn't at the bottom yet." Cycle and
+            // diamond presence is still visible through node multiplicity; only the edge
+            // glyph is suppressed.
+            if (tgt.Y <= src.Y + src.Height) continue;
+
+            var x1 = src.X + src.Width / 2;
+            var y1 = src.Y + src.Height - scrollY;
+            var x2 = tgt.X + tgt.Width / 2;
+            var y2 = tgt.Y - 1 - scrollY;
+            if (y2 < 0 && y1 < 0) continue;
+            if (y1 >= h && y2 >= h) continue;
+
             var midY = (y1 + y2) / 2;
             var edgeC = hasQuery ? HighlightHelper.DimColor :
                 edge.TypeRefCount > 10 ? Hex1bColor.FromRgb(140, 140, 180) : EdgeColor;
 
             for (var y = Math.Min(y1, midY); y <= Math.Max(y1, midY); y++)
-                surface.WriteChar(x1, y, '│', edgeC);
+                if (y >= 0 && y < h) surface.WriteChar(x1, y, '│', edgeC);
             for (var x = Math.Min(x1, x2); x <= Math.Max(x1, x2); x++)
-                surface.WriteChar(x, midY, '─', edgeC);
+                if (midY >= 0 && midY < h) surface.WriteChar(x, midY, '─', edgeC);
             for (var y = Math.Min(midY, y2); y <= Math.Max(midY, y2); y++)
-                surface.WriteChar(x2, y, '│', edgeC);
+                if (y >= 0 && y < h) surface.WriteChar(x2, y, '│', edgeC);
 
-            // Corners
-            if (x1 != x2)
+            if (x1 != x2 && midY >= 0 && midY < h)
             {
                 surface.WriteChar(x1, midY, x1 < x2 ? '└' : '┘', edgeC);
                 surface.WriteChar(x2, midY, x1 < x2 ? '┐' : '┌', edgeC);
             }
         }
 
-        // Draw nodes on top
+        // First pass: draw every non-winner node. Second pass: draw the winner on top so its
+        // highlight is never overwritten by an overlapping neighbor. GraphSelectedNode is set
+        // exactly once, from the winning node.
         state.GraphSelectedNode = null;
-        for (var i = 0; i < nodes.Count; i++)
+        for (var i = 0; i < renderNodes.Count; i++)
         {
-            var node = nodes[i];
-            var cx = (int)(node.X * (w - 1));
-            var cy = (int)(node.Y * (h - 1));
-            var label = node.Name;
-            var halfW = Math.Min(label.Length / 2 + 2, w / 2 - 1);
-            var boxW = halfW * 2 + 1;
-            var x0 = Math.Max(0, cx - halfW);
-            var y0 = Math.Max(0, cy - 1);
+            if (i == hoverWinner) continue;
+            DrawRenderNode(surface, renderNodes[i], scrollY, h,
+                isSelected: i == selectedIndex, isHovered: false, query, hasQuery);
+        }
+        if (hoverWinner >= 0)
+        {
+            var node = renderNodes[hoverWinner];
+            DrawRenderNode(surface, node, scrollY, h,
+                isSelected: hoverWinner == selectedIndex, isHovered: true, query, hasQuery);
+            state.GraphSelectedNode = FormatLabel(node.Node, disambig);
+        }
+        else if (selectedIndex >= 0 && selectedIndex < renderNodes.Count)
+        {
+            // No hover winner — fall back to keyboard selection for the status line so the
+            // user can see what they're about to open with Enter.
+            state.GraphSelectedNode = FormatLabel(renderNodes[selectedIndex].Node, disambig);
+        }
+    }
 
-            if (x0 + boxW > w) x0 = w - boxW;
-            if (y0 + 3 > h) y0 = h - 3;
+    private static void DrawRenderNode(
+        Surface surface, GraphRenderNode rn, int scrollY, int surfaceHeight,
+        bool isSelected, bool isHovered, string? query, bool hasQuery)
+    {
+        var node = rn.Node;
+        var x0 = rn.X;
+        var y0 = rn.Y - scrollY;
+        var boxW = rn.Width;
 
-            var isMatch = hasQuery && node.Name.Contains(query!, StringComparison.OrdinalIgnoreCase);
-            var isSelected = i == selectedIndex;
-            var bg = isMatch ? (node.IsRoot ? RootColor : RefColor)
-                : hasQuery ? HighlightHelper.DimColor
-                : node.IsRoot ? RootColor : RefColor;
-            var fg = Hex1bColor.Black;
+        if (y0 + rn.Height <= 0 || y0 >= surfaceHeight) return;
 
-            // Check mouse hover
-            if (mouseX >= x0 && mouseX < x0 + boxW && mouseY >= y0 && mouseY < y0 + 3)
-            {
-                bg = HighlightColor;
-                var version = node.Version is not null ? $" v{node.Version}" : "";
-                state.GraphSelectedNode = $"{node.Name}{version}";
-            }
+        var isMatch = hasQuery && node.Name.Contains(query!, StringComparison.OrdinalIgnoreCase);
+        Hex1bColor baseColor = node.Unresolved ? UnresolvedColor
+            : node.IsRoot ? RootColor : RefColor;
+        var bg = isHovered ? HighlightColor
+            : isMatch ? baseColor
+            : hasQuery ? HighlightHelper.DimColor
+            : baseColor;
+        var fg = Hex1bColor.Black;
+        var borderColor = isSelected ? SelectionBorder : bg;
 
-            var borderColor = isSelected ? SelectionBorder : bg;
+        void Put(int x, int y, char ch, Hex1bColor c)
+        {
+            if (y < 0 || y >= surfaceHeight) return;
+            surface.WriteChar(x, y, ch, c);
+        }
+        void Fill(int x, int y, char ch, Hex1bColor fgc, Hex1bColor bgc)
+        {
+            if (y < 0 || y >= surfaceHeight) return;
+            surface.WriteChar(x, y, ch, fgc, bgc);
+        }
 
-            // Draw box
-            surface.WriteChar(x0, y0, '┌', borderColor);
-            surface.WriteChar(x0 + boxW - 1, y0, '┐', borderColor);
-            surface.WriteChar(x0, y0 + 2, '└', borderColor);
-            surface.WriteChar(x0 + boxW - 1, y0 + 2, '┘', borderColor);
-            for (var x = x0 + 1; x < x0 + boxW - 1; x++)
-            {
-                surface.WriteChar(x, y0, '─', borderColor);
-                surface.WriteChar(x, y0 + 2, '─', borderColor);
-            }
-            surface.WriteChar(x0, y0 + 1, '│', borderColor);
-            surface.WriteChar(x0 + boxW - 1, y0 + 1, '│', borderColor);
+        Put(x0, y0, '┌', borderColor);
+        Put(x0 + boxW - 1, y0, '┐', borderColor);
+        Put(x0, y0 + 2, '└', borderColor);
+        Put(x0 + boxW - 1, y0 + 2, '┘', borderColor);
+        for (var x = x0 + 1; x < x0 + boxW - 1; x++)
+        {
+            Put(x, y0, '─', borderColor);
+            Put(x, y0 + 2, '─', borderColor);
+        }
+        Put(x0, y0 + 1, '│', borderColor);
+        Put(x0 + boxW - 1, y0 + 1, '│', borderColor);
 
-            // Fill interior and write label
-            for (var x = x0 + 1; x < x0 + boxW - 1; x++)
-                surface.WriteChar(x, y0 + 1, ' ', fg, bg);
+        for (var x = x0 + 1; x < x0 + boxW - 1; x++)
+            Fill(x, y0 + 1, ' ', fg, bg);
 
-            var truncLabel = label.Length > boxW - 2 ? label[..(boxW - 4)] + ".." : label;
+        if (y0 + 1 >= 0 && y0 + 1 < surfaceHeight)
+        {
+            var truncLabel = rn.Label.Length > boxW - 2 ? rn.Label[..(boxW - 4)] + ".." : rn.Label;
             surface.WriteText(x0 + 1, y0 + 1, truncLabel, fg, bg);
         }
+    }
+
+    private static void ScrollSelectionIntoView(DotsiderState state)
+    {
+        // Pull the vertical scroll just enough to reveal the selected node. Runs in response
+        // to a selection change (Left/Right arrow) rather than every frame, so explicit
+        // scroll input (End, PageDown, Home, etc.) is never overridden while the selection
+        // happens to be offscreen.
+        if (state.CachedGraphRenderLayout is not { } layout) return;
+        if (state.CachedGraphRenderLayoutKey is not { } key) return;
+        var i = state.GraphSelectedIndex;
+        if (i < 0 || i >= layout.Nodes.Count) return;
+
+        var sel = layout.Nodes[i];
+        if (sel.Y < state.DepGraphScrollY)
+            state.DepGraphScrollY = sel.Y;
+        else if (sel.Y + sel.Height > state.DepGraphScrollY + key.Height)
+            state.DepGraphScrollY = sel.Y + sel.Height - key.Height;
+    }
+
+    private static GraphRenderLayout GetOrBuildRenderLayout(
+        DotsiderState state,
+        VisibleGraphModel visible,
+        IReadOnlyDictionary<string, GraphNavigationContext>? nav,
+        IReadOnlyDictionary<string, IdentityDiscriminator> disambig,
+        int width,
+        int height)
+    {
+        object? nodesRef = state.CachedGraph is { } cg ? cg.Nodes : null;
+        var key = new GraphRenderLayoutKey(
+            nodesRef, state.DepGraphScope, state.DepGraphHideFramework, width, height);
+
+        if (state.CachedGraphRenderLayoutKey is { } existingKey
+            && existingKey.Equals(key)
+            && state.CachedGraphRenderLayout is { } existingLayout)
+        {
+            return existingLayout;
+        }
+
+        var built = BuildRenderLayout(visible, nav, disambig, width, height);
+        state.CachedGraphRenderLayout = built;
+        state.CachedGraphRenderLayoutKey = key;
+        return built;
+    }
+
+    /// <summary>
+    /// Computes the single visible projection used by rendering, search, selection, yank,
+    /// and Enter navigation. Two orthogonal controls narrow the graph: <paramref name="scope"/>
+    /// selects which nodes are in the view at all (all depths, or root + direct refs only),
+    /// and <paramref name="hideFramework"/> hides nodes classified as .NET framework assemblies
+    /// on top of whatever scope is active. The root is always visible regardless of the
+    /// controls.
+    /// </summary>
+    /// <param name="allNodes">All nodes from the cached full graph.</param>
+    /// <param name="allEdges">All edges from the cached full graph.</param>
+    /// <param name="nav">Navigation metadata keyed by node id, or <see langword="null"/> while a build is in flight.</param>
+    /// <param name="scope">The scope control — <c>All</c> or <c>DirectOnly</c>.</param>
+    /// <param name="hideFramework">Whether the framework-filter toggle is active.</param>
+    /// <returns>The filtered view. All downstream operations must be indexed against this model.</returns>
+    internal static VisibleGraphModel BuildVisibleModel(
+        IReadOnlyList<GraphNode> allNodes,
+        IReadOnlyList<GraphEdge> allEdges,
+        IReadOnlyDictionary<string, GraphNavigationContext>? nav,
+        DependencyGraphScope scope,
+        bool hideFramework)
+    {
+        var visibleIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var n in allNodes)
+        {
+            if (n.IsRoot)
+            {
+                visibleIds.Add(n.Id);
+                continue;
+            }
+
+            if (scope == DependencyGraphScope.DirectOnly && n.Depth != 1)
+                continue;
+
+            if (hideFramework && nav is not null
+                && nav.TryGetValue(n.Id, out var ctx) && ctx.IsFrameworkAssembly)
+                continue;
+
+            visibleIds.Add(n.Id);
+        }
+
+        var rootId = allNodes.FirstOrDefault(n => n.IsRoot)?.Id;
+
+        // Under DirectOnly, restrict edges to root→direct only. Sibling edges between two
+        // depth-1 nodes exist in the closure but would feel out of place in a "direct
+        // dependencies" view — those cross-references are a transitive-closure concern.
+        IEnumerable<GraphEdge> edgeSource = allEdges
+            .Where(e => visibleIds.Contains(e.SourceId) && visibleIds.Contains(e.TargetId));
+        if (scope == DependencyGraphScope.DirectOnly && rootId is not null)
+            edgeSource = edgeSource.Where(e => e.SourceId == rootId);
+        var preReachEdges = edgeSource.ToList();
+
+        // Prune to nodes reachable from the root through the visible edges. When the framework
+        // filter cuts through the middle of a chain — e.g. root → (hidden framework) → leaf —
+        // the leaf becomes a disconnected island. Keeping it would show an explanationless box
+        // drifting on the canvas; dropping it keeps the rooted subgraph coherent.
+        var reachable = new HashSet<string>(StringComparer.Ordinal);
+        if (rootId is not null && visibleIds.Contains(rootId))
+        {
+            reachable.Add(rootId);
+            var outgoingBySource = preReachEdges
+                .GroupBy(e => e.SourceId, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.Select(e => e.TargetId).ToList(), StringComparer.Ordinal);
+            var queue = new Queue<string>();
+            queue.Enqueue(rootId);
+            while (queue.Count > 0)
+            {
+                var cur = queue.Dequeue();
+                if (!outgoingBySource.TryGetValue(cur, out var children)) continue;
+                foreach (var childId in children)
+                {
+                    if (reachable.Add(childId)) queue.Enqueue(childId);
+                }
+            }
+        }
+
+        var visibleNodes = allNodes.Where(n => reachable.Contains(n.Id)).ToList();
+        var visibleEdges = preReachEdges
+            .Where(e => reachable.Contains(e.SourceId) && reachable.Contains(e.TargetId))
+            .ToList();
+
+        var index = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < visibleNodes.Count; i++)
+            index[visibleNodes[i].Id] = i;
+
+        return new VisibleGraphModel(visibleNodes, visibleEdges, index);
+    }
+
+    /// <summary>
+    /// Projects a <see cref="VisibleGraphModel"/> into placed character-space boxes for the
+    /// supplied viewport. Recomputes BFS depth on the visible edge set so DirectOnly and
+    /// filtered views collapse into a compact rooted layout without inheriting stale positions
+    /// from the full-graph layout. Packs each depth band into rows of actual box widths plus
+    /// a fixed 2-column horizontal gap and wraps to a new sub-row when the next box would
+    /// overflow the canvas.
+    /// </summary>
+    /// <param name="visible">The topology-filtered visible graph.</param>
+    /// <param name="nav">Navigation metadata keyed by node id.</param>
+    /// <param name="disambig">Collision discriminator map used by the label formatter.</param>
+    /// <param name="width">Surface width in columns.</param>
+    /// <param name="height">Surface height in rows.</param>
+    /// <returns>The placed render layout. Empty when the visible graph has no root.</returns>
+    internal static GraphRenderLayout BuildRenderLayout(
+        VisibleGraphModel visible,
+        IReadOnlyDictionary<string, GraphNavigationContext>? nav,
+        IReadOnlyDictionary<string, IdentityDiscriminator> disambig,
+        int width,
+        int height)
+    {
+        const int horizontalGap = 2;
+        const int verticalGap = 1;
+        const int boxHeight = 3;
+        const int minBoxWidth = 6;
+        const int boxPadding = 2;
+
+        if (visible.Nodes.Count == 0 || width <= 0 || height <= 0)
+        {
+            return new GraphRenderLayout(
+                [], visible.Edges, new Dictionary<string, int>(StringComparer.Ordinal), ContentHeight: 0);
+        }
+
+        var rootId = visible.Nodes.FirstOrDefault(n => n.IsRoot)?.Id;
+        if (rootId is null)
+        {
+            return new GraphRenderLayout(
+                [], visible.Edges, new Dictionary<string, int>(StringComparer.Ordinal), ContentHeight: 0);
+        }
+
+        // Compute each node's rendered label up-front so box widths reflect what will
+        // actually be drawn — matches the user-visible collision discriminator.
+        var labels = new Dictionary<string, string>(StringComparer.Ordinal);
+        var widths = new Dictionary<string, int>(StringComparer.Ordinal);
+        var maxBoxWidth = Math.Max(minBoxWidth, width - 2);
+        foreach (var n in visible.Nodes)
+        {
+            var ctx = nav is not null && nav.TryGetValue(n.Id, out var c) ? c : null;
+            var label = FormatNodeBoxLabel(n, ctx, disambig);
+            labels[n.Id] = label;
+            var desired = label.Length + boxPadding;
+            widths[n.Id] = Math.Clamp(desired, minBoxWidth, maxBoxWidth);
+        }
+
+        // BFS depth from root on the visible edge set. Gives DirectOnly a single band below
+        // root and lets framework-filtered graphs rebalance after islands are pruned.
+        var outgoingBySource = visible.Edges
+            .GroupBy(e => e.SourceId, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Select(e => e.TargetId).ToList(), StringComparer.Ordinal);
+
+        var visibleDepth = new Dictionary<string, int>(StringComparer.Ordinal) { [rootId] = 0 };
+        var bfs = new Queue<string>();
+        bfs.Enqueue(rootId);
+        while (bfs.Count > 0)
+        {
+            var cur = bfs.Dequeue();
+            if (!outgoingBySource.TryGetValue(cur, out var children)) continue;
+            foreach (var childId in children)
+            {
+                if (visibleDepth.ContainsKey(childId)) continue;
+                visibleDepth[childId] = visibleDepth[cur] + 1;
+                bfs.Enqueue(childId);
+            }
+        }
+
+        // Preserve the stable builder order (visible.Nodes comes from the builder's
+        // deterministic ordering) so toggling filters does not jitter sibling placement.
+        var nodeOrder = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < visible.Nodes.Count; i++)
+            nodeOrder[visible.Nodes[i].Id] = i;
+
+        var depthGroups = visibleDepth
+            .GroupBy(kv => kv.Value, kv => kv.Key)
+            .OrderBy(g => g.Key)
+            .ToList();
+
+        // Phase 1: pack each depth band into rows keyed by actual label widths.
+        var bandRows = new List<List<List<string>>>();
+        foreach (var group in depthGroups)
+        {
+            var idsInDepth = group
+                .OrderBy(id => nodeOrder.TryGetValue(id, out var o) ? o : int.MaxValue)
+                .ToList();
+
+            var rows = new List<List<string>>();
+            var currentRow = new List<string>();
+            var currentRowWidth = 0;
+            foreach (var id in idsInDepth)
+            {
+                var w = widths[id];
+                var added = currentRow.Count == 0 ? w : currentRowWidth + horizontalGap + w;
+                if (added > width && currentRow.Count > 0)
+                {
+                    rows.Add(currentRow);
+                    currentRow = [id];
+                    currentRowWidth = w;
+                }
+                else
+                {
+                    currentRow.Add(id);
+                    currentRowWidth = added;
+                }
+            }
+            if (currentRow.Count > 0) rows.Add(currentRow);
+            bandRows.Add(rows);
+        }
+
+        // Phase 2: vertical spacing. Within a band sub-rows are separated by verticalGap (1
+        // row). Between depth bands a fixed aesthetic gap gives visual separation without
+        // stretching the graph to fill every pixel of the viewport — stretching pushes
+        // direct children to the bottom of the canvas on small graphs, which reads as
+        // broken rather than rebalanced. If the aesthetic gap would itself overflow a small
+        // viewport, shrink it but never below verticalGap so bands stay distinguishable.
+        const int defaultInterBandExtra = 3;
+        var totalRows = bandRows.Sum(b => b.Count);
+        var bandCount = bandRows.Count;
+        var tightHeight = totalRows * boxHeight + Math.Max(0, totalRows - 1) * verticalGap;
+
+        var interBandExtra = defaultInterBandExtra;
+        if (bandCount > 1)
+        {
+            var roomForExtras = height - tightHeight;
+            if (roomForExtras < defaultInterBandExtra * (bandCount - 1))
+            {
+                var perGap = roomForExtras / (bandCount - 1);
+                interBandExtra = Math.Max(0, perGap);
+            }
+        }
+        else
+        {
+            interBandExtra = 0;
+        }
+
+        // Phase 3: assign positions.
+        var renderNodes = new List<GraphRenderNode>();
+        var indexById = new Dictionary<string, int>(StringComparer.Ordinal);
+        var yCursor = 0;
+        var contentHeight = 0;
+
+        for (var b = 0; b < bandCount; b++)
+        {
+            var rows = bandRows[b];
+            for (var r = 0; r < rows.Count; r++)
+            {
+                var row = rows[r];
+                var rowWidth = row.Sum(id => widths[id]) + horizontalGap * Math.Max(0, row.Count - 1);
+                var xStart = Math.Max(0, (width - rowWidth) / 2);
+                var x = xStart;
+                foreach (var id in row)
+                {
+                    var w = widths[id];
+                    var depth = visibleDepth[id];
+                    var node = visible.Nodes[visible.IndexById[id]];
+                    var rn = new GraphRenderNode(node, labels[id], x, yCursor, w, boxHeight, depth);
+                    indexById[id] = renderNodes.Count;
+                    renderNodes.Add(rn);
+                    x += w + horizontalGap;
+                }
+                contentHeight = yCursor + boxHeight;
+                yCursor = contentHeight + verticalGap;
+            }
+
+            if (b < bandCount - 1)
+                yCursor += interBandExtra;
+        }
+
+        return new GraphRenderLayout(renderNodes, visible.Edges, indexById, contentHeight);
+    }
+
+    /// <summary>
+    /// Resolves a single hover winner for the supplied mouse position. Candidates are all
+    /// render nodes whose bounding box contains the mouse; the winner is the candidate with
+    /// the smallest distance from the mouse to its box center, with ties broken by draw
+    /// order (later wins). Returns <c>-1</c> when no box contains the mouse.
+    /// </summary>
+    internal static int ResolveHoverWinner(
+        IReadOnlyList<GraphRenderNode> nodes, int mouseX, int mouseY)
+    {
+        var winner = -1;
+        var bestDist = double.MaxValue;
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            var rn = nodes[i];
+            if (mouseX < rn.X || mouseX >= rn.X + rn.Width) continue;
+            if (mouseY < rn.Y || mouseY >= rn.Y + rn.Height) continue;
+            var cx = rn.X + rn.Width / 2.0;
+            var cy = rn.Y + rn.Height / 2.0;
+            var dx = mouseX - cx;
+            var dy = mouseY - cy;
+            var d = dx * dx + dy * dy;
+            if (d <= bestDist)
+            {
+                bestDist = d;
+                winner = i;
+            }
+        }
+        return winner;
+    }
+
+    internal static IReadOnlyDictionary<string, IdentityDiscriminator> ComputeDisambiguation(
+        IReadOnlyList<GraphNode> nodes)
+    {
+        var result = new Dictionary<string, IdentityDiscriminator>(StringComparer.OrdinalIgnoreCase);
+        var groups = nodes.GroupBy(n => n.Name, StringComparer.OrdinalIgnoreCase);
+        foreach (var group in groups)
+        {
+            var list = group.ToList();
+            if (list.Count <= 1) continue;
+            var versionDiffers = list.Select(n => n.Version ?? string.Empty)
+                .Distinct(StringComparer.Ordinal).Count() > 1;
+            var cultureDiffers = list.Select(n => n.Culture)
+                .Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1;
+            var pktDiffers = list.Select(n => n.PublicKeyToken ?? string.Empty)
+                .Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1;
+            result[group.Key] = new IdentityDiscriminator(versionDiffers, cultureDiffers, pktDiffers);
+        }
+        return result;
+    }
+
+    internal static string FormatLabel(
+        GraphNode node,
+        IReadOnlyDictionary<string, IdentityDiscriminator> disambig)
+    {
+        if (!disambig.TryGetValue(node.Name, out var fields))
+        {
+            return node.Version is not null ? $"{node.Name} v{node.Version}" : node.Name;
+        }
+
+        var sb = new StringBuilder(node.Name);
+        if (fields.IncludeVersion && node.Version is not null) sb.Append(" v").Append(node.Version);
+        if (fields.IncludeCulture) sb.Append(" [").Append(node.Culture).Append(']');
+        if (fields.IncludePkt && node.PublicKeyToken is not null)
+        {
+            var pkt = node.PublicKeyToken.Length > 8 ? node.PublicKeyToken[..8] : node.PublicKeyToken;
+            sb.Append(" (").Append(pkt).Append(')');
+        }
+        return sb.ToString();
+    }
+
+    private static string FormatNodeBoxLabel(
+        GraphNode node,
+        GraphNavigationContext? ctx,
+        IReadOnlyDictionary<string, IdentityDiscriminator> disambig)
+    {
+        var prefix = ctx?.Provenance == AssemblyProvenance.IdentityMismatch ? "! " :
+                     node.Unresolved ? "? " : string.Empty;
+        return prefix + FormatLabel(node, disambig);
     }
 }

--- a/src/Dotsider/Views/GraphRenderLayout.cs
+++ b/src/Dotsider/Views/GraphRenderLayout.cs
@@ -1,0 +1,24 @@
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// The laid-out render model for the Dep Graph view. Produced by
+/// <see cref="DependencyGraphView.BuildRenderLayout"/> from a <see cref="VisibleGraphModel"/>
+/// plus the current viewport size, and cached by invalidation key so repeated renders in
+/// the same frame or across mouse moves reuse the same geometry.
+/// </summary>
+/// <param name="Nodes">Placed render nodes in draw order.</param>
+/// <param name="Edges">Edges connecting placed nodes.</param>
+/// <param name="IndexById">Map from <see cref="GraphNode.Id"/> to index into <see cref="Nodes"/>.</param>
+/// <param name="ContentHeight">
+/// Total vertical extent of the laid-out graph in character rows — the Y just past the bottom
+/// of the lowest box. When this exceeds the viewport height, the view enables vertical
+/// scrolling; when it is less than or equal to the viewport height, the layout already
+/// redistributes nodes through the available height.
+/// </param>
+internal sealed record GraphRenderLayout(
+    IReadOnlyList<GraphRenderNode> Nodes,
+    IReadOnlyList<GraphEdge> Edges,
+    IReadOnlyDictionary<string, int> IndexById,
+    int ContentHeight);

--- a/src/Dotsider/Views/GraphRenderLayoutKey.cs
+++ b/src/Dotsider/Views/GraphRenderLayoutKey.cs
@@ -1,0 +1,23 @@
+namespace Dotsider.Views;
+
+/// <summary>
+/// Cache key for a computed <see cref="GraphRenderLayout"/>. The layout must be recomputed
+/// whenever any of these inputs changes: the cached graph identity (a new analyzer or build
+/// replaces the nodes list), the active scope, the framework filter flag, or the viewport
+/// width or height. Mouse moves do not invalidate — hover is resolved separately without
+/// rebuilding geometry.
+/// </summary>
+/// <param name="NodesRef">
+/// Identity handle for the cached graph's node list. Compared by reference, so a new build
+/// replacing the list invalidates the layout even if it contains the same node ids.
+/// </param>
+/// <param name="Scope">The active scope control.</param>
+/// <param name="HideFramework">Whether the framework filter is on.</param>
+/// <param name="Width">Current surface width in columns.</param>
+/// <param name="Height">Current surface height in rows.</param>
+internal readonly record struct GraphRenderLayoutKey(
+    object? NodesRef,
+    DependencyGraphScope Scope,
+    bool HideFramework,
+    int Width,
+    int Height);

--- a/src/Dotsider/Views/GraphRenderNode.cs
+++ b/src/Dotsider/Views/GraphRenderNode.cs
@@ -1,0 +1,25 @@
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// A placed render-time projection of a single <see cref="GraphNode"/>. Carries the
+/// rendered label, the pre-computed box geometry in character coordinates, and the depth
+/// within the visible rooted subgraph so filter changes produce a compact layout rather
+/// than reusing stale positions from the full graph.
+/// </summary>
+/// <param name="Node">The underlying topology node.</param>
+/// <param name="Label">The rendered label (with any <c>?</c> or <c>!</c> prefix).</param>
+/// <param name="X">Left column of the box in character coordinates.</param>
+/// <param name="Y">Top row of the box in character coordinates.</param>
+/// <param name="Width">Box width in columns.</param>
+/// <param name="Height">Box height in rows (always 3 in the current renderer).</param>
+/// <param name="VisibleDepth">Depth from the root within the currently visible graph.</param>
+internal sealed record GraphRenderNode(
+    GraphNode Node,
+    string Label,
+    int X,
+    int Y,
+    int Width,
+    int Height,
+    int VisibleDepth);

--- a/src/Dotsider/Views/IdentityDiscriminator.cs
+++ b/src/Dotsider/Views/IdentityDiscriminator.cs
@@ -1,0 +1,14 @@
+namespace Dotsider.Views;
+
+/// <summary>
+/// Flags indicating which identity fields differ among graph nodes sharing a simple name and
+/// therefore need to appear in disambiguated labels. Computed per render over the visible
+/// nodes so that the disambiguator always reflects what the user actually sees.
+/// </summary>
+/// <param name="IncludeVersion">The version component differs among colliding nodes.</param>
+/// <param name="IncludeCulture">The culture component differs among colliding nodes.</param>
+/// <param name="IncludePkt">The public key token differs among colliding nodes.</param>
+internal sealed record IdentityDiscriminator(
+    bool IncludeVersion,
+    bool IncludeCulture,
+    bool IncludePkt);

--- a/src/Dotsider/Views/VisibleGraphModel.cs
+++ b/src/Dotsider/Views/VisibleGraphModel.cs
@@ -1,0 +1,17 @@
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// A filtered view over the underlying dependency graph, computed once per render of the
+/// Dep Graph tab and used as the single source of truth for search, selection, yank, and
+/// rendering. When the framework-filter toggle is on, framework-classified nodes and any
+/// edges touching them are absent from the visible model; the root is always present.
+/// </summary>
+/// <param name="Nodes">Visible nodes in render order.</param>
+/// <param name="Edges">Visible edges whose source and target are both visible.</param>
+/// <param name="IndexById">Map from <see cref="GraphNode.Id"/> to index into <see cref="Nodes"/>.</param>
+internal sealed record VisibleGraphModel(
+    IReadOnlyList<GraphNode> Nodes,
+    IReadOnlyList<GraphEdge> Edges,
+    IReadOnlyDictionary<string, int> IndexById);

--- a/src/Dotsider/Views/YankHelper.cs
+++ b/src/Dotsider/Views/YankHelper.cs
@@ -141,18 +141,23 @@ public static class YankHelper
         if (state.GraphSelectedNode is not null)
             return state.GraphSelectedNode;
 
-        if (state.GraphSelectedIndex >= 0 && state.CachedGraph is { } graph)
-        {
-            var nodes = graph.Nodes;
-            if (state.GraphSelectedIndex < nodes.Count)
-            {
-                var node = nodes[state.GraphSelectedIndex];
-                var version = node.Version is not null ? $" v{node.Version}" : "";
-                return $"{node.Name}{version}";
-            }
-        }
+        if (state.GraphSelectedIndex < 0 || state.CachedGraph is not { } graph)
+            return null;
 
-        return null;
+        // Selection indices and the rendered label both come from the visible model the view
+        // computes each frame, so yank must use the same projection — otherwise a filtered
+        // view with selection index 1 would yank the underlying cached node at index 1,
+        // which is a hidden framework assembly, not the assembly the user sees.
+        var visible = DependencyGraphView.BuildVisibleModel(
+            graph.Nodes, graph.Edges, state.GraphNavigation,
+            state.DepGraphScope, state.DepGraphHideFramework);
+
+        if (state.GraphSelectedIndex >= visible.Nodes.Count)
+            return null;
+
+        var node = visible.Nodes[state.GraphSelectedIndex];
+        var disambig = DependencyGraphView.ComputeDisambiguation(visible.Nodes);
+        return DependencyGraphView.FormatLabel(node, disambig);
     }
 
     private static string? GetSizeTreemapYankText(DotsiderState state)

--- a/tests/Dotsider.Mcp.Tests/DependencyToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/DependencyToolsTests.cs
@@ -32,10 +32,13 @@ public class DependencyToolsTests(SampleAssemblyFixture samples) : McpServerTest
     }
 
     /// <summary>
-    /// get_dependency_graph returns a graph with nodes and edges for reference visualization.
+    /// get_dependency_graph returns a transitive graph. Every node carries an opaque id,
+    /// at least one node lives at depth greater than zero, and at least one edge has a source
+    /// id that is not the root — proving the tool emits transitive child-to-child edges, not
+    /// only root-to-child edges. No internal navigation fields leak into the JSON payload.
     /// </summary>
     [Fact]
-    public async Task GetDependencyGraph_RichLibrary_ReturnsNodesAndEdges()
+    public async Task GetDependencyGraph_RichLibrary_ReturnsTransitiveGraphWithoutNavigationLeak()
     {
         await StartServerAsync();
         await using var client = await CreateClientAsync();
@@ -50,8 +53,41 @@ public class DependencyToolsTests(SampleAssemblyFixture samples) : McpServerTest
         var json = JsonSerializer.Deserialize<JsonElement>(text);
         Assert.True(json.TryGetProperty("nodes", out var nodes));
         Assert.True(nodes.GetArrayLength() > 0);
-        Assert.True(json.TryGetProperty("edges", out _));
+        Assert.True(json.TryGetProperty("edges", out var edges));
+
+        string? rootId = null;
+        var anyDepthOverZero = false;
+        foreach (var n in nodes.EnumerateArray())
+        {
+            Assert.True(n.TryGetProperty("id", out var id));
+            Assert.False(string.IsNullOrEmpty(id.GetString()));
+            foreach (var leak in NavigationFieldsThatMustNotLeak)
+                Assert.False(n.TryGetProperty(leak, out _), $"node should not expose {leak}");
+            if (n.TryGetProperty("isRoot", out var isRoot) && isRoot.GetBoolean())
+                rootId = id.GetString();
+            if (n.TryGetProperty("depth", out var depth) && depth.GetInt32() > 0)
+                anyDepthOverZero = true;
+        }
+
+        Assert.True(anyDepthOverZero, "expected at least one node with depth > 0");
+        Assert.NotNull(rootId);
+
+        var anyNonRootSource = false;
+        foreach (var e in edges.EnumerateArray())
+        {
+            Assert.True(e.TryGetProperty("sourceId", out var src));
+            Assert.True(e.TryGetProperty("targetId", out _));
+            if (src.GetString() != rootId) anyNonRootSource = true;
+        }
+        Assert.True(anyNonRootSource, "expected at least one edge whose source is not the root");
     }
+
+    private static readonly string[] NavigationFieldsThatMustNotLeak =
+    {
+        "resolvedPath", "referencingFilePath", "referencingBundlePath",
+        "referencingTargetFramework", "referencingPreferredRuntimePack",
+        "candidateProbePath", "isFrameworkAssembly", "resolved",
+    };
 
     /// <summary>
     /// get_type_refs surfaces externally-referenced types imported by the assembly.

--- a/tests/Dotsider.Mcp.Tests/PromptTests.cs
+++ b/tests/Dotsider.Mcp.Tests/PromptTests.cs
@@ -75,4 +75,30 @@ public class PromptTests : McpServerTestBase
         Assert.NotNull(result);
         Assert.True(result.Messages.Count > 0);
     }
+
+    /// <summary>
+    /// dependency_health's materialized prompt must describe the tool's actual capabilities —
+    /// transitive closure traversal including diamond dependencies, circular references, and
+    /// transitive depth — and must acknowledge that framework assemblies are included so
+    /// models don't expect the tool to filter them. Asserting content (not just registration)
+    /// catches future prompt/tool contract drift that was the original issue behind #149.
+    /// </summary>
+    [Fact]
+    public async Task GetPrompt_DependencyHealth_ContentMentionsTransitiveClosureAndFrameworkInclusion()
+    {
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.GetPromptAsync(
+            "dependency_health",
+            new Dictionary<string, object?> { ["assemblyPath"] = "/test/path.dll" },
+            cancellationToken: TestCancellationToken);
+
+        Assert.NotNull(result);
+        var content = string.Join("\n", result.Messages.Select(m => m.Content.ToString()));
+        Assert.Contains("transitive", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("diamond", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("circular", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("framework", content, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tests/Dotsider.Tests/CliTests.cs
+++ b/tests/Dotsider.Tests/CliTests.cs
@@ -365,6 +365,56 @@ public class CliTests(SampleAssemblyFixture fixture)
         Assert.NotNull(json.GetProperty("preferredRuntimePack").GetString());
     }
 
+    /// <summary>
+    /// Verifies <c>analyze --deps --json</c> emits a transitive graph with nodes at depth
+    /// greater than zero and edges whose source is not always the root, and that no internal
+    /// navigation fields leak into the payload.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_Deps_Json_EmitsTransitiveGraphWithoutNavigationLeak()
+    {
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.RichLibraryDll, "--deps", "--json");
+
+        Assert.Equal(0, exitCode);
+        var root = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(stdout);
+        Assert.True(root.TryGetProperty("graph", out var graph));
+        Assert.True(graph.TryGetProperty("nodes", out var nodes));
+        Assert.True(graph.TryGetProperty("edges", out var edges));
+
+        string? rootId = null;
+        var anyDepthOverZero = false;
+        foreach (var n in nodes.EnumerateArray())
+        {
+            Assert.True(n.TryGetProperty("id", out var id));
+            foreach (var leak in new[]
+            {
+                "resolvedPath", "referencingFilePath", "referencingBundlePath",
+                "referencingTargetFramework", "referencingPreferredRuntimePack",
+                "candidateProbePath", "isFrameworkAssembly", "resolved",
+            })
+            {
+                Assert.False(n.TryGetProperty(leak, out _), $"node must not expose {leak}");
+            }
+
+            if (n.TryGetProperty("isRoot", out var isRoot) && isRoot.GetBoolean())
+                rootId = id.GetString();
+            if (n.TryGetProperty("depth", out var depth) && depth.GetInt32() > 0)
+                anyDepthOverZero = true;
+        }
+
+        Assert.True(anyDepthOverZero);
+        Assert.NotNull(rootId);
+
+        var anyNonRootSource = false;
+        foreach (var e in edges.EnumerateArray())
+        {
+            Assert.True(e.TryGetProperty("sourceId", out var src));
+            if (src.GetString() != rootId) anyNonRootSource = true;
+        }
+        Assert.True(anyNonRootSource);
+    }
+
     // --- Helpers ---
 
     private static async Task<(int ExitCode, string Stdout, string Stderr)> RunDotsiderAsync(

--- a/tests/Dotsider.Tests/DependencyGraphBuilderTests.cs
+++ b/tests/Dotsider.Tests/DependencyGraphBuilderTests.cs
@@ -1,129 +1,384 @@
 using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Tests;
 
 /// <summary>
-/// Tests for Dependency Graph Builder.
+/// Tests for <see cref="DependencyGraphBuilder"/> covering transitive traversal, identity-based
+/// dedupe, cycle and diamond preservation, unresolved and identity-mismatch leaves, per-edge
+/// TypeRef counts by full identity, determinism, and behavior across bundle, apphost, and
+/// native deployment shapes.
 /// </summary>
 [Collection("SampleAssemblies")]
 public class DependencyGraphBuilderTests(SampleAssemblyFixture samples)
 {
-    /// <summary>
-    /// Verifies hello world has root node.
-    /// </summary>
+    /// <summary>HelloWorld produces a root node marked IsRoot.</summary>
     [Fact(Timeout = 30_000)]
     public void HelloWorld_HasRootNode()
     {
         using var a = new AssemblyAnalyzer(samples.HelloWorldDll);
-        var (nodes, edges) = DependencyGraphBuilder.Build(a);
-        Assert.NotEmpty(nodes);
-        Assert.Contains(nodes, n => n.IsRoot);
+        var graph = DependencyGraphBuilder.Build(a);
+        Assert.NotEmpty(graph.Nodes);
+        Assert.Single(graph.Nodes, n => n.IsRoot);
     }
 
-    /// <summary>
-    /// Verifies hello world root node name matches assembly.
-    /// </summary>
+    /// <summary>The root node's name matches the analyzed assembly name.</summary>
     [Fact(Timeout = 30_000)]
     public void HelloWorld_RootNodeNameMatchesAssembly()
     {
         using var a = new AssemblyAnalyzer(samples.HelloWorldDll);
-        var (nodes, _) = DependencyGraphBuilder.Build(a);
-        var root = nodes.First(n => n.IsRoot);
-        Assert.Equal("HelloWorld", root.Name);
+        var graph = DependencyGraphBuilder.Build(a);
+        Assert.Equal("HelloWorld", graph.Nodes.First(n => n.IsRoot).Name);
     }
 
-    /// <summary>
-    /// Verifies rich library has newton soft node.
-    /// </summary>
+    /// <summary>RichLibrary still sees its direct third-party references as nodes.</summary>
     [Fact(Timeout = 30_000)]
-    public void RichLibrary_HasNewtonSoftNode()
+    public void RichLibrary_HasDirectReferenceNode_NewtonSoft()
     {
         using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
-        var (nodes, _) = DependencyGraphBuilder.Build(a);
-        Assert.Contains(nodes, n => n.Name == "Newtonsoft.Json");
+        var graph = DependencyGraphBuilder.Build(a);
+        Assert.Contains(graph.Nodes, n => n.Name == "Newtonsoft.Json");
     }
 
     /// <summary>
-    /// Verifies rich library has system text json node.
+    /// RichLibrary's graph has nodes at depth greater than one, proving the traversal walks
+    /// past the root's direct references into transitive references.
     /// </summary>
-    [Fact(Timeout = 30_000)]
-    public void RichLibrary_HasSystemTextJsonNode()
+    [Fact(Timeout = 60_000)]
+    public void RichLibrary_HasNodesAtDepthGreaterThanOne()
     {
         using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
-        var (nodes, _) = DependencyGraphBuilder.Build(a);
-        Assert.Contains(nodes, n => n.Name == "System.Text.Json");
+        var graph = DependencyGraphBuilder.Build(a);
+        Assert.Contains(graph.Nodes, n => n.Depth > 1);
     }
 
     /// <summary>
-    /// Verifies rich library edge type ref count positive.
+    /// RichLibrary's graph contains edges whose source is not the root — direct evidence that
+    /// the builder is emitting transitive child-to-child edges, not only root-to-child.
     /// </summary>
-    [Fact(Timeout = 30_000)]
-    public void RichLibrary_EdgeTypeRefCountPositive()
+    [Fact(Timeout = 60_000)]
+    public void RichLibrary_HasEdgesWhereSourceIsNotRoot()
     {
         using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
-        var (_, edges) = DependencyGraphBuilder.Build(a);
-        Assert.NotEmpty(edges);
-        Assert.Contains(edges, e => e.TypeRefCount > 0);
+        var graph = DependencyGraphBuilder.Build(a);
+        var rootId = graph.Nodes.First(n => n.IsRoot).Id;
+        Assert.Contains(graph.Edges, e => e.SourceId != rootId);
     }
 
-    /// <summary>
-    /// Verifies minimal api has many nodes.
-    /// </summary>
-    [Fact(Timeout = 30_000)]
-    public void MinimalApi_HasManyNodes()
-    {
-        using var a = new AssemblyAnalyzer(samples.MinimalApiDll);
-        var (nodes, _) = DependencyGraphBuilder.Build(a);
-        Assert.True(nodes.Count > 1);
-    }
-
-    /// <summary>
-    /// Verifies empty lib has root and minimal refs.
-    /// </summary>
-    [Fact(Timeout = 30_000)]
-    public void EmptyLib_HasRootAndMinimalRefs()
-    {
-        using var a = new AssemblyAnalyzer(samples.EmptyLibDll);
-        var (nodes, _) = DependencyGraphBuilder.Build(a);
-        Assert.Contains(nodes, n => n.IsRoot);
-    }
-
-    /// <summary>
-    /// Verifies all edges reference existing nodes.
-    /// </summary>
-    [Fact(Timeout = 30_000)]
-    public void AllEdgesReferenceExistingNodes()
+    /// <summary>Every edge references a node id that exists in the node set.</summary>
+    [Fact(Timeout = 60_000)]
+    public void AllEdgesReferenceExistingNodesById()
     {
         using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
-        var (nodes, edges) = DependencyGraphBuilder.Build(a);
-        var nodeNames = nodes.Select(n => n.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        foreach (var edge in edges)
+        var graph = DependencyGraphBuilder.Build(a);
+        var ids = graph.Nodes.Select(n => n.Id).ToHashSet(StringComparer.Ordinal);
+        foreach (var e in graph.Edges)
         {
-            Assert.Contains(edge.SourceName, nodeNames);
-            Assert.Contains(edge.TargetName, nodeNames);
+            Assert.Contains(e.SourceId, ids);
+            Assert.Contains(e.TargetId, ids);
         }
     }
 
-    /// <summary>
-    /// Verifies no duplicate node names.
-    /// </summary>
-    [Fact(Timeout = 30_000)]
-    public void NoDuplicateNodeNames()
+    /// <summary>Node ids are unique across the graph.</summary>
+    [Fact(Timeout = 60_000)]
+    public void NoDuplicateNodeIds()
     {
         using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
-        var (nodes, _) = DependencyGraphBuilder.Build(a);
-        var names = nodes.Select(n => n.Name).ToList();
-        Assert.Equal(names.Count, names.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        var graph = DependencyGraphBuilder.Build(a);
+        var ids = graph.Nodes.Select(n => n.Id).ToList();
+        Assert.Equal(ids.Count, ids.Distinct(StringComparer.Ordinal).Count());
     }
 
-    /// <summary>
-    /// Verifies only one root node.
-    /// </summary>
+    /// <summary>Exactly one root node.</summary>
     [Fact(Timeout = 30_000)]
     public void OnlyOneRootNode()
     {
         using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
-        var (nodes, _) = DependencyGraphBuilder.Build(a);
-        Assert.Single(nodes, n => n.IsRoot);
+        var graph = DependencyGraphBuilder.Build(a);
+        Assert.Single(graph.Nodes, n => n.IsRoot);
     }
+
+    /// <summary>At least one transitive edge has a positive TypeRef count.</summary>
+    [Fact(Timeout = 60_000)]
+    public void TransitiveEdgesCarryTypeRefCounts()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var graph = DependencyGraphBuilder.Build(a);
+        Assert.Contains(graph.Edges, e => e.TypeRefCount > 0);
+    }
+
+    /// <summary>
+    /// Every non-root node carries navigation context keyed by its id, and the root entry
+    /// has <see cref="AssemblyProvenance.Root"/>.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NavigationById_CoversEveryNode_AndRootIsRoot()
+    {
+        using var a = new AssemblyAnalyzer(samples.HelloWorldDll);
+        var graph = DependencyGraphBuilder.Build(a);
+        foreach (var n in graph.Nodes)
+            Assert.True(graph.NavigationById.ContainsKey(n.Id), $"missing nav for {n.Id}");
+
+        var root = graph.Nodes.First(n => n.IsRoot);
+        Assert.Equal(AssemblyProvenance.Root, graph.NavigationById[root.Id].Provenance);
+    }
+
+    /// <summary>Building the same graph twice produces identical node id order and edge lists.</summary>
+    [Fact(Timeout = 60_000)]
+    public void Determinism_NodesAndEdgesOrderStableAcrossRuns()
+    {
+        using var a1 = new AssemblyAnalyzer(samples.RichLibraryDll);
+        using var a2 = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var g1 = DependencyGraphBuilder.Build(a1);
+        var g2 = DependencyGraphBuilder.Build(a2);
+
+        Assert.Equal<IEnumerable<string>>(
+            [.. g1.Nodes.Select(n => n.Id)],
+            [.. g2.Nodes.Select(n => n.Id)]);
+        Assert.Equal<IEnumerable<(string, string)>>(
+            [.. g1.Edges.Select(e => (e.SourceId, e.TargetId))],
+            [.. g2.Edges.Select(e => (e.SourceId, e.TargetId))]);
+    }
+
+    /// <summary>
+    /// A reference to an assembly that cannot be located anywhere produces an unresolved leaf
+    /// with <see cref="GraphNode.Unresolved"/> set and provenance <see cref="AssemblyProvenance.Unresolved"/>.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void UnresolvedRef_AddedAsLeafWithUnresolvedFlag()
+    {
+        using var scope = SyntheticAssemblyScope.Create();
+        var rootPath = scope.WriteAssembly("RootUnres", refs: new[] { ("NonExistentTarget_ZZZ", new Version(1, 0, 0, 0)) });
+
+        using var a = new AssemblyAnalyzer(rootPath);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var leaf = graph.Nodes.FirstOrDefault(n => n.Name == "NonExistentTarget_ZZZ");
+        Assert.NotNull(leaf);
+        Assert.True(leaf!.Unresolved);
+        Assert.Equal(AssemblyProvenance.Unresolved,
+            graph.NavigationById[leaf.Id].Provenance);
+    }
+
+    /// <summary>
+    /// When a probe finds a file whose simple name matches but whose manifest identity does not,
+    /// the builder must mark the node as an unresolved leaf with
+    /// <see cref="AssemblyProvenance.IdentityMismatch"/> and must not expand from the mismatched
+    /// file. The candidate probe path is recorded on the navigation context for diagnostics.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void IdentityMismatch_DoesNotGraftSubtree()
+    {
+        using var scope = SyntheticAssemblyScope.Create();
+        // Place a "MisIdent" assembly on disk with version 9.9.9.9 and a child ref to "ChildOfMis".
+        scope.WriteAssembly(
+            "MisIdent", new Version(9, 9, 9, 9),
+            refs: new[] { ("ChildOfMis", new Version(1, 0, 0, 0)) });
+        // Also place the child so, if the mismatch were silently expanded, ChildOfMis would appear.
+        scope.WriteAssembly("ChildOfMis", new Version(1, 0, 0, 0));
+        // Root requests "MisIdent" version 1.0.0.0 — identity mismatch.
+        var rootPath = scope.WriteAssembly(
+            "RootMis",
+            refs: new[] { ("MisIdent", new Version(1, 0, 0, 0)) });
+
+        using var a = new AssemblyAnalyzer(rootPath);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var mis = graph.Nodes.FirstOrDefault(n => n.Name == "MisIdent");
+        Assert.NotNull(mis);
+        Assert.True(mis!.Unresolved);
+        Assert.Equal(AssemblyProvenance.IdentityMismatch,
+            graph.NavigationById[mis.Id].Provenance);
+        Assert.DoesNotContain(graph.Nodes, n => n.Name == "ChildOfMis");
+        Assert.NotNull(graph.NavigationById[mis.Id].CandidateProbePath);
+    }
+
+    /// <summary>
+    /// Two references with the same simple name but different versions produce two distinct nodes.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void DuplicateSimpleName_DifferentVersion_ProducesTwoNodes()
+    {
+        using var scope = SyntheticAssemblyScope.Create();
+        var rootPath = scope.WriteAssembly(
+            "RootDupVersion",
+            refs: new[]
+            {
+                ("TargetLib", new Version(1, 0, 0, 0)),
+                ("TargetLib", new Version(2, 0, 0, 0)),
+            });
+
+        using var a = new AssemblyAnalyzer(rootPath);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var targets = graph.Nodes.Where(n => n.Name == "TargetLib").ToList();
+        Assert.Equal(2, targets.Count);
+        Assert.NotEqual(targets[0].Id, targets[1].Id);
+    }
+
+    /// <summary>
+    /// Two references with the same simple name but different public key tokens produce two distinct nodes.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void DuplicateSimpleName_DifferentPublicKeyToken_ProducesTwoNodes()
+    {
+        using var scope = SyntheticAssemblyScope.Create();
+        var rootPath = scope.WriteAssembly(
+            "RootDupPkt",
+            refs: new[]
+            {
+                ("TargetPktLib", new Version(1, 0, 0, 0), (byte[]?)new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }),
+                ("TargetPktLib", new Version(1, 0, 0, 0), (byte[]?)new byte[] { 9, 9, 9, 9, 9, 9, 9, 9 }),
+            });
+
+        using var a = new AssemblyAnalyzer(rootPath);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var targets = graph.Nodes.Where(n => n.Name == "TargetPktLib").ToList();
+        Assert.Equal(2, targets.Count);
+        Assert.NotEqual(targets[0].Id, targets[1].Id);
+    }
+
+    /// <summary>
+    /// TypeRefs whose resolution scope ultimately derives from an AssemblyRef are counted against
+    /// the full identity of that AssemblyRef, so an edge's TypeRefCount is meaningful even when
+    /// two refs share a simple name.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void TypeRefCount_GroupsByFullIdentity_NotSimpleName()
+    {
+        using var scope = SyntheticAssemblyScope.Create();
+        var rootPath = scope.WriteAssembly(
+            "RootCountCheck",
+            refs: new[]
+            {
+                ("TargetCountLib", new Version(1, 0, 0, 0)),
+                ("TargetCountLib", new Version(2, 0, 0, 0)),
+            },
+            typeRefs: new[]
+            {
+                ("Sample.T1", 0),
+                ("Sample.T2", 0),
+                ("Sample.T3", 1),
+            });
+
+        using var a = new AssemblyAnalyzer(rootPath);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var rootId = graph.Nodes.First(n => n.IsRoot).Id;
+        var v1Id = graph.Nodes.Single(n => n.Name == "TargetCountLib" && n.Version == "1.0.0.0").Id;
+        var v2Id = graph.Nodes.Single(n => n.Name == "TargetCountLib" && n.Version == "2.0.0.0").Id;
+
+        var edgeToV1 = graph.Edges.Single(e => e.SourceId == rootId && e.TargetId == v1Id);
+        var edgeToV2 = graph.Edges.Single(e => e.SourceId == rootId && e.TargetId == v2Id);
+
+        Assert.Equal(2, edgeToV1.TypeRefCount);
+        Assert.Equal(1, edgeToV2.TypeRefCount);
+    }
+
+    /// <summary>
+    /// When a reference forms a cycle back to an ancestor, the cycle-closing edge is emitted but
+    /// the ancestor is not re-expanded.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Cycle_EdgeEmittedButNotRecursed()
+    {
+        using var scope = SyntheticAssemblyScope.Create();
+        scope.WriteAssembly("CycA", refs: new[] { ("CycB", new Version(1, 0, 0, 0)) });
+        scope.WriteAssembly("CycB", refs: new[] { ("CycA", new Version(1, 0, 0, 0)) });
+        var rootPath = Path.Combine(scope.Directory, "CycA.dll");
+
+        using var a = new AssemblyAnalyzer(rootPath);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var cycA = graph.Nodes.Single(n => n.Name == "CycA");
+        var cycB = graph.Nodes.Single(n => n.Name == "CycB");
+
+        Assert.Contains(graph.Edges, e => e.SourceId == cycA.Id && e.TargetId == cycB.Id);
+        Assert.Contains(graph.Edges, e => e.SourceId == cycB.Id && e.TargetId == cycA.Id);
+        Assert.Equal(1, graph.Nodes.Count(n => n.Name == "CycA"));
+        Assert.Equal(1, graph.Nodes.Count(n => n.Name == "CycB"));
+    }
+
+    /// <summary>
+    /// When two different parents reference the same child, the child appears once (merged on
+    /// identity) and both parent-to-child edges are emitted.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Diamond_MergedOnIdentity()
+    {
+        using var scope = SyntheticAssemblyScope.Create();
+        scope.WriteAssembly("DiaRoot", refs: new[]
+        {
+            ("DiaLeftBranch", new Version(1, 0, 0, 0)),
+            ("DiaRightBranch", new Version(1, 0, 0, 0)),
+        });
+        scope.WriteAssembly("DiaLeftBranch", refs: new[] { ("DiaCommon", new Version(1, 0, 0, 0)) });
+        scope.WriteAssembly("DiaRightBranch", refs: new[] { ("DiaCommon", new Version(1, 0, 0, 0)) });
+        scope.WriteAssembly("DiaCommon");
+
+        var rootPath = Path.Combine(scope.Directory, "DiaRoot.dll");
+        using var a = new AssemblyAnalyzer(rootPath);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        Assert.Equal(1, graph.Nodes.Count(n => n.Name == "DiaCommon"));
+        var commonId = graph.Nodes.Single(n => n.Name == "DiaCommon").Id;
+        Assert.Equal(2, graph.Edges.Count(e => e.TargetId == commonId));
+    }
+
+    /// <summary>
+    /// An assembly whose PE has no CLR metadata (for example a native binary or unknown format)
+    /// still produces a root-only graph and does not throw.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NativeOrNoMetadata_ReturnsRootOnlyGraph()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null || !File.Exists(samples.NativeAotConsoleExe),
+            "Native AOT sample is not available on this platform.");
+        using var a = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        var graph = DependencyGraphBuilder.Build(a);
+        Assert.Single(graph.Nodes);
+        Assert.True(graph.Nodes[0].IsRoot);
+        Assert.Empty(graph.Edges);
+    }
+
+    /// <summary>
+    /// A bundle-backed analyzer opened via <see cref="AssemblyLoader"/> still yields a transitive
+    /// graph without throwing when the builder walks through bundle-extracted refs.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public void BundleBacked_Traversal_Works()
+    {
+        Assert.SkipWhen(samples.SelfContainedConsoleExe is null || !File.Exists(samples.SelfContainedConsoleExe),
+            "Self-contained sample is not available on this platform.");
+        var result = AssemblyLoader.Open(samples.SelfContainedConsoleExe!);
+        using var analyzer = result switch
+        {
+            AssemblyOpenResult.Direct d => d.Analyzer,
+            AssemblyOpenResult.ApphostWithCompanion ac => ac.HostAnalyzer,
+            AssemblyOpenResult.BundleEntry be => be.EntryAnalyzer,
+            _ => throw new InvalidOperationException("unexpected open result"),
+        };
+
+        var graph = DependencyGraphBuilder.Build(analyzer);
+        Assert.Contains(graph.Nodes, n => n.IsRoot);
+        Assert.Contains(graph.Nodes, n => n.Depth > 0);
+    }
+
+    /// <summary>
+    /// Framework classification identifies well-known Microsoft framework assemblies even when
+    /// they are resolved outside of the shared runtime directory (e.g., from app-local copies
+    /// in a self-contained publish).
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public void FrameworkAssemblies_AreClassifiedAcrossDeploymentModels()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var systemRuntime = graph.Nodes.FirstOrDefault(n => n.Name == "System.Runtime");
+        Assert.NotNull(systemRuntime);
+        Assert.True(graph.NavigationById[systemRuntime!.Id].IsFrameworkAssembly);
+    }
+
 }

--- a/tests/Dotsider.Tests/DependencyGraphRenderLayoutTests.cs
+++ b/tests/Dotsider.Tests/DependencyGraphRenderLayoutTests.cs
@@ -1,0 +1,317 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+using Dotsider.Views;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for the Dep Graph render layer: the view-side projection from
+/// <see cref="VisibleGraphModel"/> to placed character-space boxes. The layer rebalances on
+/// every scope, framework, or viewport change, prunes islands created by mid-chain filtering,
+/// and resolves a single hover winner across overlapping or adjacent boxes.
+/// </summary>
+[Collection("SampleAssemblies")]
+public sealed class DependencyGraphRenderLayoutTests(SampleAssemblyFixture samples)
+{
+    /// <summary>
+    /// Toggling scope from <c>All</c> to <c>DirectOnly</c> rebalances the rendered layout —
+    /// depth-1 nodes move (and deep-band nodes disappear) because the layout is computed
+    /// from the visible subgraph, not from stale full-graph coordinates.
+    /// </summary>
+    [Fact]
+    public void FilterChange_RebalancesVisibleGraph()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var graph = DependencyGraphBuilder.Build(a);
+        var disambig = EmptyDisambig();
+
+        var all = LayoutFor(graph, DependencyGraphScope.All, hideFramework: false, w: 200, h: 80);
+        var direct = LayoutFor(graph, DependencyGraphScope.DirectOnly, hideFramework: false, w: 200, h: 80);
+
+        Assert.True(direct.Nodes.Count < all.Nodes.Count,
+            "DirectOnly should drop transitive nodes");
+        Assert.All(direct.Nodes, rn => Assert.True(rn.VisibleDepth <= 1));
+
+        // Rebalance: the direct layout is vertically shorter because it loses the deeper
+        // bands entirely. If the view reused full-graph geometry, the direct layout's max Y
+        // would still extend into what used to be deeper bands — the shrink proves the
+        // layout was recomputed from the visible subgraph, not sliced from stale positions.
+        var allMaxY = all.Nodes.Max(rn => rn.Y);
+        var directMaxY = direct.Nodes.Max(rn => rn.Y);
+        Assert.True(directMaxY < allMaxY,
+            $"DirectOnly should be shorter; got direct max Y = {directMaxY} vs all = {allMaxY}");
+    }
+
+    /// <summary>
+    /// Under <c>DirectOnly</c> there are at most two visible-depth bands: root (depth 0) and
+    /// the direct refs (depth 1). No node lives deeper.
+    /// </summary>
+    [Fact]
+    public void DirectOnly_UsesOnlyVisibleDepthBands()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var graph = DependencyGraphBuilder.Build(a);
+        var direct = LayoutFor(graph, DependencyGraphScope.DirectOnly, hideFramework: false, w: 180, h: 60);
+
+        Assert.All(direct.Nodes, rn => Assert.InRange(rn.VisibleDepth, 0, 1));
+        Assert.Single(direct.Nodes, rn => rn.VisibleDepth == 0);
+    }
+
+    /// <summary>
+    /// Framework filtering that cuts the middle of a chain leaves no orphaned leaves in the
+    /// visible model — every visible non-root node is reachable from the root via visible
+    /// edges. Synthetic chain <c>Root → (framework leaf)</c> where the leaf has identity but
+    /// no further refs exercises the pruning path; with <c>hideFramework</c> on, the leaf
+    /// vanishes and nothing else remains at depth &gt; 0.
+    /// </summary>
+    [Fact]
+    public void FrameworkFilter_PrunesDisconnectedVisibleIslands()
+    {
+        using var scope = SyntheticAssemblyScope.Create();
+        var pkt = new byte[] { 0xb7, 0x7a, 0x5c, 0x56, 0x19, 0x34, 0xe0, 0x89 };
+        scope.WriteAssembly("IslandRoot",
+            refs: new[] { ("mscorlib", new Version(4, 0, 0, 0), (byte[]?)pkt) });
+        var rootPath = Path.Combine(scope.Directory, "IslandRoot.dll");
+
+        using var a = new AssemblyAnalyzer(rootPath);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var visible = DependencyGraphView.BuildVisibleModel(
+            graph.Nodes, graph.Edges, graph.NavigationById,
+            DependencyGraphScope.All, hideFramework: true);
+
+        Assert.Single(visible.Nodes, n => n.IsRoot);
+        Assert.DoesNotContain(visible.Nodes, n => !n.IsRoot);
+        Assert.Empty(visible.Edges);
+    }
+
+    /// <summary>
+    /// Doubling the viewport width reflows the layout and produces a valid, non-overlapping
+    /// arrangement. No two rendered boxes share any character cell in the larger layout.
+    /// </summary>
+    [Fact]
+    public void ViewportResize_ReflowsWithoutBoxOverlap()
+    {
+        using var scope = SyntheticAssemblyScope.Create();
+        var refs = new List<(string Name, Version Version)>();
+        for (var i = 0; i < 20; i++)
+        {
+            scope.WriteAssembly($"Wide{i:00}");
+            refs.Add(($"Wide{i:00}", new Version(1, 0, 0, 0)));
+        }
+        scope.WriteAssembly("WideRoot", refs: refs);
+        var rootPath = Path.Combine(scope.Directory, "WideRoot.dll");
+
+        using var a = new AssemblyAnalyzer(rootPath);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var narrow = LayoutFor(graph, DependencyGraphScope.All, hideFramework: false, w: 80, h: 40);
+        var wide = LayoutFor(graph, DependencyGraphScope.All, hideFramework: false, w: 200, h: 40);
+
+        AssertNoOverlap(wide);
+        AssertNoOverlap(narrow);
+        Assert.NotEqual<IEnumerable<(int, int)>>(
+            [.. narrow.Nodes.Select(rn => (rn.X, rn.Y))],
+            [.. wide.Nodes.Select(rn => (rn.X, rn.Y))]);
+    }
+
+    /// <summary>
+    /// When two boxes overlap the same character cell, <see cref="DependencyGraphView.ResolveHoverWinner"/>
+    /// returns exactly one winner — the closest box center to the mouse, with ties broken by
+    /// later draw order.
+    /// </summary>
+    [Fact]
+    public void Hover_OverlappingBoxes_SelectsSingleWinner()
+    {
+        // first box: X=10..30, center 20.  second box: X=15..35, center 25.
+        var nodes = MakeRenderNodes(
+            ("first", X: 10, Y: 5, Width: 20),
+            ("second", X: 15, Y: 5, Width: 20));
+
+        // Column 24 is inside both boxes. Distance to first center (20) = 4; to second
+        // center (25) = 1. Second wins on closer-to-center.
+        var winner = DependencyGraphView.ResolveHoverWinner(nodes, mouseX: 24, mouseY: 6);
+        Assert.Equal(1, winner);
+
+        // Column 12 is inside only the first box.
+        winner = DependencyGraphView.ResolveHoverWinner(nodes, mouseX: 12, mouseY: 6);
+        Assert.Equal(0, winner);
+
+        // Outside both.
+        winner = DependencyGraphView.ResolveHoverWinner(nodes, mouseX: 0, mouseY: 0);
+        Assert.Equal(-1, winner);
+    }
+
+    /// <summary>
+    /// The hover winner is the node whose label would appear in the status bar — the render
+    /// node returned by <see cref="DependencyGraphView.ResolveHoverWinner"/> drives what the
+    /// view writes to <c>GraphSelectedNode</c>. Validates the single-source-of-truth contract
+    /// for hover.
+    /// </summary>
+    [Fact]
+    public void Hover_WinnerMatchesStatusBarAndHighlight()
+    {
+        // left box: X=0..12,  center 6.   right box: X=6..18, center 12.
+        var nodes = MakeRenderNodes(
+            ("overlap-left", X: 0, Y: 0, Width: 12),
+            ("overlap-right", X: 6, Y: 0, Width: 12));
+
+        // Column 11 is inside both. Distance to left center (6) = 5; to right center (12) = 1.
+        // Right wins on closer-to-center — and that is also what the status bar will show.
+        var winner = DependencyGraphView.ResolveHoverWinner(nodes, mouseX: 11, mouseY: 1);
+
+        Assert.Equal(1, winner);
+        Assert.Equal("overlap-right", nodes[winner].Node.Name);
+    }
+
+    /// <summary>
+    /// Non-winning overlapping boxes do not end up treated as hovered. The winner is unique,
+    /// and any other boxes that also contained the mouse point are left at their base colors.
+    /// </summary>
+    [Fact]
+    public void Hover_NonWinningOverlapsStayUnhighlighted()
+    {
+        var nodes = MakeRenderNodes(
+            ("losing", X: 0, Y: 0, Width: 20),
+            ("winning", X: 10, Y: 0, Width: 10));
+
+        // Column 14 is inside both; the 'winning' center is at column 15, the 'losing' center
+        // is at column 10. Closer to winning => winning wins, losing stays in neither
+        // hovered nor selected sets.
+        var winner = DependencyGraphView.ResolveHoverWinner(nodes, mouseX: 14, mouseY: 1);
+        Assert.Equal(1, winner);
+
+        // Sanity: the losing box still contains the mouse point, but is not the winner.
+        var losing = nodes[0];
+        Assert.True(14 >= losing.X && 14 < losing.X + losing.Width);
+        Assert.NotEqual(0, winner);
+    }
+
+    /// <summary>
+    /// When a wide tall graph exceeds the viewport, every node still has a valid position in
+    /// layout coordinates — rendering just scrolls to reach them. Without scroll, rows past
+    /// the viewport height would be stranded off-screen; with scroll, the view slides until
+    /// any node's box lies entirely inside the viewport band.
+    /// </summary>
+    [Fact]
+    public void ContentExceedingViewport_RemainsReachableViaScroll()
+    {
+        var graph = BuildManyDirectRefsGraph(count: 80);
+        var layout = LayoutFor(graph, DependencyGraphScope.All, hideFramework: false, w: 80, h: 20);
+
+        Assert.True(layout.ContentHeight > 20, "expected content to exceed viewport");
+
+        // For every node, there exists a scroll offset in [0, contentHeight - viewport] that
+        // lands the node's full box inside the viewport.
+        foreach (var rn in layout.Nodes)
+        {
+            var needed = Math.Max(0, rn.Y + rn.Height - 20);
+            needed = Math.Min(needed, layout.ContentHeight - 20);
+            var visibleTop = rn.Y - needed;
+            var visibleBottom = visibleTop + rn.Height;
+            Assert.True(visibleTop >= 0 && visibleBottom <= 20,
+                $"{rn.Node.Name}: no scroll offset reveals the full box");
+        }
+    }
+
+    /// <summary>
+    /// Depth bands are separated by a small fixed aesthetic gap so the two-band transition
+    /// reads visually — not so large that content gets stretched to fill a tall viewport,
+    /// which looks broken. Two adjacent bands should stay within a handful of rows of each
+    /// other regardless of viewport height.
+    /// </summary>
+    [Fact]
+    public void AdjacentDepthBands_SeparatedByFixedAestheticGap()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var narrow = LayoutFor(graph, DependencyGraphScope.DirectOnly, hideFramework: true, w: 200, h: 20);
+        var tall = LayoutFor(graph, DependencyGraphScope.DirectOnly, hideFramework: true, w: 200, h: 200);
+
+        var narrowGap = GapBetweenRootAndFirstDirect(narrow);
+        var tallGap = GapBetweenRootAndFirstDirect(tall);
+
+        // Gap is small and does not scale with viewport height.
+        Assert.InRange(tallGap, 1, 8);
+        Assert.Equal(narrowGap, tallGap);
+    }
+
+    private static int GapBetweenRootAndFirstDirect(GraphRenderLayout layout)
+    {
+        var root = layout.Nodes.Single(rn => rn.Node.IsRoot);
+        var direct1 = layout.Nodes.First(rn => !rn.Node.IsRoot);
+        return direct1.Y - (root.Y + root.Height);
+    }
+
+    /// <summary>
+    /// <see cref="GraphRenderLayout.ContentHeight"/> never exceeds the sum of row heights
+    /// plus the distributed inter-band padding — it reflects the actual layout footprint
+    /// so scroll-range and fits-vs-scrolls decisions can be made from one authoritative value.
+    /// </summary>
+    [Fact]
+    public void ContentHeight_MatchesRenderedExtent()
+    {
+        var graph = BuildManyDirectRefsGraph(count: 80);
+        var layout = LayoutFor(graph, DependencyGraphScope.All, hideFramework: false, w: 80, h: 20);
+
+        var bottom = layout.Nodes.Max(rn => rn.Y + rn.Height);
+        Assert.Equal(bottom, layout.ContentHeight);
+    }
+
+    private static DependencyGraphResult BuildManyDirectRefsGraph(int count)
+    {
+        using var scope = SyntheticAssemblyScope.Create();
+        var refs = new List<(string Name, Version Version)>();
+        for (var i = 0; i < count; i++)
+        {
+            scope.WriteAssembly($"ManyRef{i:000}");
+            refs.Add(($"ManyRef{i:000}", new Version(1, 0, 0, 0)));
+        }
+        scope.WriteAssembly("ManyRoot", refs: refs);
+        var rootPath = Path.Combine(scope.Directory, "ManyRoot.dll");
+        using var a = new AssemblyAnalyzer(rootPath);
+        return DependencyGraphBuilder.Build(a);
+    }
+
+    private static GraphRenderLayout LayoutFor(
+        DependencyGraphResult graph,
+        DependencyGraphScope scope,
+        bool hideFramework,
+        int w,
+        int h)
+    {
+        var visible = DependencyGraphView.BuildVisibleModel(
+            graph.Nodes, graph.Edges, graph.NavigationById, scope, hideFramework);
+        var disambig = DependencyGraphView.ComputeDisambiguation(visible.Nodes);
+        return DependencyGraphView.BuildRenderLayout(visible, graph.NavigationById, disambig, w, h);
+    }
+
+    private static void AssertNoOverlap(GraphRenderLayout layout)
+    {
+        for (var i = 0; i < layout.Nodes.Count; i++)
+        {
+            var a = layout.Nodes[i];
+            for (var j = i + 1; j < layout.Nodes.Count; j++)
+            {
+                var b = layout.Nodes[j];
+                var horizOverlap = a.X < b.X + b.Width && b.X < a.X + a.Width;
+                var vertOverlap = a.Y < b.Y + b.Height && b.Y < a.Y + a.Height;
+                Assert.False(horizOverlap && vertOverlap,
+                    $"boxes overlap: {a.Node.Name} at ({a.X},{a.Y},{a.Width},{a.Height}) " +
+                    $"and {b.Node.Name} at ({b.X},{b.Y},{b.Width},{b.Height})");
+            }
+        }
+    }
+
+    private static List<GraphRenderNode> MakeRenderNodes(
+        params (string Name, int X, int Y, int Width)[] items) =>
+        [.. items.Select(item => new GraphRenderNode(
+            new GraphNode(
+                Id: item.Name, Name: item.Name, Version: null, Culture: "neutral",
+                PublicKeyToken: null, IsRoot: false, Depth: 1, Unresolved: false),
+            Label: item.Name,
+            X: item.X, Y: item.Y, Width: item.Width, Height: 3, VisibleDepth: 1))];
+
+    private static Dictionary<string, IdentityDiscriminator> EmptyDisambig() => [];
+}

--- a/tests/Dotsider.Tests/DependencyGraphScopeTests.cs
+++ b/tests/Dotsider.Tests/DependencyGraphScopeTests.cs
@@ -1,0 +1,119 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Views;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for the Dep Graph scope control. Scope (all / direct-only) and the framework filter
+/// compose through a single visible-model projection, so rendering, search, yank, and Enter
+/// all operate on the same view. Transitive-only is intentionally not offered: hiding direct
+/// parents would produce disconnected islands.
+/// </summary>
+[Collection("SampleAssemblies")]
+public sealed class DependencyGraphScopeTests(SampleAssemblyFixture samples)
+{
+    /// <summary>
+    /// <see cref="DependencyGraphScope.DirectOnly"/> keeps only the root and depth-1 nodes
+    /// plus the edges between them; deeper transitive refs drop out.
+    /// </summary>
+    [Fact]
+    public void DirectOnly_KeepsOnlyRootAndDepthOne()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        Assert.Contains(graph.Nodes, n => n.Depth > 1);
+
+        var visible = DependencyGraphView.BuildVisibleModel(
+            graph.Nodes, graph.Edges, graph.NavigationById,
+            DependencyGraphScope.DirectOnly, hideFramework: false);
+
+        Assert.All(visible.Nodes, n => Assert.True(n.IsRoot || n.Depth == 1));
+        var rootId = visible.Nodes.First(n => n.IsRoot).Id;
+        Assert.All(visible.Edges, e => Assert.Equal(rootId, e.SourceId));
+        Assert.All(visible.Edges, e => Assert.Contains(visible.Nodes, n => n.Id == e.TargetId));
+    }
+
+    /// <summary>
+    /// <see cref="DependencyGraphScope.All"/> is the default and returns the full closure
+    /// unchanged — anything the builder produced is visible, edges included.
+    /// </summary>
+    [Fact]
+    public void All_ReturnsFullClosure()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var visible = DependencyGraphView.BuildVisibleModel(
+            graph.Nodes, graph.Edges, graph.NavigationById,
+            DependencyGraphScope.All, hideFramework: false);
+
+        Assert.Equal(graph.Nodes.Count, visible.Nodes.Count);
+        Assert.Equal(graph.Edges.Count, visible.Edges.Count);
+    }
+
+    /// <summary>
+    /// Scope and framework filter compose: DirectOnly plus hideFramework yields only the root
+    /// and the non-framework direct references. For RichLibrary that collapses to root plus
+    /// Newtonsoft.Json.
+    /// </summary>
+    [Fact]
+    public void DirectOnly_ComposesWithFrameworkFilter()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var visible = DependencyGraphView.BuildVisibleModel(
+            graph.Nodes, graph.Edges, graph.NavigationById,
+            DependencyGraphScope.DirectOnly, hideFramework: true);
+
+        Assert.Contains(visible.Nodes, n => n.IsRoot);
+        Assert.All(visible.Nodes, n => Assert.True(n.IsRoot || n.Depth == 1));
+        Assert.All(visible.Nodes, n =>
+        {
+            if (n.IsRoot) return;
+            var ctx = graph.NavigationById[n.Id];
+            Assert.False(ctx.IsFrameworkAssembly);
+        });
+    }
+
+    /// <summary>
+    /// Root stays visible under every combination of scope and framework filter, so the
+    /// anchor of the graph is never lost.
+    /// </summary>
+    [Theory]
+    [InlineData(DependencyGraphScope.All, false)]
+    [InlineData(DependencyGraphScope.All, true)]
+    [InlineData(DependencyGraphScope.DirectOnly, false)]
+    [InlineData(DependencyGraphScope.DirectOnly, true)]
+    public void Root_IsAlwaysVisible(DependencyGraphScope scope, bool hideFramework)
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var visible = DependencyGraphView.BuildVisibleModel(
+            graph.Nodes, graph.Edges, graph.NavigationById, scope, hideFramework);
+
+        Assert.Contains(visible.Nodes, n => n.IsRoot);
+    }
+
+    /// <summary>
+    /// The <see cref="VisibleGraphModel.IndexById"/> map exposes exactly the visible nodes,
+    /// so index-based consumers (search, selection, yank) cannot accidentally reach into
+    /// hidden nodes.
+    /// </summary>
+    [Fact]
+    public void VisibleIndex_MapsOnlyVisibleNodes()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var visible = DependencyGraphView.BuildVisibleModel(
+            graph.Nodes, graph.Edges, graph.NavigationById,
+            DependencyGraphScope.DirectOnly, hideFramework: false);
+
+        Assert.Equal(visible.Nodes.Count, visible.IndexById.Count);
+        foreach (var n in visible.Nodes)
+            Assert.Equal(n.Id, visible.Nodes[visible.IndexById[n.Id]].Id);
+    }
+}

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -856,6 +856,141 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
     }
 
     /// <summary>
+    /// Pressing <c>f</c> on the Dep Graph toggles framework filtering. The status line
+    /// reports hidden counts, and the state flag flips. Root stays visible by contract —
+    /// verified by asserting the nodes cached for the filtered view still include the root id.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Tab6_FilterToggle_HidesFrameworkAssembliesAndKeepsRootVisible()
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.D6)
+            .WaitUntil(s => s.ContainsText("Nodes:"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.False(_state!.DepGraphHideFramework);
+        Assert.NotNull(_state.CachedGraph);
+        var rootId = _state.CachedGraph!.Value.Nodes.First(n => n.IsRoot).Id;
+        Assert.NotNull(_state.GraphNavigation);
+        Assert.Contains(_state.CachedGraph.Value.Nodes, n => _state.GraphNavigation!.TryGetValue(n.Id, out var c) && c.IsFrameworkAssembly);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.F)
+            .WaitUntil(_ => _state!.DepGraphHideFramework, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Hidden:"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.True(_state.DepGraphHideFramework);
+        // Root id is still in the cached graph after toggle (underlying graph not rebuilt).
+        Assert.Contains(_state.CachedGraph.Value.Nodes, n => n.Id == rootId && n.IsRoot);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Pressing <c>d</c> on the Dep Graph tab toggles scope between <c>All</c> and
+    /// <c>DirectOnly</c>. The status line reflects the active scope and selection / match
+    /// indices reset on each change so stale indices cannot survive into a smaller view.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Tab6_ScopeToggle_SwitchesBetweenAllAndDirectOnly()
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.D6)
+            .WaitUntil(s => s.ContainsText("Nodes:"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(Views.DependencyGraphScope.All, _state!.DepGraphScope);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.D)
+            .WaitUntil(_ => _state!.DepGraphScope == Views.DependencyGraphScope.DirectOnly,
+                TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("scope: direct"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(Views.DependencyGraphScope.DirectOnly, _state.DepGraphScope);
+        Assert.Equal(-1, _state.GraphSelectedIndex);
+        Assert.Equal(-1, _state.GraphMatchIndex);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.D)
+            .WaitUntil(_ => _state!.DepGraphScope == Views.DependencyGraphScope.All,
+                TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("d: scope all"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(Views.DependencyGraphScope.All, _state.DepGraphScope);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Pressing <c>End</c> on the Dep Graph must reach the bottom of the content even when
+    /// a node is currently selected. Previously a per-frame selection-follow rule pulled the
+    /// scroll back to the selected node's Y before the clamp, so <c>End</c> never actually
+    /// showed the last row. Regression test: select a node near the top, press <c>End</c>,
+    /// and assert the scroll offset matches the full <c>ContentHeight - viewport</c> range.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Tab6_End_ScrollsToBottom_EvenWhenNodeSelected()
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.D6)
+            .WaitUntil(s => s.ContainsText("Nodes:"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.GraphSelectedIndex == 0, TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.NotNull(_state!.CachedGraphRenderLayout);
+        Assert.NotNull(_state.CachedGraphRenderLayoutKey);
+        var layout = _state.CachedGraphRenderLayout!;
+        var key = _state.CachedGraphRenderLayoutKey!.Value;
+        var expectedMax = Math.Max(0, layout.ContentHeight - key.Height);
+        Assert.True(expectedMax > 0, "viewport must be smaller than content for this test");
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Key(Hex1bKey.End)
+            .WaitUntil(_ => _state!.DepGraphScrollY == expectedMax, TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(expectedMax, _state.DepGraphScrollY);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
     /// Verifies tab7 arrow keys cycle selected index.
     /// </summary>
     [Fact(Timeout = 30_000)]

--- a/tests/Dotsider.Tests/SyntheticAssemblyScope.cs
+++ b/tests/Dotsider.Tests/SyntheticAssemblyScope.cs
@@ -1,0 +1,139 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Disposable scope for writing minimal synthetic PE assemblies into a temp directory so
+/// tests can probe them from disk the same way the graph builder probes a real referencing
+/// assembly. Supports emitting AssemblyRefs with explicit version and public key token, and
+/// TypeRefs whose resolution scope points at one of those AssemblyRefs so duplicate-name
+/// scenarios can exercise the per-identity TypeRef count path.
+/// </summary>
+internal sealed class SyntheticAssemblyScope : IDisposable
+{
+    /// <summary>The scope's temp directory.</summary>
+    public string Directory { get; }
+
+    private SyntheticAssemblyScope(string dir) { Directory = dir; }
+
+    /// <summary>Creates a new temp directory scope.</summary>
+    public static SyntheticAssemblyScope Create()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "dotsider-depgraph-" + Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        return new SyntheticAssemblyScope(dir);
+    }
+
+    /// <summary>
+    /// Writes a minimal synthetic managed PE with the given name, version, and AssemblyRefs.
+    /// </summary>
+    /// <param name="name">Assembly simple name (also used as the file name).</param>
+    /// <param name="version">Assembly version, defaulting to 1.0.0.0 when null.</param>
+    /// <param name="refs">AssemblyRefs to emit, each as (name, version).</param>
+    /// <param name="typeRefs">TypeRefs keyed to <paramref name="refs"/> by index.</param>
+    /// <returns>The full path to the written assembly.</returns>
+    public string WriteAssembly(
+        string name,
+        Version? version = null,
+        IReadOnlyList<(string Name, Version Version)>? refs = null,
+        IReadOnlyList<(string FullName, int RefIndex)>? typeRefs = null)
+    {
+        var bytes = BuildAssembly(
+            name, version ?? new Version(1, 0, 0, 0),
+            refs is null
+                ? []
+                : [.. refs.Select(r => (r.Name, r.Version, (byte[]?)null))],
+            typeRefs ?? []);
+        var path = Path.Combine(Directory, $"{name}.dll");
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    /// <summary>
+    /// Writes a minimal synthetic managed PE with AssemblyRefs carrying explicit public key tokens.
+    /// </summary>
+    /// <param name="name">Assembly simple name.</param>
+    /// <param name="refs">AssemblyRefs to emit, each as (name, version, pkt).</param>
+    /// <returns>The full path to the written assembly.</returns>
+    public string WriteAssembly(
+        string name,
+        IReadOnlyList<(string Name, Version Version, byte[]? PublicKeyToken)> refs)
+    {
+        var bytes = BuildAssembly(
+            name, new Version(1, 0, 0, 0),
+            [.. refs],
+            []);
+        var path = Path.Combine(Directory, $"{name}.dll");
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        try { System.IO.Directory.Delete(Directory, recursive: true); }
+        catch { }
+    }
+
+    private static byte[] BuildAssembly(
+        string moduleName,
+        Version version,
+        IReadOnlyList<(string Name, Version Version, byte[]? PublicKeyToken)> refs,
+        IReadOnlyList<(string FullName, int RefIndex)> typeRefs)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddAssembly(
+            metadata.GetOrAddString(moduleName),
+            version,
+            default, default,
+            0, AssemblyHashAlgorithm.None);
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString(moduleName + ".dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default, default);
+        metadata.AddTypeDefinition(
+            default, default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var asmRefHandles = new List<AssemblyReferenceHandle>();
+        foreach (var r in refs)
+        {
+            var pktBlob = r.PublicKeyToken is null
+                ? default
+                : metadata.GetOrAddBlob(r.PublicKeyToken);
+            asmRefHandles.Add(metadata.AddAssemblyReference(
+                metadata.GetOrAddString(r.Name),
+                r.Version,
+                default,
+                pktBlob,
+                0,
+                default));
+        }
+
+        foreach (var (fullName, idx) in typeRefs)
+        {
+            var dot = fullName.LastIndexOf('.');
+            var ns = dot >= 0 ? fullName[..dot] : string.Empty;
+            var n = dot >= 0 ? fullName[(dot + 1)..] : fullName;
+            metadata.AddTypeReference(
+                asmRefHandles[idx],
+                metadata.GetOrAddString(ns),
+                metadata.GetOrAddString(n));
+        }
+
+        var pe = new ManagedPEBuilder(
+            new PEHeaderBuilder(imageCharacteristics: Characteristics.Dll),
+            new MetadataRootBuilder(metadata),
+            ilStream: new BlobBuilder());
+        var blob = new BlobBuilder();
+        pe.Serialize(blob);
+        return blob.ToArray();
+    }
+}

--- a/tests/Dotsider.Tests/YankHelperTests.cs
+++ b/tests/Dotsider.Tests/YankHelperTests.cs
@@ -258,7 +258,13 @@ public class YankHelperTests(SampleAssemblyFixture samples) : IDisposable
     {
         using var state = CreateState(samples.RichLibraryDll);
         state.CurrentTab = TabId.DepGraph;
-        var (nodes, _) = state.CachedGraph ??= DependencyGraphBuilder.Build(state.Analyzer);
+        if (state.CachedGraph is null)
+        {
+            var result = DependencyGraphBuilder.Build(state.Analyzer);
+            state.CachedGraph = (result.Nodes, result.Edges);
+            state.GraphNavigation = result.NavigationById;
+        }
+        var nodes = state.CachedGraph!.Value.Nodes;
         Assert.True(nodes.Count > 0);
         state.GraphSelectedIndex = 0;
 
@@ -266,6 +272,36 @@ public class YankHelperTests(SampleAssemblyFixture samples) : IDisposable
 
         Assert.NotNull(text);
         Assert.Contains(nodes[0].Name, text);
+    }
+
+    /// <summary>
+    /// Under <see cref="Views.DependencyGraphScope.DirectOnly"/>, yank at selection index 0
+    /// returns the first visible node (the root), not whatever node sits at index 0 in the
+    /// underlying cached graph. The selected-index-to-node mapping must follow the same
+    /// visible projection the view uses.
+    /// </summary>
+    [Fact]
+    public void DepGraph_Yank_UsesVisibleModel_UnderDirectOnlyScope()
+    {
+        using var state = CreateState(samples.RichLibraryDll);
+        state.CurrentTab = TabId.DepGraph;
+        var result = DependencyGraphBuilder.Build(state.Analyzer);
+        state.CachedGraph = (result.Nodes, result.Edges);
+        state.GraphNavigation = result.NavigationById;
+
+        state.DepGraphScope = Views.DependencyGraphScope.DirectOnly;
+
+        var visible = Views.DependencyGraphView.BuildVisibleModel(
+            result.Nodes, result.Edges, result.NavigationById,
+            state.DepGraphScope, state.DepGraphHideFramework);
+        Assert.True(visible.Nodes.Count >= 2,
+            "RichLibrary should have root plus at least one direct ref");
+
+        state.GraphSelectedIndex = 1;
+        var text = YankHelper.GetYankText(state);
+
+        Assert.NotNull(text);
+        Assert.Contains(visible.Nodes[1].Name, text);
     }
 
     /// <summary>


### PR DESCRIPTION
Rewrites the Dep Graph from a one-level star into a full transitive closure. BFS walks each AssemblyRef by full identity (name, version, culture, public key token), opens it, and recurses; cycles and diamonds are preserved on revisit and per-edge TypeRef counts group by full identity rather than simple name. Resolution adds a NuGet `.deps.json` probe so library projects find their dependencies in the NuGet cache, plus framework roll-forward for shared-runtime assemblies with well-known Microsoft PKTs. The framework classifier is deployment-model-agnostic — a self-contained publish's BCL and the shared runtime's BCL classify the same way.

Topology and geometry split. `GraphNode` is pure identity; a new render layer computes label-aware packed rows per viewport and rebuilds on scope, filter, or viewport change. Vertical scroll is first-class (`Home`, `End`, `PageUp`/`Down`, arrow keys) with selection-follow tied to the arrow-key handlers so explicit scroll input is never overridden. Hover resolves to a single winner across overlapping boxes and drives both the highlight and the status line. Two controls narrow the graph, each on its own key: `d` toggles scope between `all` and `direct`, `f` toggles framework filtering — both compose through one visible-model projection so render, search, selection, yank, and Enter all agree on what the user sees. Per-node Enter uses the resolved location recorded during traversal instead of probing from the root, which only ever worked for direct refs.

Consumer surfaces follow the new shape: CLI `analyze --deps --json`, diagnostics UDS `get-dependency-graph`, MCP `get_dependency_graph` tool + DependencyHealth prompt, docs. Navigation metadata stays internal and never serializes. Benchmarks reflect the actual transitive walk (Xml closure: 20 ms / 79 MB, up from the previous 8 μs that only measured the direct-ref star); the resolve chain is now seven steps with the NuGet probe called out in the benchmarks README.

Fixes: #149