### PR TITLE
Ship sample as a published unit so deps resolve on the live site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,16 +60,26 @@ jobs:
           -p:PublishSingleFile=true
           -o ./publish/website
 
-      - name: Build sample assembly
-        run: dotnet build samples/RichLibrary/RichLibrary.csproj -c Release
-
-      - name: Copy sample assembly
-        run: cp samples/RichLibrary/bin/Release/net10.0/RichLibrary.dll ./publish/website/
+      - name: Publish sample assembly
+        # Publish (not build) so the .deps.json and every NuGet dependency that
+        # RichLibrary resolves at runtime ship together as a unit. Hand-copying
+        # just RichLibrary.dll drifts every time the sample's package closure
+        # changes — Newtonsoft.Json, any future deps, etc.
+        run: >
+          dotnet publish samples/RichLibrary/RichLibrary.csproj
+          -c Release
+          -r linux-x64
+          -o ./publish/sample
 
       - uses: actions/upload-artifact@v7
         with:
           name: website-server
           path: publish/website/
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: website-sample
+          path: publish/sample/
 
   preflight:
     needs: build
@@ -107,6 +117,11 @@ jobs:
           name: website-server
           path: website-server/
 
+      - uses: actions/download-artifact@v8
+        with:
+          name: website-sample
+          path: website-sample/
+
       - name: Setup SSH
         env:
           HOST: ${{ secrets.DEPLOY_HOST }}
@@ -133,19 +148,34 @@ jobs:
           ssh -i ~/.ssh/deploy_key brandon@"$HOST" \
             'sudo systemctl stop integrity-check.timer integrity-check.service 2>/dev/null || true'
 
+          # Website binary. Exclude the sample payload and its backups/manifest
+          # so a website-only rsync doesn't wipe them out.
           rsync -avz --delete --chmod=F755 \
             --exclude='caddy-report.sh' \
             --exclude='integrity-check.sh' \
-            --exclude='.RichLibrary.dll.bak' \
-            --exclude='.RichLibrary.dll.sha256' \
+            --exclude='sample/' \
+            --exclude='sample.bak/' \
+            --exclude='sample.sha256' \
             -e "ssh -i ~/.ssh/deploy_key" \
             website-server/ \
             brandon@"$HOST":/opt/dotsider-website/
 
+          # Sample payload shipped as a directory unit. RichLibrary.dll,
+          # RichLibrary.deps.json, and Newtonsoft.Json.dll (plus any future
+          # package deps) travel together and are verified together.
+          rsync -avz --delete --chmod=F644 \
+            -e "ssh -i ~/.ssh/deploy_key" \
+            website-sample/ \
+            brandon@"$HOST":/opt/dotsider-website/sample/
+
           ssh -i ~/.ssh/deploy_key brandon@"$HOST" bash -s << 'REMOTE'
             cd /opt/dotsider-website
-            cp RichLibrary.dll .RichLibrary.dll.bak
-            sha256sum RichLibrary.dll | cut -d' ' -f1 > .RichLibrary.dll.sha256
+            rm -rf sample.bak
+            cp -r sample sample.bak
+            # Manifest: one "<sha256>  <relative-path>" per file, sorted.
+            (cd sample && find . -type f -print0 \
+              | LC_ALL=C sort -z \
+              | xargs -0 sha256sum) > sample.sha256
             sudo systemctl start integrity-check.timer
           REMOTE
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -15,7 +15,7 @@ Infrastructure for deploying dotsider.dev to a Hetzner VM running Debian behind 
 | `caddy-report.service` | systemd oneshot unit for the metrics report |
 | `caddy-report.timer` | Runs `caddy-report.service` every 5 minutes |
 | `caddy-metrics-logrotate` | Weekly log rotation for `/var/log/caddy-metrics.log` (4 compressed archives) |
-| `integrity-check.sh` | SHA256-checks `RichLibrary.dll` against a known-good hash, restores from backup and restarts the service if corrupted |
+| `integrity-check.sh` | SHA256-checks every file under `sample/` against a deploy-time manifest; if any file is missing or altered, restores the whole directory from `sample.bak/` and restarts the service |
 | `integrity-check.service` | systemd oneshot unit for the integrity check |
 | `integrity-check.timer` | Runs `integrity-check.service` every minute |
 

--- a/deploy/dotsider-website.service
+++ b/deploy/dotsider-website.service
@@ -13,7 +13,7 @@ RestartSec=5
 
 Environment=ASPNETCORE_URLS=http://localhost:5100
 Environment=DOTNET_ENVIRONMENT=Production
-Environment=Demo__SampleAssembly=/opt/dotsider-website/RichLibrary.dll
+Environment=Demo__SampleAssembly=/opt/dotsider-website/sample/RichLibrary.dll
 Environment=Demo__MaxSessions=50
 Environment=Demo__SessionTimeoutMinutes=10
 Environment=Demo__AllowedOrigins__0=https://dotsider.dev

--- a/deploy/integrity-check.service
+++ b/deploy/integrity-check.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Verify RichLibrary.dll integrity
+Description=Verify dotsider-website sample payload integrity
 After=dotsider-website.service
 
 [Service]

--- a/deploy/integrity-check.sh
+++ b/deploy/integrity-check.sh
@@ -1,28 +1,38 @@
 #!/usr/bin/env bash
-# integrity-check.sh — Verify RichLibrary.dll hasn't been corrupted
+# integrity-check.sh — Verify the sample payload hasn't been corrupted
 #
-# Compares the current SHA256 against a known-good hash stored at deploy time.
-# If the hash doesn't match, restores from the backup copy and restarts the service.
+# The sample is shipped as a directory unit (RichLibrary.dll, RichLibrary.deps.json,
+# Newtonsoft.Json.dll, and any other files the publish output contains). A single
+# manifest of "<sha256>  <relative-path>" per file is written at deploy time and
+# verified each minute; on mismatch or missing entries the whole sample/ is
+# restored from the deploy-time backup and the service is restarted.
 set -euo pipefail
 
 DIR="/opt/dotsider-website"
-DLL="$DIR/RichLibrary.dll"
-BACKUP="$DIR/.RichLibrary.dll.bak"
-HASH_FILE="$DIR/.RichLibrary.dll.sha256"
+SAMPLE="$DIR/sample"
+BACKUP="$DIR/sample.bak"
+MANIFEST="$DIR/sample.sha256"
 LOG="/var/log/integrity-check.log"
 
-if [[ ! -f "$DLL" || ! -f "$BACKUP" || ! -f "$HASH_FILE" ]]; then
+if [[ ! -d "$SAMPLE" || ! -d "$BACKUP" || ! -f "$MANIFEST" ]]; then
     exit 0
 fi
 
-EXPECTED=$(cat "$HASH_FILE")
-ACTUAL=$(sha256sum "$DLL" | cut -d' ' -f1)
-
-if [[ "$ACTUAL" != "$EXPECTED" ]]; then
-    NOW=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-    echo "$NOW | CORRUPTED expected=$EXPECTED actual=$ACTUAL — restoring from backup" >> "$LOG"
-    cp "$BACKUP" "$DLL"
-    systemctl reset-failed dotsider-website 2>/dev/null
-    systemctl restart dotsider-website
-    echo "$NOW | RESTORED and restarted dotsider-website" >> "$LOG"
+# sha256sum -c reads the manifest and reports per-file status. Running from
+# inside sample/ resolves the recorded relative paths. --quiet only prints
+# mismatches; any non-zero exit means at least one file drifted or vanished.
+if (cd "$SAMPLE" && sha256sum --quiet -c "$MANIFEST") >/dev/null 2>&1; then
+    exit 0
 fi
+
+NOW=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+echo "$NOW | CORRUPTED sample payload — restoring from backup" >> "$LOG"
+rm -rf "$SAMPLE"
+# cp -a preserves ownership. The backup was created during deploy as brandon,
+# so restoring with -a keeps sample/ owned by brandon. Plain cp -r would run
+# as root (the service user), leaving sample/ root-owned and blocking every
+# subsequent deploy's rsync (brandon cannot overwrite root-owned files).
+cp -a "$BACKUP" "$SAMPLE"
+systemctl reset-failed dotsider-website 2>/dev/null
+systemctl restart dotsider-website
+echo "$NOW | RESTORED sample/ and restarted dotsider-website" >> "$LOG"

--- a/deploy/integrity-check.timer
+++ b/deploy/integrity-check.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Check RichLibrary.dll integrity every minute
+Description=Check dotsider-website sample payload integrity every minute
 
 [Timer]
 OnBootSec=2min

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -66,7 +66,7 @@ RestartSec=5
 
 Environment=ASPNETCORE_URLS=http://localhost:5100
 Environment=DOTNET_ENVIRONMENT=Production
-Environment=Demo__SampleAssembly=/opt/dotsider-website/RichLibrary.dll
+Environment=Demo__SampleAssembly=/opt/dotsider-website/sample/RichLibrary.dll
 Environment=Demo__MaxSessions=50
 Environment=Demo__SessionTimeoutMinutes=10
 Environment=Demo__AllowedOrigins__0=https://dotsider.dev
@@ -184,39 +184,46 @@ systemctl start caddy-report.timer
 echo "── Installing integrity checker ──"
 cp /dev/stdin /opt/dotsider-website/integrity-check.sh << 'ICHK'
 #!/usr/bin/env bash
-# integrity-check.sh — Verify RichLibrary.dll hasn't been corrupted
+# integrity-check.sh — Verify the sample payload hasn't been corrupted
 #
-# Compares the current SHA256 against a known-good hash stored at deploy time.
-# If the hash doesn't match, restores from the backup copy and restarts the service.
+# The sample is shipped as a directory unit (RichLibrary.dll, RichLibrary.deps.json,
+# Newtonsoft.Json.dll, and any other files the publish output contains). A single
+# manifest of "<sha256>  <relative-path>" per file is written at deploy time and
+# verified each minute; on mismatch or missing entries the whole sample/ is
+# restored from the deploy-time backup and the service is restarted.
 set -euo pipefail
 
 DIR="/opt/dotsider-website"
-DLL="$DIR/RichLibrary.dll"
-BACKUP="$DIR/.RichLibrary.dll.bak"
-HASH_FILE="$DIR/.RichLibrary.dll.sha256"
+SAMPLE="$DIR/sample"
+BACKUP="$DIR/sample.bak"
+MANIFEST="$DIR/sample.sha256"
 LOG="/var/log/integrity-check.log"
 
-if [[ ! -f "$DLL" || ! -f "$BACKUP" || ! -f "$HASH_FILE" ]]; then
+if [[ ! -d "$SAMPLE" || ! -d "$BACKUP" || ! -f "$MANIFEST" ]]; then
     exit 0
 fi
 
-EXPECTED=$(cat "$HASH_FILE")
-ACTUAL=$(sha256sum "$DLL" | cut -d' ' -f1)
-
-if [[ "$ACTUAL" != "$EXPECTED" ]]; then
-    NOW=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-    echo "$NOW | CORRUPTED expected=$EXPECTED actual=$ACTUAL — restoring from backup" >> "$LOG"
-    cp "$BACKUP" "$DLL"
-    systemctl reset-failed dotsider-website 2>/dev/null
-    systemctl restart dotsider-website
-    echo "$NOW | RESTORED and restarted dotsider-website" >> "$LOG"
+if (cd "$SAMPLE" && sha256sum --quiet -c "$MANIFEST") >/dev/null 2>&1; then
+    exit 0
 fi
+
+NOW=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+echo "$NOW | CORRUPTED sample payload — restoring from backup" >> "$LOG"
+rm -rf "$SAMPLE"
+# cp -a preserves ownership. The backup was created during deploy as brandon,
+# so restoring with -a keeps sample/ owned by brandon. Plain cp -r would run
+# as root (the service user), leaving sample/ root-owned and blocking every
+# subsequent deploy's rsync (brandon cannot overwrite root-owned files).
+cp -a "$BACKUP" "$SAMPLE"
+systemctl reset-failed dotsider-website 2>/dev/null
+systemctl restart dotsider-website
+echo "$NOW | RESTORED sample/ and restarted dotsider-website" >> "$LOG"
 ICHK
 chmod +x /opt/dotsider-website/integrity-check.sh
 
 cat > /etc/systemd/system/integrity-check.service << 'SVC'
 [Unit]
-Description=Verify RichLibrary.dll integrity
+Description=Verify dotsider-website sample payload integrity
 After=dotsider-website.service
 
 [Service]
@@ -227,7 +234,7 @@ SVC
 
 cat > /etc/systemd/system/integrity-check.timer << 'TMR'
 [Unit]
-Description=Check RichLibrary.dll integrity every minute
+Description=Check dotsider-website sample payload integrity every minute
 
 [Timer]
 OnBootSec=2min

--- a/tests/Dotsider.Website.Tests/BundleResolutionRegressionTests.cs
+++ b/tests/Dotsider.Website.Tests/BundleResolutionRegressionTests.cs
@@ -26,8 +26,6 @@ public sealed class BundleResolutionRegressionTests(SampleAssemblyFixture sample
         var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
         listener.Stop();
 
-        var richLibPath = Path.Combine(samples.WebsitePublishedDir, "RichLibrary.dll");
-
         _serverProcess = new Process
         {
             StartInfo = new ProcessStartInfo
@@ -41,7 +39,9 @@ public sealed class BundleResolutionRegressionTests(SampleAssemblyFixture sample
                 {
                     ["ASPNETCORE_URLS"] = $"http://localhost:{port}",
                     ["DOTNET_ENVIRONMENT"] = "Production",
-                    ["Demo__SampleAssembly"] = richLibPath,
+                    // Point at the published sample payload (RichLibrary.dll sits alongside
+                    // its .deps.json and Newtonsoft.Json.dll), exactly as systemd does in prod.
+                    ["Demo__SampleAssembly"] = samples.RichLibraryDll,
                     ["Demo__MaxSessions"] = "5",
                     ["Demo__SessionTimeoutMinutes"] = "1",
                     ["Demo__AllowedOrigins__0"] = "*"
@@ -155,6 +155,47 @@ public sealed class BundleResolutionRegressionTests(SampleAssemblyFixture sample
         // Title bar renders "System.Console.dll (depth 2)" — this exact format
         // from DotsiderApp.cs cannot appear in pre-navigation IL text.
         await WaitForOutputAsync(output, "System.Console.dll (depth 2)", TimeSpan.FromSeconds(5), ct);
+        drainCts.Cancel();
+    }
+
+    /// <summary>
+    /// Launches the published single-file Website, navigates to the Dep Graph tab, and
+    /// asserts that the sample's <c>Newtonsoft.Json</c> reference resolves — the node
+    /// renders without the <c>?</c> unresolved prefix. Catches the regression where
+    /// the deploy pipeline shipped only <c>RichLibrary.dll</c> and left the NuGet
+    /// dependencies behind. This test only passes when the sample is deployed as its
+    /// full published payload (<c>RichLibrary.dll</c> + <c>RichLibrary.deps.json</c>
+    /// + <c>Newtonsoft.Json.dll</c>, etc.) alongside the website.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task DepGraph_NewtonsoftResolvesFromPublishedSample()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var port = await StartWebsiteAsync(ct);
+
+        _ws = new ClientWebSocket();
+        await _ws.ConnectAsync(new Uri($"ws://localhost:{port}/ws"), ct);
+
+        var output = new StringBuilder();
+        var drainCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _ = DrainOutputAsync(_ws, output, drainCts.Token);
+
+        await WaitForOutputAsync(output, "Assembly Name", TimeSpan.FromSeconds(5), ct);
+
+        // Tab 6 is the Dep Graph. Wait for "Nodes:" in the status line — that means the
+        // graph has been built, cached, and the box layer has rendered at least once.
+        await SendKeysAsync("6", ct);
+        await WaitForOutputAsync(output, "Nodes:", TimeSpan.FromSeconds(10), ct);
+        // One extra frame so the node boxes are definitely drawn.
+        await Task.Delay(250, ct);
+
+        string captured;
+        lock (output) { captured = output.ToString(); }
+
+        Assert.Contains("Newtonsoft.Json", captured);
+        Assert.DoesNotContain("? Newtonsoft", captured);
+        Assert.DoesNotContain("! Newtonsoft", captured);
+
         drainCts.Cancel();
     }
 

--- a/tests/Dotsider.Website.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Website.Tests/SampleAssemblyFixture.cs
@@ -11,12 +11,14 @@ public class SampleAssemblyFixture : IAsyncLifetime
     private string _repoRoot = null!;
 
     /// <summary>
-    /// Path to the built RichLibrary.dll sample assembly.
+    /// Path to the published RichLibrary.dll sitting inside the website payload's sample
+    /// directory. This is what the deployed server serves, so tests that reason about
+    /// production resolution behavior must read from here.
     /// </summary>
     public string RichLibraryDll { get; private set; } = null!;
 
     /// <summary>
-    /// Directory containing the published single-file Website and RichLibrary.dll.
+    /// Directory containing the published single-file Website executable.
     /// </summary>
     public string WebsitePublishedDir { get; private set; } = null!;
 
@@ -26,26 +28,24 @@ public class SampleAssemblyFixture : IAsyncLifetime
     public string WebsitePublishedExe { get; private set; } = null!;
 
     /// <summary>
+    /// Directory containing the published sample payload (RichLibrary.dll plus its
+    /// .deps.json and every NuGet dependency the sample resolves at runtime). Mirrors
+    /// <c>/opt/dotsider-website/sample/</c> on the deploy target.
+    /// </summary>
+    public string SamplePublishedDir { get; private set; } = null!;
+
+    /// <summary>
     /// Builds the sample projects and publishes the website once per test collection.
     /// </summary>
     public async ValueTask InitializeAsync()
     {
         _repoRoot = GetRepoRoot();
 
-        await BuildProject("samples/RichLibrary");
         await PublishWebsite();
-
-        const string config = "Debug";
-        const string tfm = "net10.0";
-
-        RichLibraryDll = Path.Combine(_repoRoot, "samples", "RichLibrary", "bin", config, tfm, "RichLibrary.dll");
+        await PublishSample();
 
         Assert.True(File.Exists(RichLibraryDll), $"RichLibrary.dll not found at {RichLibraryDll}");
         Assert.True(File.Exists(WebsitePublishedExe), $"Website not found at {WebsitePublishedExe}");
-
-        // Copy RichLibrary.dll into publish directory (mirrors deploy workflow)
-        File.Copy(RichLibraryDll,
-            Path.Combine(WebsitePublishedDir, "RichLibrary.dll"), overwrite: true);
     }
 
     /// <summary>
@@ -101,11 +101,18 @@ public class SampleAssemblyFixture : IAsyncLifetime
         }
     }
 
-    private async Task BuildProject(string relativePath)
+    private async Task PublishSample()
     {
-        var lockName = "dotsider-build-" + relativePath.Replace('/', '-').Replace('\\', '-') + ".lock";
-        var lockPath = Path.Combine(Path.GetTempPath(), lockName);
+        // Publish the sample project — not plain build + cp — so every runtime artifact
+        // the deployed website needs (RichLibrary.dll, RichLibrary.deps.json, and the
+        // NuGet package assemblies the manifest points at) lands in one directory as
+        // a unit. Place it under the website publish dir at sample/ to match the
+        // deploy layout exactly; tests then exercise the same shape production runs.
+        var rid = RuntimeInformation.RuntimeIdentifier;
+        SamplePublishedDir = Path.Combine(WebsitePublishedDir, "sample");
+        RichLibraryDll = Path.Combine(SamplePublishedDir, "RichLibrary.dll");
 
+        var lockPath = Path.Combine(Path.GetTempPath(), "dotsider-build-sample-publish.lock");
         FileStream lockFile;
         while (true)
         {
@@ -119,12 +126,19 @@ public class SampleAssemblyFixture : IAsyncLifetime
 
         try
         {
-            var projectDir = Path.Combine(_repoRoot, relativePath);
+            // Clean the sample directory before publishing. `dotnet publish -o` is additive
+            // — it overwrites files it emits but does not remove anything left behind. If a
+            // previous run's Newtonsoft.Json.dll stays on disk after a regression that stops
+            // publishing it, the new website regression test would still find the adjacent
+            // DLL and report Newtonsoft as resolved, hiding a real break in the publish shape.
+            if (Directory.Exists(SamplePublishedDir))
+                Directory.Delete(SamplePublishedDir, recursive: true);
+
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = "build --no-restore -c Debug -v q",
-                WorkingDirectory = projectDir,
+                Arguments = $"publish samples/RichLibrary/RichLibrary.csproj -c Release -r {rid} -o {SamplePublishedDir} -v q",
+                WorkingDirectory = _repoRoot,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -137,7 +151,7 @@ public class SampleAssemblyFixture : IAsyncLifetime
 
             if (process.ExitCode != 0)
                 throw new InvalidOperationException(
-                    $"dotnet build failed for {relativePath} (exit {process.ExitCode}):\n{stdout}\n{stderr}");
+                    $"Sample publish failed (exit {process.ExitCode}):\n{stdout}\n{stderr}");
         }
         finally
         {

--- a/tests/deploy/integrity-check.bats
+++ b/tests/deploy/integrity-check.bats
@@ -1,108 +1,150 @@
 #!/usr/bin/env bats
 # Tests for deploy/integrity-check.sh
 #
-# Simulates a corrupt RichLibrary.dll and verifies the integrity checker
-# detects the corruption and restores from backup.
+# The sample is shipped as a directory unit (RichLibrary.dll, RichLibrary.deps.json,
+# Newtonsoft.Json.dll, etc.). The checker verifies every file against a deploy-time
+# manifest and restores the whole directory from backup when any file drifts.
 
 load 'helpers/common'
 
 DIR="/opt/dotsider-website"
-DLL="$DIR/RichLibrary.dll"
-BACKUP="$DIR/.RichLibrary.dll.bak"
-HASH_FILE="$DIR/.RichLibrary.dll.sha256"
+SAMPLE="$DIR/sample"
+BACKUP="$DIR/sample.bak"
+MANIFEST="$DIR/sample.sha256"
 LOG="/var/log/integrity-check.log"
 
 setup() {
     rm -f "$LOG"
-    # Create a known-good DLL, backup, and hash
-    echo "good-assembly-content" > "$DLL"
-    cp "$DLL" "$BACKUP"
-    sha256sum "$DLL" | cut -d' ' -f1 > "$HASH_FILE"
+    rm -rf "$SAMPLE" "$BACKUP"
+    mkdir -p "$SAMPLE"
+    # Known-good payload with multiple files so the test exercises the whole
+    # directory contract, not just one file.
+    echo "good-assembly-content" > "$SAMPLE/RichLibrary.dll"
+    echo '{"targets":{}}'          > "$SAMPLE/RichLibrary.deps.json"
+    echo "newtonsoft-bytes"        > "$SAMPLE/Newtonsoft.Json.dll"
+    cp -r "$SAMPLE" "$BACKUP"
+    (cd "$SAMPLE" && find . -type f -print0 \
+        | LC_ALL=C sort -z \
+        | xargs -0 sha256sum) > "$MANIFEST"
 }
 
 teardown() {
-    rm -f "$DLL" "$BACKUP" "$HASH_FILE" "$LOG"
+    rm -rf "$SAMPLE" "$BACKUP"
+    rm -f "$MANIFEST" "$LOG"
 }
 
-# ── Clean file ────────────────────────────────────────────────────
+# ── Clean payload ─────────────────────────────────────────────────
 
-@test "exits cleanly when DLL matches hash" {
+@test "exits cleanly when manifest matches" {
     run bash "$DEPLOY_DIR/integrity-check.sh"
     [[ "$status" -eq 0 ]]
     [[ ! -f "$LOG" ]]
 }
 
-@test "does not overwrite DLL when hash matches" {
+@test "does not modify sample files when manifest matches" {
     local before after
-    before=$(stat -c '%Y' "$DLL")
+    before=$(stat -c '%Y' "$SAMPLE/RichLibrary.dll")
     bash "$DEPLOY_DIR/integrity-check.sh"
-    after=$(stat -c '%Y' "$DLL")
+    after=$(stat -c '%Y' "$SAMPLE/RichLibrary.dll")
     [[ "$before" == "$after" ]]
 }
 
 # ── Corrupted file ───────────────────────────────────────────────
 
-@test "detects corrupted DLL and restores from backup" {
-    echo "corrupted-bytes" > "$DLL"
+@test "detects corrupted RichLibrary.dll and restores from backup" {
+    echo "corrupted-bytes" > "$SAMPLE/RichLibrary.dll"
     bash "$DEPLOY_DIR/integrity-check.sh"
-    local actual expected
-    actual=$(sha256sum "$DLL" | cut -d' ' -f1)
-    expected=$(cat "$HASH_FILE")
-    [[ "$actual" == "$expected" ]]
+    diff -q "$SAMPLE/RichLibrary.dll" "$BACKUP/RichLibrary.dll"
 }
 
-@test "logs corruption event with expected and actual hashes" {
-    echo "corrupted-bytes" > "$DLL"
+@test "detects corrupted Newtonsoft.Json.dll and restores the whole payload" {
+    echo "tampered" > "$SAMPLE/Newtonsoft.Json.dll"
+    bash "$DEPLOY_DIR/integrity-check.sh"
+    diff -rq "$SAMPLE" "$BACKUP"
+}
+
+@test "detects corrupted RichLibrary.deps.json and restores from backup" {
+    echo '{"targets":{"evil":{}}}' > "$SAMPLE/RichLibrary.deps.json"
+    bash "$DEPLOY_DIR/integrity-check.sh"
+    diff -q "$SAMPLE/RichLibrary.deps.json" "$BACKUP/RichLibrary.deps.json"
+}
+
+@test "logs corruption event" {
+    echo "corrupted-bytes" > "$SAMPLE/RichLibrary.dll"
     bash "$DEPLOY_DIR/integrity-check.sh"
     assert_file_exists "$LOG"
     grep -q "CORRUPTED" "$LOG"
-    grep -q "expected=" "$LOG"
-    grep -q "actual=" "$LOG"
 }
 
 @test "logs restoration event" {
-    echo "corrupted-bytes" > "$DLL"
+    echo "corrupted-bytes" > "$SAMPLE/RichLibrary.dll"
     bash "$DEPLOY_DIR/integrity-check.sh"
     grep -q "RESTORED" "$LOG"
 }
 
-@test "restored DLL content matches backup" {
-    echo "corrupted-bytes" > "$DLL"
+# ── Missing listed file ──────────────────────────────────────────
+
+@test "detects missing Newtonsoft.Json.dll and restores from backup" {
+    rm -f "$SAMPLE/Newtonsoft.Json.dll"
     bash "$DEPLOY_DIR/integrity-check.sh"
-    diff -q "$DLL" "$BACKUP"
+    diff -q "$SAMPLE/Newtonsoft.Json.dll" "$BACKUP/Newtonsoft.Json.dll"
 }
 
-# ── Missing files ────────────────────────────────────────────────
+# ── Missing payload directories / manifest ───────────────────────
 
-@test "exits cleanly when DLL is missing" {
-    rm -f "$DLL"
+@test "exits cleanly when sample directory is missing" {
+    rm -rf "$SAMPLE"
     run bash "$DEPLOY_DIR/integrity-check.sh"
     [[ "$status" -eq 0 ]]
 }
 
 @test "exits cleanly when backup is missing" {
-    rm -f "$BACKUP"
+    rm -rf "$BACKUP"
     run bash "$DEPLOY_DIR/integrity-check.sh"
     [[ "$status" -eq 0 ]]
 }
 
-@test "exits cleanly when hash file is missing" {
-    rm -f "$HASH_FILE"
+@test "exits cleanly when manifest is missing" {
+    rm -f "$MANIFEST"
     run bash "$DEPLOY_DIR/integrity-check.sh"
     [[ "$status" -eq 0 ]]
 }
 
-# ── Multiple corruptions ─────────────────────────────────────────
+# ── Ownership preservation ──────────────────────────────────────
+# Deploys rsync the sample payload as `brandon`; the checker runs as root. If
+# the restore path creates files owned by root, the next deploy cannot overwrite
+# them and every subsequent sample deploy fails with permission-denied. The
+# backup directory is authoritative for ownership, so the restore must preserve
+# whatever uid:gid it holds at deploy time.
+
+@test "restored sample directory retains backup's ownership" {
+    # Simulate a deploy-time backup owned by the deploy user. The test harness
+    # runs as root inside the container, so we can force any ownership we want
+    # on the backup and verify the restore carries it across.
+    chown -R nobody:nogroup "$BACKUP"
+    echo "corrupted-bytes" > "$SAMPLE/RichLibrary.dll"
+    bash "$DEPLOY_DIR/integrity-check.sh"
+
+    local owner group
+    owner=$(stat -c '%U' "$SAMPLE")
+    group=$(stat -c '%G' "$SAMPLE")
+    [[ "$owner" == "nobody" ]]
+    [[ "$group" == "nogroup" ]]
+
+    owner=$(stat -c '%U' "$SAMPLE/RichLibrary.dll")
+    group=$(stat -c '%G' "$SAMPLE/RichLibrary.dll")
+    [[ "$owner" == "nobody" ]]
+    [[ "$group" == "nogroup" ]]
+}
+
+# ── Repeated corruption ──────────────────────────────────────────
 
 @test "recovers from repeated corruption" {
-    echo "bad1" > "$DLL"
+    echo "bad1" > "$SAMPLE/RichLibrary.dll"
     bash "$DEPLOY_DIR/integrity-check.sh"
-    echo "bad2" > "$DLL"
+    echo "bad2" > "$SAMPLE/Newtonsoft.Json.dll"
     bash "$DEPLOY_DIR/integrity-check.sh"
-    local actual expected
-    actual=$(sha256sum "$DLL" | cut -d' ' -f1)
-    expected=$(cat "$HASH_FILE")
-    [[ "$actual" == "$expected" ]]
+    diff -rq "$SAMPLE" "$BACKUP"
     local line_count
     line_count=$(grep -c "CORRUPTED" "$LOG")
     [[ "$line_count" -eq 2 ]]

--- a/tests/deploy/setup.bats
+++ b/tests/deploy/setup.bats
@@ -155,9 +155,9 @@ load 'helpers/common'
         "ASPNETCORE_URLS=http://localhost:5100"
 }
 
-@test "dotsider-website.service points to RichLibrary.dll" {
+@test "dotsider-website.service points to the sample payload directory" {
     assert_file_contains /etc/systemd/system/dotsider-website.service \
-        "Demo__SampleAssembly=/opt/dotsider-website/RichLibrary.dll"
+        "Demo__SampleAssembly=/opt/dotsider-website/sample/RichLibrary.dll"
 }
 
 @test "dotsider-website.service restricts CORS to dotsider.dev" {


### PR DESCRIPTION
The dep graph on dotsider.dev rendered Newtonsoft.Json with a `?` prefix because the deploy pipeline copied only `RichLibrary.dll`. The NuGet package assemblies and the `.deps.json` that points at them were left behind, so the resolver had nothing to probe for app-local or NuGet-cache matches. Replacing the hand-picked `cp` with `dotnet publish -c Release -r linux-x64 -o ./publish/sample` ships the closure as one unit — `RichLibrary.dll`, `RichLibrary.deps.json`, `Newtonsoft.Json.dll`, and anything a future sample depends on.

On the server the sample moves to `/opt/dotsider-website/sample/` with the systemd `Demo__SampleAssembly` env var pointing at it. The website rsync excludes the sample payload so a website-only deploy can't wipe it; the sample rsyncs separately as a directory unit. The integrity checker swaps the single-file hash for a manifest of `<sha256>  <relative-path>` per file, verified each minute from inside the sample directory; any drift restores the whole directory from `sample.bak/`. Restore uses `cp -a` so the root-owned service preserves brandon's ownership — plain `cp -r` would have left the restored tree root-owned and locked out every subsequent deploy's rsync.

Coverage catches up. The website test fixture publishes the sample into the same `sample/` layout and cleans that directory first so a previous run's dll can't mask a future regression that stops emitting it. `DepGraph_NewtonsoftResolvesFromPublishedSample` boots the published website, navigates to the Dep Graph tab, and asserts the rendered node has no `?` or `!` prefix. The BATS integrity suite rewrites around the directory-manifest contract and picks up an ownership-preservation case.