### PR TITLE
fix(il): preserve cross-view back target across cross-assembly gd

### DIFF
--- a/samples/RichLibrary/IlNavigationFixture.cs
+++ b/samples/RichLibrary/IlNavigationFixture.cs
@@ -45,4 +45,7 @@ public class IlNavigationFixture
 
     /// <summary>Constructs a type locally owned in the partial-facade System.Collections.dll.</summary>
     public LinkedList<int> CreateLinkedList() { _counter++; return new LinkedList<int>(); }
+
+    /// <summary>Casts to an external type (produces castclass with TypeRef to System.IO.Stream).</summary>
+    public Stream CastToExternalStream(object o) { _counter++; return (Stream)o; }
 }

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -834,9 +834,10 @@ public sealed class DotsiderState : IDisposable
 
         if (entry.CrossAssembly && NavigationStack.Count > 0)
         {
-            PopAssembly(); // Calls ResetViewState → clears IlEditorKeyCache + IlCachedEditors
+            PopAssembly(); // Calls ResetViewState → clears IlEditorKeyCache + IlCachedEditors + CrossViewBackTarget
+            CrossViewBackTarget = entry.PreviousCrossViewBackTarget;
         }
-        
+
         IlSelectedMethod = entry.Method;
         IlSelectedField = null;
         IlEditorState = entry.EditorState;
@@ -926,7 +927,8 @@ public sealed class DotsiderState : IDisposable
         IlBackStack.Push(new IlBackEntry(
             IlSelectedMethod, IlEditorState, IlEditorMethod, IlEditorAnalyzer,
             IlFocusedTreeKey, new Dictionary<string, bool>(IlTreeExpansionState), crossAssembly,
-            IlEditorKey));
+            IlEditorKey,
+            CrossViewBackTarget));
     }
 
     private void ExpandIlTreeForMethod(MethodDefInfo method)

--- a/src/Dotsider/IlBackEntry.cs
+++ b/src/Dotsider/IlBackEntry.cs
@@ -16,6 +16,7 @@ namespace Dotsider;
 /// <param name="TreeExpansionState">Cloned snapshot of the tree expansion state.</param>
 /// <param name="CrossAssembly">Whether PushAssembly was called for this navigation (requires PopAssembly on back).</param>
 /// <param name="EditorKey">The editor identity key for StatePanelWidget matching on back-nav.</param>
+/// <param name="PreviousCrossViewBackTarget">Snapshot of <c>CrossViewBackTarget</c> taken before the push, so cross-assembly back can restore the originating tab (e.g. Size Map) after PopAssembly clears it.</param>
 public sealed record IlBackEntry(
     MethodDefInfo Method,
     EditorState EditorState,
@@ -24,4 +25,5 @@ public sealed record IlBackEntry(
     object? FocusedTreeKey,
     Dictionary<string, bool> TreeExpansionState,
     bool CrossAssembly,
-    object? EditorKey);
+    object? EditorKey,
+    (int Tab, int SubTab)? PreviousCrossViewBackTarget);

--- a/tests/Dotsider.Tests/IlEditorLifecycleTests.cs
+++ b/tests/Dotsider.Tests/IlEditorLifecycleTests.cs
@@ -163,7 +163,7 @@ public class IlEditorLifecycleTests(SampleAssemblyFixture samples) : IDisposable
 
         var entry = new IlBackEntry(
             method, state.IlEditorState, method, state.Analyzer,
-            $"method:{method.Token}", [], false, editorKey);
+            $"method:{method.Token}", [], false, editorKey, null);
 
         // Simulate what ResetViewState does (called by PopAssembly on cross-assembly back)
         state.IlEditorKeyCache.Clear();
@@ -199,7 +199,7 @@ public class IlEditorLifecycleTests(SampleAssemblyFixture samples) : IDisposable
         var editorStateA = new EditorState(new Hex1bDocument("method A")) { IsReadOnly = true };
         var entry = new IlBackEntry(
             methodA, editorStateA, methodA, state.Analyzer,
-            $"method:{methodA.Token}", [], false, keyA);
+            $"method:{methodA.Token}", [], false, keyA, null);
 
         state.RestoreFromIlBackEntry(entry);
 

--- a/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
+++ b/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
@@ -2,6 +2,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using Dotsider.Views;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -492,6 +493,279 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         // because entries reference the old analyzer's state
         state.PushAssembly(samples.HelloWorldDll);
         Assert.Empty(state.IlBackStack);
+    }
+
+    // --- Issue #159: Esc on IL Inspector loses Size Map back target after gd into external ---
+
+    /// <summary>
+    /// Verifies the cross-view back target survives a cross-assembly method gd
+    /// round-trip (Size Map → IL Inspector → external method → Esc back).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void EscBack_FromCrossAssemblyMethodGd_RestoresSizeMapCrossViewBackTarget()
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+
+        var method = state.Analyzer.MethodDefs.First(m =>
+            m.Name == "CallExternal" && m.DeclaringType.Contains("IlNavigationFixture"));
+        state.CurrentTab = TabId.SizeMap;
+        state.NavigateToIlMethod(method);
+
+        Assert.Equal(TabId.IlInspector, state.CurrentTab);
+        Assert.Equal((TabId.SizeMap, 0), state.CrossViewBackTarget);
+
+        var result = state.IlDisassembler!.DisassembleWithText(method);
+        Assert.NotNull(result);
+        state.IlEditorState = new EditorState(
+            new Hex1b.Documents.Hex1bDocument(result.Value.Text)) { IsReadOnly = true };
+        state.IlEditorMethod = method;
+        state.IlEditorAnalyzer = state.Analyzer;
+
+        var callInst = result.Value.Instructions.First(i =>
+            i.OpCode == "call" && i.MetadataToken is not null && i.Operand.Contains("WriteLine"));
+        var navigated = state.NavigateToIlDefinition(callInst.MetadataToken!.Value);
+
+        Assert.True(navigated);
+        Assert.Single(state.IlBackStack);
+        Assert.True(state.NavigationStack.Count > 0);
+        Assert.Null(state.CrossViewBackTarget);
+
+        var entry = state.IlBackStack.Pop();
+        state.RestoreFromIlBackEntry(entry);
+
+        Assert.Equal(TabId.IlInspector, state.CurrentTab);
+        Assert.Empty(state.NavigationStack);
+        Assert.Empty(state.IlBackStack);
+        Assert.Equal((TabId.SizeMap, 0), state.CrossViewBackTarget);
+
+        state.NavigateBack();
+        Assert.Equal(TabId.SizeMap, state.CurrentTab);
+        Assert.Null(state.CrossViewBackTarget);
+    }
+
+    /// <summary>
+    /// Verifies the cross-view back target survives a cross-assembly field gd round-trip.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void EscBack_FromCrossAssemblyFieldGd_RestoresSizeMapCrossViewBackTarget()
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+
+        // GetStringEmpty has body `ldsfld string.Empty` — external FieldRef
+        var method = state.Analyzer.MethodDefs.First(m =>
+            m.Name == "GetStringEmpty" && m.DeclaringType.Contains("IlNavigationFixture"));
+        state.CurrentTab = TabId.SizeMap;
+        state.NavigateToIlMethod(method);
+
+        Assert.Equal(TabId.IlInspector, state.CurrentTab);
+        Assert.Equal((TabId.SizeMap, 0), state.CrossViewBackTarget);
+
+        var result = state.IlDisassembler!.DisassembleWithText(method);
+        Assert.NotNull(result);
+        state.IlEditorState = new EditorState(
+            new Hex1b.Documents.Hex1bDocument(result.Value.Text)) { IsReadOnly = true };
+        state.IlEditorMethod = method;
+        state.IlEditorAnalyzer = state.Analyzer;
+
+        var ldsInst = result.Value.Instructions.First(i =>
+            i.OpCode == "ldsfld" && i.MetadataToken is not null);
+        var navigated = state.NavigateToIlDefinition(ldsInst.MetadataToken!.Value);
+
+        Assert.True(navigated);
+        Assert.Single(state.IlBackStack);
+        Assert.True(state.NavigationStack.Count > 0);
+        Assert.Null(state.CrossViewBackTarget);
+
+        var entry = state.IlBackStack.Pop();
+        state.RestoreFromIlBackEntry(entry);
+
+        Assert.Equal(TabId.IlInspector, state.CurrentTab);
+        Assert.Empty(state.NavigationStack);
+        Assert.Empty(state.IlBackStack);
+        Assert.Equal((TabId.SizeMap, 0), state.CrossViewBackTarget);
+
+        state.NavigateBack();
+        Assert.Equal(TabId.SizeMap, state.CurrentTab);
+        Assert.Null(state.CrossViewBackTarget);
+    }
+
+    /// <summary>
+    /// Verifies the cross-view back target survives a cross-assembly type gd round-trip.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void EscBack_FromCrossAssemblyTypeGd_RestoresSizeMapCrossViewBackTarget()
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+
+        // CastToExternalStream has body `castclass System.IO.Stream` — external TypeRef
+        var method = state.Analyzer.MethodDefs.First(m =>
+            m.Name == "CastToExternalStream" && m.DeclaringType.Contains("IlNavigationFixture"));
+        state.CurrentTab = TabId.SizeMap;
+        state.NavigateToIlMethod(method);
+
+        Assert.Equal(TabId.IlInspector, state.CurrentTab);
+        Assert.Equal((TabId.SizeMap, 0), state.CrossViewBackTarget);
+
+        var result = state.IlDisassembler!.DisassembleWithText(method);
+        Assert.NotNull(result);
+        state.IlEditorState = new EditorState(
+            new Hex1b.Documents.Hex1bDocument(result.Value.Text)) { IsReadOnly = true };
+        state.IlEditorMethod = method;
+        state.IlEditorAnalyzer = state.Analyzer;
+
+        var castInst = result.Value.Instructions.First(i =>
+            i.OpCode == "castclass" && i.MetadataToken is not null);
+        var navigated = state.NavigateToIlDefinition(castInst.MetadataToken!.Value);
+
+        Assert.True(navigated);
+        Assert.Single(state.IlBackStack);
+        Assert.True(state.NavigationStack.Count > 0);
+        Assert.Null(state.CrossViewBackTarget);
+
+        var entry = state.IlBackStack.Pop();
+        state.RestoreFromIlBackEntry(entry);
+
+        Assert.Equal(TabId.IlInspector, state.CurrentTab);
+        Assert.Empty(state.NavigationStack);
+        Assert.Empty(state.IlBackStack);
+        Assert.Equal((TabId.SizeMap, 0), state.CrossViewBackTarget);
+
+        state.NavigateBack();
+        Assert.Equal(TabId.SizeMap, state.CurrentTab);
+        Assert.Null(state.CrossViewBackTarget);
+    }
+
+    /// <summary>
+    /// Regression guard: local-method gd from Size Map preserves the cross-view
+    /// back target without going through the snapshot/restore round-trip,
+    /// because the local path never calls PushAssemblyDirect → ResetViewState.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void EscBack_FromLocalGd_PreservesSizeMapCrossViewBackTarget()
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+
+        var method = state.Analyzer.MethodDefs.First(m =>
+            m.Name == "CallLocalMethod" && m.DeclaringType.Contains("IlNavigationFixture"));
+        state.CurrentTab = TabId.SizeMap;
+        state.NavigateToIlMethod(method);
+
+        Assert.Equal(TabId.IlInspector, state.CurrentTab);
+        Assert.Equal((TabId.SizeMap, 0), state.CrossViewBackTarget);
+
+        var result = state.IlDisassembler!.DisassembleWithText(method);
+        Assert.NotNull(result);
+        state.IlEditorState = new EditorState(
+            new Hex1b.Documents.Hex1bDocument(result.Value.Text)) { IsReadOnly = true };
+        state.IlEditorMethod = method;
+        state.IlEditorAnalyzer = state.Analyzer;
+
+        var callInst = result.Value.Instructions.First(i =>
+            i.OpCode == "call" && i.MetadataToken is not null && i.Operand.Contains("LocalTarget"));
+        var navigated = state.NavigateToIlDefinition(callInst.MetadataToken!.Value);
+
+        Assert.True(navigated);
+        Assert.Single(state.IlBackStack);
+        Assert.Empty(state.NavigationStack);
+        Assert.Equal((TabId.SizeMap, 0), state.CrossViewBackTarget);
+
+        state.RestoreFromIlBackEntry(state.IlBackStack.Pop());
+        Assert.Equal((TabId.SizeMap, 0), state.CrossViewBackTarget);
+
+        state.NavigateBack();
+        Assert.Equal(TabId.SizeMap, state.CurrentTab);
+    }
+
+    /// <summary>
+    /// End-to-end: from Size Map, drill into IL, gd into Console.WriteLine,
+    /// and confirm two REAL Esc presses return to Size Map. Pre-fix the second
+    /// Esc binding de-registers and the user is stuck on IL Inspector.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task EscBack_FromSizeMapToExternalCall_TwoRealEscapesReturnToSizeMap()
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp();
+        var runTask = app.RunAsync(cts.Token);
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
+
+        await auto.WaitUntilAlternateScreenAsync();
+        await auto.WaitUntilTextAsync("Select a method");
+
+        // Programmatic Size Map → IL drill-down (mirrors SizeTreemapView.cs:157).
+        // The bug is independent of how CrossViewBackTarget got set; we drive
+        // the gd round-trip with real keys.
+        var callExternal = _state!.Analyzer.MethodDefs.First(m =>
+            m.Name == "CallExternal" && m.DeclaringType.Contains("IlNavigationFixture"));
+        _state.CurrentTab = TabId.SizeMap;
+        _state.NavigateToIlMethod(callExternal);
+        Assert.Equal((TabId.SizeMap, 0), _state.CrossViewBackTarget);
+
+        await auto.WaitUntilTextAsync("// Method: RichLibrary.IlNavigationFixture::CallExternal");
+        await auto.WaitUntilTextAsync("call System.Console::WriteLine");
+
+        // Focus editor with 'l' — cursor lands on the first IL instruction.
+        await auto.KeyAsync(Hex1bKey.L, cts.Token);
+        await Task.Delay(200, cts.Token);
+
+        // Move down callIndex times to land on the WriteLine call instruction.
+        var instructions = _state.IlInstructions!.ToList();
+        var callIndex = instructions.FindIndex(i =>
+            i.OpCode == "call" && i.MetadataToken is not null && i.Operand.Contains("WriteLine"));
+        Assert.True(callIndex >= 0, "WriteLine call instruction must exist in CallExternal body");
+        for (var i = 0; i < callIndex; i++)
+            await auto.DownAsync(cts.Token);
+        await Task.Delay(200, cts.Token);
+
+        var instAtCursor = IlNavigationHelper.GetInstructionAtCursor(
+            _state.IlEditorState!, _state.IlInstructions!, _state.IlHeaderLineCount);
+        Assert.NotNull(instAtCursor);
+        Assert.Equal("call", instAtCursor!.OpCode);
+        Assert.Contains("WriteLine", instAtCursor.Operand);
+
+        // Real gd via Enter — crosses into System.Console.dll.
+        await auto.EnterAsync(cts.Token);
+
+        // The IlDisassembler emits "// Method: System.Console::WriteLine" only
+        // in the destination's IL header — unique landing marker.
+        await auto.WaitUntilTextAsync("// Method: System.Console::WriteLine");
+        Assert.True(_state.NavigationStack.Count > 0);
+        Assert.Single(_state.IlBackStack);
+        Assert.Null(_state.CrossViewBackTarget);
+
+        // First REAL Esc — pops IL back entry, returns to CallExternal IL.
+        await auto.EscapeAsync(cts.Token);
+        await auto.WaitUntilTextAsync("// Method: RichLibrary.IlNavigationFixture::CallExternal");
+
+        // Hints bar must still show "Esc: Back" — proves the unified Esc
+        // binding is registered for the second press. Pre-fix all three back
+        // signals are zero/null and the binding de-registers.
+        await auto.WaitUntilTextAsync("Esc: Back");
+        Assert.Equal((TabId.SizeMap, 0), _state.CrossViewBackTarget);
+        Assert.Equal(TabId.IlInspector, _state.CurrentTab);
+        Assert.Empty(_state.IlBackStack);
+        Assert.Empty(_state.NavigationStack);
+
+        // Second REAL Esc — drives cross-view return to Size Map.
+        await auto.EscapeAsync(cts.Token);
+        await auto.WaitUntilTextAsync("Total:");
+        Assert.Equal(TabId.SizeMap, _state.CurrentTab);
+        Assert.Null(_state.CrossViewBackTarget);
+
+        cts.Cancel();
+        await runTask;
     }
 
     /// <summary>

--- a/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
+++ b/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
@@ -716,18 +716,37 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         await auto.WaitUntilTextAsync("// Method: RichLibrary.IlNavigationFixture::CallExternal");
         await auto.WaitUntilTextAsync("call System.Console::WriteLine");
 
-        // Focus editor with 'l' — cursor lands on the first IL instruction.
+        // Focus editor with 'l' and wait until focus shift settles (cursor on
+        // first IL instruction). Per hex1b testing guide, poll on state rather
+        // than Task.Delay — Linux/macOS CI rendered slower than Windows and
+        // raced the down loop below.
         await auto.KeyAsync(Hex1bKey.L, cts.Token);
-        await Task.Delay(200, cts.Token);
+        await auto.WaitUntilAsync(_ =>
+        {
+            if (_state!.IlEditorState is null || _state.IlInstructions is null
+                || _state.IlInstructions.Count == 0) return false;
+            var inst = IlNavigationHelper.GetInstructionAtCursor(
+                _state.IlEditorState, _state.IlInstructions, _state.IlHeaderLineCount);
+            return inst is not null && inst.Offset == _state.IlInstructions[0].Offset;
+        });
 
-        // Move down callIndex times to land on the WriteLine call instruction.
-        var instructions = _state.IlInstructions!.ToList();
+        // Step cursor down to the WriteLine call, polling for cursor advance
+        // after each Down so a slow render doesn't drop a keypress.
+        var instructions = _state!.IlInstructions!.ToList();
         var callIndex = instructions.FindIndex(i =>
             i.OpCode == "call" && i.MetadataToken is not null && i.Operand.Contains("WriteLine"));
         Assert.True(callIndex >= 0, "WriteLine call instruction must exist in CallExternal body");
         for (var i = 0; i < callIndex; i++)
+        {
+            var expected = instructions[i + 1];
             await auto.DownAsync(cts.Token);
-        await Task.Delay(200, cts.Token);
+            await auto.WaitUntilAsync(_ =>
+            {
+                var inst = IlNavigationHelper.GetInstructionAtCursor(
+                    _state!.IlEditorState!, _state.IlInstructions!, _state.IlHeaderLineCount);
+                return inst is not null && inst.Offset == expected.Offset;
+            });
+        }
 
         var instAtCursor = IlNavigationHelper.GetInstructionAtCursor(
             _state.IlEditorState!, _state.IlInstructions!, _state.IlHeaderLineCount);


### PR DESCRIPTION
Fixes: #159

When the user drilled from Size Map into a method, IL Inspector opened with a cross-view back target pointing at Size Map. If they then pressed gd/Enter on a call that crossed an assembly boundary (mscorlib, System.Console, etc.), the first Esc correctly popped the IL back stack but the second Esc did nothing — the user was stuck on IL Inspector.

The cause is in DotsiderState. NavigateToExternalMethod calls PushAssemblyDirect, which calls ResetViewState, which sets CrossViewBackTarget to null. The IlBackEntry didn't carry the previous CrossViewBackTarget, and RestoreFromIlBackEntry never put it back. By the time the user pressed Esc the second time, all three back signals (NavigationStack, CrossViewBackTarget, IlBackStack) were empty, so the unified Esc binding in DotsiderApp wasn't even registered.

Fix: snapshot CrossViewBackTarget into IlBackEntry on push, restore it after PopAssembly on the cross-assembly branch of RestoreFromIlBackEntry. The local-method gd path is unaffected because it never goes through PushAssemblyDirect.

Coverage uses the real RichLibrary sample assembly. Five tests: external method (Console.WriteLine), external field (string.Empty), external type (CastToExternalStream → System.IO.Stream, added to the fixture for a stable TypeRef), a local-gd regression guard, and a full integration test that drives real Esc keys and asserts the hints bar still shows "Esc: Back" between the two presses.