### PR TITLE
fix(il): unwind chained cross-view jumps via stack instead of single slot

### DIFF
--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -663,9 +663,20 @@ public sealed class DotsiderState : IDisposable
     // --- Cross-View Navigation ---
 
     /// <summary>
-    /// Saved source tab for cross-view back navigation, or null if no cross-view jump has occurred.
+    /// Stack of cross-view back targets, top-first. Pushed by
+    /// <see cref="NavigateToIlMethod"/> / <see cref="NavigateToHexOffset"/>, popped by
+    /// <see cref="NavigateBack"/>, cleared by <c>ResetViewState</c>. Each frame stores
+    /// the originating <c>(Tab, SubTab)</c> so chained jumps unwind one step at a time.
     /// </summary>
-    public (int Tab, int SubTab)? CrossViewBackTarget { get; set; }
+    public Stack<(int Tab, int SubTab)> CrossViewBackStack { get; } = new();
+
+    /// <summary>
+    /// Top of <see cref="CrossViewBackStack"/>, or null if the stack is empty. Used by
+    /// the unified Esc binding gate, the hint bar, and existing tests as the "current
+    /// back target" projection.
+    /// </summary>
+    public (int Tab, int SubTab)? CrossViewBackTarget =>
+        CrossViewBackStack.Count > 0 ? CrossViewBackStack.Peek() : null;
 
     /// <summary>
     /// Switches to the specified tab, finalizing any in-progress search on the current tab.
@@ -692,7 +703,7 @@ public sealed class DotsiderState : IDisposable
     /// </summary>
     public void NavigateToIlMethod(MethodDefInfo method)
     {
-        CrossViewBackTarget = (CurrentTab, PeSubTab);
+        CrossViewBackStack.Push((CurrentTab, PeSubTab));
 
         // Expand namespace and type in the IL tree
         var typeDef = Analyzer.TypeDefs.FirstOrDefault(t => t.FullName == method.DeclaringType);
@@ -719,7 +730,7 @@ public sealed class DotsiderState : IDisposable
         var fileOffset = RvaToFileOffset(rva);
         if (fileOffset < 0) return;
 
-        CrossViewBackTarget = (CurrentTab, PeSubTab);
+        CrossViewBackStack.Push((CurrentTab, PeSubTab));
 
         // Set cursor position + scroll target (mirrors HexDumpView.NavigateToOffset)
         var doc = HexEditorState.Document;
@@ -834,8 +845,10 @@ public sealed class DotsiderState : IDisposable
 
         if (entry.CrossAssembly && NavigationStack.Count > 0)
         {
-            PopAssembly(); // Calls ResetViewState → clears IlEditor*Cache + CrossViewBackTarget + Treemap* + Search
-            CrossViewBackTarget = entry.PreviousCrossViewBackTarget;
+            PopAssembly(); // Calls ResetViewState → clears IlEditor*Cache + CrossViewBackStack + Treemap* + Search
+            CrossViewBackStack.Clear();
+            for (var i = entry.PreviousCrossViewBackStack.Count - 1; i >= 0; i--)
+                CrossViewBackStack.Push(entry.PreviousCrossViewBackStack[i]);
             if (entry.PreviousTreemapState is { } tm)
             {
                 CachedSizeTree = tm.CachedTree;
@@ -956,7 +969,7 @@ public sealed class DotsiderState : IDisposable
             IlSelectedMethod, IlEditorState, IlEditorMethod, IlEditorAnalyzer,
             IlFocusedTreeKey, new Dictionary<string, bool>(IlTreeExpansionState), crossAssembly,
             IlEditorKey,
-            CrossViewBackTarget,
+            [.. CrossViewBackStack],
             treemapSnapshot));
     }
 
@@ -1172,12 +1185,9 @@ public sealed class DotsiderState : IDisposable
     /// </summary>
     public void NavigateBack()
     {
-        if (CrossViewBackTarget is not { } back)
-        {
-             return;
-        }
+        if (CrossViewBackStack.Count == 0) return;
 
-        CrossViewBackTarget = null;
+        var back = CrossViewBackStack.Pop();
         NavigateToTab(back.Tab);
         if (back.Tab == TabId.PeMetadata)
             PeSubTab = back.SubTab;
@@ -1342,7 +1352,7 @@ public sealed class DotsiderState : IDisposable
         foreach (var s in Search) s.Reset();
         NavigateNextMatch = null;
         NavigatePrevMatch = null;
-        CrossViewBackTarget = null;
+        CrossViewBackStack.Clear();
         GeneralFocusedDep = Analyzer.AssemblyRefs.Count > 0 ? Analyzer.AssemblyRefs[0].Name : null;
         PeSubTab = 0;
         PeFocusedKey = null;

--- a/src/Dotsider/IlBackEntry.cs
+++ b/src/Dotsider/IlBackEntry.cs
@@ -16,7 +16,7 @@ namespace Dotsider;
 /// <param name="TreeExpansionState">Cloned snapshot of the tree expansion state.</param>
 /// <param name="CrossAssembly">Whether PushAssembly was called for this navigation (requires PopAssembly on back).</param>
 /// <param name="EditorKey">The editor identity key for StatePanelWidget matching on back-nav.</param>
-/// <param name="PreviousCrossViewBackTarget">Snapshot of <c>CrossViewBackTarget</c> taken before the push, so cross-assembly back can restore the originating tab (e.g. Size Map) after PopAssembly clears it.</param>
+/// <param name="PreviousCrossViewBackStack">Top-first snapshot of <c>CrossViewBackStack</c> taken before the push, so cross-assembly back can restore the full chain of originating tabs after PopAssembly clears the stack.</param>
 /// <param name="PreviousTreemapState">Snapshot of the Size Map navigation state (cached tree, current level, breadcrumb, selection, search) taken before the cross-assembly push so the user lands back at the original drilled level after Esc. Null on local-gd entries since the local path never clears treemap state.</param>
 public sealed record IlBackEntry(
     MethodDefInfo Method,
@@ -27,5 +27,5 @@ public sealed record IlBackEntry(
     Dictionary<string, bool> TreeExpansionState,
     bool CrossAssembly,
     object? EditorKey,
-    (int Tab, int SubTab)? PreviousCrossViewBackTarget,
+    IReadOnlyList<(int Tab, int SubTab)> PreviousCrossViewBackStack,
     TreemapBackState? PreviousTreemapState);

--- a/src/Dotsider/NuGetApp.cs
+++ b/src/Dotsider/NuGetApp.cs
@@ -239,6 +239,7 @@ public sealed class NuGetApp(NuGetState state)
                                 _state.App.Invalidate();
                                 return;
                             }
+                            
                             if (dllState.StringsDetailContent is not null)
                             {
                                 dllState.StringsDetailContent = null;
@@ -253,6 +254,12 @@ public sealed class NuGetApp(NuGetState state)
                             {
                                 var entry = dllState.IlBackStack.Pop();
                                 dllState.RestoreFromIlBackEntry(entry);
+                                return;
+                            }
+
+                            if (dllState.CrossViewBackTarget is not null)
+                            {
+                                dllState.NavigateBack();
                                 return;
                             }
                         }

--- a/tests/Dotsider.Tests/DotsiderStateTests.cs
+++ b/tests/Dotsider.Tests/DotsiderStateTests.cs
@@ -647,6 +647,7 @@ public class DotsiderStateTests(SampleAssemblyFixture samples) : IDisposable
         var app = CreateApp();
         using var state = new DotsiderState(app, samples.RichLibraryDll);
         state.CurrentTab = TabId.PeMetadata;
+        state.PeSubTab = PeSubTabId.MethodDef;
 
         // PE → IL Inspector
         var method = state.Analyzer.MethodDefs.First(m => m.Rva > 0);
@@ -662,6 +663,11 @@ public class DotsiderStateTests(SampleAssemblyFixture samples) : IDisposable
         // Back → IL Inspector
         state.NavigateBack();
         Assert.Equal(TabId.IlInspector, state.CurrentTab);
+
+        // The PE Metadata frame underneath must remain reachable via a second
+        // Esc — chained cross-view jumps unwind one frame at a time, with the
+        // exact origin sub-tab preserved.
+        Assert.Equal((TabId.PeMetadata, PeSubTabId.MethodDef), state.CrossViewBackTarget);
     }
 
     // --- Apphost Detection ---

--- a/tests/Dotsider.Tests/IlEditorLifecycleTests.cs
+++ b/tests/Dotsider.Tests/IlEditorLifecycleTests.cs
@@ -163,7 +163,8 @@ public class IlEditorLifecycleTests(SampleAssemblyFixture samples) : IDisposable
 
         var entry = new IlBackEntry(
             method, state.IlEditorState, method, state.Analyzer,
-            $"method:{method.Token}", [], false, editorKey, null, null);
+            $"method:{method.Token}", [], false, editorKey,
+            [], null);
 
         // Simulate what ResetViewState does (called by PopAssembly on cross-assembly back)
         state.IlEditorKeyCache.Clear();
@@ -199,7 +200,8 @@ public class IlEditorLifecycleTests(SampleAssemblyFixture samples) : IDisposable
         var editorStateA = new EditorState(new Hex1bDocument("method A")) { IsReadOnly = true };
         var entry = new IlBackEntry(
             methodA, editorStateA, methodA, state.Analyzer,
-            $"method:{methodA.Token}", [], false, keyA, null, null);
+            $"method:{methodA.Token}", [], false, keyA,
+            [], null);
 
         state.RestoreFromIlBackEntry(entry);
 

--- a/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
+++ b/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
@@ -1118,6 +1118,243 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         await runTask;
     }
 
+    // --- Issue #162: Esc on IL Inspector loses Size Map back target after x to Hex Dump ---
+
+    /// <summary>
+    /// Verifies that two NavigateBack calls unwind the Size Map → IL → Hex chain
+    /// to the original Size Map drill — chained cross-view jumps must each store
+    /// their own back frame instead of overwriting one another.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void EscBack_FromSizeMapIlHexChain_TwoEscsReturnToSizeMap()
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+
+        state.CachedSizeTree = SizeAnalyzer.BuildSizeTree(state.Analyzer);
+        var origTree = state.CachedSizeTree;
+        var method = state.Analyzer.MethodDefs.First(m =>
+            m.Name == "CallExternal" && m.DeclaringType.Contains("IlNavigationFixture"));
+        var (root, ns, type, methodIdx) = FindSizeMapPath(origTree, method);
+
+        state.TreemapBreadcrumb.Push(root);
+        state.TreemapCurrentLevel = ns;
+        state.TreemapBreadcrumb.Push(ns);
+        state.TreemapCurrentLevel = type;
+        state.TreemapSelectedIndex = methodIdx;
+
+        state.CurrentTab = TabId.SizeMap;
+        state.NavigateToIlMethod(method);
+        Assert.Equal((TabId.SizeMap, 0), state.CrossViewBackTarget);
+
+        state.NavigateToHexOffset(method.Rva);
+        Assert.Equal(TabId.HexDump, state.CurrentTab);
+        Assert.Equal((TabId.IlInspector, 0), state.CrossViewBackTarget);
+
+        // First Esc — Hex → IL Inspector. Pre-fix the back target is null after
+        // this because the Hex push clobbered the SizeMap frame.
+        state.NavigateBack();
+        Assert.Equal(TabId.IlInspector, state.CurrentTab);
+        Assert.Equal((TabId.SizeMap, 0), state.CrossViewBackTarget);
+
+        // Second Esc — IL → Size Map.
+        state.NavigateBack();
+        Assert.Equal(TabId.SizeMap, state.CurrentTab);
+        Assert.Null(state.CrossViewBackTarget);
+
+        // Breadcrumb survives end-to-end (NavigateToHexOffset never calls ResetViewState).
+        Assert.Same(origTree, state.CachedSizeTree);
+        Assert.Same(type, state.TreemapCurrentLevel);
+        Assert.Equal(2, state.TreemapBreadcrumb.Count);
+    }
+
+    /// <summary>
+    /// Verifies that the PE → IL → Hex chain unwinds to the originating PE
+    /// Metadata sub-tab, proving both Tab and SubTab are stored per frame.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void EscBack_FromPeIlHexChain_RestoresPeWithExactSubTab()
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+
+        state.CurrentTab = TabId.PeMetadata;
+        state.PeSubTab = PeSubTabId.MethodDef;
+
+        var method = state.Analyzer.MethodDefs.First(m => m.Rva > 0);
+        state.NavigateToIlMethod(method);
+        Assert.Equal((TabId.PeMetadata, PeSubTabId.MethodDef), state.CrossViewBackTarget);
+
+        state.NavigateToHexOffset(method.Rva);
+        // The Hex frame captures (CurrentTab, PeSubTab) — PeSubTab is unchanged
+        // since the user was on IL Inspector, but the SubTab value is unused
+        // when NavigateBack returns to a non-PE tab. Only assert the Tab here.
+        Assert.Equal(TabId.IlInspector, state.CrossViewBackTarget!.Value.Tab);
+
+        state.NavigateBack();
+        Assert.Equal(TabId.IlInspector, state.CurrentTab);
+        Assert.Equal((TabId.PeMetadata, PeSubTabId.MethodDef), state.CrossViewBackTarget);
+
+        state.NavigateBack();
+        Assert.Equal(TabId.PeMetadata, state.CurrentTab);
+        Assert.Equal(PeSubTabId.MethodDef, state.PeSubTab);
+        Assert.Null(state.CrossViewBackTarget);
+    }
+
+    /// <summary>
+    /// End-to-end: from a deep Size Map drill, IL Inspector → real x key →
+    /// Hex Dump → real Esc → real Esc must land back on Size Map at the
+    /// originating breadcrumb (proves the chain works through real input).
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task EscBack_FromSizeMapIlHexChain_RealKeysReturnToSizeMap()
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp();
+        var runTask = app.RunAsync(cts.Token);
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
+
+        await auto.WaitUntilAlternateScreenAsync();
+        await auto.WaitUntilTextAsync("Select a method");
+
+        _state!.CachedSizeTree = SizeAnalyzer.BuildSizeTree(_state.Analyzer);
+        var origTree = _state.CachedSizeTree;
+        var callExternal = _state.Analyzer.MethodDefs.First(m =>
+            m.Name == "CallExternal" && m.DeclaringType.Contains("IlNavigationFixture"));
+        var (root, ns, type, methodIdx) = FindSizeMapPath(origTree, callExternal);
+
+        _state.TreemapBreadcrumb.Push(root);
+        _state.TreemapCurrentLevel = ns;
+        _state.TreemapBreadcrumb.Push(ns);
+        _state.TreemapCurrentLevel = type;
+        _state.TreemapSelectedIndex = methodIdx;
+
+        _state.CurrentTab = TabId.SizeMap;
+        _state.NavigateToIlMethod(callExternal);
+        Assert.Equal((TabId.SizeMap, 0), _state.CrossViewBackTarget);
+
+        await auto.WaitUntilTextAsync("// Method: RichLibrary.IlNavigationFixture::CallExternal");
+
+        // Real x key → NavigateToHexOffset (DllInspectorBindings.cs:221).
+        await auto.KeyAsync(Hex1bKey.X, cts.Token);
+        await auto.WaitUntilAsync(_ => _state!.CurrentTab == TabId.HexDump);
+        Assert.Equal((TabId.IlInspector, 0), _state.CrossViewBackTarget);
+
+        // First REAL Esc — Hex → IL Inspector.
+        await auto.EscapeAsync(cts.Token);
+        await auto.WaitUntilTextAsync("// Method: RichLibrary.IlNavigationFixture::CallExternal");
+        await auto.WaitUntilTextAsync("Esc: Back");
+
+        // Second REAL Esc — IL → Size Map.
+        await auto.EscapeAsync(cts.Token);
+        await auto.WaitUntilTextAsync("Total:");
+
+        var expectedCrumb = $" {origTree.Name} > {ns.Name} > {type.Name} ";
+        await auto.WaitUntilTextAsync(expectedCrumb);
+
+        Assert.Equal(TabId.SizeMap, _state.CurrentTab);
+        Assert.Same(type, _state.TreemapCurrentLevel);
+        Assert.Null(_state.CrossViewBackTarget);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// ResetViewState (triggered by PushAssembly's dependency drill) clears the
+    /// entire cross-view back stack, not just the top frame.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ResetViewState_ClearsEntireBackStack()
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+
+        var method = state.Analyzer.MethodDefs.First(m => m.Rva > 0);
+        state.CurrentTab = TabId.SizeMap;
+        state.NavigateToIlMethod(method);
+        state.NavigateToHexOffset(method.Rva);
+        Assert.Equal(2, state.CrossViewBackStack.Count);
+
+        // PushAssembly → ResetViewState clears everything
+        state.PushAssembly(samples.HelloWorldDll);
+
+        Assert.Empty(state.CrossViewBackStack);
+        Assert.Null(state.CrossViewBackTarget);
+    }
+
+    /// <summary>
+    /// Cross-assembly gd snapshots and restores the full multi-frame back stack,
+    /// not just the top tuple. Seeds a 2-deep stack before the gd push so a
+    /// single-tuple snapshot implementation would fail the count assertion.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void CrossAssemblyGd_SnapshotsAndRestoresMultiFrameStack()
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+
+        // Seed a multi-frame stack — bottom: PE/TypeDef, top: SizeMap.
+        state.CrossViewBackStack.Push((TabId.PeMetadata, PeSubTabId.TypeDef));
+        state.CrossViewBackStack.Push((TabId.SizeMap, 0));
+        state.CurrentTab = TabId.IlInspector;
+
+        var method = state.Analyzer.MethodDefs.First(m =>
+            m.Name == "CallExternal" && m.DeclaringType.Contains("IlNavigationFixture"));
+        state.IlSelectedMethod = method;
+        var dis = state.IlDisassembler!.DisassembleWithText(method);
+        Assert.NotNull(dis);
+        state.IlEditorState = new EditorState(
+            new Hex1b.Documents.Hex1bDocument(dis.Value.Text)) { IsReadOnly = true };
+        state.IlEditorMethod = method;
+        state.IlEditorAnalyzer = state.Analyzer;
+
+        var callInst = dis.Value.Instructions.First(i =>
+            i.OpCode == "call" && i.MetadataToken is not null && i.Operand.Contains("WriteLine"));
+        Assert.True(state.NavigateToIlDefinition(callInst.MetadataToken!.Value));
+
+        // Cross-assembly push cleared the stack mid-flight.
+        Assert.Empty(state.CrossViewBackStack);
+
+        state.RestoreFromIlBackEntry(state.IlBackStack.Pop());
+
+        // Whole stack is restored in correct top-first order.
+        var arr = state.CrossViewBackStack.ToArray();
+        Assert.Equal(2, arr.Length);
+        Assert.Equal((TabId.SizeMap, 0), arr[0]);
+        Assert.Equal((TabId.PeMetadata, PeSubTabId.TypeDef), arr[1]);
+    }
+
+    /// <summary>
+    /// NavigateToHexOffset bails out early on an invalid RVA without mutating
+    /// the back stack — the early return precedes the push.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NavigateToHexOffset_InvalidRva_DoesNotMutateBackStack()
+    {
+        var app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = new Hex1bAppWorkloadAdapter() });
+        using var state = new DotsiderState(app, samples.RichLibraryDll);
+
+        state.CrossViewBackStack.Push((TabId.SizeMap, 0));
+        Assert.Single(state.CrossViewBackStack);
+
+        // RvaToFileOffset returns -1 for an out-of-range RVA — early return fires.
+        state.NavigateToHexOffset(int.MaxValue);
+
+        Assert.Single(state.CrossViewBackStack);
+        Assert.Equal((TabId.SizeMap, 0), state.CrossViewBackTarget);
+    }
+
     /// <summary>
     /// Verifies external method filters by declaring type.
     /// </summary>

--- a/tests/Dotsider.Tests/NuGetModeViewTests.cs
+++ b/tests/Dotsider.Tests/NuGetModeViewTests.cs
@@ -212,6 +212,61 @@ public class NuGetModeViewTests(SampleAssemblyFixture samples) : IDisposable
     }
 
     /// <summary>
+    /// Verifies the NuGet DLL inspector unwinds the PE → IL → Hex chain on
+    /// two Esc presses without ejecting back to the package browser. Mirrors
+    /// the behavior already covered for standalone dotsider in
+    /// <see cref="DotsiderStateTests.NavigateToIlMethod_ThenHex_ThenBack_RestoresIl"/>.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task NuGet_EscBack_FromPeIlHexChain_TwoEscsReturnToPe()
+    {
+        var (terminal, app) = CreateNuGetApp();
+        var ct = TestContext.Current.CancellationToken;
+        var runTask = app.RunAsync(ct);
+        await Task.Delay(100, ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("RichLibrary.dll"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.DownArrow)
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => !_state!.IsBrowsingPackage, TimeSpan.FromSeconds(10))
+            .WaitUntil(s =>
+            {
+                // Set up a PE → IL → Hex chain on the inner DLL state, then drive
+                // real Esc keys through the NuGet Escape handler.
+                var dllState = _state!.SelectedDllState!;
+                dllState.CurrentTab = TabId.PeMetadata;
+                dllState.PeSubTab = PeSubTabId.MethodDef;
+                var method = dllState.Analyzer.MethodDefs.First(m => m.Rva > 0);
+                dllState.NavigateToIlMethod(method);
+                dllState.NavigateToHexOffset(method.Rva);
+                _state.App.Invalidate();
+                return dllState.CurrentTab == TabId.HexDump;
+            }, TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => _state!.SelectedDllState!.CurrentTab == TabId.IlInspector,
+                TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.Escape)
+            .WaitUntil(_ => _state!.SelectedDllState!.CurrentTab == TabId.PeMetadata,
+                TimeSpan.FromSeconds(10))
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        // Two Escs landed back on PE Metadata with the original sub-tab — and
+        // the user is still inside the DLL inspector (not ejected to the package
+        // browser, which is the pre-fix fall-through branch in NuGet's Esc handler).
+        Assert.NotNull(_state!.SelectedDllState);
+        Assert.False(_state.IsBrowsingPackage);
+        Assert.Equal(TabId.PeMetadata, _state.SelectedDllState.CurrentTab);
+        Assert.Equal(PeSubTabId.MethodDef, _state.SelectedDllState.PeSubTab);
+        Assert.Null(_state.SelectedDllState.CrossViewBackTarget);
+
+        await runTask.ContinueWith(_ => { }, ct);
+    }
+
+    /// <summary>
     /// Disposes test resources created during the run.
     /// </summary>
     public void Dispose()

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -2558,7 +2558,7 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
             .ApplyAsync(terminal, cts.Token);
 
         // Programmatically set a cross-view back target (simulating a g/x navigation)
-        _state!.CrossViewBackTarget = (TabId.PeMetadata, PeSubTabId.TypeDef);
+        _state!.CrossViewBackStack.Push((TabId.PeMetadata, PeSubTabId.TypeDef));
         _hex1bApp!.Invalidate();
 
         // Wait for "Esc: Back" hint to appear


### PR DESCRIPTION
Fixes: #162

CrossViewBackTarget was a single nullable tuple. Each cross-view jump (NavigateToIlMethod, NavigateToHexOffset) clobbered the prior back frame, so drilling Size Map → IL Inspector → Hex Dump via `x` made the second Esc a no-op — the first Esc consumed the IL frame and zeroed the slot, the unified Esc binding's `hasBackTarget` gate flipped to false on the next render, and the binding silently de-registered. Same gating mechanism that bit #159.

Replace the slot with a `Stack<(int Tab, int SubTab)> CrossViewBackStack`. Setters push, NavigateBack pops, ResetViewState clears, IlBackEntry's snapshot captures the whole stack so cross-assembly gd round-trips no longer lose intermediate frames. The existing `CrossViewBackTarget` stays as a top-of-stack projection (`Peek()` or null), which keeps every reader — the Esc gate, the hint bar, the diagnostics listener, and ~30 existing assertions — working unchanged.

NuGet's Esc handler also needed a `CrossViewBackTarget` dispatch branch. Pre-fix it fell through from the IL-back-stack pop straight to the dispose-and-back-to-package fall-through, ejecting the user out of the DLL inspector instead of unwinding the cross-view chain. The new branch mirrors the priority-2 dispatch in DotsiderApp and the diagnostics listener, so NuGet now handles the same PE → IL → Hex → Esc → Esc round-trip natively.

Coverage parameterizes the obvious paths (Size Map and PE Metadata origins, real keys plus state-only), strengthens the existing NavigateToIlMethod_ThenHex_ThenBack_RestoresIl test to assert the underlying frame survives the first Esc with its sub-tab intact, and adds a NuGet integration test that proves both halves of the fix together. Three structural tests cover the new stack semantics: ResetViewState clears every frame (not just the top), a seeded 2-deep stack is restored top-first across a cross-assembly gd round-trip (catches a "single-tuple snapshot" implementation), and an invalid-RVA call is a no-op rather than a partial mutation.