### PR TITLE
Adapt to Hex1b 0.149.0 fluent API renames

### DIFF
--- a/samples/NetFxBindingRedirects.Clr2/Program.cs
+++ b/samples/NetFxBindingRedirects.Clr2/Program.cs
@@ -85,8 +85,8 @@ namespace NetFxBindingRedirects.Clr2
 
                 var fr = new CultureInfo("fr");
                 var culturedType = neutral.GetType("NetFxBindingRedirects.Clr2.CulturedLib.CulturedClass", true);
-                var greetingMethod = culturedType.GetMethod("Greeting", new[] { typeof(CultureInfo) });
-                var greeting = (string)greetingMethod.Invoke(null, new object[] { fr });
+                var greetingMethod = culturedType.GetMethod("Greeting", [typeof(CultureInfo)]);
+                var greeting = (string)greetingMethod.Invoke(null, [fr]);
 
                 if (string.IsNullOrEmpty(greeting))
                 {

--- a/src/Dotsider.Core/Analysis/Models/BindingPolicy.cs
+++ b/src/Dotsider.Core/Analysis/Models/BindingPolicy.cs
@@ -486,9 +486,9 @@ public sealed record BindingPolicy(
         // we record here is reachable later. Clr2 also includes the bare "GAC" bucket
         // (CLR 1.x carryover, still consulted by CLR2 fusion).
         var archSubdir = architecture == NetFxArchitecture.Amd64 ? "GAC_64" : "GAC_32";
-        var subdirs = runtimeVersion == NetFxRuntimeVersion.Clr2
-            ? new[] { "GAC_MSIL", archSubdir, "GAC" }
-            : new[] { "GAC_MSIL", archSubdir };
+        string[] subdirs = runtimeVersion == NetFxRuntimeVersion.Clr2
+            ? ["GAC_MSIL", archSubdir, "GAC"]
+            : ["GAC_MSIL", archSubdir];
 
         foreach (var root in gacRoots)
         {
@@ -554,7 +554,7 @@ public sealed record BindingPolicy(
         if (runtimeVersion == NetFxRuntimeVersion.Clr4)
         {
             if (!token.StartsWith("v4.0_", StringComparison.OrdinalIgnoreCase)) return false;
-            rest = token.Substring(5);
+            rest = token[5..];
         }
         else
         {
@@ -777,9 +777,9 @@ public sealed record BindingPolicy(
         // The CLR2 GAC also has a bare "GAC" bucket (CLR 1.x carryover); CLR2 fusion still
         // consults it, so include it in the publisher-policy scan for Clr2 contexts.
         var archSubdir = architecture == NetFxArchitecture.Amd64 ? "GAC_64" : "GAC_32";
-        var subdirs = runtimeVersion == NetFxRuntimeVersion.Clr2
-            ? new[] { "GAC_MSIL", archSubdir, "GAC" }
-            : new[] { "GAC_MSIL", archSubdir };
+        string[] subdirs = runtimeVersion == NetFxRuntimeVersion.Clr2
+            ? ["GAC_MSIL", archSubdir, "GAC"]
+            : ["GAC_MSIL", archSubdir];
         foreach (var root in gacRoots)
         {
             if (!Directory.Exists(root)) continue;

--- a/src/Dotsider.Core/Dotsider.Core.csproj
+++ b/src/Dotsider.Core/Dotsider.Core.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.*" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.*" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Dotsider/DiffApp.cs
+++ b/src/Dotsider/DiffApp.cs
@@ -38,7 +38,7 @@ public sealed class DiffApp(DiffState state)
                 bar.Section(" dotsider diff ").Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.Black)
                     .Set(GlobalTheme.BackgroundColor, Hex1bColor.FromRgb(200, 200, 80))),
-                bar.Separator(" "),
+                bar.Divider(" "),
                 bar.Section(_state.Left.FileName).Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(80, 80, 100))),
                 bar.Section(" <> "),
@@ -87,7 +87,7 @@ public sealed class DiffApp(DiffState state)
             // Hints bar
             BuildHintsBar(outer)
         ])
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             var currentSearch = _state.Search[_state.CurrentTab];
             var isSearchEditing = currentSearch.IsActive && !currentSearch.IsConfirmed;
@@ -292,12 +292,12 @@ public sealed class DiffApp(DiffState state)
             {
                 hints.Add(s.Section(_state.YankNotification).Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(120, 180, 120))));
-                hints.Add(s.Separator(" "));
+                hints.Add(s.Divider(" "));
             }
 
             hints.Add(s.Section("q: Quit"));
             return hints;
-        }).WithDefaultSeparator(" | ");
+        }).Divider(" | ");
 
     /// <summary>
     /// Performs a neovim-style yank on the focused diff editor's selection.

--- a/src/Dotsider/Dotsider.csproj
+++ b/src/Dotsider/Dotsider.csproj
@@ -43,8 +43,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hex1b" Version="0.128.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.5" />
+    <PackageReference Include="Hex1b" Version="0.149.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -62,7 +62,7 @@ public sealed class DotsiderApp(DotsiderState state)
                 bar.Section($" dotsider ").Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.Black)
                     .Set(GlobalTheme.BackgroundColor, Hex1bColor.FromRgb(0, 200, 180))),
-                bar.Separator(" "),
+                bar.Divider(" "),
                 bar.Section(_state.NavigationStack.Count > 0
                     ? $"{_state.Analyzer.DisplayName} (depth {_state.NavigationStack.Count + 1})"
                     : _state.Analyzer.DisplayName).Theme(t => t
@@ -70,7 +70,7 @@ public sealed class DotsiderApp(DotsiderState state)
                 bar.Spacer(),
                 bar.Section(_state.Analyzer.Architecture).Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(140, 120, 40))),
-                bar.Separator(" | "),
+                bar.Divider(" | "),
                 bar.Section(_state.FormatSizeToggleable(_state.Analyzer.FileSize)).Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(140, 120, 40)))
             ]),
@@ -112,7 +112,7 @@ public sealed class DotsiderApp(DotsiderState state)
             // Keybinding hints bar
             BuildHintsBar(outer)
         ])
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             var currentSearch = _state.Search[_state.CurrentTab];
             var isSearchEditing = currentSearch.IsActive && !currentSearch.IsConfirmed;
@@ -434,7 +434,7 @@ public sealed class DotsiderApp(DotsiderState state)
                             dlg.Text("  Enter: Yes | Esc: No, keep .exe")
                         ])
                     ).Title(" Apphost Detected ").FixedWidth(55).FixedHeight(12)
-                    .WithInputBindings(bindings =>
+                    .InputBindings(bindings =>
                     {
                         bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
                         {
@@ -518,7 +518,7 @@ public sealed class DotsiderApp(DotsiderState state)
             {
                 hints.Add(s.Section("-- INSERT --").Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(200, 120, 80))));
-                hints.Add(s.Separator(" "));
+                hints.Add(s.Divider(" "));
             }
 
             hints.Add(s.Section("1-8: Tabs"));
@@ -636,7 +636,7 @@ public sealed class DotsiderApp(DotsiderState state)
             {
                 hints.Add(s.Section(_state.YankNotification).Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(120, 180, 120))));
-                hints.Add(s.Separator(" "));
+                hints.Add(s.Divider(" "));
             }
 
             // Transient notice (right side, all tabs)
@@ -644,7 +644,7 @@ public sealed class DotsiderApp(DotsiderState state)
             {
                 hints.Add(s.Section(_state.TransientNotice).Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(200, 80, 60))));
-                hints.Add(s.Separator(" "));
+                hints.Add(s.Divider(" "));
             }
 
             // General tab: navigation error (right side)
@@ -652,7 +652,7 @@ public sealed class DotsiderApp(DotsiderState state)
             {
                 hints.Add(s.Section(_state.NavigationError).Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(200, 80, 60))));
-                hints.Add(s.Separator(" "));
+                hints.Add(s.Divider(" "));
             }
 
             // Hex tab: vim-style save notification (right side)
@@ -660,12 +660,12 @@ public sealed class DotsiderApp(DotsiderState state)
             {
                 hints.Add(s.Section(_state.HexNotification).Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(120, 110, 30))));
-                hints.Add(s.Separator(" "));
+                hints.Add(s.Divider(" "));
             }
 
             hints.Add(s.Section("q: Quit"));
             return hints;
-        }).WithDefaultSeparator(" | ");
+        }).Divider(" | ");
 
     /// <summary>Delegate for the reopen-or-fallback step, injectable for testing.</summary>
     internal delegate (AssemblyAnalyzer Analyzer, string? ResolvedPath) ReopenFunc(

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -1209,10 +1209,10 @@ public sealed class DotsiderState : IDisposable
     {
         if (CrossViewBackStack.Count == 0) return;
 
-        var back = CrossViewBackStack.Pop();
-        NavigateToTab(back.Tab);
-        if (back.Tab == TabId.PeMetadata)
-            PeSubTab = back.SubTab;
+        var (Tab, SubTab) = CrossViewBackStack.Pop();
+        NavigateToTab(Tab);
+        if (Tab == TabId.PeMetadata)
+            PeSubTab = SubTab;
         App.RequestFocus(node =>
             node is ListNode or TreeNode or InteractableNode
             || node.GetType().Name.StartsWith("TableNode"));

--- a/src/Dotsider/NuGetApp.cs
+++ b/src/Dotsider/NuGetApp.cs
@@ -46,13 +46,13 @@ public sealed class NuGetApp(NuGetState state)
                 bar.Section(" dotsider nupkg ").Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.Black)
                     .Set(GlobalTheme.BackgroundColor, Hex1bColor.FromRgb(160, 100, 200))),
-                bar.Separator(" "),
+                bar.Divider(" "),
                 bar.Section(_state.Package.FileName).Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(80, 80, 100))),
                 bar.Spacer(),
                 bar.Section(_state.IsBrowsingPackage ? "Package Browser" : "DLL Inspector").Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(130, 110, 30))),
-                bar.Separator(" | "),
+                bar.Divider(" | "),
                 bar.Section($"{_state.Package.DllFiles.Count} DLLs").Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(130, 110, 30)))
             ]),
@@ -111,7 +111,7 @@ public sealed class NuGetApp(NuGetState state)
                 {
                     hints.Add(s.Section(yankNotification).Theme(t => t
                         .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(120, 180, 120))));
-                    hints.Add(s.Separator(" "));
+                    hints.Add(s.Divider(" "));
                 }
 
                 // Navigation error in DLL inspector (right side)
@@ -119,14 +119,14 @@ public sealed class NuGetApp(NuGetState state)
                 {
                     hints.Add(s.Section(navError).Theme(t => t
                         .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(200, 80, 60))));
-                    hints.Add(s.Separator(" "));
+                    hints.Add(s.Divider(" "));
                 }
 
                 hints.Add(s.Section("q: Quit"));
                 return hints;
-            }).WithDefaultSeparator(" | ")
+            }).Divider(" | ")
         ])
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             // VimReset wraps all Global bindings to cancel pending vim text-object sequences
             Action<InputBindingActionContext> VimReset(Action<InputBindingActionContext> action)

--- a/src/Dotsider/Views/DataInterpretationPanel.cs
+++ b/src/Dotsider/Views/DataInterpretationPanel.cs
@@ -112,9 +112,9 @@ public static class DataInterpretationPanel
                 .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
                 .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
             ctx.Editor(state.DataInterpEditorState!)
-                .WithViewRenderer(DataInterpViewRenderer.Instance)
+                .ViewRenderer(DataInterpViewRenderer.Instance)
                 .Decorations(state.DataInterpYankProvider)
-                .WithInputBindings(bindings =>
+                .InputBindings(bindings =>
                 {
                     TextObjectHelper.ConfigureReadOnlyEditorBindings(
                         bindings,

--- a/src/Dotsider/Views/DependencyGraphView.cs
+++ b/src/Dotsider/Views/DependencyGraphView.cs
@@ -173,7 +173,7 @@ public static class DependencyGraphView
                         s.Layer(surface => DrawGraph(surface, visible, nav, disambig,
                             state, s.MouseX, s.MouseY, query))
                     ]).Fill()
-                ).WithInputBindings(bindings =>
+                ).InputBindings(bindings =>
                 {
                     bindings.Key(Hex1bKey.RightArrow).Action(_ =>
                     {
@@ -318,7 +318,7 @@ public static class DependencyGraphView
 
             return [.. widgets];
         })
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
             {

--- a/src/Dotsider/Views/DiffMethodsView.cs
+++ b/src/Dotsider/Views/DiffMethodsView.cs
@@ -120,7 +120,7 @@ public static class DiffMethodsView
 
             return [.. widgets];
         })
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
             {

--- a/src/Dotsider/Views/DiffRefsView.cs
+++ b/src/Dotsider/Views/DiffRefsView.cs
@@ -117,7 +117,7 @@ public static class DiffRefsView
 
             return [.. widgets];
         })
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
             {

--- a/src/Dotsider/Views/DiffSummaryView.cs
+++ b/src/Dotsider/Views/DiffSummaryView.cs
@@ -90,10 +90,10 @@ public static class DiffSummaryView
                             .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
                             .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
                         left.Editor(state.LeftInfoEditorState!)
-                            .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                            .ViewRenderer(InfoEditorViewRenderer.Instance)
                             .Decorations(new InfoLabelDecorationProvider())
                             .Decorations(leftSearchProvider)
-                            .WithInputBindings(bindings =>
+                            .InputBindings(bindings =>
                             {
                                 TextObjectHelper.ConfigureReadOnlyEditorBindings(
                                     bindings,
@@ -116,10 +116,10 @@ public static class DiffSummaryView
                             .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
                             .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
                         right.Editor(state.RightInfoEditorState!)
-                            .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                            .ViewRenderer(InfoEditorViewRenderer.Instance)
                             .Decorations(new InfoLabelDecorationProvider())
                             .Decorations(rightSearchProvider)
-                            .WithInputBindings(bindings =>
+                            .InputBindings(bindings =>
                             {
                                 TextObjectHelper.ConfigureReadOnlyEditorBindings(
                                     bindings,
@@ -143,11 +143,11 @@ public static class DiffSummaryView
                     .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
                     .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
                 outer.Editor(state.ChangeStatsEditorState!)
-                    .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                    .ViewRenderer(InfoEditorViewRenderer.Instance)
                     .Decorations(new InfoLabelDecorationProvider())
                     .Decorations(new DiffStatsDecorationProvider())
                     .Decorations(statsSearchProvider)
-                    .WithInputBindings(bindings =>
+                    .InputBindings(bindings =>
                     {
                         TextObjectHelper.ConfigureReadOnlyEditorBindings(
                             bindings,
@@ -165,7 +165,7 @@ public static class DiffSummaryView
 
             return [.. widgets];
         })
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             // Tab cycles focus: Left Info → Right Info → Change Stats → Left Info
             bindings.Key(Hex1bKey.Tab).Global().Action(_ =>

--- a/src/Dotsider/Views/DiffTypesView.cs
+++ b/src/Dotsider/Views/DiffTypesView.cs
@@ -114,7 +114,7 @@ public static class DiffTypesView
 
             return [.. widgets];
         })
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
             {

--- a/src/Dotsider/Views/DynamicAnalysisView.cs
+++ b/src/Dotsider/Views/DynamicAnalysisView.cs
@@ -118,7 +118,7 @@ public static class DynamicAnalysisView
             outer.Text("    System.Runtime — Performance Counters (1s interval)"),
             outer.Text("    System.Net.Http, System.Net.Sockets")
         ])
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             bindings.Key(Hex1bKey.Enter).Global().Action(_ =>
             {
@@ -192,7 +192,7 @@ public static class DynamicAnalysisView
 
             return [.. widgets];
         })
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             var isSearchEditing = search.IsActive && !search.IsConfirmed;
 
@@ -413,7 +413,7 @@ public static class DynamicAnalysisView
                 .FillWidth()
                 .FillHeight()
         ])
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             bindings.Key(Hex1bKey.G).Action(_ => SetFilter(state, TraceEventCategory.GC), "Filter GC");
             bindings.Key(Hex1bKey.J).Action(_ => SetFilter(state, TraceEventCategory.JIT), "Filter JIT");
@@ -682,10 +682,10 @@ public static class DynamicAnalysisView
                 .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
                 .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
             ctx.Editor(editorState)
-                .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                .ViewRenderer(InfoEditorViewRenderer.Instance)
                 .Decorations(new InfoLabelDecorationProvider())
                 .Decorations(yankProvider)
-                .WithInputBindings(bindings =>
+                .InputBindings(bindings =>
                 {
                     TextObjectHelper.ConfigureReadOnlyEditorBindings(
                         bindings,

--- a/src/Dotsider/Views/GeneralView.cs
+++ b/src/Dotsider/Views/GeneralView.cs
@@ -106,10 +106,10 @@ public static class GeneralView
                         .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
                         .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
                     outer.Editor(state.GeneralInfoEditorState!)
-                        .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                        .ViewRenderer(InfoEditorViewRenderer.Instance)
                         .Decorations(new InfoLabelDecorationProvider())
                         .Decorations(state.GeneralInfoYankProvider)
-                        .WithInputBindings(bindings =>
+                        .InputBindings(bindings =>
                         {
                             TextObjectHelper.ConfigureReadOnlyEditorBindings(
                                 bindings,
@@ -176,7 +176,7 @@ public static class GeneralView
                     .Compact()
                     .Empty(e => e.Text("  No assembly references"))
                     .Fill()
-                    .WithInputBindings(bindings =>
+                    .InputBindings(bindings =>
                     {
                         bindings.Key(Hex1bKey.Enter).Action(_ =>
                         {
@@ -205,7 +205,7 @@ public static class GeneralView
 
             return [.. widgets];
         })
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             bindings.Key(Hex1bKey.Tab).Global().Action(_ =>
             {

--- a/src/Dotsider/Views/HexDumpView.cs
+++ b/src/Dotsider/Views/HexDumpView.cs
@@ -89,7 +89,7 @@ public static class HexDumpView
 
                 // Hex editor with custom renderer
                 widgets.Add(outer.Editor(state.HexEditorState)
-                    .WithViewRenderer(new DotsiderHexRenderer(state))
+                    .ViewRenderer(new DotsiderHexRenderer(state))
                     .FillWidth()
                     .FillHeight());
 
@@ -98,7 +98,7 @@ public static class HexDumpView
 
                 return [.. widgets];
             })
-            .WithInputBindings(bindings =>
+            .InputBindings(bindings =>
             {
                 bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
                 {
@@ -183,7 +183,7 @@ public static class HexDumpView
                             dlg.Text("  Enter: Jump | Esc: Cancel")
                         ])
                     ).Title(" Jump to Byte ").FixedWidth(40).FixedHeight(7)
-                    .WithInputBindings(bindings =>
+                    .InputBindings(bindings =>
                     {
                         bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
                         {

--- a/src/Dotsider/Views/IlEditorHost.cs
+++ b/src/Dotsider/Views/IlEditorHost.cs
@@ -29,7 +29,7 @@ internal static class IlEditorHost
                 .Decorations(state.IlSearchProvider)
                 .Decorations(state.IlYankProvider)
                 .Decorations(state.IlNavigationProvider)
-                .WithInputBindings(bindings =>
+                .InputBindings(bindings =>
                 {
                     // Escape: IL back navigation takes priority over vim cancel.
                     // Must be registered BEFORE TextObjectHelper which also binds Escape.

--- a/src/Dotsider/Views/IlInspectorView.cs
+++ b/src/Dotsider/Views/IlInspectorView.cs
@@ -189,7 +189,7 @@ public static class IlInspectorView
 
             return [.. widgets];
         })
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             // Escape: search dismiss OR IL back navigation (local binding, not global)
             bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>

--- a/src/Dotsider/Views/IlTreeList.cs
+++ b/src/Dotsider/Views/IlTreeList.cs
@@ -50,7 +50,7 @@ internal static class IlTreeList
             captureNode?.Invoke(e.Node);
             itemActivated?.Invoke(e.ActivatedIndex);
         })
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             bindings.Key(Hex1bKey.RightArrow).Action(_ =>
             {

--- a/src/Dotsider/Views/NuGetBrowserView.cs
+++ b/src/Dotsider/Views/NuGetBrowserView.cs
@@ -78,10 +78,10 @@ public static class NuGetBrowserView
                         .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
                         .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
                     outer.Editor(state.PackageInfoEditorState!)
-                        .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                        .ViewRenderer(InfoEditorViewRenderer.Instance)
                         .Decorations(new InfoLabelDecorationProvider())
                         .Decorations(state.PackageInfoYankProvider)
-                        .WithInputBindings(bindings =>
+                        .InputBindings(bindings =>
                         {
                             TextObjectHelper.ConfigureReadOnlyEditorBindings(
                                 bindings,
@@ -166,7 +166,7 @@ public static class NuGetBrowserView
 
             return [.. widgets];
         })
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             // Tab toggles focus between Package Info editor and DLL table
             bindings.Key(Hex1b.Input.Hex1bKey.Tab).Global().Action(_ =>

--- a/src/Dotsider/Views/PeMetadataView.cs
+++ b/src/Dotsider/Views/PeMetadataView.cs
@@ -155,10 +155,10 @@ public static class PeMetadataView
                                 .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
                                 .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
                             left.Editor(state.PeHeadersEditorState!)
-                                .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                                .ViewRenderer(InfoEditorViewRenderer.Instance)
                                 .Decorations(new InfoLabelDecorationProvider())
                                 .Decorations(state.PeHeadersYankProvider)
-                                .WithInputBindings(bindings =>
+                                .InputBindings(bindings =>
                                 {
                                     TextObjectHelper.ConfigureReadOnlyEditorBindings(
                                         bindings,
@@ -181,10 +181,10 @@ public static class PeMetadataView
                                 .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
                                 .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
                             right.Editor(state.ClrHeaderEditorState!)
-                                .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                                .ViewRenderer(InfoEditorViewRenderer.Instance)
                                 .Decorations(new InfoLabelDecorationProvider())
                                 .Decorations(state.ClrHeaderYankProvider)
-                                .WithInputBindings(bindings =>
+                                .InputBindings(bindings =>
                                 {
                                     TextObjectHelper.ConfigureReadOnlyEditorBindings(
                                         bindings,
@@ -250,7 +250,7 @@ public static class PeMetadataView
 
                 return [.. widgets];
             })
-            .WithInputBindings(bindings =>
+            .InputBindings(bindings =>
             {
                 var isSearchEditing = search.IsActive && !search.IsConfirmed;
 
@@ -367,10 +367,10 @@ public static class PeMetadataView
                             .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
                             .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
                         z.Editor(state.PeDetailEditorState)
-                            .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                            .ViewRenderer(InfoEditorViewRenderer.Instance)
                             .Decorations(new InfoLabelDecorationProvider())
                             .Decorations(state.PeDetailYankProvider)
-                            .WithInputBindings(bindings =>
+                            .InputBindings(bindings =>
                             {
                                 TextObjectHelper.ConfigureReadOnlyEditorBindings(
                                     bindings,

--- a/src/Dotsider/Views/SizeTreemapView.cs
+++ b/src/Dotsider/Views/SizeTreemapView.cs
@@ -157,7 +157,7 @@ public static class SizeTreemapView
                             state.NavigateToIlMethod(method);
                     }
                 }
-            }).WithInputBindings(bindings =>
+            }).InputBindings(bindings =>
             {
                 // Esc pops the treemap breadcrumb (when no search is active)
                 var treemapSearch = state.Search[TabId.SizeMap];
@@ -221,7 +221,7 @@ public static class SizeTreemapView
 
             return [.. widgets];
         })
-        .WithInputBindings(bindings =>
+        .InputBindings(bindings =>
         {
             bindings.Key(Hex1bKey.Escape).OverridesCapture().Action(_ =>
             {

--- a/src/Dotsider/Views/StringsView.cs
+++ b/src/Dotsider/Views/StringsView.cs
@@ -138,7 +138,7 @@ public static class StringsView
 
                 return [.. widgets];
             })
-            .WithInputBindings(bindings =>
+            .InputBindings(bindings =>
             {
                 var isSearchEditing = search.IsActive && !search.IsConfirmed;
 
@@ -235,10 +235,10 @@ public static class StringsView
                                     .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
                                     .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
                                 outer.Editor(state.StringsDetailEditorState)
-                                    .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                                    .ViewRenderer(InfoEditorViewRenderer.Instance)
                                     .Decorations(new StringsDetailDecorationProvider())
                                     .Decorations(state.StringsDetailYankProvider)
-                                    .WithInputBindings(bindings =>
+                                    .InputBindings(bindings =>
                                     {
                                         TextObjectHelper.ConfigureReadOnlyEditorBindings(
                                             bindings,

--- a/tests/Dotsider.Tests/EscapeTimeoutPresentationAdapterTests.cs
+++ b/tests/Dotsider.Tests/EscapeTimeoutPresentationAdapterTests.cs
@@ -129,7 +129,7 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
                 {
                     return ctx.TextBox()
                         .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .WithInputBindings(bindings =>
+                        .InputBindings(bindings =>
                         {
                             bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
                             bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
@@ -173,7 +173,7 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
                 {
                     return ctx.TextBox()
                         .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .WithInputBindings(bindings =>
+                        .InputBindings(bindings =>
                         {
                             bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
                             bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
@@ -220,7 +220,7 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
                 {
                     return ctx.TextBox()
                         .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .WithInputBindings(bindings =>
+                        .InputBindings(bindings =>
                         {
                             bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
                             bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
@@ -266,7 +266,7 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
                 {
                     return ctx.TextBox()
                         .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .WithInputBindings(bindings =>
+                        .InputBindings(bindings =>
                         {
                             bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
                             bindings.Key(Hex1bKey.I).Global().Action(_ => events.Enqueue("i"), "I");
@@ -316,7 +316,7 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
                 {
                     return ctx.TextBox()
                         .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .WithInputBindings(bindings =>
+                        .InputBindings(bindings =>
                         {
                             bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
                             bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
@@ -372,7 +372,7 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
                 {
                     return ctx.TextBox()
                         .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .WithInputBindings(bindings =>
+                        .InputBindings(bindings =>
                         {
                             bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
                             bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
@@ -496,7 +496,7 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
                 {
                     return ctx.TextBox()
                         .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .WithInputBindings(bindings =>
+                        .InputBindings(bindings =>
                         {
                             bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
                             bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");

--- a/tests/Dotsider.Tests/InfoEditorViewRendererTests.cs
+++ b/tests/Dotsider.Tests/InfoEditorViewRendererTests.cs
@@ -38,7 +38,7 @@ public class InfoEditorViewRendererTests : IDisposable
             {
                 var widget = ctx.Border(
                     ctx.Editor(editorState)
-                        .WithViewRenderer(InfoEditorViewRenderer.Instance)
+                        .ViewRenderer(InfoEditorViewRenderer.Instance)
                         .FillWidth().FillHeight()
                 ).Title(" Info ").Fill();
                 return Task.FromResult<Hex1bWidget>(widget);


### PR DESCRIPTION
Hex1b 0.149.0 renamed three fluent extension method families: WithInputBindings, WithViewRenderer, and InfoBar's Separator and WithDefaultSeparator. They become InputBindings, ViewRenderer, and Divider. Signatures are unchanged, so the change is mechanical across roughly 20 source and test files. Also pins System.CommandLine to 2.0.7 and Microsoft.Diagnostics.Tracing.TraceEvent to 3.2.2.

Fixes: #165