### PR TITLE
De-flake IL tree, go-to-definition, and NuGet yank tests

### DIFF
--- a/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
+++ b/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
@@ -279,16 +279,25 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         await auto.EscapeAsync(cts.Token);
         await auto.WaitUntilTextAsync("// Method: RichLibrary.IlNavigationFixture::CallLocalMethod");
 
+        // RestoreFromIlBackEntry queues focus on the EditorNode. The actual focus shift
+        // applies on a later frame; without an explicit wait, Down/Up below can race
+        // a frame where focus is still on the tree and the cursor never moves.
+        await auto.WaitUntilAsync(_ => _state!.App.FocusedNode is Hex1b.EditorNode,
+            description: "editor focused after Esc back");
+        var cursorBeforeScroll = _state!.IlEditorState?.Cursor.Position.Value ?? -1;
+
         // SCROLL: press Down arrow to scroll — this must work (not be frozen)
         await auto.DownAsync(cts.Token);
-        await Task.Delay(100, cts.Token);
-
-        // Verify cursor moved (scroll not frozen)
-        var cursorAfterScroll = _state!.IlEditorState?.Cursor.Position.Value ?? -1;
+        await auto.WaitUntilAsync(
+            _ => (_state.IlEditorState?.Cursor.Position.Value ?? -1) != cursorBeforeScroll,
+            description: "Down moved editor cursor");
+        var cursorAfterScroll = _state.IlEditorState?.Cursor.Position.Value ?? -1;
 
         // Press Up arrow back
         await auto.UpAsync(cts.Token);
-        await Task.Delay(100, cts.Token);
+        await auto.WaitUntilAsync(
+            _ => (_state.IlEditorState?.Cursor.Position.Value ?? -1) != cursorAfterScroll,
+            description: "Up moved editor cursor");
 
         var cursorAfterUp = _state.IlEditorState?.Cursor.Position.Value ?? -1;
         Assert.NotEqual(cursorAfterScroll, cursorAfterUp);

--- a/tests/Dotsider.Tests/IlInspectorScrollbarTests.cs
+++ b/tests/Dotsider.Tests/IlInspectorScrollbarTests.cs
@@ -112,14 +112,22 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
     private static async Task<ScrollPanelNode> WaitForPanelAsync(
         Hex1bTerminalAutomator auto, Hex1bApp app)
     {
-        await auto.WaitUntilAsync(_ => FindPanel(app) is not null,
-            description: "ScrollPanelNode to enter focus ring");
-        await auto.WaitUntilAsync(_ => app.FocusedNode is ScrollPanelNode,
-            description: "ScrollPanelNode to receive keyboard focus");
-        var sp = FindPanel(app)!;
-        await auto.WaitUntilAsync(_ => sp.ViewportSize > 0,
-            description: "ScrollPanelNode to be arranged");
-        return sp;
+        // Single predicate that re-evaluates the panel reference on every poll, so
+        // a brief stretch where the focus ring rebuilds (e.g. tab switch reconciles
+        // the panel out and back in) cannot leave a captured `sp` null between two
+        // sequential WaitUntilAsync calls. The reference is only published to the
+        // caller once all three conditions hold simultaneously on the same poll.
+        ScrollPanelNode? captured = null;
+        await auto.WaitUntilAsync(_ =>
+        {
+            var current = FindPanel(app);
+            if (current is null || current.ViewportSize <= 0) return false;
+            if (app.FocusedNode is not ScrollPanelNode focused
+                || !ReferenceEquals(focused, current)) return false;
+            captured = current;
+            return true;
+        }, description: "ScrollPanelNode focused, arranged, and stable");
+        return captured!;
     }
 
     private static int FirstThumbY(Hex1bTerminalSnapshot snapshot, int sbCol, int yStart, int yEnd)
@@ -752,13 +760,13 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
     /// a zero-row tree must be a complete no-op — no exception, no key change, no
     /// offset change.
     /// </summary>
-    public static IEnumerable<object[]> NoMatchKeyVariants() =>
+    public static TheoryData<Hex1bKey> NoMatchKeyVariants() =>
     [
-        [Hex1bKey.UpArrow], [Hex1bKey.DownArrow],
-        [Hex1bKey.Home], [Hex1bKey.End],
-        [Hex1bKey.PageUp], [Hex1bKey.PageDown],
-        [Hex1bKey.Enter], [Hex1bKey.Spacebar],
-        [Hex1bKey.LeftArrow], [Hex1bKey.RightArrow],
+        Hex1bKey.UpArrow, Hex1bKey.DownArrow,
+        Hex1bKey.Home, Hex1bKey.End,
+        Hex1bKey.PageUp, Hex1bKey.PageDown,
+        Hex1bKey.Enter, Hex1bKey.Spacebar,
+        Hex1bKey.LeftArrow, Hex1bKey.RightArrow,
     ];
 
     /// <summary>
@@ -1116,23 +1124,30 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
         var rows = Views.IlInspectorView.BuildTreeRows(_state!);
         await SetSelectionDirectAsync(auto, app, _state!, rows, 0);
 
-        // Wheel down enough times to push row 0 offscreen.
+        // Wheel down enough times to push row 0 offscreen. Each tick advances Offset
+        // by 3 (hex1b's ScrollPanelNode default). Send all five ticks in a single
+        // sequence and wait until every tick has been applied — only then is it safe
+        // to capture the post-wheel offset, because in-flight events finishing during
+        // a later Task.Delay would otherwise bump it further and break the
+        // "did not snap back" equality below.
         var bodyX = sp.Bounds.X + 5;
         var bodyY = sp.Bounds.Y + 5;
-        for (var i = 0; i < 5; i++)
-        {
-            await new Hex1bTerminalInputSequenceBuilder()
-                .MouseMoveTo(bodyX, bodyY)
-                .ScrollDown()
-                .Build()
-                .ApplyAsync(terminal, ct);
-        }
-        await auto.WaitUntilAsync(_ => sp.Offset > 0, description: "offset advanced via wheel");
+        const int ticks = 5;
+        const int expectedAdvance = 3 * ticks;
+        await new Hex1bTerminalInputSequenceBuilder()
+            .MouseMoveTo(bodyX, bodyY)
+            .ScrollDown(ticks)
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await auto.WaitUntilAsync(_ => sp.Offset >= Math.Min(expectedAdvance, sp.MaxOffset),
+            description: "all wheel ticks applied to Offset");
         var offsetAfterWheel = sp.Offset;
 
-        // Force a repaint.
+        // Force a repaint and wait one render cycle. The repaint must NOT trigger any
+        // EnsureSelectionVisible-style snap-back; the wheel-only path leaves the
+        // pending-scroll flag clear, so Offset stays where the wheel left it.
         _state!.App.Invalidate();
-        await Task.Delay(50, ct);
+        await auto.WaitUntilAsync(_ => true, description: "render frame elapses");
 
         Assert.Equal(rows[0].Key, _state!.IlFocusedTreeKey as string);
         Assert.Equal(offsetAfterWheel, sp.Offset);

--- a/tests/Dotsider.Tests/IlInspectorViewTests.cs
+++ b/tests/Dotsider.Tests/IlInspectorViewTests.cs
@@ -89,12 +89,23 @@ public class IlInspectorViewTests(SampleAssemblyFixture samples) : IDisposable
         await auto.WaitUntilAsync(s => s.ContainsText("User Strings") || s.ContainsText("Metadata"));
         await auto.KeyAsync(Hex1bKey.D3, ct: ct);
         await auto.WaitUntilTextAsync("IL_0000");
+        // Wait for focus to STABILIZE on the panel — three consecutive polls must
+        // see ScrollPanelNode focused. A single-poll wait can return on a transient
+        // frame where RequestContentFocus has applied but a subsequent deferred
+        // focus callback briefly lands on the editor before settling, which used to
+        // race the DownArrow below into the editor and move the cursor.
+        var stableCount = 0;
         await auto.WaitUntilAsync(_ =>
             {
-                try { return _state!.App.FocusedNode is Hex1b.Nodes.ScrollPanelNode; }
-                catch (NullReferenceException) { return false; }
+                try
+                {
+                    if (_state!.App.FocusedNode is Hex1b.Nodes.ScrollPanelNode) stableCount++;
+                    else stableCount = 0;
+                }
+                catch (NullReferenceException) { stableCount = 0; }
+                return stableCount >= 3;
             },
-            description: "focus to return to tree");
+            description: "focus stable on ScrollPanelNode across consecutive frames");
 
         // Selected method must be preserved after tab round-trip
         var selectedBefore = _state!.IlSelectedMethod;

--- a/tests/Dotsider.Tests/NuGetModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/NuGetModeYankIntegrationTests.cs
@@ -706,13 +706,15 @@ public class NuGetModeYankIntegrationTests(SampleAssemblyFixture samples) : IDis
             .Build()
             .ApplyAsync(terminal, ct);
 
-        // Press y — should go into search box, not yank
+        // Press y — should go into search box, not yank. Wait deterministically for
+        // the typed character to land in the search query so a slow-to-process input
+        // event cannot leave the assertion racing the search-bar TextBox update.
         await new Hex1bTerminalInputSequenceBuilder()
             .Type("y")
+            .WaitUntil(_ => (dllState.Search[dllState.CurrentTab].Query ?? "").Contains('y'),
+                TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal, ct);
-
-        await Task.Delay(200, ct);
 
         Assert.Contains("y", dllState.Search[dllState.CurrentTab].Query ?? "");
         Assert.Null(_state.YankNotification);


### PR DESCRIPTION
Five tests had been retrying on CI inside otherwise-green runs. The patterns were the usual ones: a Task.Delay sized for the median case but tight against the long tail, a state read taken between two awaits where a render thread can mutate the captured reference, and a focus check that returns true on the one frame where focus has landed before something else briefly steals it back.

Each fix swaps a Task.Delay for a WaitUntilAsync on a deterministic post-condition. The mouse-wheel offscreen test now sends all five wheel ticks in one input sequence and waits until ScrollPanelNode.Offset has reached the expected total before capturing it, so an in-flight tick finishing during the next delay can't bump the value past the equality assertion below. WaitForPanelAsync collapses into a single predicate that re-evaluates the panel each poll, so a focus-ring rebuild between two sequential awaits cannot leave the captured reference null. EscBack_ScrollWorksAfterRestore waits for the editor to actually take focus after Esc-back before the arrow keys, and then waits for the cursor position to change rather than blindly trusting a 100 ms delay. The NuGet child-search test waits for the search query to contain "y" instead of guessing how long it takes to land. Tab3_TreeFocusedOnReturn_AfterEditorHadFocus now requires focus to remain on ScrollPanelNode for three consecutive polls — long enough that a transient focus the editor steals back on the next deferred callback can't fool the wait.