### PR TITLE
fix(dep-graph): roll forward AppLocal framework-PKT version skew

### DIFF
--- a/Dotsider.slnx
+++ b/Dotsider.slnx
@@ -19,6 +19,7 @@
     <Project Path="samples/NativeAotConsole/NativeAotConsole.csproj" />
     <Project Path="samples/Dotted.Name.App/Dotted.Name.App.csproj" />
     <Project Path="samples/SelfContainedConsole/SelfContainedConsole.csproj" />
+    <Project Path="samples/AppLocalRollForward/AppLocalRollForward.csproj" />
     <Project Path="samples/NetFxBindingRedirects/NetFxBindingRedirects.csproj" />
     <Project Path="samples/NetFxBindingRedirects.OldDep/NetFxBindingRedirects.OldDep.csproj" />
     <Project Path="samples/NetFxBindingRedirects.NewDep/NetFxBindingRedirects.NewDep.csproj" />

--- a/samples/AppLocalRollForward/AppLocalRollForward.csproj
+++ b/samples/AppLocalRollForward/AppLocalRollForward.csproj
@@ -1,0 +1,30 @@
+<!-- FROZEN TEST FIXTURE — do not modify without updating Dotsider.Tests -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <Version>1.0.0</Version>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <Description>
+      Reproduces the AppLocal framework-PKT roll-forward scenario for the dependency graph
+      resolver. Microsoft.Diagnostics.Tracing.TraceEvent 3.2.2 has a stale AssemblyRef to
+      Microsoft.Diagnostics.NETCore.Client v0.2.10.10501, while the package restore deploys
+      v0.2.13.11903 next to it. Both share PKT 31bf3856ad364e35 (a well-known framework key),
+      so the resolver must roll the AppLocal probe forward to the deployed version rather
+      than reporting AssemblyProvenance.IdentityMismatch.
+    </Description>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- TraceEvent's compiled AssemblyRef targets NETCore.Client 0.2.10.10501 (PKT
+         31bf3856ad364e35). The direct PackageReference below floats NuGet to a higher
+         build of the same package, so the deployed app-local DLL has the same simple
+         name and PKT but a strictly greater assembly version. That divergence is the
+         scenario the resolver fix exists to handle. -->
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.2" />
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.661903" />
+  </ItemGroup>
+</Project>

--- a/samples/AppLocalRollForward/Marker.cs
+++ b/samples/AppLocalRollForward/Marker.cs
@@ -1,0 +1,16 @@
+namespace AppLocalRollForward;
+
+/// <summary>
+/// Anchors a single TypeRef into Microsoft.Diagnostics.Tracing.TraceEvent so the C# compiler
+/// emits the AssemblyRef row that drives the roll-forward scenario this sample exists to test.
+/// </summary>
+public static class Marker
+{
+    /// <summary>
+    /// Forces a TypeRef into a TraceEvent type so the C# compiler keeps the
+    /// Microsoft.Diagnostics.Tracing.TraceEvent AssemblyRef row in the emitted PE.
+    /// </summary>
+    /// <returns>The TraceEvent type's full name.</returns>
+    public static string GetTraceEventTypeName()
+        => typeof(Microsoft.Diagnostics.Tracing.ActivityComputer).FullName!;
+}

--- a/samples/AppLocalRollForward/README.md
+++ b/samples/AppLocalRollForward/README.md
@@ -1,0 +1,8 @@
+# AppLocalRollForward
+
+Library that reproduces the AppLocal framework-PKT roll-forward scenario for the dependency-graph resolver. Used as a regression fixture for `AssemblyAnalyzer.IsFrameworkRollForwardMatch`.
+
+- Transitive `Microsoft.Diagnostics.Tracing.TraceEvent 3.2.2` carries a stale `AssemblyRef` to `Microsoft.Diagnostics.NETCore.Client v0.2.10.10501` (PKT `31bf3856ad364e35`)
+- Direct `PackageReference` floats `Microsoft.Diagnostics.NETCore.Client` to `0.2.661903` so NuGet deploys the higher build (`v0.2.13.11903`) app-local
+- `<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>` ensures the package assembly lands next to the library output
+- The dep graph must collapse onto a single resolved node keyed at the deployed version with the older requested identity stamped on the edge — no `IdentityMismatch` leaf

--- a/samples/README.md
+++ b/samples/README.md
@@ -15,6 +15,7 @@ Sample .NET projects used as test fixtures for dotsider's analysis, diff, and tr
 | [NativeAotConsole](NativeAotConsole/) | Console app (NativeAOT) | NativeAOT-published binary for Dynamic tab tracing tests |
 | [Dotted.Name.App](Dotted.Name.App/) | Console app | Dotted assembly name for cross-platform apphost detection testing |
 | [SelfContainedConsole](SelfContainedConsole/) | Console app (single-file) | Self-contained single-file bundle for bundle reading and resolution testing |
+| [AppLocalRollForward](AppLocalRollForward/) | Library | Reproduces the AppLocal framework-PKT roll-forward scenario: TraceEvent's stale `AssemblyRef` to `Microsoft.Diagnostics.NETCore.Client v0.2.10.10501` paired with a higher app-local deployment (`v0.2.13.11903`) under the same well-known framework PKT |
 | [NetFxBindingRedirects](NetFxBindingRedirects/) | Console app (.NET Fx) | Runtime oracle for `NetFxBinder`: GAC + framework runtime + binding redirects + `<probing privatePath>` + `<codeBase>` (success and missing) + culture-aware probing |
 | [NetFxBindingRedirects.OldDep](NetFxBindingRedirects.OldDep/) | Library (.NET Fx) | Compiled against Newtonsoft.Json 12.0.1 — drives transitive binding-redirect tests |
 | [NetFxBindingRedirects.NewDep](NetFxBindingRedirects.NewDep/) | Library (.NET Fx) | Compiled against Newtonsoft.Json 13.0.3 — pairs with OldDep to prove two requested versions collapse to one bound graph node |

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -1286,34 +1286,34 @@ public sealed class AssemblyAnalyzer : IDisposable
 
         string? mismatchPath = null;
 
-        (ResolvedAssembly?, AssemblyProvenance)? TryFile(string path, AssemblyProvenance provenance)
+        (ResolvedAssembly?, AssemblyProvenance, AssemblyRefInfo?)? TryFile(string path, AssemblyProvenance provenance)
         {
             if (!File.Exists(path)) return null;
             var actual = TryReadFileIdentity(path);
             if (actual is null) return null;
             if (IdentityEquals(identity, actual.Value))
-                return (new ResolvedAssembly.FromFile(path), provenance);
+                return (new ResolvedAssembly.FromFile(path), provenance, null);
             if (IsFrameworkRollForwardMatch(identity, actual.Value, provenance))
-                return (new ResolvedAssembly.FromFile(path), provenance);
+                return (new ResolvedAssembly.FromFile(path), provenance, ToAssemblyRefInfo(actual.Value));
             mismatchPath ??= path;
             return null;
         }
 
-        (ResolvedAssembly?, AssemblyProvenance)? TryBundle(
+        (ResolvedAssembly?, AssemblyProvenance, AssemblyRefInfo?)? TryBundle(
             ResolvedAssembly.FromBundle? candidate, AssemblyProvenance provenance)
         {
             if (candidate is null) return null;
             var actual = TryReadBundleIdentity(candidate.Bytes);
             if (actual is null) return null;
             if (IdentityEquals(identity, actual.Value))
-                return (candidate, provenance);
+                return (candidate, provenance, null);
             if (IsFrameworkRollForwardMatch(identity, actual.Value, provenance))
-                return (candidate, provenance);
+                return (candidate, provenance, ToAssemblyRefInfo(actual.Value));
             mismatchPath ??= $"{candidate.BundlePath}:{candidate.Name}";
             return null;
         }
 
-        (ResolvedAssembly?, AssemblyProvenance)? TryNuGet()
+        (ResolvedAssembly?, AssemblyProvenance, AssemblyRefInfo?)? TryNuGet()
         {
             var resolved = NuGetDepsJsonResolver.TryResolve(referencingAssemblyPath, identity.Name);
             if (resolved is ResolvedAssembly.FromFile f)
@@ -1342,7 +1342,7 @@ public sealed class AssemblyAnalyzer : IDisposable
         }
 
         if (hit is { } h)
-            return new AssemblyResolution(h.Item1, h.Item2, null);
+            return new AssemblyResolution(h.Item1, h.Item2, null, LoadedIdentity: h.Item3);
 
         return mismatchPath is not null
             ? new AssemblyResolution(null, AssemblyProvenance.IdentityMismatch, mismatchPath)
@@ -1489,19 +1489,19 @@ public sealed class AssemblyAnalyzer : IDisposable
     /// Whether a probe candidate qualifies as a .NET host-style framework roll-forward of the
     /// requested reference. Matches the binding behavior the .NET host applies when a binary
     /// compiled against an older framework version runs against a newer shared framework:
-    /// if the candidate came from the shared framework, runtime directory, or NuGet package
-    /// cache, shares the simple name and public key token, and carries a well-known Microsoft
-    /// framework public key token, accept the version difference. Without this, every
-    /// framework-referencing package (net6-targeted third-party libraries running on net10)
-    /// would fill the graph with identity-mismatched leaves even though the .NET host itself
-    /// binds them happily.
+    /// if the candidate came from app-local, the shared framework, runtime directory, or NuGet
+    /// package cache, shares the simple name and public key token, carries a well-known Microsoft
+    /// framework public key token, and is at an equal-or-higher assembly version, accept the
+    /// version difference. The version floor matches the default <c>AssemblyLoadContext</c>
+    /// equal-or-higher rule; downgrades remain a true <see cref="AssemblyProvenance.IdentityMismatch"/>.
     /// </summary>
     private static bool IsFrameworkRollForwardMatch(
         AssemblyRefInfo requested,
         (string Name, string Version, string Culture, string? PublicKeyToken) actual,
         AssemblyProvenance provenance)
     {
-        if (provenance is not (AssemblyProvenance.SharedFramework
+        if (provenance is not (AssemblyProvenance.AppLocal
+                              or AssemblyProvenance.SharedFramework
                               or AssemblyProvenance.RuntimeDirectory
                               or AssemblyProvenance.NuGetPackageCache))
             return false;
@@ -1511,8 +1511,17 @@ public sealed class AssemblyAnalyzer : IDisposable
             return false;
         if (!string.Equals(requested.PublicKeyToken, actual.PublicKeyToken, StringComparison.OrdinalIgnoreCase))
             return false;
-        return WellKnownFrameworkPublicKeyTokens.Contains(requested.PublicKeyToken);
+        if (!WellKnownFrameworkPublicKeyTokens.Contains(requested.PublicKeyToken))
+            return false;
+        return ParseVersionOrZero(actual.Version) >= ParseVersionOrZero(requested.Version);
     }
+
+    private static Version ParseVersionOrZero(string s) =>
+        Version.TryParse(s, out var v) ? v : new Version(0, 0, 0, 0);
+
+    private static AssemblyRefInfo ToAssemblyRefInfo(
+        (string Name, string Version, string Culture, string? PublicKeyToken) actual)
+        => new(actual.Name, actual.Version, actual.Culture, actual.PublicKeyToken);
 
     private static bool IdentityEquals(
         AssemblyRefInfo requested,

--- a/tests/Dotsider.Tests/DependencyGraphBuilderTests.cs
+++ b/tests/Dotsider.Tests/DependencyGraphBuilderTests.cs
@@ -277,6 +277,41 @@ public class DependencyGraphBuilderTests(SampleAssemblyFixture samples)
     }
 
     /// <summary>
+    /// AppLocal probe finds a strong-named Microsoft framework assembly whose deployed version
+    /// is a strict roll-forward of a stale AssemblyRef in a transitive dependency. The graph
+    /// keys the node on the loaded (deployed) identity and records the original requested
+    /// identity on the edge — no IdentityMismatch leaf, no duplicate node. Reproduced with the
+    /// AppLocalRollForward sample where Microsoft.Diagnostics.Tracing.TraceEvent 3.2.2's
+    /// AssemblyRef points at Microsoft.Diagnostics.NETCore.Client v0.2.10.10501 while NuGet
+    /// restored v0.2.13.11903 next to it.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void AppLocalRollForward_FrameworkPkt_HigherVersion_ResolvesAndRecordsRequestedIdentity()
+    {
+        using var a = new AssemblyAnalyzer(samples.AppLocalRollForwardDll);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var nodes = graph.Nodes
+            .Where(n => n.Name == "Microsoft.Diagnostics.NETCore.Client")
+            .ToList();
+        var node = Assert.Single(nodes);
+        Assert.False(node.Unresolved);
+
+        var nav = graph.NavigationById[node.Id];
+        Assert.Equal(AssemblyProvenance.AppLocal, nav.Provenance);
+        Assert.NotNull(nav.LoadedIdentity);
+        Assert.Equal(node.Version, nav.LoadedIdentity!.Version);
+
+        var traceEventNode = graph.Nodes.Single(
+            n => n.Name == "Microsoft.Diagnostics.Tracing.TraceEvent");
+        var edge = graph.Edges.Single(
+            e => e.SourceId == traceEventNode.Id && e.TargetId == node.Id);
+        Assert.NotNull(edge.RequestedIdentity);
+        Assert.NotEqual(node.Version, edge.RequestedIdentity!.Version);
+        Assert.Equal("31bf3856ad364e35", edge.RequestedIdentity.PublicKeyToken);
+    }
+
+    /// <summary>
     /// When a reference forms a cycle back to an ancestor, the cycle-closing edge is emitted but
     /// the ancestor is not re-expanded.
     /// </summary>

--- a/tests/Dotsider.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Tests/SampleAssemblyFixture.cs
@@ -55,6 +55,15 @@ public class SampleAssemblyFixture : IAsyncLifetime
     /// </summary>
     public string EmptyLibDll { get; private set; } = null!;
 
+    /// <summary>
+    /// Path to the built AppLocalRollForward.dll sample assembly. Reproduces the AppLocal
+    /// framework-PKT roll-forward scenario: Microsoft.Diagnostics.Tracing.TraceEvent's
+    /// compiled AssemblyRef targets <c>Microsoft.Diagnostics.NETCore.Client v0.2.10.10501</c>,
+    /// while the package-restored runtime asset on disk is a strictly higher build of the
+    /// same simple name and PKT.
+    /// </summary>
+    public string AppLocalRollForwardDll { get; private set; } = null!;
+
     // NuGet package
     /// <summary>
     /// Path to the built RichLibrary NuGet package.
@@ -150,6 +159,7 @@ public class SampleAssemblyFixture : IAsyncLifetime
             BuildProject("samples/NativeLib"),
             BuildProject("samples/EmptyLib"),
             BuildProject("samples/Dotted.Name.App"),
+            BuildProject("samples/AppLocalRollForward"),
         };
 
         // net48 needs Windows; NativeAOT builds on all platforms.
@@ -183,6 +193,8 @@ public class SampleAssemblyFixture : IAsyncLifetime
         RichLibraryV2Dll = SamplePath("RichLibraryV2", config, tfm, "RichLibrary.dll");
         NativeLibDll = SamplePath("NativeLib", config, tfm, "NativeLib.dll");
         EmptyLibDll = SamplePath("EmptyLib", config, tfm, "EmptyLib.dll");
+        AppLocalRollForwardDll = SamplePath(
+            "AppLocalRollForward", config, tfm, "AppLocalRollForward.dll");
         DottedNameAppDll = SamplePath("Dotted.Name.App", config, tfm, "Dotted.Name.App.dll");
         DottedNameAppExe = SamplePath("Dotted.Name.App", config, tfm, $"Dotted.Name.App{apphostExt}");
 
@@ -235,6 +247,13 @@ public class SampleAssemblyFixture : IAsyncLifetime
         Assert.True(File.Exists(HelloWorldDll), $"HelloWorld.dll not found at {HelloWorldDll}");
         Assert.True(File.Exists(RichLibraryDll), $"RichLibrary.dll not found at {RichLibraryDll}");
         Assert.True(File.Exists(RichLibraryNupkg), $"RichLibrary.nupkg not found at {RichLibraryNupkg}");
+        Assert.True(File.Exists(AppLocalRollForwardDll),
+            $"AppLocalRollForward.dll not found at {AppLocalRollForwardDll}");
+        var rollForwardBin = Path.GetDirectoryName(AppLocalRollForwardDll)!;
+        Assert.True(File.Exists(Path.Combine(rollForwardBin, "Microsoft.Diagnostics.NETCore.Client.dll")),
+            "AppLocalRollForward must deploy NETCore.Client.dll app-local for the roll-forward probe");
+        Assert.True(File.Exists(Path.Combine(rollForwardBin, "Microsoft.Diagnostics.Tracing.TraceEvent.dll")),
+            "AppLocalRollForward must deploy TraceEvent.dll app-local for its stale AssemblyRef to drive the test");
         if (NetFxConsoleExe is not null)
             Assert.True(File.Exists(NetFxConsoleExe), $"NetFxConsole.exe not found at {NetFxConsoleExe}");
         if (NetFxBindingRedirectsExe is not null)

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -553,6 +553,46 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
     }
 
     /// <summary>
+    /// Opening the AppLocalRollForward sample on the Dep Graph tab must not render the
+    /// <c>! </c> IdentityMismatch marker for <c>Microsoft.Diagnostics.NETCore.Client</c>.
+    /// The sample's transitive AssemblyRef from <c>Microsoft.Diagnostics.Tracing.TraceEvent</c>
+    /// targets v0.2.10.10501 while NuGet deploys v0.2.13.11903 next to it, so the AppLocal
+    /// probe must roll forward (same well-known framework PKT, equal-or-higher version) and
+    /// the cached graph must collapse onto a single resolved node keyed at the deployed version.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Tab6_AppLocalRollForward_NoIdentityMismatchMarker()
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.AppLocalRollForwardDll);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.D6)
+            .WaitUntil(s => s.ContainsText("Microsoft.Diagnostics.NETCore.Client"),
+                TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        var snapshot = terminal.CreateSnapshot();
+        Assert.False(snapshot.ContainsText("! Microsoft.Diagnostics.NETCore.Client"),
+            "AppLocal roll-forward must suppress the IdentityMismatch marker on the Dep Graph tab.");
+
+        Assert.NotNull(_state!.CachedGraph);
+        var clientNodes = _state.CachedGraph!.Value.Nodes
+            .Where(n => n.Name == "Microsoft.Diagnostics.NETCore.Client")
+            .ToList();
+        var clientNode = Assert.Single(clientNodes);
+        Assert.False(clientNode.Unresolved);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
     /// Verifies tab7 shows size map.
     /// </summary>
     [Fact(Timeout = 30_000)]


### PR DESCRIPTION
TraceEvent 3.2.2's compiled AssemblyRef pins `Microsoft.Diagnostics.NETCore.Client` to v0.2.10.10501; NuGet floats the deployed runtime asset to v0.2.13.11903 under the same well-known framework PKT. The default `AssemblyLoadContext` binds this without complaint — the dep graph was reporting an `IdentityMismatch` leaf only because `IsFrameworkRollForwardMatch` refused the AppLocal probe.

The rule now accepts AppLocal and gates on `actual.Version >= requested.Version`, so downgrades remain a real mismatch. The on-disk identity is threaded through `AssemblyResolution.LoadedIdentity`, and `DependencyGraphBuilder.SelectChildId` keys the node on the deployed version and stamps the older requested identity onto the edge — the same redirect-collapse path already used for net48 binding policy.

A new `AppLocalRollForward` sample reproduces the scenario: TraceEvent's stale ref paired with an explicit higher `PackageReference` to NETCore.Client and `CopyLocalLockFileAssemblies=true`. Covered by a graph-builder test and a Hex1b TUI test that asserts the `! ` marker no longer renders on the Dep Graph tab.

Fixes #171