### PR TITLE
Add portable PDB support

### DIFF
--- a/Dotsider.slnx
+++ b/Dotsider.slnx
@@ -20,6 +20,7 @@
     <Project Path="samples/Dotted.Name.App/Dotted.Name.App.csproj" />
     <Project Path="samples/SelfContainedConsole/SelfContainedConsole.csproj" />
     <Project Path="samples/AppLocalRollForward/AppLocalRollForward.csproj" />
+    <Project Path="samples/EmbeddedSourceLib/EmbeddedSourceLib.csproj" />
     <Project Path="samples/NetFxBindingRedirects/NetFxBindingRedirects.csproj" />
     <Project Path="samples/NetFxBindingRedirects.OldDep/NetFxBindingRedirects.OldDep.csproj" />
     <Project Path="samples/NetFxBindingRedirects.NewDep/NetFxBindingRedirects.NewDep.csproj" />

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ dotsider opens any .NET DLL or EXE and lets you explore it across 8 tabs. If you
 | Tab | What you see |
 |-----|-------------|
 | **1 General** | Assembly identity, target framework, architecture, dependency table. Press Enter on a reference to drill into it. |
-| **2 PE/Metadata** | COFF headers, CLR header, sections, TypeDefs, MethodDefs, AssemblyRefs, custom attributes, resources. Press `g` on a TypeDef or MethodDef to jump to its IL. |
-| **3 IL Inspector** | Namespace/Type/Method tree with IL disassembly. Select a method, read its bytecode. Press `Enter` or `gd` on a `call`, `ldfld`, `newobj`, etc. to go to the target — works across assemblies. Press `Esc` to go back. Press `x` to jump to the method body in the hex dump. |
+| **2 PE/Metadata** | COFF headers, CLR header, sections, TypeDefs, MethodDefs, AssemblyRefs, custom attributes, resources, and debug directory rows. Press `g` on a TypeDef or MethodDef to jump to its IL. |
+| **3 IL Inspector** | Namespace/Type/Method tree with IL disassembly. Portable PDBs add source spans, Source Link markers, and local names when available. Press `Enter` or `gd` on a `call`, `ldfld`, `newobj`, etc. to go to the target — works across assemblies. Press `Esc` to go back. Press `x` to jump to the method body in the hex dump. |
 | **4 Strings** | User strings, metadata strings, and raw binary string scan with configurable minimum length. |
 | **5 Hex Dump** | Hex editor with vi-style modal editing (read-only by default), byte category coloring, data interpretation panel, jump-to-offset, and vim navigation. |
 | **6 Dep Graph** | Visual dependency graph — your assembly at the root, references as nodes, edge weights by TypeRef count. Press Enter on a node to open that assembly. |
@@ -99,6 +99,7 @@ dotsider analyze MyLib.dll                      # assembly info (default)
 dotsider analyze MyLib.dll --types              # list type definitions
 dotsider analyze MyLib.dll --methods            # list method definitions
 dotsider analyze MyLib.dll --il Type.Method     # disassemble a method
+dotsider analyze MyLib.dll --embedded-source Type.Method # print embedded source
 dotsider analyze MyLib.dll --deps               # assembly references
 dotsider analyze MyLib.dll --strings            # extract strings
 dotsider analyze MyLib.dll --fields             # list field definitions
@@ -242,7 +243,7 @@ Add to your MCP client configuration (e.g. `.mcp.json` for Claude Code):
 
 ### What it provides
 
-**38 tools** across assembly analysis, IL disassembly, metadata inspection, dependency graphs, size analysis, string extraction, diffing, NuGet package analysis, single-file bundle reading, and runtime tracing. Tools work in two modes:
+**40 tools** across assembly analysis, IL disassembly, portable PDB debug info, metadata inspection, dependency graphs, size analysis, string extraction, diffing, NuGet package analysis, single-file bundle reading, and runtime tracing. Tools work in two modes:
 
 - **Direct mode** — pass an assembly path, get results (no TUI needed)
 - **Session mode** — connect to a running dotsider TUI instance via Unix domain socket for live state, tracing, and navigation
@@ -278,6 +279,7 @@ src/Dotsider.Mcp/
 samples/
   HelloWorld/         Minimal console app
   ComplexApp/         Async pipeline with embedded resources
+  EmbeddedSourceLib/  Embedded portable PDB source fixture
   RichLibrary/        Library with NuGet deps (Newtonsoft.Json, System.Text.Json)
   RichLibraryV2/      Same library with deliberate API changes (for diff testing)
   MinimalApi/         ASP.NET Core minimal API (web SDK, hosted entry point)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ dotsider opens any .NET DLL or EXE and lets you explore it across 8 tabs. If you
 |-----|-------------|
 | **1 General** | Assembly identity, target framework, architecture, dependency table. Press Enter on a reference to drill into it. |
 | **2 PE/Metadata** | COFF headers, CLR header, sections, TypeDefs, MethodDefs, AssemblyRefs, custom attributes, resources, and debug directory rows. Press `g` on a TypeDef or MethodDef to jump to its IL. |
-| **3 IL Inspector** | Namespace/Type/Method tree with IL disassembly. Portable PDBs add source spans, Source Link markers, and local names when available. Press `Enter` or `gd` on a `call`, `ldfld`, `newobj`, etc. to go to the target — works across assemblies. Press `Esc` to go back. Press `x` to jump to the method body in the hex dump. |
+| **3 IL Inspector** | Namespace/Type/Method tree with IL disassembly. Portable PDBs add source spans, Source Link markers, and local names when available. Press `u` on a `[source link]` marker to copy its resolved URL. Press `Enter` or `gd` on a `call`, `ldfld`, `newobj`, etc. to go to the target — works across assemblies. Press `Esc` to go back. Press `x` to jump to the method body in the hex dump. |
 | **4 Strings** | User strings, metadata strings, and raw binary string scan with configurable minimum length. |
 | **5 Hex Dump** | Hex editor with vi-style modal editing (read-only by default), byte category coloring, data interpretation panel, jump-to-offset, and vim navigation. |
 | **6 Dep Graph** | Visual dependency graph — your assembly at the root, references as nodes, edge weights by TypeRef count. Press Enter on a node to open that assembly. |
@@ -157,6 +157,7 @@ Supported `--ai` providers: claude, gemini, copilot, cursor-agent, opencode, cod
 | `Tab` | Cycle focus between info panels and tables |
 | `Enter` / `gd` | Go to definition (IL Inspector tab, cursor on a token-bearing instruction) |
 | `g` | Go to IL Inspector for the focused TypeDef/MethodDef (PE/Metadata tab) |
+| `u` | Copy Source Link URL from a `[source link]` marker in the IL Inspector |
 | `x` | Jump to method body in Hex Dump (IL Inspector tab, when a method with RVA is selected) |
 | `/` | Search (highlights matches inline) |
 | `n` / `N` | Next / previous search match |

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
@@ -152,6 +152,16 @@ Gets the custom attributes applied to metadata entities.
 public IReadOnlyList<CustomAttributeInfo> CustomAttributes { get; }
 ```
 
+### DebugDirectory
+
+Gets the PE debug directory entries.
+
+**Returns:** [IReadOnlyList\<DebugDirectoryInfo\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<DebugDirectoryInfo> DebugDirectory { get; }
+```
+
 ### DisplayName
 
 Logical display name for the analyzed artifact. For bundle-backed analyzers this is
@@ -214,6 +224,16 @@ Whether the PE file contains .NET metadata.
 public bool HasMetadata { get; }
 ```
 
+### HasPortablePdb
+
+Gets whether a portable PDB was opened.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool HasPortablePdb { get; }
+```
+
 ### IsBundleBacked
 
 Whether this analyzer was created from bytes extracted from a single-file bundle.
@@ -273,6 +293,16 @@ Gets the MethodDef metadata table entries.
 
 ```csharp
 public IReadOnlyList<MethodDefInfo> MethodDefs { get; }
+```
+
+### PdbProvenance
+
+Portable PDB provenance for the analyzed assembly.
+
+**Returns:** [PdbProvenance](/api/dotsider.core.analysis.models.pdbprovenance/)
+
+```csharp
+public PdbProvenance PdbProvenance { get; }
 ```
 
 ### PeHeaders
@@ -349,6 +379,16 @@ Used as resolution context when probing for referenced assemblies.
 public string? SourceBundlePath { get; }
 ```
 
+### SourceLink
+
+Gets decoded Source Link information from the portable PDB.
+
+**Returns:** [SourceLinkInfo](/api/dotsider.core.analysis.models.sourcelinkinfo/)
+
+```csharp
+public SourceLinkInfo SourceLink { get; }
+```
+
 ### TargetFramework
 
 The target framework moniker (e.g., ".NETCoreApp,Version=v10.0"), or null.
@@ -389,6 +429,38 @@ Performs application-defined tasks associated with freeing, releasing, or resett
 public void Dispose()
 ```
 
+### GetEmbeddedSource(MethodDefInfo)
+
+Gets the first embedded source document referenced by a method's sequence points.
+
+**Parameters:**
+
+- `method` ([MethodDefInfo](/api/dotsider.core.analysis.models.methoddefinfo/)): The method whose source should be resolved.
+
+**Returns:** [EmbeddedSourceInfo](/api/dotsider.core.analysis.models.embeddedsourceinfo/)
+
+The decoded embedded source, or null when none is available.
+
+```csharp
+public EmbeddedSourceInfo? GetEmbeddedSource(MethodDefInfo method)
+```
+
+### GetEmbeddedSource(string)
+
+Gets embedded source for a portable PDB document path.
+
+**Parameters:**
+
+- `documentPath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The document path from the portable PDB.
+
+**Returns:** [EmbeddedSourceInfo](/api/dotsider.core.analysis.models.embeddedsourceinfo/)
+
+The decoded embedded source, or null when the document has none.
+
+```csharp
+public EmbeddedSourceInfo? GetEmbeddedSource(string documentPath)
+```
+
 ### GetMetadataReader()
 
 Gets the underlying [MetadataReader](https://learn.microsoft.com/dotnet/api/system.reflection.metadata.metadatareader) for advanced queries.
@@ -415,6 +487,32 @@ The method body block, or null.
 
 ```csharp
 public MethodBodyBlock? GetMethodBody(MethodDefInfo method)
+```
+
+### GetMethodDebugInfo(MethodDefInfo)
+
+Gets portable PDB debug information for a method definition.
+
+**Parameters:**
+
+- `method` ([MethodDefInfo](/api/dotsider.core.analysis.models.methoddefinfo/)): The method definition to inspect.
+
+**Returns:** [MethodDebugInfo](/api/dotsider.core.analysis.models.methoddebuginfo/)
+
+Decoded portable PDB information, or an empty result when no portable PDB is available.
+
+```csharp
+public MethodDebugInfo GetMethodDebugInfo(MethodDefInfo method)
+```
+
+### GetPdbReader()
+
+Gets the portable PDB [MetadataReader](https://learn.microsoft.com/dotnet/api/system.reflection.metadata.metadatareader), or null when no portable PDB is available.
+
+**Returns:** [MetadataReader](https://learn.microsoft.com/dotnet/api/system.reflection.metadata.metadatareader)
+
+```csharp
+public MetadataReader? GetPdbReader()
 ```
 
 ### IsFrameworkAssembly(AssemblyProvenance, AssemblyRefInfo, string?, string?)
@@ -509,6 +607,22 @@ Returns `null` for bundle-backed results.
 
 ```csharp
 public static string? ResolveAssemblyPath(string referencingAssemblyPath, string assemblyName)
+```
+
+### ResolveSourceLinkUrl(string)
+
+Resolves a portable PDB document path through Source Link mappings.
+
+**Parameters:**
+
+- `documentPath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The document path from the portable PDB.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+The resolved Source Link URL, or null when no mapping applies.
+
+```csharp
+public string? ResolveSourceLinkUrl(string documentPath)
 ```
 
 ### ResolveToken(int)

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-DebugDirectoryInfo.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-DebugDirectoryInfo.md
@@ -1,0 +1,129 @@
+---
+title: "DebugDirectoryInfo"
+description: "Display-ready PE debug directory entry information."
+slug: api/dotsider.core.analysis.models.debugdirectoryinfo
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+Display-ready PE debug directory entry information.
+
+```csharp
+public sealed record DebugDirectoryInfo : IEquatable<DebugDirectoryInfo>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **DebugDirectoryInfo**
+
+## Implements
+
+- [IEquatable\<DebugDirectoryInfo\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### DebugDirectoryInfo(DebugDirectoryEntryType, uint, ushort, ushort, int, int, int, string)
+
+Display-ready PE debug directory entry information.
+
+**Parameters:**
+
+- `Type` ([DebugDirectoryEntryType](https://learn.microsoft.com/dotnet/api/system.reflection.portableexecutable.debugdirectoryentrytype)): The debug directory entry type.
+- `Stamp` ([UInt32](https://learn.microsoft.com/dotnet/api/system.uint32)): The entry stamp.
+- `MajorVersion` ([UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)): The major debug format version.
+- `MinorVersion` ([UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)): The minor debug format version.
+- `DataSize` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The payload size in bytes.
+- `AddressOfRawData` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The payload RVA.
+- `PointerToRawData` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The payload file pointer.
+- `Payload` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Inline payload summary for known entry types.
+
+```csharp
+public DebugDirectoryInfo(DebugDirectoryEntryType Type, uint Stamp, ushort MajorVersion, ushort MinorVersion, int DataSize, int AddressOfRawData, int PointerToRawData, string Payload)
+```
+
+## Properties
+
+### AddressOfRawData
+
+The payload RVA.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int AddressOfRawData { get; init; }
+```
+
+### DataSize
+
+The payload size in bytes.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int DataSize { get; init; }
+```
+
+### MajorVersion
+
+The major debug format version.
+
+**Returns:** [UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)
+
+```csharp
+public ushort MajorVersion { get; init; }
+```
+
+### MinorVersion
+
+The minor debug format version.
+
+**Returns:** [UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)
+
+```csharp
+public ushort MinorVersion { get; init; }
+```
+
+### Payload
+
+Inline payload summary for known entry types.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Payload { get; init; }
+```
+
+### PointerToRawData
+
+The payload file pointer.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int PointerToRawData { get; init; }
+```
+
+### Stamp
+
+The entry stamp.
+
+**Returns:** [UInt32](https://learn.microsoft.com/dotnet/api/system.uint32)
+
+```csharp
+public uint Stamp { get; init; }
+```
+
+### Type
+
+The debug directory entry type.
+
+**Returns:** [DebugDirectoryEntryType](https://learn.microsoft.com/dotnet/api/system.reflection.portableexecutable.debugdirectoryentrytype)
+
+```csharp
+public DebugDirectoryEntryType Type { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-EmbeddedSourceInfo.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-EmbeddedSourceInfo.md
@@ -1,0 +1,74 @@
+---
+title: "EmbeddedSourceInfo"
+description: "Embedded source decoded from a portable PDB document."
+slug: api/dotsider.core.analysis.models.embeddedsourceinfo
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+Embedded source decoded from a portable PDB document.
+
+```csharp
+public sealed record EmbeddedSourceInfo : IEquatable<EmbeddedSourceInfo>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **EmbeddedSourceInfo**
+
+## Implements
+
+- [IEquatable\<EmbeddedSourceInfo\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### EmbeddedSourceInfo(string, string, byte[])
+
+Embedded source decoded from a portable PDB document.
+
+**Parameters:**
+
+- `Document` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The PDB document path.
+- `Text` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The decoded source text.
+- `Bytes` ([Byte[]](https://learn.microsoft.com/dotnet/api/system.byte[])): The decoded source bytes.
+
+```csharp
+public EmbeddedSourceInfo(string Document, string Text, byte[] Bytes)
+```
+
+## Properties
+
+### Bytes
+
+The decoded source bytes.
+
+**Returns:** [Byte[]](https://learn.microsoft.com/dotnet/api/system.byte[])
+
+```csharp
+public byte[] Bytes { get; init; }
+```
+
+### Document
+
+The PDB document path.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Document { get; init; }
+```
+
+### Text
+
+The decoded source text.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Text { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-IlInstruction.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-IlInstruction.md
@@ -26,7 +26,7 @@ public sealed record IlInstruction : IEquatable<IlInstruction>
 
 ## Constructors
 
-### IlInstruction(int, string, string, int?)
+### IlInstruction(int, string, string, int?, string?, int?, int?, int?, int?, bool, string?, bool, int?, string?, int?)
 
 A single decoded IL (Intermediate Language) instruction.
 
@@ -36,12 +36,63 @@ A single decoded IL (Intermediate Language) instruction.
 - `OpCode` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The IL opcode mnemonic (e.g., "ldstr", "call", "ret").
 - `Operand` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The decoded operand as a display string, or empty if the opcode takes no operand.
 - `MetadataToken` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The raw metadata token for token-bearing operands (methods, fields, types), or null.
+- `SequenceDocument` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The source document for a sequence point starting at this instruction, or null.
+- `SequenceStartLine` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The sequence point start line, or null.
+- `SequenceStartColumn` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The sequence point start column, or null.
+- `SequenceEndLine` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The sequence point end line, or null.
+- `SequenceEndColumn` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The sequence point end column, or null.
+- `SequenceHidden` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether the sequence point is hidden.
+- `SourceLinkUrl` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The Source Link URL resolved for the sequence point document, or null.
+- `HasEmbeddedSource` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether the sequence point document has embedded source.
+- `LocalSlot` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The local variable slot referenced by this instruction, or null.
+- `LocalName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The active PDB local variable name for LocalSlot, or null.
+- `DisplayLine` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The 1-based rendered line number in formatted disassembly, or null.
 
 ```csharp
-public IlInstruction(int Offset, string OpCode, string Operand, int? MetadataToken = null)
+public IlInstruction(int Offset, string OpCode, string Operand, int? MetadataToken = null, string? SequenceDocument = null, int? SequenceStartLine = null, int? SequenceStartColumn = null, int? SequenceEndLine = null, int? SequenceEndColumn = null, bool SequenceHidden = false, string? SourceLinkUrl = null, bool HasEmbeddedSource = false, int? LocalSlot = null, string? LocalName = null, int? DisplayLine = null)
 ```
 
 ## Properties
+
+### DisplayLine
+
+The 1-based rendered line number in formatted disassembly, or null.
+
+**Returns:** [Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)
+
+```csharp
+public int? DisplayLine { get; init; }
+```
+
+### HasEmbeddedSource
+
+Whether the sequence point document has embedded source.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool HasEmbeddedSource { get; init; }
+```
+
+### LocalName
+
+The active PDB local variable name for LocalSlot, or null.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? LocalName { get; init; }
+```
+
+### LocalSlot
+
+The local variable slot referenced by this instruction, or null.
+
+**Returns:** [Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)
+
+```csharp
+public int? LocalSlot { get; init; }
+```
 
 ### MetadataToken
 
@@ -81,5 +132,75 @@ The decoded operand as a display string, or empty if the opcode takes no operand
 
 ```csharp
 public string Operand { get; init; }
+```
+
+### SequenceDocument
+
+The source document for a sequence point starting at this instruction, or null.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? SequenceDocument { get; init; }
+```
+
+### SequenceEndColumn
+
+The sequence point end column, or null.
+
+**Returns:** [Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)
+
+```csharp
+public int? SequenceEndColumn { get; init; }
+```
+
+### SequenceEndLine
+
+The sequence point end line, or null.
+
+**Returns:** [Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)
+
+```csharp
+public int? SequenceEndLine { get; init; }
+```
+
+### SequenceHidden
+
+Whether the sequence point is hidden.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool SequenceHidden { get; init; }
+```
+
+### SequenceStartColumn
+
+The sequence point start column, or null.
+
+**Returns:** [Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)
+
+```csharp
+public int? SequenceStartColumn { get; init; }
+```
+
+### SequenceStartLine
+
+The sequence point start line, or null.
+
+**Returns:** [Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)
+
+```csharp
+public int? SequenceStartLine { get; init; }
+```
+
+### SourceLinkUrl
+
+The Source Link URL resolved for the sequence point document, or null.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? SourceLinkUrl { get; init; }
 ```
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-LocalSlotInfo.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-LocalSlotInfo.md
@@ -1,0 +1,96 @@
+---
+title: "LocalSlotInfo"
+description: "A PDB local variable slot and the IL range where its name is active."
+slug: api/dotsider.core.analysis.models.localslotinfo
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+A PDB local variable slot and the IL range where its name is active.
+
+```csharp
+public sealed record LocalSlotInfo : IEquatable<LocalSlotInfo>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **LocalSlotInfo**
+
+## Implements
+
+- [IEquatable\<LocalSlotInfo\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### LocalSlotInfo(int, string, int, int, bool)
+
+A PDB local variable slot and the IL range where its name is active.
+
+**Parameters:**
+
+- `Slot` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The local variable slot index.
+- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The local variable name.
+- `StartOffset` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The first IL offset where the name is active.
+- `EndOffset` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The exclusive end IL offset for the local scope.
+- `IsDebuggerHidden` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether the local is marked debugger-hidden.
+
+```csharp
+public LocalSlotInfo(int Slot, string Name, int StartOffset, int EndOffset, bool IsDebuggerHidden)
+```
+
+## Properties
+
+### EndOffset
+
+The exclusive end IL offset for the local scope.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int EndOffset { get; init; }
+```
+
+### IsDebuggerHidden
+
+Whether the local is marked debugger-hidden.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool IsDebuggerHidden { get; init; }
+```
+
+### Name
+
+The local variable name.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Name { get; init; }
+```
+
+### Slot
+
+The local variable slot index.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int Slot { get; init; }
+```
+
+### StartOffset
+
+The first IL offset where the name is active.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int StartOffset { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MethodDebugInfo.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MethodDebugInfo.md
@@ -1,0 +1,85 @@
+---
+title: "MethodDebugInfo"
+description: "Portable PDB debug information for a method."
+slug: api/dotsider.core.analysis.models.methoddebuginfo
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+Portable PDB debug information for a method.
+
+```csharp
+public sealed record MethodDebugInfo : IEquatable<MethodDebugInfo>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **MethodDebugInfo**
+
+## Implements
+
+- [IEquatable\<MethodDebugInfo\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### MethodDebugInfo(int, PdbProvenance, IReadOnlyList\<SequencePointInfo\>, IReadOnlyList\<LocalSlotInfo\>)
+
+Portable PDB debug information for a method.
+
+**Parameters:**
+
+- `MethodToken` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The method definition metadata token.
+- `Pdb` ([PdbProvenance](/api/dotsider.core.analysis.models.pdbprovenance/)): The portable PDB provenance.
+- `SequencePoints` ([IReadOnlyList\<SequencePointInfo\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Decoded sequence points for the method.
+- `Locals` ([IReadOnlyList\<LocalSlotInfo\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Decoded local slots and PDB names for the method.
+
+```csharp
+public MethodDebugInfo(int MethodToken, PdbProvenance Pdb, IReadOnlyList<SequencePointInfo> SequencePoints, IReadOnlyList<LocalSlotInfo> Locals)
+```
+
+## Properties
+
+### Locals
+
+Decoded local slots and PDB names for the method.
+
+**Returns:** [IReadOnlyList\<LocalSlotInfo\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<LocalSlotInfo> Locals { get; init; }
+```
+
+### MethodToken
+
+The method definition metadata token.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int MethodToken { get; init; }
+```
+
+### Pdb
+
+The portable PDB provenance.
+
+**Returns:** [PdbProvenance](/api/dotsider.core.analysis.models.pdbprovenance/)
+
+```csharp
+public PdbProvenance Pdb { get; init; }
+```
+
+### SequencePoints
+
+Decoded sequence points for the method.
+
+**Returns:** [IReadOnlyList\<SequencePointInfo\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<SequencePointInfo> SequencePoints { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-PdbProvenance.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-PdbProvenance.md
@@ -1,0 +1,88 @@
+---
+title: "PdbProvenance"
+description: "Describes where portable PDB information was found, or why it could not be used."
+slug: api/dotsider.core.analysis.models.pdbprovenance
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+Describes where portable PDB information was found, or why it could not be used.
+
+```csharp
+public sealed record PdbProvenance : IEquatable<PdbProvenance>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **PdbProvenance**
+
+## Implements
+
+- [IEquatable\<PdbProvenance\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### PdbProvenance(PdbProvenanceKind, string?, string?)
+
+Describes where portable PDB information was found, or why it could not be used.
+
+**Parameters:**
+
+- `Kind` ([PdbProvenanceKind](/api/dotsider.core.analysis.models.pdbprovenancekind/)): The resolved provenance category.
+- `Path` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The sidecar PDB path when one was used or probed.
+- `Details` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Additional diagnostic context for display surfaces.
+
+```csharp
+public PdbProvenance(PdbProvenanceKind Kind, string? Path = null, string? Details = null)
+```
+
+## Properties
+
+### Details
+
+Additional diagnostic context for display surfaces.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? Details { get; init; }
+```
+
+### Kind
+
+The resolved provenance category.
+
+**Returns:** [PdbProvenanceKind](/api/dotsider.core.analysis.models.pdbprovenancekind/)
+
+```csharp
+public PdbProvenanceKind Kind { get; init; }
+```
+
+### Path
+
+The sidecar PDB path when one was used or probed.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? Path { get; init; }
+```
+
+## Methods
+
+### ToString()
+
+Returns a string that represents the current object.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+A string that represents the current object.
+
+```csharp
+public override string ToString()
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-PdbProvenanceKind.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-PdbProvenanceKind.md
@@ -1,0 +1,90 @@
+---
+title: "PdbProvenanceKind"
+description: "Portable PDB discovery outcomes that are meaningful to .NET developers."
+slug: api/dotsider.core.analysis.models.pdbprovenancekind
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+Portable PDB discovery outcomes that are meaningful to .NET developers.
+
+```csharp
+public enum PdbProvenanceKind
+```
+
+## Fields
+
+### BundleSidecarSkipped
+
+The assembly came from a single-file bundle, so sidecar probing was intentionally skipped.
+
+**Returns:** [PdbProvenanceKind](/api/dotsider.core.analysis.models.pdbprovenancekind/)
+
+```csharp
+BundleSidecarSkipped = 6
+```
+
+### CodeViewSidecarMismatched
+
+A portable sidecar PDB was found, but its ID does not match the PE CodeView entry.
+
+**Returns:** [PdbProvenanceKind](/api/dotsider.core.analysis.models.pdbprovenancekind/)
+
+```csharp
+CodeViewSidecarMismatched = 2
+```
+
+### CodeViewSidecarMissing
+
+A portable CodeView entry points at a sidecar PDB that was not found.
+
+**Returns:** [PdbProvenanceKind](/api/dotsider.core.analysis.models.pdbprovenancekind/)
+
+```csharp
+CodeViewSidecarMissing = 1
+```
+
+### Embedded
+
+An embedded portable PDB was opened.
+
+**Returns:** [PdbProvenanceKind](/api/dotsider.core.analysis.models.pdbprovenancekind/)
+
+```csharp
+Embedded = 4
+```
+
+### NoDebugDirectory
+
+The PE has no debug directory.
+
+**Returns:** [PdbProvenanceKind](/api/dotsider.core.analysis.models.pdbprovenancekind/)
+
+```csharp
+NoDebugDirectory = 0
+```
+
+### Sidecar
+
+A matching portable sidecar PDB was opened.
+
+**Returns:** [PdbProvenanceKind](/api/dotsider.core.analysis.models.pdbprovenancekind/)
+
+```csharp
+Sidecar = 3
+```
+
+### UnsupportedWindowsPdb
+
+A CodeView entry was present, but it identifies a Windows PDB or another non-portable PDB.
+
+**Returns:** [PdbProvenanceKind](/api/dotsider.core.analysis.models.pdbprovenancekind/)
+
+```csharp
+UnsupportedWindowsPdb = 5
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SequencePointInfo.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SequencePointInfo.md
@@ -1,0 +1,140 @@
+---
+title: "SequencePointInfo"
+description: "A source sequence point decoded from a portable PDB."
+slug: api/dotsider.core.analysis.models.sequencepointinfo
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+A source sequence point decoded from a portable PDB.
+
+```csharp
+public sealed record SequencePointInfo : IEquatable<SequencePointInfo>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **SequencePointInfo**
+
+## Implements
+
+- [IEquatable\<SequencePointInfo\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### SequencePointInfo(int, string?, int, int, int, int, bool, string?, bool)
+
+A source sequence point decoded from a portable PDB.
+
+**Parameters:**
+
+- `Offset` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The IL offset where the sequence point starts.
+- `Document` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The source document path.
+- `StartLine` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The source start line.
+- `StartColumn` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The source start column.
+- `EndLine` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The source end line.
+- `EndColumn` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The source end column.
+- `IsHidden` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether the sequence point is hidden.
+- `SourceLinkUrl` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The Source Link URL resolved for the document, or null.
+- `HasEmbeddedSource` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether the document has embedded source.
+
+```csharp
+public SequencePointInfo(int Offset, string? Document, int StartLine, int StartColumn, int EndLine, int EndColumn, bool IsHidden, string? SourceLinkUrl, bool HasEmbeddedSource)
+```
+
+## Properties
+
+### Document
+
+The source document path.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? Document { get; init; }
+```
+
+### EndColumn
+
+The source end column.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int EndColumn { get; init; }
+```
+
+### EndLine
+
+The source end line.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int EndLine { get; init; }
+```
+
+### HasEmbeddedSource
+
+Whether the document has embedded source.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool HasEmbeddedSource { get; init; }
+```
+
+### IsHidden
+
+Whether the sequence point is hidden.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool IsHidden { get; init; }
+```
+
+### Offset
+
+The IL offset where the sequence point starts.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int Offset { get; init; }
+```
+
+### SourceLinkUrl
+
+The Source Link URL resolved for the document, or null.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? SourceLinkUrl { get; init; }
+```
+
+### StartColumn
+
+The source start column.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int StartColumn { get; init; }
+```
+
+### StartLine
+
+The source start line.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int StartLine { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SourceLinkInfo.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SourceLinkInfo.md
@@ -1,0 +1,62 @@
+---
+title: "SourceLinkInfo"
+description: "Source Link mappings decoded from portable PDB custom debug information."
+slug: api/dotsider.core.analysis.models.sourcelinkinfo
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+Source Link mappings decoded from portable PDB custom debug information.
+
+```csharp
+public sealed record SourceLinkInfo : IEquatable<SourceLinkInfo>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **SourceLinkInfo**
+
+## Implements
+
+- [IEquatable\<SourceLinkInfo\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### SourceLinkInfo(IReadOnlyList\<SourceLinkMapping\>)
+
+Source Link mappings decoded from portable PDB custom debug information.
+
+**Parameters:**
+
+- `Mappings` ([IReadOnlyList\<SourceLinkMapping\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): The document pattern to URL template mappings.
+
+```csharp
+public SourceLinkInfo(IReadOnlyList<SourceLinkMapping> Mappings)
+```
+
+## Properties
+
+### IsPresent
+
+Gets whether Source Link data was present.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool IsPresent { get; }
+```
+
+### Mappings
+
+The document pattern to URL template mappings.
+
+**Returns:** [IReadOnlyList\<SourceLinkMapping\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<SourceLinkMapping> Mappings { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SourceLinkMapping.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SourceLinkMapping.md
@@ -1,0 +1,63 @@
+---
+title: "SourceLinkMapping"
+description: "A single Source Link document mapping."
+slug: api/dotsider.core.analysis.models.sourcelinkmapping
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+A single Source Link document mapping.
+
+```csharp
+public sealed record SourceLinkMapping : IEquatable<SourceLinkMapping>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **SourceLinkMapping**
+
+## Implements
+
+- [IEquatable\<SourceLinkMapping\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### SourceLinkMapping(string, string)
+
+A single Source Link document mapping.
+
+**Parameters:**
+
+- `DocumentPattern` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The document path pattern.
+- `UrlTemplate` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The URL template.
+
+```csharp
+public SourceLinkMapping(string DocumentPattern, string UrlTemplate)
+```
+
+## Properties
+
+### DocumentPattern
+
+The document path pattern.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string DocumentPattern { get; init; }
+```
+
+### UrlTemplate
+
+The URL template.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string UrlTemplate { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models.md
@@ -165,6 +165,14 @@ Information about a custom attribute applied to a metadata entity.
 public sealed record CustomAttributeInfo : IEquatable<CustomAttributeInfo>
 ```
 
+### [DebugDirectoryInfo](/api/dotsider.core.analysis.models.debugdirectoryinfo/)
+
+Display-ready PE debug directory entry information.
+
+```csharp
+public sealed record DebugDirectoryInfo : IEquatable<DebugDirectoryInfo>
+```
+
 ### [DependencyGraphResult](/api/dotsider.core.analysis.models.dependencygraphresult/)
 
 The result of building a transitive assembly dependency graph. Contains the public topology
@@ -189,6 +197,14 @@ Summary statistics for the diff.
 
 ```csharp
 public sealed record DiffSummary : IEquatable<DiffSummary>
+```
+
+### [EmbeddedSourceInfo](/api/dotsider.core.analysis.models.embeddedsourceinfo/)
+
+Embedded source decoded from a portable PDB document.
+
+```csharp
+public sealed record EmbeddedSourceInfo : IEquatable<EmbeddedSourceInfo>
 ```
 
 ### [FieldDefInfo](/api/dotsider.core.analysis.models.fielddefinfo/)
@@ -330,12 +346,28 @@ reuse: only one filesystem read per loaded identity.
 public sealed record LoadedAssemblyEntry : IEquatable<LoadedAssemblyEntry>
 ```
 
+### [LocalSlotInfo](/api/dotsider.core.analysis.models.localslotinfo/)
+
+A PDB local variable slot and the IL range where its name is active.
+
+```csharp
+public sealed record LocalSlotInfo : IEquatable<LocalSlotInfo>
+```
+
 ### [MemberRefInfo](/api/dotsider.core.analysis.models.memberrefinfo/)
 
 Information about a referenced member (method or field) from the MemberRef metadata table.
 
 ```csharp
 public sealed record MemberRefInfo : IEquatable<MemberRefInfo>
+```
+
+### [MethodDebugInfo](/api/dotsider.core.analysis.models.methoddebuginfo/)
+
+Portable PDB debug information for a method.
+
+```csharp
+public sealed record MethodDebugInfo : IEquatable<MethodDebugInfo>
 ```
 
 ### [MethodDefInfo](/api/dotsider.core.analysis.models.methoddefinfo/)
@@ -382,6 +414,14 @@ A line of output captured from the traced process's stdout or stderr.
 
 ```csharp
 public sealed record OutputLine : IEquatable<OutputLine>
+```
+
+### [PdbProvenance](/api/dotsider.core.analysis.models.pdbprovenance/)
+
+Describes where portable PDB information was found, or why it could not be used.
+
+```csharp
+public sealed record PdbProvenance : IEquatable<PdbProvenance>
 ```
 
 ### [PeHeaders](/api/dotsider.core.analysis.models.peheaders/)
@@ -432,12 +472,36 @@ Information about a single PE section (e.g., .text, .rsrc, .reloc).
 public sealed record SectionInfo : IEquatable<SectionInfo>
 ```
 
+### [SequencePointInfo](/api/dotsider.core.analysis.models.sequencepointinfo/)
+
+A source sequence point decoded from a portable PDB.
+
+```csharp
+public sealed record SequencePointInfo : IEquatable<SequencePointInfo>
+```
+
 ### [SizeNode](/api/dotsider.core.analysis.models.sizenode/)
 
 A node in the size treemap hierarchy. Can be assembly, namespace, type, or method.
 
 ```csharp
 public sealed record SizeNode : IEquatable<SizeNode>
+```
+
+### [SourceLinkInfo](/api/dotsider.core.analysis.models.sourcelinkinfo/)
+
+Source Link mappings decoded from portable PDB custom debug information.
+
+```csharp
+public sealed record SourceLinkInfo : IEquatable<SourceLinkInfo>
+```
+
+### [SourceLinkMapping](/api/dotsider.core.analysis.models.sourcelinkmapping/)
+
+A single Source Link document mapping.
+
+```csharp
+public sealed record SourceLinkMapping : IEquatable<SourceLinkMapping>
 ```
 
 ### [StringEntry](/api/dotsider.core.analysis.models.stringentry/)
@@ -535,6 +599,14 @@ runs on `v2.0.50727`); [Clr4](/api/dotsider.core.analysis.models.netfxruntimever
 
 ```csharp
 public enum NetFxRuntimeVersion
+```
+
+### [PdbProvenanceKind](/api/dotsider.core.analysis.models.pdbprovenancekind/)
+
+Portable PDB discovery outcomes that are meaningful to .NET developers.
+
+```csharp
+public enum PdbProvenanceKind
 ```
 
 ### [PolicyLayer](/api/dotsider.core.analysis.models.policylayer/)

--- a/docs/src/content/docs/api/Dotsider-Core-Protocol-DotsiderRequest.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Protocol-DotsiderRequest.md
@@ -62,6 +62,16 @@ Trace event category filter.
 public string? CategoryFilter { get; set; }
 ```
 
+### IncludeDebugInfo
+
+Whether IL responses should include portable PDB debug information.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool IncludeDebugInfo { get; set; }
+```
+
 ### LeftPath
 
 Left assembly path for diff.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -33,6 +33,7 @@ dotsider analyze MyLib.dll                    # assembly info (default)
 dotsider analyze MyLib.dll --types            # list type definitions
 dotsider analyze MyLib.dll --methods          # list method definitions
 dotsider analyze MyLib.dll --il Type.Method   # disassemble a method
+dotsider analyze MyLib.dll --embedded-source Type.Method # print embedded source
 dotsider analyze MyLib.dll --deps             # assembly references
 dotsider analyze MyLib.dll --strings          # extract strings
 dotsider analyze MyLib.dll --fields           # list field definitions
@@ -46,11 +47,14 @@ dotsider analyze MyApp                        # single-file bundle → extracts 
 
 If the file is a native apphost with a companion `.dll`, `analyze` auto-redirects. If it's a self-contained single-file bundle, `analyze` extracts the entry assembly from the bundle. Both cases print a note to stderr.
 
+When portable PDB data is available, default output reports where it came from, and `--il` includes source spans, local names, and Source Link markers. Use `--json` when you need the exact URLs. `--embedded-source` prints source embedded in the PDB.
+
 | Option | Description |
 |--------|-------------|
 | `--types` | List type definitions |
 | `--methods` | List method definitions |
 | `--il <name>` | Disassemble a specific method |
+| `--embedded-source <name>` | Print embedded source for a method |
 | `--deps` | Show assembly references |
 | `--strings` | Extract strings |
 | `--fields` | List field definitions |

--- a/docs/src/content/docs/reference/keyboard.md
+++ b/docs/src/content/docs/reference/keyboard.md
@@ -38,6 +38,7 @@ description: All keyboard shortcuts for navigating dotsider.
 | `Esc` | Go back from go-to-definition |
 | `x` | Jump to method body in Hex Dump |
 | `o` | Open embedded source for the selected method, when available |
+| `u` | Copy Source Link URL from a `[source link]` marker |
 | `l` | Focus the IL disassembly editor |
 
 ## Hex Dump tab — Normal mode

--- a/docs/src/content/docs/reference/keyboard.md
+++ b/docs/src/content/docs/reference/keyboard.md
@@ -37,6 +37,7 @@ description: All keyboard shortcuts for navigating dotsider.
 | `Enter` / `gd` | Go to definition (on a token-bearing instruction) |
 | `Esc` | Go back from go-to-definition |
 | `x` | Jump to method body in Hex Dump |
+| `o` | Open embedded source for the selected method, when available |
 | `l` | Focus the IL disassembly editor |
 
 ## Hex Dump tab — Normal mode

--- a/docs/src/content/docs/reference/mcp.md
+++ b/docs/src/content/docs/reference/mcp.md
@@ -51,13 +51,13 @@ Add to your MCP client configuration (e.g. `.mcp.json` for Claude Code):
 
 ## What it provides
 
-**38 tools** across:
+**40 tools** across:
 
 | Category | Tools |
 |----------|-------|
 | Assembly analysis | `get_assembly_info`, `list_types`, `list_methods`, `find_members` |
 | Field analysis | `list_fields` |
-| IL disassembly | `disassemble_method`, `search_il_opcodes` |
+| IL disassembly | `disassemble_method`, `get_method_debug_info`, `get_source_link`, `search_il_opcodes` |
 | Metadata inspection | `get_pe_headers`, `get_clr_header`, `get_sections`, `get_custom_attributes`, `get_resources`, `resolve_token` |
 | Dependencies | `get_assembly_refs`, `get_dependency_graph`, `get_type_refs` |
 | Size analysis | `get_size_breakdown`, `get_largest_methods` |
@@ -75,7 +75,7 @@ Tools work in two modes:
 - **Direct mode** — pass an assembly path, get results (no TUI needed)
 - **Session mode** — connect to a running dotsider TUI via Unix domain socket for live state, tracing, and navigation
 
-Single-file executables and native apphosts are handled transparently in direct mode — the server extracts the entry assembly from bundles and redirects apphosts to their companion DLLs, matching CLI and TUI behavior.
+Single-file executables and native apphosts are handled transparently in direct mode — the server extracts the entry assembly from bundles and redirects apphosts to their companion DLLs, matching CLI and TUI behavior. Portable PDB data is exposed when present, including provenance, Source Link mappings, sequence points, and local names.
 
 Session sockets are access-controlled. The socket directory and socket file are restricted to the current user on all platforms, connections are verified against the process owner, and a versioned protocol rejects mismatched clients. Concurrent connections are capped at four per session.
 

--- a/docs/src/content/docs/usage/general.md
+++ b/docs/src/content/docs/usage/general.md
@@ -10,6 +10,7 @@ The **General** tab (`1`) is the first thing you see when opening an assembly. I
 - **Assembly identity** — name, version, culture, public key token
 - **Target framework** — which .NET version the assembly targets
 - **Architecture** — AnyCPU, x64, ARM64, etc.
+- **PDB summary** — whether portable debug information came from a sidecar, an embedded PDB, or was unavailable
 - **Dependency table** — all referenced assemblies with their versions
 
 ## Text selection and copy

--- a/docs/src/content/docs/usage/il-inspector.md
+++ b/docs/src/content/docs/usage/il-inspector.md
@@ -13,7 +13,7 @@ Each instruction shows:
 - **Opcode** — the IL instruction
 - **Operand** — decoded metadata tokens, string literals, branch targets
 
-When a portable PDB is available, the disassembly also shows PDB provenance, source spans, Source Link markers, and local variable names. Embedded source documents can be opened from selected methods.
+When a portable PDB is available, the disassembly also shows PDB provenance, source spans, Source Link markers, and local variable names. Press `u` on a `[source link]` marker to copy the resolved URL. Embedded source documents can be opened from selected methods.
 
 ## Go to definition
 

--- a/docs/src/content/docs/usage/il-inspector.md
+++ b/docs/src/content/docs/usage/il-inspector.md
@@ -13,6 +13,8 @@ Each instruction shows:
 - **Opcode** — the IL instruction
 - **Operand** — decoded metadata tokens, string literals, branch targets
 
+When a portable PDB is available, the disassembly also shows PDB provenance, source spans, Source Link markers, and local variable names. Embedded source documents can be opened from selected methods.
+
 ## Go to definition
 
 Press `Enter` or `gd` while the cursor is on a token-bearing instruction (`call`, `callvirt`, `newobj`, `ldfld`, `castclass`, etc.) to navigate to the target. Navigable operands are underlined.
@@ -27,6 +29,7 @@ Press `Esc` to go back. The previous IL bytecode, cursor position, tree expansio
 ## Cross-tab navigation
 
 - Press `x` on a selected method to jump to its body in the **Hex Dump** tab. The hex view scrolls to the method's RVA.
+- Press `o` on a selected method to open embedded source when the PDB carries it.
 - Press `Esc` to return to where you came from.
 
 ## Copy

--- a/docs/src/content/docs/usage/pe-metadata.md
+++ b/docs/src/content/docs/usage/pe-metadata.md
@@ -15,6 +15,7 @@ The **PE / Metadata** tab (`2`) exposes the raw structure of the Portable Execut
 - **AssemblyRefs** — referenced assembly metadata
 - **Custom attributes** — applied attributes with decoded arguments
 - **Resources** — embedded resources with names and sizes
+- **Debug Directory** — CodeView, embedded portable PDB, checksum, and reproducible-build entries
 
 ## Text selection and copy
 

--- a/samples/EmbeddedSourceLib/EmbeddedSourceFixture.cs
+++ b/samples/EmbeddedSourceLib/EmbeddedSourceFixture.cs
@@ -1,0 +1,10 @@
+namespace EmbeddedSourceLib;
+
+internal static class EmbeddedSourceFixture
+{
+    internal static int Compute(int value)
+    {
+        var doubled = value * 2;
+        return doubled + 1;
+    }
+}

--- a/samples/EmbeddedSourceLib/EmbeddedSourceLib.csproj
+++ b/samples/EmbeddedSourceLib/EmbeddedSourceLib.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DebugType>embedded</DebugType>
+    <EmbedAllSources>true</EmbedAllSources>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/samples/README.md
+++ b/samples/README.md
@@ -16,6 +16,7 @@ Sample .NET projects used as test fixtures for dotsider's analysis, diff, and tr
 | [Dotted.Name.App](Dotted.Name.App/) | Console app | Dotted assembly name for cross-platform apphost detection testing |
 | [SelfContainedConsole](SelfContainedConsole/) | Console app (single-file) | Self-contained single-file bundle for bundle reading and resolution testing |
 | [AppLocalRollForward](AppLocalRollForward/) | Library | Reproduces the AppLocal framework-PKT roll-forward scenario: TraceEvent's stale `AssemblyRef` to `Microsoft.Diagnostics.NETCore.Client v0.2.10.10501` paired with a higher app-local deployment (`v0.2.13.11903`) under the same well-known framework PKT |
+| [EmbeddedSourceLib](EmbeddedSourceLib/) | Library | Embedded portable PDB source fixture for source navigation and CLI extraction tests |
 | [NetFxBindingRedirects](NetFxBindingRedirects/) | Console app (.NET Fx) | Runtime oracle for `NetFxBinder`: GAC + framework runtime + binding redirects + `<probing privatePath>` + `<codeBase>` (success and missing) + culture-aware probing |
 | [NetFxBindingRedirects.OldDep](NetFxBindingRedirects.OldDep/) | Library (.NET Fx) | Compiled against Newtonsoft.Json 12.0.1 — drives transitive binding-redirect tests |
 | [NetFxBindingRedirects.NewDep](NetFxBindingRedirects.NewDep/) | Library (.NET Fx) | Compiled against Newtonsoft.Json 13.0.3 — pairs with OldDep to prove two requested versions collapse to one bound graph node |

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -18,6 +18,8 @@ public sealed class AssemblyAnalyzer : IDisposable
     private readonly Stream _stream;
     private readonly PEReader? _peReader;
     private readonly MetadataReader? _metadataReader;
+    private MetadataReaderProvider? _pdbReaderProvider;
+    private MetadataReader? _pdbReader;
     private readonly byte[] _rawBytes;
     private volatile bool _disposed;
 
@@ -30,6 +32,8 @@ public sealed class AssemblyAnalyzer : IDisposable
     private IReadOnlyList<CustomAttributeInfo>? _customAttributes;
     private IReadOnlyList<ResourceInfo>? _resources;
     private IReadOnlyList<SectionInfo>? _sections;
+    private IReadOnlyList<DebugDirectoryInfo>? _debugDirectory;
+    private SourceLinkInfo? _sourceLink;
     private string? _preferredRuntimePack;
 
     /// <summary>
@@ -65,6 +69,7 @@ public sealed class AssemblyAnalyzer : IDisposable
 
             ReadPeHeaders();
             ReadClrHeader();
+            ReadDebugInformation();
         }
         catch (BadImageFormatException) when (IsNativeExecutable(_rawBytes))
         {
@@ -126,6 +131,7 @@ public sealed class AssemblyAnalyzer : IDisposable
 
             ReadPeHeaders();
             ReadClrHeader();
+            ReadDebugInformation();
         }
         catch (BadImageFormatException) when (IsNativeExecutable(_rawBytes))
         {
@@ -192,6 +198,13 @@ public sealed class AssemblyAnalyzer : IDisposable
     /// <summary>Whether the PE file contains .NET metadata.</summary>
     public bool HasMetadata => _metadataReader is not null;
 
+    /// <summary>Portable PDB provenance for the analyzed assembly.</summary>
+    public PdbProvenance PdbProvenance { get; private set; } =
+        new(PdbProvenanceKind.NoDebugDirectory);
+
+    /// <summary>Gets whether a portable PDB was opened.</summary>
+    public bool HasPortablePdb => _pdbReader is not null;
+
     /// <summary>
     /// If this assembly was loaded from a single-file bundle, the path to the bundle file.
     /// Used as resolution context when probing for referenced assemblies.
@@ -228,6 +241,26 @@ public sealed class AssemblyAnalyzer : IDisposable
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
             return _sections ??= ReadSections();
+        }
+    }
+
+    /// <summary>Gets the PE debug directory entries.</summary>
+    public IReadOnlyList<DebugDirectoryInfo> DebugDirectory
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _debugDirectory ??= ReadDebugDirectory();
+        }
+    }
+
+    /// <summary>Gets decoded Source Link information from the portable PDB.</summary>
+    public SourceLinkInfo SourceLink
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _sourceLink ??= PortablePdbUtilities.ReadSourceLink(_pdbReader);
         }
     }
 
@@ -335,6 +368,84 @@ public sealed class AssemblyAnalyzer : IDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         return _metadataReader;
+    }
+
+    /// <summary>
+    /// Gets the portable PDB <see cref="MetadataReader"/>, or null when no portable PDB is available.
+    /// </summary>
+    public MetadataReader? GetPdbReader()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _pdbReader;
+    }
+
+    /// <summary>
+    /// Gets portable PDB debug information for a method definition.
+    /// </summary>
+    /// <param name="method">The method definition to inspect.</param>
+    /// <returns>Decoded portable PDB information, or an empty result when no portable PDB is available.</returns>
+    public MethodDebugInfo GetMethodDebugInfo(MethodDefInfo method)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_pdbReader is null)
+            return new MethodDebugInfo(method.Token, PdbProvenance, [], []);
+
+        try
+        {
+            var methodHandle = (MethodDefinitionHandle)MetadataTokens.EntityHandle(method.Token);
+            var methodDebug = _pdbReader.GetMethodDebugInformation(methodHandle);
+            var sequencePoints = ReadSequencePoints(methodDebug);
+            var locals = ReadLocalSlots(methodHandle);
+            return new MethodDebugInfo(method.Token, PdbProvenance, sequencePoints, locals);
+        }
+        catch (Exception ex) when (ex is ArgumentException or BadImageFormatException)
+        {
+            return new MethodDebugInfo(method.Token, PdbProvenance, [], []);
+        }
+    }
+
+    /// <summary>
+    /// Resolves a portable PDB document path through Source Link mappings.
+    /// </summary>
+    /// <param name="documentPath">The document path from the portable PDB.</param>
+    /// <returns>The resolved Source Link URL, or null when no mapping applies.</returns>
+    public string? ResolveSourceLinkUrl(string documentPath)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return PortablePdbUtilities.ResolveSourceLinkUrl(SourceLink, documentPath);
+    }
+
+    /// <summary>
+    /// Gets embedded source for a portable PDB document path.
+    /// </summary>
+    /// <param name="documentPath">The document path from the portable PDB.</param>
+    /// <returns>The decoded embedded source, or null when the document has none.</returns>
+    public EmbeddedSourceInfo? GetEmbeddedSource(string documentPath)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return PortablePdbUtilities.ReadEmbeddedSource(_pdbReader, documentPath);
+    }
+
+    /// <summary>
+    /// Gets the first embedded source document referenced by a method's sequence points.
+    /// </summary>
+    /// <param name="method">The method whose source should be resolved.</param>
+    /// <returns>The decoded embedded source, or null when none is available.</returns>
+    public EmbeddedSourceInfo? GetEmbeddedSource(MethodDefInfo method)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var debugInfo = GetMethodDebugInfo(method);
+        foreach (var sequencePoint in debugInfo.SequencePoints)
+        {
+            if (sequencePoint.Document is { Length: > 0 } document
+                && sequencePoint.HasEmbeddedSource
+                && GetEmbeddedSource(document) is { } source)
+            {
+                return source;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -509,6 +620,7 @@ public sealed class AssemblyAnalyzer : IDisposable
     public void Dispose()
     {
         _disposed = true;
+        _pdbReaderProvider?.Dispose();
         _peReader?.Dispose();
         _stream.Dispose();
     }
@@ -624,6 +736,336 @@ public sealed class AssemblyAnalyzer : IDisposable
             ResourcesSize: corHeader.ResourcesDirectory.Size,
             StrongNameSignatureRva: corHeader.StrongNameSignatureDirectory.RelativeVirtualAddress,
             StrongNameSignatureSize: corHeader.StrongNameSignatureDirectory.Size);
+    }
+
+    private void ReadDebugInformation()
+    {
+        if (_peReader is null)
+        {
+            _debugDirectory = [];
+            PdbProvenance = new PdbProvenance(PdbProvenanceKind.NoDebugDirectory);
+            return;
+        }
+
+        _debugDirectory = ReadDebugDirectory();
+        OpenPortablePdb();
+        _sourceLink = PortablePdbUtilities.ReadSourceLink(_pdbReader);
+    }
+
+    private List<DebugDirectoryInfo> ReadDebugDirectory()
+    {
+        if (_peReader is null) return [];
+
+        var entries = _peReader.ReadDebugDirectory();
+        return [.. entries.Select(entry => new DebugDirectoryInfo(
+            Type: entry.Type,
+            Stamp: entry.Stamp,
+            MajorVersion: entry.MajorVersion,
+            MinorVersion: entry.MinorVersion,
+            DataSize: entry.DataSize,
+            AddressOfRawData: entry.DataRelativeVirtualAddress,
+            PointerToRawData: entry.DataPointer,
+            Payload: FormatDebugDirectoryPayload(entry)))];
+    }
+
+    private string FormatDebugDirectoryPayload(DebugDirectoryEntry entry)
+    {
+        if (_peReader is null) return "";
+
+        try
+        {
+            return entry.Type switch
+            {
+                DebugDirectoryEntryType.CodeView => FormatCodeViewPayload(entry),
+                DebugDirectoryEntryType.Reproducible => "present",
+                DebugDirectoryEntryType.PdbChecksum => FormatPdbChecksumPayload(entry),
+                DebugDirectoryEntryType.EmbeddedPortablePdb => FormatEmbeddedPortablePdbPayload(entry),
+                _ => ""
+            };
+        }
+        catch (Exception ex) when (ex is ArgumentException or BadImageFormatException or IOException)
+        {
+            return $"unreadable: {ex.Message}";
+        }
+    }
+
+    private string FormatCodeViewPayload(DebugDirectoryEntry entry)
+    {
+        var data = _peReader!.ReadCodeViewDebugDirectoryData(entry);
+        var format = entry.IsPortableCodeView ? "Portable PDB" : "Windows/non-portable PDB";
+        return $"{format}; PDB GUID: {data.Guid}; age: {data.Age}; path: {data.Path}";
+    }
+
+    private string FormatPdbChecksumPayload(DebugDirectoryEntry entry)
+    {
+        var data = _peReader!.ReadPdbChecksumDebugDirectoryData(entry);
+        return $"Algorithm: {data.AlgorithmName}; checksum: {Convert.ToHexString([.. data.Checksum])}";
+    }
+
+    private string FormatEmbeddedPortablePdbPayload(DebugDirectoryEntry entry)
+    {
+        var uncompressedSize = entry.DataPointer >= 0 && entry.DataPointer + 4 <= _rawBytes.Length
+            ? BitConverter.ToInt32(_rawBytes, entry.DataPointer)
+            : -1;
+        return uncompressedSize >= 0
+            ? $"present; uncompressed size: {uncompressedSize} bytes"
+            : "present";
+    }
+
+    private void OpenPortablePdb()
+    {
+        if (_peReader is null)
+        {
+            PdbProvenance = new PdbProvenance(PdbProvenanceKind.NoDebugDirectory);
+            return;
+        }
+
+        var entries = _peReader.ReadDebugDirectory();
+        if (entries.Length == 0)
+        {
+            PdbProvenance = new PdbProvenance(PdbProvenanceKind.NoDebugDirectory);
+            return;
+        }
+
+        if (!IsBundleBacked && TryOpenAssociatedPortablePdb())
+            return;
+
+        var embeddedEntry = entries.FirstOrDefault(e => e.Type == DebugDirectoryEntryType.EmbeddedPortablePdb);
+        if (embeddedEntry.Type == DebugDirectoryEntryType.EmbeddedPortablePdb
+            && TryOpenEmbeddedPortablePdb(embeddedEntry))
+        {
+            return;
+        }
+
+        var codeViewEntry = entries.FirstOrDefault(e => e.Type == DebugDirectoryEntryType.CodeView);
+        if (codeViewEntry.Type != DebugDirectoryEntryType.CodeView)
+        {
+            PdbProvenance = new PdbProvenance(PdbProvenanceKind.NoDebugDirectory);
+            return;
+        }
+
+        CodeViewDebugDirectoryData codeViewData;
+        try
+        {
+            codeViewData = _peReader.ReadCodeViewDebugDirectoryData(codeViewEntry);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or IOException)
+        {
+            PdbProvenance = new PdbProvenance(
+                PdbProvenanceKind.UnsupportedWindowsPdb,
+                Details: $"UnsupportedWindowsPdb ({ex.Message})");
+            return;
+        }
+
+        if (!codeViewEntry.IsPortableCodeView)
+        {
+            PdbProvenance = new PdbProvenance(
+                PdbProvenanceKind.UnsupportedWindowsPdb,
+                codeViewData.Path,
+                $"UnsupportedWindowsPdb ({codeViewData.Path})");
+            return;
+        }
+
+        if (IsBundleBacked)
+        {
+            PdbProvenance = new PdbProvenance(
+                PdbProvenanceKind.BundleSidecarSkipped,
+                codeViewData.Path,
+                "BundleSidecarSkipped (sidecar probing skipped for bundle-backed assembly)");
+            return;
+        }
+
+        var probePaths = GetSidecarProbePaths(codeViewData.Path);
+        var foundPath = probePaths.FirstOrDefault(File.Exists);
+        if (foundPath is null)
+        {
+            var expected = probePaths.Count > 0 ? probePaths[0] : codeViewData.Path;
+            PdbProvenance = new PdbProvenance(
+                PdbProvenanceKind.CodeViewSidecarMissing,
+                expected,
+                $"CodeViewSidecarMissing ({expected})");
+            return;
+        }
+
+        if (!TryOpenPortablePdbFile(foundPath, codeViewData.Guid, codeViewData.Age, out var mismatch))
+        {
+            PdbProvenance = mismatch
+                ? new PdbProvenance(
+                    PdbProvenanceKind.CodeViewSidecarMismatched,
+                    foundPath,
+                    $"CodeViewSidecarMismatched ({foundPath})")
+                : new PdbProvenance(
+                    PdbProvenanceKind.UnsupportedWindowsPdb,
+                    foundPath,
+                    $"UnsupportedWindowsPdb ({foundPath})");
+        }
+    }
+
+    private bool TryOpenAssociatedPortablePdb()
+    {
+        if (_peReader is null) return false;
+
+        try
+        {
+            if (!_peReader.TryOpenAssociatedPortablePdb(
+                    FilePath,
+                    path => File.Exists(path) ? File.OpenRead(path) : null,
+                    out var provider,
+                    out var pdbPath))
+            {
+                return false;
+            }
+
+            _pdbReaderProvider = provider;
+            if (_pdbReaderProvider is null)
+                return false;
+
+            _pdbReader = _pdbReaderProvider.GetMetadataReader();
+            PdbProvenance = pdbPath is null
+                ? new PdbProvenance(PdbProvenanceKind.Embedded)
+                : new PdbProvenance(PdbProvenanceKind.Sidecar, pdbPath);
+            return true;
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or IOException or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private bool TryOpenEmbeddedPortablePdb(DebugDirectoryEntry entry)
+    {
+        if (_peReader is null) return false;
+
+        try
+        {
+            _pdbReaderProvider = _peReader.ReadEmbeddedPortablePdbDebugDirectoryData(entry);
+            _pdbReader = _pdbReaderProvider.GetMetadataReader();
+            PdbProvenance = new PdbProvenance(PdbProvenanceKind.Embedded);
+            return true;
+        }
+        catch (Exception ex) when (ex is ArgumentException or BadImageFormatException or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private bool TryOpenPortablePdbFile(string path, Guid expectedGuid, int expectedAge, out bool mismatched)
+    {
+        mismatched = false;
+        FileStream? stream = null;
+        MetadataReaderProvider? provider = null;
+        try
+        {
+            stream = File.OpenRead(path);
+            provider = MetadataReaderProvider.FromPortablePdbStream(stream);
+            var reader = provider.GetMetadataReader();
+            if (!PortablePdbUtilities.PortablePdbIdMatches(reader, expectedGuid, expectedAge))
+            {
+                mismatched = true;
+                provider.Dispose();
+                return false;
+            }
+
+            _pdbReaderProvider = provider;
+            _pdbReader = reader;
+            PdbProvenance = new PdbProvenance(PdbProvenanceKind.Sidecar, path);
+            return true;
+        }
+        catch (BadImageFormatException)
+        {
+            provider?.Dispose();
+            stream?.Dispose();
+            return false;
+        }
+        catch (IOException)
+        {
+            provider?.Dispose();
+            stream?.Dispose();
+            return false;
+        }
+    }
+
+    private List<string> GetSidecarProbePaths(string codeViewPath)
+    {
+        var paths = new List<string>();
+        var assemblyDirectory = Path.GetDirectoryName(FilePath);
+        var codeViewFileName = Path.GetFileName(codeViewPath);
+
+        if (!string.IsNullOrEmpty(assemblyDirectory) && !string.IsNullOrEmpty(codeViewFileName))
+            paths.Add(Path.Combine(assemblyDirectory, codeViewFileName));
+
+        var defaultPath = Path.ChangeExtension(FilePath, ".pdb");
+        if (!paths.Contains(defaultPath, StringComparer.OrdinalIgnoreCase))
+            paths.Add(defaultPath);
+
+        if (Path.IsPathFullyQualified(codeViewPath)
+            && !paths.Contains(codeViewPath, StringComparer.OrdinalIgnoreCase))
+        {
+            paths.Add(codeViewPath);
+        }
+
+        return paths;
+    }
+
+    private List<SequencePointInfo> ReadSequencePoints(MethodDebugInformation methodDebug)
+    {
+        if (_pdbReader is null) return [];
+
+        var points = new List<SequencePointInfo>();
+        foreach (var point in methodDebug.GetSequencePoints())
+        {
+            var documentHandle = point.Document.IsNil ? methodDebug.Document : point.Document;
+            string? documentPath = null;
+            if (!documentHandle.IsNil)
+            {
+                var document = _pdbReader.GetDocument(documentHandle);
+                documentPath = _pdbReader.GetString(document.Name);
+            }
+
+            var sourceLinkUrl = documentPath is null ? null : ResolveSourceLinkUrl(documentPath);
+            var hasEmbeddedSource = PortablePdbUtilities.HasEmbeddedSource(_pdbReader, documentPath);
+            points.Add(new SequencePointInfo(
+                Offset: point.Offset,
+                Document: documentPath,
+                StartLine: point.StartLine,
+                StartColumn: point.StartColumn,
+                EndLine: point.EndLine,
+                EndColumn: point.EndColumn,
+                IsHidden: point.IsHidden,
+                SourceLinkUrl: sourceLinkUrl,
+                HasEmbeddedSource: hasEmbeddedSource));
+        }
+
+        return points;
+    }
+
+    private IReadOnlyList<LocalSlotInfo> ReadLocalSlots(MethodDefinitionHandle methodHandle)
+    {
+        if (_pdbReader is null) return [];
+
+        var locals = new List<LocalSlotInfo>();
+        foreach (var scopeHandle in _pdbReader.GetLocalScopes(methodHandle))
+        {
+            var scope = _pdbReader.GetLocalScope(scopeHandle);
+            foreach (var variableHandle in scope.GetLocalVariables())
+            {
+                var variable = _pdbReader.GetLocalVariable(variableHandle);
+                var name = _pdbReader.GetString(variable.Name);
+                if (string.IsNullOrEmpty(name)) continue;
+
+                locals.Add(new LocalSlotInfo(
+                    Slot: variable.Index,
+                    Name: name,
+                    StartOffset: scope.StartOffset,
+                    EndOffset: scope.StartOffset + scope.Length,
+                    IsDebuggerHidden: variable.Attributes.HasFlag(LocalVariableAttributes.DebuggerHidden)));
+            }
+        }
+
+        return [.. locals
+            .OrderBy(local => local.Slot)
+            .ThenBy(local => local.EndOffset - local.StartOffset)
+            .ThenBy(local => local.StartOffset)];
     }
 
     private List<SectionInfo> ReadSections()

--- a/src/Dotsider.Core/Analysis/IlDisassembler.cs
+++ b/src/Dotsider.Core/Analysis/IlDisassembler.cs
@@ -26,6 +26,10 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
         var instructions = new List<IlInstruction>();
         var ilBytes = body.GetILBytes();
         if (ilBytes is null) return [];
+        var debugInfo = analyzer.GetMethodDebugInfo(method);
+        var sequencePointsByOffset = debugInfo.SequencePoints
+            .GroupBy(point => point.Offset)
+            .ToDictionary(group => group.Key, group => group.First());
 
         var offset = 0;
         while (offset < ilBytes.Length)
@@ -47,6 +51,12 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
 
             var operandStart = offset;
             var operand = DecodeOperand(ilBytes, ref offset, opCode);
+            var localSlot = TryGetLocalSlot(opCode, ilBytes, operandStart);
+            var localName = localSlot is null
+                ? null
+                : ResolveLocalName(debugInfo.Locals, localSlot.Value, instructionOffset);
+            if (!string.IsNullOrEmpty(localName))
+                operand = string.IsNullOrEmpty(operand) ? $"// {localName}" : $"{operand} // {localName}";
 
             int? metadataToken = null;
             var operandKind = GetOperandType(opCode);
@@ -57,11 +67,22 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
                 metadataToken = BitConverter.ToInt32(ilBytes, operandStart);
             }
 
+            sequencePointsByOffset.TryGetValue(instructionOffset, out var sequencePoint);
             instructions.Add(new IlInstruction(
                 Offset: instructionOffset,
                 OpCode: FormatOpCode(opCode),
                 Operand: operand,
-                MetadataToken: metadataToken));
+                MetadataToken: metadataToken,
+                SequenceDocument: sequencePoint?.Document,
+                SequenceStartLine: sequencePoint?.StartLine,
+                SequenceStartColumn: sequencePoint?.StartColumn,
+                SequenceEndLine: sequencePoint?.EndLine,
+                SequenceEndColumn: sequencePoint?.EndColumn,
+                SequenceHidden: sequencePoint?.IsHidden == true,
+                SourceLinkUrl: sequencePoint?.SourceLinkUrl,
+                HasEmbeddedSource: sequencePoint?.HasEmbeddedSource == true,
+                LocalSlot: localSlot,
+                LocalName: localName));
         }
 
         return instructions;
@@ -74,31 +95,8 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
     /// <returns>A multi-line string with the full disassembly listing.</returns>
     public string FormatDisassembly(MethodDefInfo method)
     {
-        var body = analyzer.GetMethodBody(method);
-        if (body is null) return "// No IL body (abstract, extern, or native method)";
-
-        var lines = new List<string>
-        {
-            $"// Method: {method.DeclaringType}::{method.Name}",
-            $"// Signature: {method.Signature}",
-            $"// RVA: 0x{method.Rva:X8}",
-            $"// Code size: {body.GetILBytes()?.Length ?? 0} bytes",
-            $"// Max stack: {body.MaxStack}",
-        };
-        if (body.LocalSignature.IsNil is false)
-        {
-            lines.Add($"// Locals init: {!body.LocalVariablesInitialized}");
-        }
-        lines.Add("");
-
-        var instructions = Disassemble(method);
-        foreach (var inst in instructions)
-        {
-            var operandPart = string.IsNullOrEmpty(inst.Operand) ? "" : $" {inst.Operand}";
-            lines.Add($"IL_{inst.Offset:X4}: {inst.OpCode}{operandPart}");
-        }
-
-        return string.Join('\n', lines);
+        return DisassembleWithText(method)?.Text
+            ?? "// No IL body (abstract, extern, or native method)";
     }
 
     /// <summary>
@@ -113,25 +111,24 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
         if (body is null) return null;
 
         var instructions = Disassemble(method);
-        var lines = new List<string>
-        {
-            $"// Method: {method.DeclaringType}::{method.Name}",
-            $"// Signature: {method.Signature}",
-            $"// RVA: 0x{method.Rva:X8}",
-            $"// Code size: {body.GetILBytes()?.Length ?? 0} bytes",
-            $"// Max stack: {body.MaxStack}",
-        };
-        if (body.LocalSignature.IsNil is false)
-            lines.Add($"// Locals init: {!body.LocalVariablesInitialized}");
+        var debugInfo = analyzer.GetMethodDebugInfo(method);
+        var localTypes = DecodeLocalTypes(body.LocalSignature);
+        var lines = BuildHeaderLines(method, body, debugInfo, localTypes);
         lines.Add("");
 
         var headerLineCount = lines.Count;
+        var renderedInstructions = new List<IlInstruction>(instructions.Count);
         foreach (var inst in instructions)
         {
+            if (inst.SequenceStartLine is not null)
+                lines.Add(FormatSequencePointComment(inst));
+
             var operandPart = string.IsNullOrEmpty(inst.Operand) ? "" : $" {inst.Operand}";
+            var displayLine = lines.Count + 1;
             lines.Add($"IL_{inst.Offset:X4}: {inst.OpCode}{operandPart}");
+            renderedInstructions.Add(inst with { DisplayLine = displayLine });
         }
-        return (string.Join('\n', lines), instructions, headerLineCount);
+        return (string.Join('\n', lines), renderedInstructions, headerLineCount);
     }
 
     /// <summary>
@@ -143,10 +140,117 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
     {
         var body = analyzer.GetMethodBody(method);
         if (body is null) return 0;
-        var count = 5;
-        if (body.LocalSignature.IsNil is false) count++;
-        count++;
-        return count;
+        var debugInfo = analyzer.GetMethodDebugInfo(method);
+        var localTypes = DecodeLocalTypes(body.LocalSignature);
+        return BuildHeaderLines(method, body, debugInfo, localTypes).Count + 1;
+    }
+
+    private List<string> BuildHeaderLines(
+        MethodDefInfo method,
+        MethodBodyBlock body,
+        MethodDebugInfo debugInfo,
+        IReadOnlyList<string> localTypes)
+    {
+        var lines = new List<string>
+        {
+            $"// Method: {method.DeclaringType}::{method.Name}",
+            $"// Signature: {method.Signature}",
+            $"// RVA: 0x{method.Rva:X8}",
+            $"// Code size: {body.GetILBytes()?.Length ?? 0} bytes",
+            $"// Max stack: {body.MaxStack}",
+            $"// PDB: {analyzer.PdbProvenance}",
+        };
+
+        if (analyzer.SourceLink.IsPresent)
+            lines.Add($"// Source Link: present, {analyzer.SourceLink.Mappings.Count} mappings");
+
+        AddLocalSignatureLines(lines, body, debugInfo.Locals, localTypes);
+        return lines;
+    }
+
+    private static void AddLocalSignatureLines(
+        List<string> lines,
+        MethodBodyBlock body,
+        IReadOnlyList<LocalSlotInfo> locals,
+        IReadOnlyList<string> localTypes)
+    {
+        var highestPdbSlot = locals.Count == 0 ? -1 : locals.Max(local => local.Slot);
+        var localCount = Math.Max(localTypes.Count, highestPdbSlot + 1);
+        if (body.LocalSignature.IsNil && localCount == 0)
+            return;
+
+        lines.Add(body.LocalVariablesInitialized ? ".locals init (" : ".locals (");
+        for (var slot = 0; slot < localCount; slot++)
+        {
+            var type = slot < localTypes.Count ? localTypes[slot] : "?";
+            var name = locals.FirstOrDefault(local => local.Slot == slot)?.Name ?? $"V_{slot}";
+            var comma = slot == localCount - 1 ? "" : ",";
+            lines.Add($"    [{slot}] {type} {name}{comma}");
+        }
+        lines.Add(")");
+    }
+
+    private IReadOnlyList<string> DecodeLocalTypes(StandaloneSignatureHandle localSignature)
+    {
+        if (localSignature.IsNil) return [];
+
+        try
+        {
+            var signature = _reader.GetStandaloneSignature(localSignature);
+            return [.. signature.DecodeLocalSignature(
+                new AssemblyAnalyzer.SignatureTypeProvider(),
+                genericContext: default)];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static string FormatSequencePointComment(IlInstruction instruction)
+    {
+        if (instruction.SequenceHidden)
+            return "// (hidden)";
+
+        var document = instruction.SequenceDocument is { Length: > 0 }
+            ? Path.GetFileName(instruction.SequenceDocument)
+            : "(unknown)";
+        var line = $"// {document}({instruction.SequenceStartLine},{instruction.SequenceStartColumn})"
+            + $"-({instruction.SequenceEndLine},{instruction.SequenceEndColumn})";
+        if (!string.IsNullOrEmpty(instruction.SourceLinkUrl))
+            line += " [source link]";
+        if (instruction.HasEmbeddedSource)
+            line += " [embedded source]";
+        return line;
+    }
+
+    private static string? ResolveLocalName(IReadOnlyList<LocalSlotInfo> locals, int slot, int offset)
+    {
+        return locals
+            .Where(local => local.Slot == slot
+                && local.StartOffset <= offset
+                && offset < local.EndOffset
+                && !local.IsDebuggerHidden)
+            .OrderBy(local => local.EndOffset - local.StartOffset)
+            .ThenByDescending(local => local.StartOffset)
+            .Select(local => local.Name)
+            .FirstOrDefault();
+    }
+
+    private static int? TryGetLocalSlot(ILOpCode opCode, byte[] ilBytes, int operandStart)
+    {
+        return opCode switch
+        {
+            ILOpCode.Ldloc_0 or ILOpCode.Stloc_0 => 0,
+            ILOpCode.Ldloc_1 or ILOpCode.Stloc_1 => 1,
+            ILOpCode.Ldloc_2 or ILOpCode.Stloc_2 => 2,
+            ILOpCode.Ldloc_3 or ILOpCode.Stloc_3 => 3,
+            ILOpCode.Ldloc_s or ILOpCode.Ldloca_s or ILOpCode.Stloc_s
+                when operandStart < ilBytes.Length => ilBytes[operandStart],
+            ILOpCode.Ldloc or ILOpCode.Ldloca or ILOpCode.Stloc
+                when operandStart + 2 <= ilBytes.Length => BitConverter.ToUInt16(ilBytes, operandStart),
+            _ => null
+        };
     }
 
     private string DecodeOperand(byte[] ilBytes, ref int offset, ILOpCode opCode)
@@ -317,10 +421,12 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
             or ILOpCode.Leave
             => OperandKind.BranchTarget,
 
-        ILOpCode.Ldc_i4_s or ILOpCode.Ldarg_s or ILOpCode.Ldarga_s or ILOpCode.Starg_s
-            or ILOpCode.Ldloc_s or ILOpCode.Ldloca_s or ILOpCode.Stloc_s
-            or ILOpCode.Unaligned
+        ILOpCode.Ldc_i4_s or ILOpCode.Unaligned
             => OperandKind.ShortInlineI,
+
+        ILOpCode.Ldarg_s or ILOpCode.Ldarga_s or ILOpCode.Starg_s
+            or ILOpCode.Ldloc_s or ILOpCode.Ldloca_s or ILOpCode.Stloc_s
+            => OperandKind.ShortInlineVar,
 
         ILOpCode.Ldc_i4 => OperandKind.InlineI,
         ILOpCode.Ldc_i8 => OperandKind.InlineI8,

--- a/src/Dotsider.Core/Analysis/Models/DebugDirectoryInfo.cs
+++ b/src/Dotsider.Core/Analysis/Models/DebugDirectoryInfo.cs
@@ -1,0 +1,24 @@
+using System.Reflection.PortableExecutable;
+
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// Display-ready PE debug directory entry information.
+/// </summary>
+/// <param name="Type">The debug directory entry type.</param>
+/// <param name="Stamp">The entry stamp.</param>
+/// <param name="MajorVersion">The major debug format version.</param>
+/// <param name="MinorVersion">The minor debug format version.</param>
+/// <param name="DataSize">The payload size in bytes.</param>
+/// <param name="AddressOfRawData">The payload RVA.</param>
+/// <param name="PointerToRawData">The payload file pointer.</param>
+/// <param name="Payload">Inline payload summary for known entry types.</param>
+public sealed record DebugDirectoryInfo(
+    DebugDirectoryEntryType Type,
+    uint Stamp,
+    ushort MajorVersion,
+    ushort MinorVersion,
+    int DataSize,
+    int AddressOfRawData,
+    int PointerToRawData,
+    string Payload);

--- a/src/Dotsider.Core/Analysis/Models/EmbeddedSourceInfo.cs
+++ b/src/Dotsider.Core/Analysis/Models/EmbeddedSourceInfo.cs
@@ -1,0 +1,9 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// Embedded source decoded from a portable PDB document.
+/// </summary>
+/// <param name="Document">The PDB document path.</param>
+/// <param name="Text">The decoded source text.</param>
+/// <param name="Bytes">The decoded source bytes.</param>
+public sealed record EmbeddedSourceInfo(string Document, string Text, byte[] Bytes);

--- a/src/Dotsider.Core/Analysis/Models/IlInstruction.cs
+++ b/src/Dotsider.Core/Analysis/Models/IlInstruction.cs
@@ -7,8 +7,30 @@ namespace Dotsider.Core.Analysis.Models;
 /// <param name="OpCode">The IL opcode mnemonic (e.g., "ldstr", "call", "ret").</param>
 /// <param name="Operand">The decoded operand as a display string, or empty if the opcode takes no operand.</param>
 /// <param name="MetadataToken">The raw metadata token for token-bearing operands (methods, fields, types), or null.</param>
+/// <param name="SequenceDocument">The source document for a sequence point starting at this instruction, or null.</param>
+/// <param name="SequenceStartLine">The sequence point start line, or null.</param>
+/// <param name="SequenceStartColumn">The sequence point start column, or null.</param>
+/// <param name="SequenceEndLine">The sequence point end line, or null.</param>
+/// <param name="SequenceEndColumn">The sequence point end column, or null.</param>
+/// <param name="SequenceHidden">Whether the sequence point is hidden.</param>
+/// <param name="SourceLinkUrl">The Source Link URL resolved for the sequence point document, or null.</param>
+/// <param name="HasEmbeddedSource">Whether the sequence point document has embedded source.</param>
+/// <param name="LocalSlot">The local variable slot referenced by this instruction, or null.</param>
+/// <param name="LocalName">The active PDB local variable name for <paramref name="LocalSlot"/>, or null.</param>
+/// <param name="DisplayLine">The 1-based rendered line number in formatted disassembly, or null.</param>
 public sealed record IlInstruction(
     int Offset,
     string OpCode,
     string Operand,
-    int? MetadataToken = null);
+    int? MetadataToken = null,
+    string? SequenceDocument = null,
+    int? SequenceStartLine = null,
+    int? SequenceStartColumn = null,
+    int? SequenceEndLine = null,
+    int? SequenceEndColumn = null,
+    bool SequenceHidden = false,
+    string? SourceLinkUrl = null,
+    bool HasEmbeddedSource = false,
+    int? LocalSlot = null,
+    string? LocalName = null,
+    int? DisplayLine = null);

--- a/src/Dotsider.Core/Analysis/Models/LocalSlotInfo.cs
+++ b/src/Dotsider.Core/Analysis/Models/LocalSlotInfo.cs
@@ -1,0 +1,16 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// A PDB local variable slot and the IL range where its name is active.
+/// </summary>
+/// <param name="Slot">The local variable slot index.</param>
+/// <param name="Name">The local variable name.</param>
+/// <param name="StartOffset">The first IL offset where the name is active.</param>
+/// <param name="EndOffset">The exclusive end IL offset for the local scope.</param>
+/// <param name="IsDebuggerHidden">Whether the local is marked debugger-hidden.</param>
+public sealed record LocalSlotInfo(
+    int Slot,
+    string Name,
+    int StartOffset,
+    int EndOffset,
+    bool IsDebuggerHidden);

--- a/src/Dotsider.Core/Analysis/Models/MethodDebugInfo.cs
+++ b/src/Dotsider.Core/Analysis/Models/MethodDebugInfo.cs
@@ -1,0 +1,14 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// Portable PDB debug information for a method.
+/// </summary>
+/// <param name="MethodToken">The method definition metadata token.</param>
+/// <param name="Pdb">The portable PDB provenance.</param>
+/// <param name="SequencePoints">Decoded sequence points for the method.</param>
+/// <param name="Locals">Decoded local slots and PDB names for the method.</param>
+public sealed record MethodDebugInfo(
+    int MethodToken,
+    PdbProvenance Pdb,
+    IReadOnlyList<SequencePointInfo> SequencePoints,
+    IReadOnlyList<LocalSlotInfo> Locals);

--- a/src/Dotsider.Core/Analysis/Models/PdbProvenance.cs
+++ b/src/Dotsider.Core/Analysis/Models/PdbProvenance.cs
@@ -1,0 +1,26 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// Describes where portable PDB information was found, or why it could not be used.
+/// </summary>
+/// <param name="Kind">The resolved provenance category.</param>
+/// <param name="Path">The sidecar PDB path when one was used or probed.</param>
+/// <param name="Details">Additional diagnostic context for display surfaces.</param>
+public sealed record PdbProvenance(
+    PdbProvenanceKind Kind,
+    string? Path = null,
+    string? Details = null)
+{
+    /// <inheritdoc />
+    public override string ToString() => Kind switch
+    {
+        PdbProvenanceKind.Sidecar => Path is null ? "Sidecar" : $"Sidecar({Path})",
+        PdbProvenanceKind.Embedded => "Embedded",
+        PdbProvenanceKind.NoDebugDirectory => "NoDebugDirectory",
+        PdbProvenanceKind.CodeViewSidecarMissing => Details ?? "CodeViewSidecarMissing",
+        PdbProvenanceKind.CodeViewSidecarMismatched => Details ?? "CodeViewSidecarMismatched",
+        PdbProvenanceKind.UnsupportedWindowsPdb => Details ?? "UnsupportedWindowsPdb",
+        PdbProvenanceKind.BundleSidecarSkipped => Details ?? "BundleSidecarSkipped",
+        _ => Kind.ToString()
+    };
+}

--- a/src/Dotsider.Core/Analysis/Models/PdbProvenanceKind.cs
+++ b/src/Dotsider.Core/Analysis/Models/PdbProvenanceKind.cs
@@ -1,0 +1,28 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// Portable PDB discovery outcomes that are meaningful to .NET developers.
+/// </summary>
+public enum PdbProvenanceKind
+{
+    /// <summary>The PE has no debug directory.</summary>
+    NoDebugDirectory,
+
+    /// <summary>A portable CodeView entry points at a sidecar PDB that was not found.</summary>
+    CodeViewSidecarMissing,
+
+    /// <summary>A portable sidecar PDB was found, but its ID does not match the PE CodeView entry.</summary>
+    CodeViewSidecarMismatched,
+
+    /// <summary>A matching portable sidecar PDB was opened.</summary>
+    Sidecar,
+
+    /// <summary>An embedded portable PDB was opened.</summary>
+    Embedded,
+
+    /// <summary>A CodeView entry was present, but it identifies a Windows PDB or another non-portable PDB.</summary>
+    UnsupportedWindowsPdb,
+
+    /// <summary>The assembly came from a single-file bundle, so sidecar probing was intentionally skipped.</summary>
+    BundleSidecarSkipped
+}

--- a/src/Dotsider.Core/Analysis/Models/SequencePointInfo.cs
+++ b/src/Dotsider.Core/Analysis/Models/SequencePointInfo.cs
@@ -1,0 +1,24 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// A source sequence point decoded from a portable PDB.
+/// </summary>
+/// <param name="Offset">The IL offset where the sequence point starts.</param>
+/// <param name="Document">The source document path.</param>
+/// <param name="StartLine">The source start line.</param>
+/// <param name="StartColumn">The source start column.</param>
+/// <param name="EndLine">The source end line.</param>
+/// <param name="EndColumn">The source end column.</param>
+/// <param name="IsHidden">Whether the sequence point is hidden.</param>
+/// <param name="SourceLinkUrl">The Source Link URL resolved for the document, or null.</param>
+/// <param name="HasEmbeddedSource">Whether the document has embedded source.</param>
+public sealed record SequencePointInfo(
+    int Offset,
+    string? Document,
+    int StartLine,
+    int StartColumn,
+    int EndLine,
+    int EndColumn,
+    bool IsHidden,
+    string? SourceLinkUrl,
+    bool HasEmbeddedSource);

--- a/src/Dotsider.Core/Analysis/Models/SourceLinkInfo.cs
+++ b/src/Dotsider.Core/Analysis/Models/SourceLinkInfo.cs
@@ -1,0 +1,11 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// Source Link mappings decoded from portable PDB custom debug information.
+/// </summary>
+/// <param name="Mappings">The document pattern to URL template mappings.</param>
+public sealed record SourceLinkInfo(IReadOnlyList<SourceLinkMapping> Mappings)
+{
+    /// <summary>Gets whether Source Link data was present.</summary>
+    public bool IsPresent => Mappings.Count > 0;
+}

--- a/src/Dotsider.Core/Analysis/Models/SourceLinkMapping.cs
+++ b/src/Dotsider.Core/Analysis/Models/SourceLinkMapping.cs
@@ -1,0 +1,8 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// A single Source Link document mapping.
+/// </summary>
+/// <param name="DocumentPattern">The document path pattern.</param>
+/// <param name="UrlTemplate">The URL template.</param>
+public sealed record SourceLinkMapping(string DocumentPattern, string UrlTemplate);

--- a/src/Dotsider.Core/Analysis/PortablePdbUtilities.cs
+++ b/src/Dotsider.Core/Analysis/PortablePdbUtilities.cs
@@ -1,0 +1,234 @@
+using System.IO.Compression;
+using System.Reflection.Metadata;
+using System.Text;
+using System.Text.Json;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Core.Analysis;
+
+internal static class PortablePdbUtilities
+{
+    internal static readonly Guid EmbeddedSourceKind = new("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
+    internal static readonly Guid SourceLinkKind = new("CC110556-A091-4D38-9FEC-25AB9A351A6A");
+
+    internal static SourceLinkInfo ReadSourceLink(MetadataReader? pdbReader)
+    {
+        if (pdbReader is null) return new SourceLinkInfo([]);
+
+        foreach (var handle in pdbReader.CustomDebugInformation)
+        {
+            var info = pdbReader.GetCustomDebugInformation(handle);
+            if (pdbReader.GetGuid(info.Kind) != SourceLinkKind)
+                continue;
+
+            try
+            {
+                var json = Encoding.UTF8.GetString(pdbReader.GetBlobBytes(info.Value));
+                using var doc = JsonDocument.Parse(json);
+                if (!doc.RootElement.TryGetProperty("documents", out var documents)
+                    || documents.ValueKind != JsonValueKind.Object)
+                    return new SourceLinkInfo([]);
+
+                var mappings = new List<SourceLinkMapping>();
+                foreach (var property in documents.EnumerateObject())
+                {
+                    if (property.Value.ValueKind == JsonValueKind.String
+                        && property.Value.GetString() is { Length: > 0 } url)
+                    {
+                        mappings.Add(new SourceLinkMapping(property.Name, url));
+                    }
+                }
+
+                return new SourceLinkInfo(mappings);
+            }
+            catch
+            {
+                return new SourceLinkInfo([]);
+            }
+        }
+
+        return new SourceLinkInfo([]);
+    }
+
+    internal static string? ResolveSourceLinkUrl(SourceLinkInfo sourceLink, string? documentPath)
+    {
+        if (string.IsNullOrEmpty(documentPath) || sourceLink.Mappings.Count == 0)
+            return null;
+
+        var normalizedDocument = NormalizePath(documentPath);
+        SourceLinkMapping? best = null;
+        string? bestCapture = null;
+        var bestSpecificity = -1;
+
+        foreach (var mapping in sourceLink.Mappings)
+        {
+            if (!TryMatchSourceLinkPattern(
+                    NormalizePath(mapping.DocumentPattern),
+                    normalizedDocument,
+                    out var capture,
+                    out var specificity))
+            {
+                continue;
+            }
+
+            if (specificity > bestSpecificity)
+            {
+                best = mapping;
+                bestCapture = capture;
+                bestSpecificity = specificity;
+            }
+        }
+
+        if (best is null) return null;
+        return best.UrlTemplate.Contains('*', StringComparison.Ordinal)
+            ? best.UrlTemplate.Replace("*", bestCapture ?? "", StringComparison.Ordinal)
+            : best.UrlTemplate;
+    }
+
+    internal static EmbeddedSourceInfo? ReadEmbeddedSource(MetadataReader? pdbReader, string documentPath)
+    {
+        if (pdbReader is null) return null;
+
+        foreach (var documentHandle in pdbReader.Documents)
+        {
+            var document = pdbReader.GetDocument(documentHandle);
+            var currentPath = pdbReader.GetString(document.Name);
+            if (!PathsEqual(currentPath, documentPath))
+                continue;
+
+            foreach (var customInfoHandle in pdbReader.GetCustomDebugInformation(documentHandle))
+            {
+                var customInfo = pdbReader.GetCustomDebugInformation(customInfoHandle);
+                if (pdbReader.GetGuid(customInfo.Kind) != EmbeddedSourceKind)
+                    continue;
+
+                var blob = pdbReader.GetBlobBytes(customInfo.Value);
+                var bytes = DecodeEmbeddedSourceBlob(blob);
+                if (bytes is null) return null;
+                return new EmbeddedSourceInfo(currentPath, DecodeSourceText(bytes), bytes);
+            }
+        }
+
+        return null;
+    }
+
+    internal static bool HasEmbeddedSource(MetadataReader? pdbReader, string? documentPath)
+    {
+        if (pdbReader is null || string.IsNullOrEmpty(documentPath)) return false;
+
+        foreach (var documentHandle in pdbReader.Documents)
+        {
+            var document = pdbReader.GetDocument(documentHandle);
+            if (!PathsEqual(pdbReader.GetString(document.Name), documentPath))
+                continue;
+
+            foreach (var customInfoHandle in pdbReader.GetCustomDebugInformation(documentHandle))
+            {
+                var customInfo = pdbReader.GetCustomDebugInformation(customInfoHandle);
+                if (pdbReader.GetGuid(customInfo.Kind) == EmbeddedSourceKind)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static (Guid Guid, int Age)? TryReadPortablePdbId(MetadataReader pdbReader)
+    {
+        var header = pdbReader.DebugMetadataHeader;
+        if (header is null || header.Id.Length < 20)
+            return null;
+
+        var id = header.Id;
+        var guidBytes = new byte[16];
+        for (var i = 0; i < guidBytes.Length; i++)
+            guidBytes[i] = id[i];
+
+        var age = BitConverter.ToInt32(id.AsSpan(16, 4));
+        return (new Guid(guidBytes), age);
+    }
+
+    internal static bool PortablePdbIdMatches(MetadataReader pdbReader, Guid guid, int age)
+    {
+        var id = TryReadPortablePdbId(pdbReader);
+        return id is not null && id.Value.Guid == guid && id.Value.Age == age;
+    }
+
+    private static byte[]? DecodeEmbeddedSourceBlob(byte[] blob)
+    {
+        if (blob.Length < 4) return null;
+
+        var uncompressedSize = BitConverter.ToInt32(blob, 0);
+        var payload = blob.AsSpan(4).ToArray();
+        if (uncompressedSize == 0)
+            return payload;
+
+        if (uncompressedSize < 0) return null;
+
+        using var input = new MemoryStream(payload);
+        using var deflate = new DeflateStream(input, CompressionMode.Decompress);
+        using var output = new MemoryStream(uncompressedSize);
+        deflate.CopyTo(output);
+        var decoded = output.ToArray();
+        return decoded.Length == uncompressedSize ? decoded : null;
+    }
+
+    private static string DecodeSourceText(byte[] bytes)
+    {
+        if (bytes.Length >= 3
+            && bytes[0] == 0xEF
+            && bytes[1] == 0xBB
+            && bytes[2] == 0xBF)
+        {
+            return Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3);
+        }
+
+        if (bytes.Length >= 2)
+        {
+            if (bytes[0] == 0xFF && bytes[1] == 0xFE)
+                return Encoding.Unicode.GetString(bytes, 2, bytes.Length - 2);
+            if (bytes[0] == 0xFE && bytes[1] == 0xFF)
+                return Encoding.BigEndianUnicode.GetString(bytes, 2, bytes.Length - 2);
+        }
+
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    private static bool TryMatchSourceLinkPattern(
+        string pattern,
+        string document,
+        out string capture,
+        out int specificity)
+    {
+        capture = "";
+        specificity = -1;
+
+        var starIndex = pattern.IndexOf('*', StringComparison.Ordinal);
+        if (starIndex < 0)
+        {
+            if (!string.Equals(pattern, document, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            specificity = pattern.Length;
+            return true;
+        }
+
+        var prefix = pattern[..starIndex];
+        var suffix = pattern[(starIndex + 1)..];
+        if (!document.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            || !document.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+            || document.Length < prefix.Length + suffix.Length)
+        {
+            return false;
+        }
+
+        capture = document[prefix.Length..(document.Length - suffix.Length)];
+        specificity = prefix.Length + suffix.Length;
+        return true;
+    }
+
+    private static bool PathsEqual(string left, string right) =>
+        string.Equals(NormalizePath(left), NormalizePath(right), StringComparison.OrdinalIgnoreCase);
+
+    private static string NormalizePath(string path) => path.Replace('\\', '/');
+}

--- a/src/Dotsider.Core/Protocol/DotsiderRequest.cs
+++ b/src/Dotsider.Core/Protocol/DotsiderRequest.cs
@@ -58,4 +58,7 @@ public sealed class DotsiderRequest
 
     /// <summary>Assembly name to resolve (e.g. "System.Runtime"), used by resolve-assembly and push-assembly.</summary>
     public string? AssemblyName { get; set; }
+
+    /// <summary>Whether IL responses should include portable PDB debug information.</summary>
+    public bool IncludeDebugInfo { get; set; }
 }

--- a/src/Dotsider.Core/README.md
+++ b/src/Dotsider.Core/README.md
@@ -30,9 +30,11 @@ All models live in `Analysis/Models/` and are plain records or enums suitable fo
 
 **Metadata:** `TypeDefInfo`, `MethodDefInfo`, `MemberRefInfo`, `MemberRefKind`, `TypeRefInfo`, `FieldDefInfo`, `AssemblyRefInfo`, `CustomAttributeInfo`, `ResourceInfo`
 
-**PE / CLR:** `PeHeaders`, `ClrHeader`, `SectionInfo`
+**PE / CLR:** `PeHeaders`, `ClrHeader`, `SectionInfo`, `DebugDirectoryInfo`
 
-**IL:** `IlInstruction`, `IlNavigationTarget`
+**IL:** `IlInstruction`, `IlNavigationTarget`, `MethodDebugInfo`, `SequencePointInfo`, `LocalSlotInfo`
+
+**Portable PDB:** `PdbProvenance`, `PdbProvenanceKind`, `SourceLinkInfo`, `SourceLinkMapping`, `EmbeddedSourceInfo`
 
 **Size:** `SizeNode`, `SizeNodeKind`
 
@@ -81,7 +83,9 @@ The diagnostics protocol enables communication between the dotsider TUI and exte
 | `get-resources` | — | Manifest resources |
 | `resolve-token` | Token | Resolve a metadata token |
 | `read-bytes` | Offset, Length | Raw bytes from the loaded image |
-| `disassemble` | TypeName, MethodName | IL bytecode for a method |
+| `disassemble` | TypeName, MethodName, IncludeDebugInfo? | IL bytecode for a method |
+| `get-method-debug-info` | TypeName, MethodName | Portable PDB sequence points and local names for a method |
+| `get-source-link` | — | Source Link mappings decoded from the portable PDB |
 | `search-il-opcodes` | Query, MaxResults? | Find methods containing an opcode |
 | `get-size-tree` | — | Hierarchical size tree |
 | `get-largest-methods` | MaxResults? | Top methods by IL size |

--- a/src/Dotsider.Mcp/README.md
+++ b/src/Dotsider.Mcp/README.md
@@ -45,7 +45,9 @@ Most tools accept either parameter. Session-only tools (navigation, tracing) req
 
 | Tool | Description |
 |------|-------------|
-| `disassemble_method` | IL bytecode for a specific method |
+| `disassemble_method` | IL bytecode for a specific method, with optional portable PDB details |
+| `get_method_debug_info` | Portable PDB sequence points and local names for a method |
+| `get_source_link` | Source Link mappings decoded from the portable PDB |
 | `search_il_opcodes` | Find methods containing a specific opcode (e.g., `calli`, `newobj`) |
 
 ### Size

--- a/src/Dotsider.Mcp/Tools/AssemblyTools.cs
+++ b/src/Dotsider.Mcp/Tools/AssemblyTools.cs
@@ -39,6 +39,8 @@ public sealed partial class AssemblyTools(DotsiderSessionManager sessionManager)
                 analyzer.PreferredRuntimePack,
                 analyzer.LaunchPath,
                 analyzer.CanSaveInPlace,
+                analyzer.PdbProvenance,
+                analyzer.SourceLink,
                 TypeCount = analyzer.TypeDefs.Count,
                 MethodCount = analyzer.MethodDefs.Count,
                 AssemblyRefCount = analyzer.AssemblyRefs.Count

--- a/src/Dotsider.Mcp/Tools/IlTools.cs
+++ b/src/Dotsider.Mcp/Tools/IlTools.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
 using Dotsider.Core.Protocol;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -19,6 +20,7 @@ public sealed partial class IlTools(DotsiderSessionManager sessionManager, ILogg
     /// <param name="methodName">Exact method name (case-insensitive).</param>
     /// <param name="assemblyPath">Path to assembly file.</param>
     /// <param name="sessionId">PID of a running dotsider instance.</param>
+    /// <param name="includeDebugInfo">Include method-level portable PDB sequence points and locals.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>JSON with method metadata and IL instruction listing.</returns>
     [McpServerTool(ReadOnly = true, OpenWorld = false)]
@@ -27,6 +29,7 @@ public sealed partial class IlTools(DotsiderSessionManager sessionManager, ILogg
         string methodName,
         string? assemblyPath = null,
         int? sessionId = null,
+        bool includeDebugInfo = false,
         CancellationToken ct = default)
     {
         if (assemblyPath is not null)
@@ -43,14 +46,99 @@ public sealed partial class IlTools(DotsiderSessionManager sessionManager, ILogg
                 return $"Error: Method not found: {typeName}.{methodName}";
 
             var instructions = disassembler.Disassemble(method);
-            return JsonSerializer.Serialize(new { Method = method, Instructions = instructions },
+            return JsonSerializer.Serialize(new
+            {
+                Method = method,
+                Pdb = analyzer.PdbProvenance,
+                analyzer.SourceLink,
+                DebugInfo = includeDebugInfo ? analyzer.GetMethodDebugInfo(method) : null,
+                Instructions = instructions
+            },
                 DotsiderJsonOptions.Default);
         }
 
         if (sessionId is not null)
         {
             return await sessionManager.GetTarget(sessionId.Value)
-                .SendAndUnwrapAsync(new DotsiderRequest { Method = "disassemble", TypeName = typeName, MethodName = methodName }, ct);
+                .SendAndUnwrapAsync(new DotsiderRequest
+                {
+                    Method = "disassemble",
+                    TypeName = typeName,
+                    MethodName = methodName,
+                    IncludeDebugInfo = includeDebugInfo
+                }, ct);
+        }
+
+        return "Error: Either assemblyPath or sessionId is required.";
+    }
+
+    /// <summary>
+    /// Gets portable PDB sequence points and local names for a method.
+    /// </summary>
+    /// <param name="typeName">Full or partial declaring type name (matched with EndsWith).</param>
+    /// <param name="methodName">Exact method name (case-insensitive).</param>
+    /// <param name="assemblyPath">Path to assembly file.</param>
+    /// <param name="sessionId">PID of a running dotsider instance.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>JSON with method debug information.</returns>
+    [McpServerTool(ReadOnly = true, OpenWorld = false)]
+    public async partial Task<string> GetMethodDebugInfo(
+        string typeName,
+        string methodName,
+        string? assemblyPath = null,
+        int? sessionId = null,
+        CancellationToken ct = default)
+    {
+        if (assemblyPath is not null)
+        {
+            ToolHelpers.ValidateAssemblyPath(assemblyPath);
+            using var analyzer = ToolHelpers.OpenAnalyzer(assemblyPath);
+            var method = FindMethod(analyzer, typeName, methodName);
+            if (method is null)
+                return $"Error: Method not found: {typeName}.{methodName}";
+
+            return JsonSerializer.Serialize(analyzer.GetMethodDebugInfo(method),
+                DotsiderJsonOptions.Default);
+        }
+
+        if (sessionId is not null)
+        {
+            return await sessionManager.GetTarget(sessionId.Value)
+                .SendAndUnwrapAsync(new DotsiderRequest
+                {
+                    Method = "get-method-debug-info",
+                    TypeName = typeName,
+                    MethodName = methodName
+                }, ct);
+        }
+
+        return "Error: Either assemblyPath or sessionId is required.";
+    }
+
+    /// <summary>
+    /// Gets Source Link mappings decoded from the portable PDB.
+    /// </summary>
+    /// <param name="assemblyPath">Path to assembly file.</param>
+    /// <param name="sessionId">PID of a running dotsider instance.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>JSON with Source Link mapping information.</returns>
+    [McpServerTool(ReadOnly = true, OpenWorld = false)]
+    public async partial Task<string> GetSourceLink(
+        string? assemblyPath = null,
+        int? sessionId = null,
+        CancellationToken ct = default)
+    {
+        if (assemblyPath is not null)
+        {
+            ToolHelpers.ValidateAssemblyPath(assemblyPath);
+            using var analyzer = ToolHelpers.OpenAnalyzer(assemblyPath);
+            return JsonSerializer.Serialize(analyzer.SourceLink, DotsiderJsonOptions.Default);
+        }
+
+        if (sessionId is not null)
+        {
+            return await sessionManager.GetTarget(sessionId.Value)
+                .SendAndUnwrapAsync(new DotsiderRequest { Method = "get-source-link" }, ct);
         }
 
         return "Error: Either assemblyPath or sessionId is required.";
@@ -112,4 +200,11 @@ public sealed partial class IlTools(DotsiderSessionManager sessionManager, ILogg
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping method {Type}.{Method} — cannot disassemble")]
     private static partial void LogSkipMethod(ILogger logger, Exception exception, string type, string method);
+
+    private static MethodDefInfo? FindMethod(AssemblyAnalyzer analyzer, string typeName, string methodName)
+    {
+        return analyzer.MethodDefs.FirstOrDefault(m =>
+            m.DeclaringType.EndsWith(typeName, StringComparison.OrdinalIgnoreCase)
+            && m.Name.Equals(methodName, StringComparison.OrdinalIgnoreCase));
+    }
 }

--- a/src/Dotsider/Commands/AnalyzeCommand.cs
+++ b/src/Dotsider/Commands/AnalyzeCommand.cs
@@ -30,6 +30,11 @@ internal static class AnalyzeCommand
         Description = "Disassemble a method (format: Type.Method)"
     };
 
+    private static readonly Option<string?> s_embeddedSourceOption = new("--embedded-source")
+    {
+        Description = "Print embedded source for a method (format: Type.Method)"
+    };
+
     private static readonly Option<bool> s_depsOption = new("--deps")
     {
         Description = "Show assembly references and dependency graph"
@@ -71,6 +76,7 @@ internal static class AnalyzeCommand
             s_typesOption,
             s_methodsOption,
             s_ilOption,
+            s_embeddedSourceOption,
             s_depsOption,
             s_stringsOption,
             s_sizeOption,
@@ -176,6 +182,9 @@ internal static class AnalyzeCommand
                     return Task.FromResult(PrintIl(analyzer, disassembler, ilTarget, formatter));
                 }
 
+                if (parseResult.GetValue(s_embeddedSourceOption) is { } embeddedSourceTarget)
+                    return Task.FromResult(PrintEmbeddedSource(analyzer, embeddedSourceTarget, formatter));
+
                 if (parseResult.GetValue(s_depsOption))
                     return Task.FromResult(PrintDeps(analyzer, formatter));
 
@@ -213,6 +222,7 @@ internal static class AnalyzeCommand
                 a.FilePath, a.FileName, a.FileSize, a.AssemblyName, a.AssemblyVersion,
                 a.TargetFramework, a.Architecture, a.HasMetadata,
                 a.DisplayName, a.IsBundleBacked, a.SourceBundlePath, a.LaunchPath, a.CanSaveInPlace, a.PreferredRuntimePack,
+                a.PdbProvenance, a.SourceLink, a.DebugDirectory,
                 Types = a.TypeDefs, Methods = a.MethodDefs, References = a.AssemblyRefs
             });
         }
@@ -224,6 +234,8 @@ internal static class AnalyzeCommand
             fmt.WriteLine($"Version:    {a.AssemblyVersion ?? "(none)"}");
             fmt.WriteLine($"Framework:  {a.TargetFramework ?? "(none)"}");
             fmt.WriteLine($"Arch:       {a.Architecture}");
+            fmt.WriteLine($"PDB:        {a.PdbProvenance}");
+            fmt.WriteLine($"SourceLink: {(a.SourceLink.IsPresent ? $"present, {a.SourceLink.Mappings.Count} mappings" : "not present")}");
             if (a.IsBundleBacked)
             {
                 fmt.WriteLine($"Display:    {a.DisplayName} (from bundle)");
@@ -321,18 +333,81 @@ internal static class AnalyzeCommand
 
         if (fmt.JsonMode)
         {
-            fmt.WriteJson(new { Method = method, Instructions = instructions });
+            fmt.WriteJson(new
+            {
+                Method = method,
+                Pdb = a.PdbProvenance,
+                a.SourceLink,
+                DebugInfo = a.GetMethodDebugInfo(method),
+                Instructions = instructions
+            });
             return 0;
         }
 
-        fmt.WriteLine($"// {method.DeclaringType}.{method.Name}{method.Signature}");
-        fmt.WriteLine($"// IL size: {instructions.Count} instructions");
-        fmt.WriteLine("");
-
-        foreach (var il in instructions)
-            fmt.WriteLine($"  IL_{il.Offset:X4}: {il.OpCode,-12} {il.Operand}");
+        fmt.WriteLine(dis.FormatDisassembly(method));
 
         return 0;
+    }
+
+    private static int PrintEmbeddedSource(AssemblyAnalyzer a, string target, OutputFormatter fmt)
+    {
+        if (!a.HasMetadata)
+        {
+            OutputFormatter.WriteError("Error: --embedded-source requires a .NET assembly with metadata");
+            return 1;
+        }
+
+        if (!TryFindMethod(a, target, out var method, out var error))
+        {
+            OutputFormatter.WriteError(error!);
+            return 1;
+        }
+
+        var source = a.GetEmbeddedSource(method!);
+        if (source is null)
+        {
+            OutputFormatter.WriteError($"Error: Embedded source not found for {target}");
+            return 1;
+        }
+
+        if (fmt.JsonMode)
+        {
+            fmt.WriteJson(source);
+            return 0;
+        }
+
+        fmt.WriteLine(source.Text);
+        return 0;
+    }
+
+    private static bool TryFindMethod(
+        AssemblyAnalyzer a,
+        string target,
+        out MethodDefInfo? method,
+        out string? error)
+    {
+        method = null;
+        error = null;
+
+        var sep = target.Contains("::") ? "::" : ".";
+        var lastDot = target.LastIndexOf(sep, StringComparison.Ordinal);
+        if (lastDot < 0)
+        {
+            error = $"Error: Invalid method format '{target}'. Use Type.Method or Type::Method";
+            return false;
+        }
+
+        var typeName = target[..lastDot];
+        var methodName = target[(lastDot + sep.Length)..];
+
+        method = a.MethodDefs.FirstOrDefault(m =>
+            m.DeclaringType.EndsWith(typeName, StringComparison.OrdinalIgnoreCase)
+            && m.Name.Equals(methodName, StringComparison.OrdinalIgnoreCase));
+
+        if (method is not null) return true;
+
+        error = $"Error: Method not found: {target}";
+        return false;
     }
 
     private static int PrintDeps(AssemblyAnalyzer a, OutputFormatter fmt)

--- a/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
+++ b/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
@@ -219,6 +219,8 @@ internal sealed class DotsiderDiagnosticsListener(
 
                 // IL
                 "disassemble" => HandleDisassemble(request),
+                "get-method-debug-info" => HandleGetMethodDebugInfo(request),
+                "get-source-link" => HandleGetSourceLink(),
                 "search-il-opcodes" => HandleSearchIlOpcodes(request),
 
                 // Metadata
@@ -322,6 +324,8 @@ internal sealed class DotsiderDiagnosticsListener(
             a.LaunchPath,
             a.CanSaveInPlace,
             a.PreferredRuntimePack,
+            a.PdbProvenance,
+            a.SourceLink,
             TypeCount = a.TypeDefs.Count,
             MethodCount = a.MethodDefs.Count,
             AssemblyRefCount = a.AssemblyRefs.Count
@@ -413,8 +417,33 @@ internal sealed class DotsiderDiagnosticsListener(
             return DotsiderResponse.Fail($"Method not found: {request.TypeName}.{request.MethodName}");
 
         var instructions = state.IlDisassembler!.Disassemble(method);
-        return DotsiderResponse.Ok(new { Method = method, Instructions = instructions });
+        return DotsiderResponse.Ok(new
+        {
+            Method = method,
+            Pdb = state.Analyzer.PdbProvenance,
+            state.Analyzer.SourceLink,
+            DebugInfo = request.IncludeDebugInfo ? state.Analyzer.GetMethodDebugInfo(method) : null,
+            Instructions = instructions
+        });
     }
+
+    private DotsiderResponse HandleGetMethodDebugInfo(DotsiderRequest request)
+    {
+        if (string.IsNullOrEmpty(request.TypeName) || string.IsNullOrEmpty(request.MethodName))
+            return DotsiderResponse.Fail("TypeName and MethodName are required for get-method-debug-info");
+
+        var state = RequireState();
+        var method = state.Analyzer.MethodDefs.FirstOrDefault(m =>
+            m.DeclaringType.EndsWith(request.TypeName, StringComparison.OrdinalIgnoreCase)
+            && m.Name.Equals(request.MethodName, StringComparison.OrdinalIgnoreCase));
+
+        return method is null
+            ? DotsiderResponse.Fail($"Method not found: {request.TypeName}.{request.MethodName}")
+            : DotsiderResponse.Ok(state.Analyzer.GetMethodDebugInfo(method));
+    }
+
+    private DotsiderResponse HandleGetSourceLink() =>
+        DotsiderResponse.Ok(RequireAnalyzer().SourceLink);
 
     private DotsiderResponse HandleSearchIlOpcodes(DotsiderRequest request)
     {

--- a/src/Dotsider/DllInspectorBindings.cs
+++ b/src/Dotsider/DllInspectorBindings.cs
@@ -1,6 +1,7 @@
 using Hex1b;
 using Hex1b.Input;
 using Hex1b.Widgets;
+using Dotsider.Views;
 
 namespace Dotsider;
 
@@ -259,6 +260,8 @@ public static class DllInspectorBindings
             if (state.IlSelectedMethod is { } method
                 && state.Analyzer.GetMethodDebugInfo(method).SequencePoints.Any(p => p.HasEmbeddedSource))
                 hints.Add(s.Section("o: Source"));
+            if (HasSourceLinkUrlAtIlCursor(state))
+                hints.Add(s.Section("u: Source URL"));
             if (state.IlEditorState?.Cursor.HasSelection == true)
                 hints.Add(s.Section("y: Yank (IL)"));
         }
@@ -304,4 +307,11 @@ public static class DllInspectorBindings
         if (yankable)
             hints.Add(s.Section("y: Yank"));
     }
+
+    private static bool HasSourceLinkUrlAtIlCursor(DotsiderState state) =>
+        state.IlEditorState is { } editorState
+        && state.IlInstructions is { } instructions
+        && state.App.FocusedNode is EditorNode { State: var focusedState }
+        && ReferenceEquals(focusedState, editorState)
+        && IlNavigationHelper.GetSourceLinkUrlAtCursor(editorState, instructions) is not null;
 }

--- a/src/Dotsider/DllInspectorBindings.cs
+++ b/src/Dotsider/DllInspectorBindings.cs
@@ -256,6 +256,9 @@ public static class DllInspectorBindings
             hints.Add(s.Section("l: Focus IL"));
             if (state.IlSelectedMethod is { Rva: > 0 })
                 hints.Add(s.Section("x: Hex"));
+            if (state.IlSelectedMethod is { } method
+                && state.Analyzer.GetMethodDebugInfo(method).SequencePoints.Any(p => p.HasEmbeddedSource))
+                hints.Add(s.Section("o: Source"));
             if (state.IlEditorState?.Cursor.HasSelection == true)
                 hints.Add(s.Section("y: Yank (IL)"));
         }

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -542,6 +542,8 @@ public sealed class DotsiderApp(DotsiderState state)
                 if (_state.IlSelectedMethod is { } method
                     && _state.Analyzer.GetMethodDebugInfo(method).SequencePoints.Any(p => p.HasEmbeddedSource))
                     hints.Add(s.Section("o: Source"));
+                if (HasSourceLinkUrlAtIlCursor(_state))
+                    hints.Add(s.Section("u: Source URL"));
                 if (_state.IlEditorState?.Cursor.HasSelection == true)
                     hints.Add(s.Section("y: Yank (IL)"));
             }
@@ -813,6 +815,7 @@ public sealed class DotsiderApp(DotsiderState state)
         state.IlInstructions = null;
         state.IlHeaderLineCount = 0;
         state.IlNavigationProvider.Instructions = null;
+        state.IlSourceLinkProvider.Instructions = null;
         state.IlBackStack.Clear();
         state.IlGdPending = false;
         state.TransientNotice = null;
@@ -828,6 +831,13 @@ public sealed class DotsiderApp(DotsiderState state)
 
     private IlYankDecorationProvider? FindYankProvider(EditorState editorState) =>
         YankHelper.FindYankProvider(_state, editorState);
+
+    private static bool HasSourceLinkUrlAtIlCursor(DotsiderState state) =>
+        state.IlEditorState is { } editorState
+        && state.IlInstructions is { } instructions
+        && state.App.FocusedNode is EditorNode { State: var focusedState }
+        && ReferenceEquals(focusedState, editorState)
+        && IlNavigationHelper.GetSourceLinkUrlAtCursor(editorState, instructions) is not null;
 
     /// <summary>
     /// Performs a neovim-style yank on the focused editor's selection or current text-object range.

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -539,6 +539,9 @@ public sealed class DotsiderApp(DotsiderState state)
                 hints.Add(s.Section("l: Focus IL"));
                 if (_state.IlSelectedMethod is { Rva: > 0 })
                     hints.Add(s.Section("x: Hex"));
+                if (_state.IlSelectedMethod is { } method
+                    && _state.Analyzer.GetMethodDebugInfo(method).SequencePoints.Any(p => p.HasEmbeddedSource))
+                    hints.Add(s.Section("o: Source"));
                 if (_state.IlEditorState?.Cursor.HasSelection == true)
                     hints.Add(s.Section("y: Yank (IL)"));
             }

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -187,6 +187,9 @@ public sealed class DotsiderState : IDisposable
     /// <summary>Yank flash decoration provider for the IL editor.</summary>
     public IlYankDecorationProvider IlYankProvider { get; } = new();
 
+    /// <summary>Source Link marker decoration provider for the IL editor.</summary>
+    public IlSourceLinkDecorationProvider IlSourceLinkProvider { get; } = new();
+
     /// <summary>All text-level search matches across method disassemblies, computed on search confirm.</summary>
     public List<IlMatch> IlSearchMatches { get; set; } = [];
 
@@ -922,6 +925,7 @@ public sealed class DotsiderState : IDisposable
             IlHeaderLineCount = r?.HeaderLineCount ?? 0;
             IlNavigationProvider.Instructions = IlInstructions;
             IlNavigationProvider.HeaderLineCount = IlHeaderLineCount;
+            IlSourceLinkProvider.Instructions = IlInstructions;
         }
 
         App.RequestFocus(node => node is EditorNode);
@@ -969,6 +973,7 @@ public sealed class DotsiderState : IDisposable
     {
         TransientNotice = message;
         var gen = ++TransientNoticeGeneration;
+        App.Invalidate();
         _ = Task.Delay(TimeSpan.FromSeconds(3)).ContinueWith(_ =>
         {
             if (TransientNoticeGeneration == gen)
@@ -1421,6 +1426,7 @@ public sealed class DotsiderState : IDisposable
         IlInstructions = null;
         IlHeaderLineCount = 0;
         IlNavigationProvider.Instructions = null;
+        IlSourceLinkProvider.Instructions = null;
         IlGdPending = false;
         TransientNotice = null;
         IlYankProvider.HighlightRange = null;

--- a/src/Dotsider/PeSubTabId.cs
+++ b/src/Dotsider/PeSubTabId.cs
@@ -26,6 +26,9 @@ public static class PeSubTabId
     /// <summary>Resources sub-tab.</summary>
     public const int Resources = 6;
 
+    /// <summary>Debug Directory sub-tab.</summary>
+    public const int DebugDirectory = 7;
+
     /// <summary>Total number of PE/Metadata sub-tabs.</summary>
-    public const int Count = 7;
+    public const int Count = 8;
 }

--- a/src/Dotsider/README.md
+++ b/src/Dotsider/README.md
@@ -4,7 +4,7 @@
 
 ## Modes
 
-- **TUI mode** — `dotsider MyApp.dll` opens an interactive terminal UI with tabbed navigation
+- **TUI mode** — `dotsider MyApp.dll` opens an interactive terminal UI with tabbed navigation. The IL Inspector shows portable PDB source spans, local names, and compact Source Link markers when available.
 - **Diff mode** — `dotsider diff Left.dll Right.dll` compares two assemblies side-by-side
 - **NuGet mode** — `dotsider MyPackage.nupkg` inspects package contents and embedded assemblies
 - **CLI mode** — `dotsider analyze`, `dotsider sessions`, `dotsider agent` for headless scripting
@@ -20,6 +20,7 @@ dotsider analyze MyApp.dll                  # assembly info
 dotsider analyze MyApp.dll --types          # type definitions
 dotsider analyze MyApp.dll --methods        # method definitions
 dotsider analyze MyApp.dll --il Type.Method # disassemble a method
+dotsider analyze MyApp.dll --embedded-source Type.Method # print embedded source
 dotsider analyze MyApp.dll --deps           # assembly references
 dotsider analyze MyApp.dll --strings        # extract strings
 dotsider analyze MyApp.dll --fields         # field definitions

--- a/src/Dotsider/Views/GeneralView.cs
+++ b/src/Dotsider/Views/GeneralView.cs
@@ -79,7 +79,9 @@ public static class GeneralView
             $"  Last Modified:    {analyzer.LastModified:yyyy-MM-dd HH:mm:ss UTC}",
             $"  Created:          {analyzer.CreatedTime:yyyy-MM-dd HH:mm:ss UTC}",
             $"  Read-Only:        {(analyzer.IsReadOnly ? "Yes" : "No")}",
-            $"  Has Metadata:     {(analyzer.HasMetadata ? "Yes" : "No")}");
+            $"  Has Metadata:     {(analyzer.HasMetadata ? "Yes" : "No")}",
+            $"  PDB:              {analyzer.PdbProvenance}",
+            $"  Source Link:      {(analyzer.SourceLink.IsPresent ? $"present, {analyzer.SourceLink.Mappings.Count} mappings" : "not present")}");
 
         if (state.GeneralInfoEditorText != infoText)
         {
@@ -123,7 +125,7 @@ public static class GeneralView
                                 () => state.App.Invalidate());
                         })
                         .FillWidth().FillHeight())
-                ).Title(" Assembly Info ").FixedHeight(14)
+                ).Title(" Assembly Info ").FixedHeight(16)
             };
 
             // Search bar

--- a/src/Dotsider/Views/IlColorizer.cs
+++ b/src/Dotsider/Views/IlColorizer.cs
@@ -18,12 +18,16 @@ public static class IlColorizer
     /// <summary>Opcodes — muted teal, slightly softer than the primary theme accent.</summary>
     public static readonly Hex1bColor OpcodeColor = Hex1bColor.FromRgb(0, 170, 160);
 
+    /// <summary>IL directives such as .locals init — muted blue-gray.</summary>
+    public static readonly Hex1bColor DirectiveColor = Hex1bColor.FromRgb(125, 130, 170);
+
     /// <summary>String operands ("...") — muted green.</summary>
     public static readonly Hex1bColor StringColor = Hex1bColor.FromRgb(100, 180, 100);
 
     private static readonly string AddressFg = AddressColor.ToForegroundAnsi();
     private static readonly string CommentFg = CommentColor.ToForegroundAnsi();
     private static readonly string OpcodeFg = OpcodeColor.ToForegroundAnsi();
+    private static readonly string DirectiveFg = DirectiveColor.ToForegroundAnsi();
     private static readonly string StringFg = StringColor.ToForegroundAnsi();
     // Reset to default terminal color
     private const string Reset = "\x1b[0m";
@@ -43,7 +47,30 @@ public static class IlColorizer
         if (line.StartsWith("IL_"))
             return ColorizeInstruction(line);
 
+        if (TryGetLocalsInitSpan(line, out var startIndex, out var length))
+            return line[..startIndex] + DirectiveFg + line.Substring(startIndex, length) + Reset + line[(startIndex + length)..];
+
         return line;
+    }
+
+    internal static bool TryGetLocalsInitSpan(string line, out int startIndex, out int length)
+    {
+        startIndex = 0;
+        length = 0;
+
+        const string directive = ".locals init";
+        while (startIndex < line.Length && char.IsWhiteSpace(line[startIndex]))
+            startIndex++;
+
+        if (!line.AsSpan(startIndex).StartsWith(directive, StringComparison.Ordinal))
+            return false;
+
+        var endIndex = startIndex + directive.Length;
+        if (endIndex < line.Length && !char.IsWhiteSpace(line[endIndex]) && line[endIndex] != '(')
+            return false;
+
+        length = directive.Length;
+        return true;
     }
 
     // Parse "IL_XXXX: opcode operand", color the address and opcode,

--- a/src/Dotsider/Views/IlEditorHost.cs
+++ b/src/Dotsider/Views/IlEditorHost.cs
@@ -27,6 +27,7 @@ internal static class IlEditorHost
                 .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
             new EditorWidget(editorState)
                 .Decorations(state.IlSyntaxProvider)
+                .Decorations(state.IlSourceLinkProvider)
                 .Decorations(state.IlSearchProvider)
                 .Decorations(state.IlYankProvider)
                 .Decorations(state.IlNavigationProvider)
@@ -63,6 +64,7 @@ internal static class IlEditorHost
 
                     bindings.Key(Hex1bKey.Enter).Action(_ => PerformGoToDefinition(state), "Go to definition");
                     bindings.Key(Hex1bKey.O).Action(_ => OpenEmbeddedSource(state), "Open embedded source");
+                    bindings.Key(Hex1bKey.U).Action(ctx => YankSourceLinkUrl(state, ctx), "Yank source URL");
 
                     bindings.Key(Hex1bKey.G).Action(_ =>
                     {
@@ -103,6 +105,23 @@ internal static class IlEditorHost
                 state.App.Invalidate();
             }
         }
+    }
+
+    private static void YankSourceLinkUrl(DotsiderState state, InputBindingActionContext ctx)
+    {
+        if (state.IlInstructions is not { } instructions
+            || state.IlEditorState is not { } editorState)
+            return;
+
+        var url = IlNavigationHelper.GetSourceLinkUrlAtCursor(editorState, instructions);
+        if (url is null)
+        {
+            state.ShowTransientNotice("No Source Link URL at cursor");
+            return;
+        }
+
+        ctx.CopyToClipboard(url);
+        state.ShowTransientNotice("Yanked Source Link URL");
     }
 
     private static void OpenEmbeddedSource(DotsiderState state)

--- a/src/Dotsider/Views/IlEditorHost.cs
+++ b/src/Dotsider/Views/IlEditorHost.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Hex1b;
+using Hex1b.Documents;
 using Hex1b.Input;
 using Hex1b.Theming;
 using Hex1b.Widgets;
@@ -121,7 +122,22 @@ internal static class IlEditorHost
         }
 
         ctx.CopyToClipboard(url);
+        if (IlNavigationHelper.GetSourceLinkMarkerRangeAtCursor(editorState, instructions) is { } range)
+            FlashSourceLinkMarker(state, range);
         state.ShowTransientNotice("Yanked Source Link URL");
+    }
+
+    private static void FlashSourceLinkMarker(
+        DotsiderState state,
+        (DocumentPosition Start, DocumentPosition End) range)
+    {
+        state.IlYankProvider.HighlightRange = range;
+        state.App.Invalidate();
+        _ = Task.Delay(TimeSpan.FromMilliseconds(150)).ContinueWith(_ =>
+        {
+            state.IlYankProvider.HighlightRange = null;
+            state.App.Invalidate();
+        }, TaskScheduler.Default);
     }
 
     private static void OpenEmbeddedSource(DotsiderState state)

--- a/src/Dotsider/Views/IlEditorHost.cs
+++ b/src/Dotsider/Views/IlEditorHost.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Hex1b;
 using Hex1b.Input;
 using Hex1b.Theming;
@@ -61,6 +62,7 @@ internal static class IlEditorHost
                         () => state.App.Invalidate());
 
                     bindings.Key(Hex1bKey.Enter).Action(_ => PerformGoToDefinition(state), "Go to definition");
+                    bindings.Key(Hex1bKey.O).Action(_ => OpenEmbeddedSource(state), "Open embedded source");
 
                     bindings.Key(Hex1bKey.G).Action(_ =>
                     {
@@ -101,5 +103,112 @@ internal static class IlEditorHost
                 state.App.Invalidate();
             }
         }
+    }
+
+    private static void OpenEmbeddedSource(DotsiderState state)
+    {
+        if (state.IlSelectedMethod is null)
+            return;
+
+        var source = state.Analyzer.GetEmbeddedSource(state.IlSelectedMethod);
+        if (source is null)
+        {
+            state.ShowTransientNotice("No embedded source for this method");
+            return;
+        }
+
+        var tempPath = WriteEmbeddedSourceToTemp(state.IlSelectedMethod.Name, source.Document, source.Bytes);
+        if (TryLaunchEditor(tempPath))
+        {
+            state.ShowTransientNotice($"Opened embedded source: {Path.GetFileName(tempPath)}");
+            return;
+        }
+
+        state.ShowTransientNotice($"Embedded source: {tempPath}");
+    }
+
+    private static string WriteEmbeddedSourceToTemp(string methodName, string documentPath, byte[] bytes)
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "dotsider", "embedded-source");
+        Directory.CreateDirectory(directory);
+
+        var extension = Path.GetExtension(documentPath);
+        if (string.IsNullOrEmpty(extension))
+            extension = ".txt";
+
+        var documentName = Path.GetFileNameWithoutExtension(documentPath);
+        if (string.IsNullOrWhiteSpace(documentName))
+            documentName = methodName;
+
+        var fileName = $"{SanitizeFileName(documentName)}-{Guid.NewGuid():N}{extension}";
+        var tempPath = Path.Combine(directory, fileName);
+        File.WriteAllBytes(tempPath, bytes);
+        return tempPath;
+    }
+
+    private static bool TryLaunchEditor(string path)
+    {
+        var editor = Environment.GetEnvironmentVariable("VISUAL");
+        if (string.IsNullOrWhiteSpace(editor))
+            editor = Environment.GetEnvironmentVariable("EDITOR");
+
+        if (!string.IsNullOrWhiteSpace(editor) && TryStartEditorCommand(editor, path))
+            return true;
+
+        try
+        {
+            Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool TryStartEditorCommand(string editor, string path)
+    {
+        try
+        {
+            using var process = Process.Start(CreateEditorStartInfo(editor, path));
+            process?.WaitForExit();
+            return process is not null && process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static ProcessStartInfo CreateEditorStartInfo(string editor, string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var startInfo = new ProcessStartInfo("cmd.exe")
+            {
+                UseShellExecute = false
+            };
+            startInfo.ArgumentList.Add("/d");
+            startInfo.ArgumentList.Add("/s");
+            startInfo.ArgumentList.Add("/c");
+            startInfo.ArgumentList.Add($"{editor} \"{path}\"");
+            return startInfo;
+        }
+
+        var shellInfo = new ProcessStartInfo("/bin/sh")
+        {
+            UseShellExecute = false
+        };
+        shellInfo.ArgumentList.Add("-c");
+        shellInfo.ArgumentList.Add($"{editor} \"$1\"");
+        shellInfo.ArgumentList.Add("dotsider-editor");
+        shellInfo.ArgumentList.Add(path);
+        return shellInfo;
+    }
+
+    private static string SanitizeFileName(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        return new string([.. value.Select(ch => invalid.Contains(ch) ? '_' : ch)]);
     }
 }

--- a/src/Dotsider/Views/IlInspectorView.cs
+++ b/src/Dotsider/Views/IlInspectorView.cs
@@ -448,24 +448,15 @@ public static class IlInspectorView
             state.IlHeaderLineCount = result?.HeaderLineCount ?? 0;
             state.IlNavigationProvider.Instructions = state.IlInstructions;
             state.IlNavigationProvider.HeaderLineCount = state.IlHeaderLineCount;
+            state.IlSourceLinkProvider.Instructions = state.IlInstructions;
             state.IlEditorKey = state.GetOrCreateEditorKey(state.Analyzer, method.Token);
             state.IlCachedEditors.Remove(state.IlEditorKey);
 
-            if (state.IlHeaderLineCount > 0)
-            {
-                var offset = 0;
-                var newlines = 0;
-                for (var i = 0; i < disassembly.Length && newlines < state.IlHeaderLineCount; i++)
-                {
-                    if (disassembly[i] == '\n')
-                    {
-                        newlines++;
-                        offset = i + 1;
-                    }
-                }
-                
-                state.IlEditorState.SetCursorPosition(new DocumentOffset(offset));
-            }
+            var firstInstructionLine = state.IlInstructions?
+                .FirstOrDefault(i => i.DisplayLine is not null)
+                ?.DisplayLine;
+            var targetLine = firstInstructionLine ?? state.IlHeaderLineCount + 1;
+            state.IlEditorState.SetCursorPosition(new DocumentOffset(GetLineStartOffset(disassembly, targetLine)));
         }
 
         // Consume pending cursor match (from search n/N navigation)
@@ -550,6 +541,25 @@ public static class IlInspectorView
                 return new VStackWidget([.. children]).FillWidth().FillHeight();
             }).FillWidth().FillHeight()
         ];
+    }
+
+    private static int GetLineStartOffset(string text, int lineNumber)
+    {
+        if (lineNumber <= 1)
+            return 0;
+
+        var line = 1;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] != '\n')
+                continue;
+
+            line++;
+            if (line == lineNumber)
+                return i + 1;
+        }
+
+        return 0;
     }
 
     /// <summary>

--- a/src/Dotsider/Views/IlNavigationDecorationProvider.cs
+++ b/src/Dotsider/Views/IlNavigationDecorationProvider.cs
@@ -40,9 +40,14 @@ public sealed class IlNavigationDecorationProvider : ITextDecorationProvider
         var spans = new List<TextDecorationSpan>();
         for (var line = startLine; line <= endLine && line <= document.LineCount; line++)
         {
-            var idx = line - HeaderLineCount - 1;
-            if (idx < 0 || idx >= Instructions.Count) continue;
-            var inst = Instructions[idx];
+            var inst = Instructions.FirstOrDefault(i => i.DisplayLine == line);
+            if (inst is null)
+            {
+                var idx = line - HeaderLineCount - 1;
+                if (idx < 0 || idx >= Instructions.Count) continue;
+                inst = Instructions[idx];
+            }
+
             if (inst.MetadataToken is null || string.IsNullOrEmpty(inst.Operand)
                 || !NavigableOpcodes.Contains(inst.OpCode)) continue;
 

--- a/src/Dotsider/Views/IlNavigationHelper.cs
+++ b/src/Dotsider/Views/IlNavigationHelper.cs
@@ -28,6 +28,10 @@ public static class IlNavigationHelper
             if (text[i] == '\n') cursorLine++;
         }
 
+        var instruction = instructions.FirstOrDefault(i => i.DisplayLine == cursorLine);
+        if (instruction is not null)
+            return instruction;
+
         var instructionIndex = cursorLine - headerLineCount - 1;
         if (instructionIndex >= 0 && instructionIndex < instructions.Count)
             return instructions[instructionIndex];

--- a/src/Dotsider/Views/IlNavigationHelper.cs
+++ b/src/Dotsider/Views/IlNavigationHelper.cs
@@ -1,4 +1,5 @@
 using Dotsider.Core.Analysis.Models;
+using Hex1b.Documents;
 using Hex1b.Widgets;
 
 namespace Dotsider.Views;
@@ -58,6 +59,32 @@ public static class IlNavigationHelper
             return null;
 
         return instruction.SourceLinkUrl;
+    }
+
+    /// <summary>
+    /// Returns the rendered marker range for a Source Link source comment at the cursor, or null.
+    /// </summary>
+    /// <param name="editorState">The IL editor state containing cursor position.</param>
+    /// <param name="instructions">The instruction list for the current method.</param>
+    /// <returns>The rendered marker range for the Source Link marker, or null.</returns>
+    public static (DocumentPosition Start, DocumentPosition End)? GetSourceLinkMarkerRangeAtCursor(
+        EditorState editorState,
+        IReadOnlyList<IlInstruction> instructions)
+    {
+        var cursorLine = GetCursorLine(editorState);
+        var lineText = editorState.Document.GetLineText(cursorLine);
+        var markerStart = lineText.IndexOf(
+            IlSourceLinkDecorationProvider.SourceLinkMarker,
+            StringComparison.Ordinal);
+        if (markerStart < 0
+            || GetSourceLinkUrlAtCursor(editorState, instructions) is null)
+            return null;
+
+        return (
+            new DocumentPosition(cursorLine, markerStart + 1),
+            new DocumentPosition(
+                cursorLine,
+                markerStart + IlSourceLinkDecorationProvider.SourceLinkMarker.Length + 1));
     }
 
     private static int GetCursorLine(EditorState editorState)

--- a/src/Dotsider/Views/IlNavigationHelper.cs
+++ b/src/Dotsider/Views/IlNavigationHelper.cs
@@ -20,6 +20,48 @@ public static class IlNavigationHelper
         IReadOnlyList<IlInstruction> instructions,
         int headerLineCount)
     {
+        var cursorLine = GetCursorLine(editorState);
+
+        var instruction = instructions.FirstOrDefault(i => i.DisplayLine == cursorLine);
+        if (instruction is not null)
+            return instruction;
+
+        var lineText = editorState.Document.GetLineText(cursorLine);
+        if (!lineText.StartsWith("IL_", StringComparison.Ordinal))
+            return null;
+
+        var instructionIndex = cursorLine - headerLineCount - 1;
+        if (instructionIndex >= 0 && instructionIndex < instructions.Count)
+            return instructions[instructionIndex];
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the resolved Source Link URL represented by the source comment line
+    /// at the current cursor position, or null.
+    /// </summary>
+    /// <param name="editorState">The IL editor state containing cursor position.</param>
+    /// <param name="instructions">The instruction list for the current method.</param>
+    /// <returns>The resolved Source Link URL for the source-span line, or null.</returns>
+    public static string? GetSourceLinkUrlAtCursor(
+        EditorState editorState,
+        IReadOnlyList<IlInstruction> instructions)
+    {
+        var cursorLine = GetCursorLine(editorState);
+        var lineText = editorState.Document.GetLineText(cursorLine);
+        if (!lineText.Contains(IlSourceLinkDecorationProvider.SourceLinkMarker, StringComparison.Ordinal))
+            return null;
+
+        var instruction = instructions.FirstOrDefault(i => i.DisplayLine == cursorLine + 1);
+        if (instruction?.SequenceStartLine is null
+            || string.IsNullOrWhiteSpace(instruction.SourceLinkUrl))
+            return null;
+
+        return instruction.SourceLinkUrl;
+    }
+
+    private static int GetCursorLine(EditorState editorState)
+    {
         var cursorOffset = editorState.Cursor.Position.Value;
         var text = editorState.Document.GetText();
         var cursorLine = 1;
@@ -28,13 +70,6 @@ public static class IlNavigationHelper
             if (text[i] == '\n') cursorLine++;
         }
 
-        var instruction = instructions.FirstOrDefault(i => i.DisplayLine == cursorLine);
-        if (instruction is not null)
-            return instruction;
-
-        var instructionIndex = cursorLine - headerLineCount - 1;
-        if (instructionIndex >= 0 && instructionIndex < instructions.Count)
-            return instructions[instructionIndex];
-        return null;
+        return cursorLine;
     }
 }

--- a/src/Dotsider/Views/IlSourceLinkDecorationProvider.cs
+++ b/src/Dotsider/Views/IlSourceLinkDecorationProvider.cs
@@ -1,0 +1,60 @@
+using Dotsider.Core.Analysis.Models;
+using Hex1b;
+using Hex1b.Documents;
+using Hex1b.Theming;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// Underlines Source Link markers in IL source comments to indicate that the
+/// resolved URL can be copied.
+/// </summary>
+public sealed class IlSourceLinkDecorationProvider : ITextDecorationProvider
+{
+    /// <summary>The compact marker shown on source-span comment lines.</summary>
+    public const string SourceLinkMarker = "[source link]";
+
+    private static readonly TextDecoration SourceLinkDecoration = new()
+    {
+        Foreground = Hex1bColor.FromRgb(100, 160, 220),
+        UnderlineStyle = UnderlineStyle.Single
+    };
+
+    /// <summary>The instruction list for the current method.</summary>
+    public IReadOnlyList<IlInstruction>? Instructions { get; set; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<TextDecorationSpan> GetDecorations(
+        int startLine, int endLine, IHex1bDocument document)
+    {
+        if (Instructions is null || Instructions.Count == 0)
+            return [];
+
+        var spans = new List<TextDecorationSpan>();
+        foreach (var instruction in Instructions)
+        {
+            if (instruction.DisplayLine is not { } instructionLine
+                || instruction.SequenceStartLine is null
+                || string.IsNullOrWhiteSpace(instruction.SourceLinkUrl))
+                continue;
+
+            var markerLine = instructionLine - 1;
+            if (markerLine < startLine || markerLine > endLine || markerLine < 1
+                || markerLine > document.LineCount)
+                continue;
+
+            var lineText = document.GetLineText(markerLine);
+            var markerStart = lineText.IndexOf(SourceLinkMarker, StringComparison.Ordinal);
+            if (markerStart < 0)
+                continue;
+
+            spans.Add(new TextDecorationSpan(
+                new DocumentPosition(markerLine, markerStart + 1),
+                new DocumentPosition(markerLine, markerStart + SourceLinkMarker.Length + 1),
+                SourceLinkDecoration,
+                Priority: 12));
+        }
+
+        return spans;
+    }
+}

--- a/src/Dotsider/Views/IlSyntaxDecorationProvider.cs
+++ b/src/Dotsider/Views/IlSyntaxDecorationProvider.cs
@@ -12,6 +12,7 @@ public sealed class IlSyntaxDecorationProvider : ITextDecorationProvider
     private static readonly TextDecoration AddressDecoration = new() { Foreground = IlColorizer.AddressColor };
     private static readonly TextDecoration CommentDecoration = new() { Foreground = IlColorizer.CommentColor };
     private static readonly TextDecoration OpcodeDecoration = new() { Foreground = IlColorizer.OpcodeColor };
+    private static readonly TextDecoration DirectiveDecoration = new() { Foreground = IlColorizer.DirectiveColor };
     private static readonly TextDecoration StringDecoration = new() { Foreground = IlColorizer.StringColor };
 
     /// <inheritdoc />
@@ -40,6 +41,15 @@ public sealed class IlSyntaxDecorationProvider : ITextDecorationProvider
             if (text.StartsWith("IL_"))
             {
                 ParseInstruction(spans, text, line);
+                continue;
+            }
+
+            if (IlColorizer.TryGetLocalsInitSpan(text, out var startIndex, out var length))
+            {
+                spans.Add(new TextDecorationSpan(
+                    new DocumentPosition(line, startIndex + 1),
+                    new DocumentPosition(line, startIndex + length + 1),
+                    DirectiveDecoration));
             }
         }
 

--- a/src/Dotsider/Views/PeMetadataView.cs
+++ b/src/Dotsider/Views/PeMetadataView.cs
@@ -67,6 +67,8 @@ public static class PeMetadataView
                     PeSubTabId.Attributes when analyzer.CustomAttributes.Count > 0 =>
                         $"{analyzer.CustomAttributes[0].Parent}|{analyzer.CustomAttributes[0].Constructor}",
                     PeSubTabId.Resources when analyzer.Resources.Count > 0 => analyzer.Resources[0].Name,
+                    PeSubTabId.DebugDirectory when analyzer.DebugDirectory.Count > 0 =>
+                        GetDebugDirectoryKey(analyzer.DebugDirectory[0]),
                     _ => null
                 };
         }
@@ -222,7 +224,9 @@ public static class PeMetadataView
                     tp.Tab("Attributes", t => [BuildAttributesTable(t, state)])
                         .Selected(state.PeSubTab == PeSubTabId.Attributes),
                     tp.Tab("Resources", t => [BuildResourcesTable(t, state)])
-                        .Selected(state.PeSubTab == PeSubTabId.Resources)
+                        .Selected(state.PeSubTab == PeSubTabId.Resources),
+                    tp.Tab("Debug Directory", t => [BuildDebugDirectoryTable(t, state)])
+                        .Selected(state.PeSubTab == PeSubTabId.DebugDirectory)
                 ])
                 .OnSelectionChanged(e =>
                 {
@@ -435,6 +439,59 @@ public static class PeMetadataView
                     $"Raw Offset: 0x{s.RawDataOffset:X8}",
                     $"Raw Size: {s.RawDataSize} (0x{s.RawDataSize:X})",
                     $"Characteristics: {s.Characteristics}");
+                state.App.RequestFocus(node => node is EditorNode);
+                state.App.Invalidate();
+            })
+            .Compact().Fill();
+    }
+
+    private static TableWidget<DebugDirectoryInfo> BuildDebugDirectoryTable(
+        WidgetContext<VStackWidget> ctx,
+        DotsiderState state)
+    {
+        var query = state.Search[TabId.PeMetadata].Query;
+        var data = ApplySearch(state.Analyzer.DebugDirectory, query,
+            d => $"{d.Type} {d.Stamp:X8} {d.Payload}");
+        state.Search[TabId.PeMetadata].SetMatchCount(data.Count);
+
+        return ctx.Table(data)
+            .RowKey(GetDebugDirectoryKey)
+            .Header(h =>
+            [
+                h.Cell("Type").Width(SizeHint.Fixed(20)),
+                h.Cell("Stamp").Width(SizeHint.Fixed(12)),
+                h.Cell("Major").Width(SizeHint.Fixed(7)),
+                h.Cell("Minor").Width(SizeHint.Fixed(7)),
+                h.Cell("Size").Width(SizeHint.Fixed(10)),
+                h.Cell("RVA").Width(SizeHint.Fixed(12)),
+                h.Cell("Pointer").Width(SizeHint.Fixed(12)),
+                h.Cell("Payload").Width(SizeHint.Fill)
+            ])
+            .Row((r, d, rs) =>
+            [
+                r.Cell(c => FocusHighlightCell(c,d.Type.ToString(), query, true, rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,HexCell(c, $"0x{d.Stamp:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,c.Text(d.MajorVersion.ToString()), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,c.Text(d.MinorVersion.ToString()), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,c.Text(FormatSize(d.DataSize, state)), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,HexCell(c, $"0x{d.AddressOfRawData:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c,HexCell(c, $"0x{d.PointerToRawData:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c,d.Payload, query, true, rs.IsFocused))
+            ])
+            .Focus(state.PeDetailContent is not null || state.App.FocusedNode is EditorNode ? null : state.PeFocusedKey)
+            .OnFocusChanged(key => state.PeFocusedKey = key)
+            .OnRowActivated((_, d) =>
+            {
+                state.PeDetailContent = string.Join("\n",
+                    "Debug Directory",
+                    $"Type: {d.Type}",
+                    $"Stamp: 0x{d.Stamp:X8}",
+                    $"Major Version: {d.MajorVersion}",
+                    $"Minor Version: {d.MinorVersion}",
+                    $"Data Size: {d.DataSize} (0x{d.DataSize:X})",
+                    $"Address Of Raw Data: 0x{d.AddressOfRawData:X8}",
+                    $"Pointer To Raw Data: 0x{d.PointerToRawData:X8}",
+                    $"Payload: {d.Payload}");
                 state.App.RequestFocus(node => node is EditorNode);
                 state.App.Invalidate();
             })
@@ -739,9 +796,14 @@ public static class PeMetadataView
                 a => $"{a.Parent} {a.Constructor} {a.Value}").Select(a => (object)$"{a.Parent}|{a.Constructor}")],
             PeSubTabId.Resources => [.. ApplySearch(analyzer.Resources, query,
                 r => $"{r.Name} {r.Visibility}").Select(r => (object)r.Name)],
+            PeSubTabId.DebugDirectory => [.. ApplySearch(analyzer.DebugDirectory, query,
+                d => $"{d.Type} {d.Stamp:X8} {d.Payload}").Select(d => (object)GetDebugDirectoryKey(d))],
             _ => []
         };
     }
+
+    private static string GetDebugDirectoryKey(DebugDirectoryInfo info) =>
+        $"{info.Type}:{info.AddressOfRawData:X8}:{info.PointerToRawData:X8}";
 
     private static int FindKeyIndex(IReadOnlyList<object> keys, object? focusedKey)
     {

--- a/src/Dotsider/Views/YankHelper.cs
+++ b/src/Dotsider/Views/YankHelper.cs
@@ -124,6 +124,7 @@ public static class YankHelper
             PeSubTabId.MemberRef => FormatMemberRef(analyzer.MemberRefs, state.PeFocusedKey),
             PeSubTabId.Attributes => FormatAttribute(analyzer.CustomAttributes, state.PeFocusedKey),
             PeSubTabId.Resources => FormatResource(analyzer.Resources, state.PeFocusedKey),
+            PeSubTabId.DebugDirectory => FormatDebugDirectory(analyzer.DebugDirectory, state.PeFocusedKey),
             _ => null
         };
     }
@@ -264,6 +265,16 @@ public static class YankHelper
         var r = resources.FirstOrDefault(x => (object)x.Name == key || x.Name.Equals(key));
         return r is null ? null
             : $"{r.Name}\t{r.Visibility}\t0x{r.Offset:X8}\t{r.Size}\t{(r.IsLinked ? "Yes" : "No")}";
+    }
+
+    private static string? FormatDebugDirectory(IReadOnlyList<DebugDirectoryInfo> entries, object key)
+    {
+        if (key is not string compositeKey) return null;
+        var entry = entries.FirstOrDefault(x =>
+            $"{x.Type}:{x.AddressOfRawData:X8}:{x.PointerToRawData:X8}" == compositeKey);
+        return entry is null ? null
+            : $"{entry.Type}\t0x{entry.Stamp:X8}\t{entry.MajorVersion}\t{entry.MinorVersion}\t{entry.DataSize}\t"
+                + $"0x{entry.AddressOfRawData:X8}\t0x{entry.PointerToRawData:X8}\t{entry.Payload}";
     }
 
     private static string? FormatDiffTypesRow(DiffState state, string key)

--- a/tests/Dotsider.Mcp.Tests/IlToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/IlToolsTests.cs
@@ -38,6 +38,96 @@ public class IlToolsTests(SampleAssemblyFixture samples) : McpServerTestBase
     }
 
     /// <summary>
+    /// disassemble_method can include portable PDB debug information when requested.
+    /// </summary>
+    [Fact]
+    public async Task DisassembleMethod_WithDebugInfo_ReturnsPortablePdbData()
+    {
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "disassemble_method",
+            new Dictionary<string, object?>
+            {
+                ["assemblyPath"] = samples.RichLibraryDll,
+                ["typeName"] = "UserService",
+                ["methodName"] = "Add",
+                ["includeDebugInfo"] = true
+            },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+
+        Assert.Equal("sidecar", json.GetProperty("pdb").GetProperty("kind").GetString());
+        Assert.True(json.GetProperty("sourceLink").GetProperty("isPresent").GetBoolean());
+        Assert.True(json.GetProperty("debugInfo").GetProperty("sequencePoints").GetArrayLength() > 0);
+        Assert.Contains(json.GetProperty("instructions").EnumerateArray(),
+            instruction => instruction.TryGetProperty("localName", out var localName)
+                && localName.GetString() == "id");
+    }
+
+    /// <summary>
+    /// get_method_debug_info returns sequence points and local names for a method.
+    /// </summary>
+    [Fact]
+    public async Task GetMethodDebugInfo_ReturnsSequencePointsAndLocals()
+    {
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "get_method_debug_info",
+            new Dictionary<string, object?>
+            {
+                ["assemblyPath"] = samples.RichLibraryDll,
+                ["typeName"] = "UserService",
+                ["methodName"] = "Add"
+            },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+
+        Assert.Equal("sidecar", json.GetProperty("pdb").GetProperty("kind").GetString());
+        Assert.Contains(json.GetProperty("sequencePoints").EnumerateArray(),
+            point => point.GetProperty("document").GetString()?.EndsWith("UserService.cs",
+                StringComparison.OrdinalIgnoreCase) == true);
+        Assert.Contains(json.GetProperty("locals").EnumerateArray(),
+            local => local.GetProperty("name").GetString() == "id");
+    }
+
+    /// <summary>
+    /// get_source_link returns decoded Source Link mappings.
+    /// </summary>
+    [Fact]
+    public async Task GetSourceLink_ReturnsMappings()
+    {
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "get_source_link",
+            new Dictionary<string, object?>
+            {
+                ["assemblyPath"] = samples.RichLibraryDll
+            },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+
+        Assert.True(json.GetProperty("isPresent").GetBoolean());
+        Assert.Contains(json.GetProperty("mappings").EnumerateArray(),
+            mapping => mapping.GetProperty("urlTemplate").GetString()?.Contains("raw.githubusercontent.com",
+                StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    /// <summary>
     /// Requesting IL for a method that does not exist yields a descriptive error.
     /// </summary>
     [Fact]

--- a/tests/Dotsider.Mcp.Tests/ToolRegistrationTests.cs
+++ b/tests/Dotsider.Mcp.Tests/ToolRegistrationTests.cs
@@ -26,6 +26,8 @@ public class ToolRegistrationTests : McpServerTestBase
 
         // IL tools
         Assert.Contains("disassemble_method", names);
+        Assert.Contains("get_method_debug_info", names);
+        Assert.Contains("get_source_link", names);
         Assert.Contains("search_il_opcodes", names);
 
         // Metadata tools

--- a/tests/Dotsider.Tests/AssemblyAnalyzerTests.cs
+++ b/tests/Dotsider.Tests/AssemblyAnalyzerTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection.PortableExecutable;
 using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Tests;
 
@@ -170,6 +171,62 @@ public class AssemblyAnalyzerTests(SampleAssemblyFixture samples)
         Assert.True(a.MethodDefs.Count > 10);
     }
 
+    /// <summary>
+    /// Verifies rich library opens its matching portable PDB sidecar.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void RichLibrary_OpensPortablePdbSidecar()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+
+        Assert.True(a.HasPortablePdb);
+        Assert.Equal(PdbProvenanceKind.Sidecar, a.PdbProvenance.Kind);
+        Assert.NotNull(a.PdbProvenance.Path);
+        Assert.NotNull(a.GetPdbReader());
+        Assert.Contains(a.DebugDirectory, entry => entry.Type == DebugDirectoryEntryType.CodeView);
+    }
+
+    /// <summary>
+    /// Verifies rich library source link mappings resolve method documents.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void RichLibrary_SourceLink_ResolvesMethodDocument()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var method = FindMethod(a, "RichLibrary.Services.UserService", "Add");
+        var debugInfo = a.GetMethodDebugInfo(method);
+        var document = debugInfo.SequencePoints
+            .First(point => point.Document?.EndsWith("UserService.cs", StringComparison.OrdinalIgnoreCase) == true)
+            .Document!;
+
+        var url = a.ResolveSourceLinkUrl(document);
+
+        Assert.True(a.SourceLink.IsPresent);
+        Assert.NotEmpty(a.SourceLink.Mappings);
+        Assert.NotNull(url);
+        Assert.Contains("raw.githubusercontent.com", url);
+        Assert.EndsWith("UserService.cs", url, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Verifies method debug info exposes sequence points and PDB local names.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void RichLibrary_MethodDebugInfo_IncludesSequencePointsAndLocals()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var method = FindMethod(a, "RichLibrary.Services.UserService", "Add");
+
+        var debugInfo = a.GetMethodDebugInfo(method);
+
+        Assert.Equal(PdbProvenanceKind.Sidecar, debugInfo.Pdb.Kind);
+        Assert.Contains(debugInfo.SequencePoints,
+            point => point.Document?.EndsWith("UserService.cs", StringComparison.OrdinalIgnoreCase) == true
+                && point.SourceLinkUrl is not null);
+        Assert.Contains(debugInfo.Locals, local => local.Name == "id");
+        Assert.Contains(debugInfo.Locals, local => local.Name == "user");
+    }
+
     // --- ComplexApp (Exe, embedded resources) ---
 
     /// <summary>
@@ -264,6 +321,27 @@ public class AssemblyAnalyzerTests(SampleAssemblyFixture samples)
         using var a = new AssemblyAnalyzer(samples.EmptyLibDll);
         Assert.True(a.HasMetadata);
         Assert.NotNull(a.ClrHeader);
+    }
+
+    /// <summary>
+    /// Verifies embedded source can be decoded from an embedded portable PDB.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void EmbeddedSourceLib_DecodesEmbeddedSource()
+    {
+        using var a = new AssemblyAnalyzer(samples.EmbeddedSourceLibDll);
+        var method = FindMethod(a, "EmbeddedSourceLib.EmbeddedSourceFixture", "Compute");
+
+        var debugInfo = a.GetMethodDebugInfo(method);
+        var source = a.GetEmbeddedSource(method);
+
+        Assert.True(a.HasPortablePdb);
+        Assert.Equal(PdbProvenanceKind.Embedded, a.PdbProvenance.Kind);
+        Assert.Contains(a.DebugDirectory, entry => entry.Type == DebugDirectoryEntryType.EmbeddedPortablePdb);
+        Assert.Contains(debugInfo.SequencePoints, point => point.HasEmbeddedSource);
+        Assert.NotNull(source);
+        Assert.Contains("return doubled + 1;", source.Text);
+        Assert.NotEmpty(source.Bytes);
     }
 
     // --- RichLibraryV2 (same AssemblyName as V1) ---
@@ -764,5 +842,15 @@ public class AssemblyAnalyzerTests(SampleAssemblyFixture samples)
         var token = a.MethodDefs.First(m => m.Rva > 0).Token;
         a.Dispose();
         Assert.Throws<ObjectDisposedException>(() => a.ResolveToken(token));
+    }
+
+    private static MethodDefInfo FindMethod(AssemblyAnalyzer analyzer, string typeName, string methodName)
+    {
+        var method = analyzer.MethodDefs.FirstOrDefault(m =>
+            m.DeclaringType == typeName
+            && m.Name == methodName);
+
+        Assert.NotNull(method);
+        return method;
     }
 }

--- a/tests/Dotsider.Tests/CliTests.cs
+++ b/tests/Dotsider.Tests/CliTests.cs
@@ -46,6 +46,70 @@ public class CliTests(SampleAssemblyFixture fixture)
         Assert.Contains("System.Runtime", stdout);
     }
 
+    /// <summary>
+    /// Verifies analyze default output includes portable PDB summary lines.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_Default_ShowsPortablePdbSummary()
+    {
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.RichLibraryDll);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("PDB:", stdout);
+        Assert.Contains("Sidecar(", stdout);
+        Assert.Contains("SourceLink: present", stdout);
+    }
+
+    /// <summary>
+    /// Verifies analyze default JSON includes portable PDB metadata.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_Default_Json_IncludesPortablePdbMetadata()
+    {
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.RichLibraryDll, "--json");
+
+        Assert.Equal(0, exitCode);
+        var json = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(stdout);
+        Assert.Equal("sidecar", json.GetProperty("pdbProvenance").GetProperty("kind").GetString());
+        Assert.True(json.GetProperty("sourceLink").GetProperty("isPresent").GetBoolean());
+        Assert.True(json.GetProperty("debugDirectory").GetArrayLength() > 0);
+    }
+
+    /// <summary>
+    /// Verifies analyze IL output includes portable PDB annotations.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_Il_ShowsPortablePdbAnnotations()
+    {
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.RichLibraryDll, "--il", "RichLibrary.Services.UserService.Add");
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("// PDB: Sidecar", stdout);
+        Assert.Contains("// Source Link: present", stdout);
+        Assert.Contains("UserService.cs", stdout);
+        Assert.Contains("[source link]", stdout);
+        Assert.Contains("// id", stdout);
+        Assert.DoesNotContain("raw.githubusercontent.com", stdout);
+    }
+
+    /// <summary>
+    /// Verifies analyze embedded source prints source text from an embedded portable PDB.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_EmbeddedSource_PrintsEmbeddedSource()
+    {
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.EmbeddedSourceLibDll, "--embedded-source",
+            "EmbeddedSourceLib.EmbeddedSourceFixture.Compute");
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("internal static class EmbeddedSourceFixture", stdout);
+        Assert.Contains("return doubled + 1;", stdout);
+    }
+
     // --- P1: --output safety ---
 
     /// <summary>

--- a/tests/Dotsider.Tests/IlColorizerTests.cs
+++ b/tests/Dotsider.Tests/IlColorizerTests.cs
@@ -14,6 +14,7 @@ public class IlColorizerTests
     private static readonly string AddressFg = Hex1bColor.FromRgb(100, 100, 130).ToForegroundAnsi();
     private static readonly string CommentFg = Hex1bColor.FromRgb(90, 90, 110).ToForegroundAnsi();
     private static readonly string OpcodeFg = Hex1bColor.FromRgb(0, 170, 160).ToForegroundAnsi();
+    private static readonly string DirectiveFg = Hex1bColor.FromRgb(125, 130, 170).ToForegroundAnsi();
     private static readonly string StringFg = Hex1bColor.FromRgb(100, 180, 100).ToForegroundAnsi();
 
     // --- Passthrough cases ---
@@ -69,6 +70,16 @@ public class IlColorizerTests
         var line = "  // RVA: 0x00002050";
         var result = IlColorizer.ColorizeLine(line);
         Assert.Equal($"{CommentFg}{line}{Reset}", result);
+    }
+
+    /// <summary>
+    /// Verifies locals init directive is colored without coloring the rest of the line.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void LocalsInit_ColorsDirectiveOnly()
+    {
+        var result = IlColorizer.ColorizeLine("    .locals init (");
+        Assert.Equal($"    {DirectiveFg}.locals init{Reset} (", result);
     }
 
     // --- Instruction coloring ---

--- a/tests/Dotsider.Tests/IlDisassemblerTests.cs
+++ b/tests/Dotsider.Tests/IlDisassemblerTests.cs
@@ -1,4 +1,5 @@
 using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Tests;
 
@@ -36,6 +37,51 @@ public class IlDisassemblerTests(SampleAssemblyFixture samples)
         Assert.NotNull(method);
         var instructions = disasm.Disassemble(method);
         Assert.NotEmpty(instructions);
+    }
+
+    /// <summary>
+    /// Verifies formatted IL includes portable PDB annotations.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void RichLibrary_UserServiceAdd_FormatIncludesPortablePdbAnnotations()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var disasm = new IlDisassembler(a);
+        var method = FindMethod(a, "RichLibrary.Services.UserService", "Add");
+
+        var text = disasm.FormatDisassembly(method);
+
+        Assert.Contains("// PDB: Sidecar", text);
+        Assert.Contains("// Source Link: present", text);
+        Assert.Contains(".locals init", text);
+        Assert.Contains("UserService.cs", text);
+        Assert.Contains("[source link]", text);
+        Assert.Contains("// id", text);
+        Assert.Contains("// user", text);
+        Assert.DoesNotContain("raw.githubusercontent.com", text);
+    }
+
+    /// <summary>
+    /// Verifies decoded IL instructions carry sequence point and local variable metadata.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void RichLibrary_UserServiceAdd_InstructionsIncludeDebugMetadata()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var disasm = new IlDisassembler(a);
+        var method = FindMethod(a, "RichLibrary.Services.UserService", "Add");
+
+        var result = disasm.DisassembleWithText(method);
+
+        Assert.NotNull(result);
+        Assert.Contains(result.Value.Instructions,
+            instruction => instruction.SequenceDocument?.EndsWith("UserService.cs",
+                StringComparison.OrdinalIgnoreCase) == true
+                && instruction.SourceLinkUrl is not null);
+        Assert.Contains(result.Value.Instructions, instruction => instruction.LocalName == "id");
+        Assert.Contains(result.Value.Instructions, instruction => instruction.LocalName == "user");
+        Assert.All(result.Value.Instructions,
+            instruction => Assert.True(instruction.DisplayLine is null or > 0));
     }
 
     /// <summary>
@@ -281,5 +327,15 @@ public class IlDisassemblerTests(SampleAssemblyFixture samples)
                 return;
             }
         }
+    }
+
+    private static MethodDefInfo FindMethod(AssemblyAnalyzer analyzer, string typeName, string methodName)
+    {
+        var method = analyzer.MethodDefs.FirstOrDefault(m =>
+            m.DeclaringType == typeName
+            && m.Name == methodName);
+
+        Assert.NotNull(method);
+        return method;
     }
 }

--- a/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
+++ b/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
@@ -5,6 +5,7 @@ using Dotsider.Core.Analysis.Models;
 using Dotsider.Views;
 using Hex1b;
 using Hex1b.Automation;
+using Hex1b.Documents;
 using Hex1b.Input;
 using Hex1b.Widgets;
 
@@ -71,15 +72,49 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         await auto.WaitUntilTextAsync("// Method: RichLibrary.IlNavigationFixture::CallLocalMethod");
         await auto.WaitUntilTextAsync("call RichLibrary.IlNavigationFixture::LocalTarget");
 
-        // Focus editor with 'l', then navigate down to the call line.
-        // Cursor starts on the first IL instruction (IL_0000: nop), so 8 downs
-        // lands on IL_0010: call — independent of header line count.
+        // Focus the editor, then place the cursor on the call line by searching
+        // the rendered document. Portable PDB comments can add lines before the
+        // instruction, so fixed arrow counts are intentionally avoided here.
         await auto.KeyAsync(Hex1bKey.L, ct);
-        await Task.Delay(200, ct);
-        for (var i = 0; i < 8; i++) await auto.DownAsync(ct);
-        await Task.Delay(200, ct);
+        await auto.WaitUntilAsync(_ => _state!.IlEditorState is not null,
+            description: "IL editor state is ready");
+
+        const string callText = "call RichLibrary.IlNavigationFixture::LocalTarget";
+        var text = _state!.IlEditorState!.Document.GetText();
+        var callOffset = text.IndexOf(callText, StringComparison.Ordinal);
+        Assert.True(callOffset >= 0, $"Expected rendered IL to contain '{callText}'.");
+
+        await SetIlCursorAsync(auto, callOffset, "cursor moved to local call instruction");
 
         return _state!.IlEditorState?.Cursor.Position.Value ?? -1;
+    }
+
+    private async Task SetIlCursorAsync(
+        Hex1bTerminalAutomator auto,
+        int offset,
+        string description)
+    {
+        _state!.IlEditorState!.SetCursorPosition(new DocumentOffset(offset));
+        _state.App.Invalidate();
+        await auto.WaitUntilAsync(
+            _ => _state.IlEditorState?.Cursor.Position.Value == offset,
+            description: description);
+    }
+
+    private async Task SetIlCursorOnInstructionAsync(
+        Hex1bTerminalAutomator auto,
+        IlInstruction instruction)
+    {
+        var marker = $"IL_{instruction.Offset:X4}:";
+        var text = _state!.IlEditorState!.Document.GetText();
+        var offset = text.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(offset >= 0, $"Expected rendered IL to contain '{marker}'.");
+
+        await SetIlCursorAsync(auto, offset, $"cursor moved to {marker}");
+        var instAtCursor = IlNavigationHelper.GetInstructionAtCursor(
+            _state.IlEditorState!, _state.IlInstructions!, _state.IlHeaderLineCount);
+        Assert.NotNull(instAtCursor);
+        Assert.Equal(instruction.Offset, instAtCursor!.Offset);
     }
 
     /// <inheritdoc/>
@@ -136,7 +171,8 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
             m.Name == "CallLocalMethod" && m.DeclaringType.Contains("IlNavigationFixture"));
         var result = dis.DisassembleWithText(method);
         Assert.NotNull(result);
-        Assert.Equal(result.Value.HeaderLineCount + result.Value.Instructions.Count,
+        var sequenceCommentCount = result.Value.Instructions.Count(i => i.SequenceStartLine is not null);
+        Assert.Equal(result.Value.HeaderLineCount + result.Value.Instructions.Count + sequenceCommentCount,
             result.Value.Text.Split('\n').Length);
     }
 
@@ -745,17 +781,7 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         var callIndex = instructions.FindIndex(i =>
             i.OpCode == "call" && i.MetadataToken is not null && i.Operand.Contains("WriteLine"));
         Assert.True(callIndex >= 0, "WriteLine call instruction must exist in CallExternal body");
-        for (var i = 0; i < callIndex; i++)
-        {
-            var expected = instructions[i + 1];
-            await auto.DownAsync(cts.Token);
-            await auto.WaitUntilAsync(_ =>
-            {
-                var inst = IlNavigationHelper.GetInstructionAtCursor(
-                    _state!.IlEditorState!, _state.IlInstructions!, _state.IlHeaderLineCount);
-                return inst is not null && inst.Offset == expected.Offset;
-            });
-        }
+        await SetIlCursorOnInstructionAsync(auto, instructions[callIndex]);
 
         var instAtCursor = IlNavigationHelper.GetInstructionAtCursor(
             _state.IlEditorState!, _state.IlInstructions!, _state.IlHeaderLineCount);
@@ -1089,17 +1115,7 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         var callIndex = instructions.FindIndex(i =>
             i.OpCode == "call" && i.MetadataToken is not null && i.Operand.Contains("WriteLine"));
         Assert.True(callIndex >= 0);
-        for (var i = 0; i < callIndex; i++)
-        {
-            var expected = instructions[i + 1];
-            await auto.DownAsync(cts.Token);
-            await auto.WaitUntilAsync(_ =>
-            {
-                var inst = IlNavigationHelper.GetInstructionAtCursor(
-                    _state!.IlEditorState!, _state.IlInstructions!, _state.IlHeaderLineCount);
-                return inst is not null && inst.Offset == expected.Offset;
-            });
-        }
+        await SetIlCursorOnInstructionAsync(auto, instructions[callIndex]);
 
         // Real gd via Enter — cross-assembly into System.Console.dll.
         await auto.EnterAsync(cts.Token);

--- a/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
+++ b/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
@@ -75,9 +75,7 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         // Focus the editor, then place the cursor on the call line by searching
         // the rendered document. Portable PDB comments can add lines before the
         // instruction, so fixed arrow counts are intentionally avoided here.
-        await auto.KeyAsync(Hex1bKey.L, ct);
-        await auto.WaitUntilAsync(_ => _state!.IlEditorState is not null,
-            description: "IL editor state is ready");
+        await FocusIlEditorAsync(auto, ct);
 
         const string callText = "call RichLibrary.IlNavigationFixture::LocalTarget";
         var text = _state!.IlEditorState!.Document.GetText();
@@ -99,6 +97,15 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         await auto.WaitUntilAsync(
             _ => _state.IlEditorState?.Cursor.Position.Value == offset,
             description: description);
+    }
+
+    private async Task FocusIlEditorAsync(Hex1bTerminalAutomator auto, CancellationToken ct)
+    {
+        await auto.KeyAsync(Hex1bKey.L, ct);
+        await auto.WaitUntilAsync(
+            _ => _state!.App.FocusedNode is Hex1b.EditorNode { State: var editorState }
+                && ReferenceEquals(editorState, _state.IlEditorState),
+            description: "IL editor focused");
     }
 
     private async Task SetIlCursorOnInstructionAsync(
@@ -318,7 +325,9 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         // RestoreFromIlBackEntry queues focus on the EditorNode. The actual focus shift
         // applies on a later frame; without an explicit wait, Down/Up below can race
         // a frame where focus is still on the tree and the cursor never moves.
-        await auto.WaitUntilAsync(_ => _state!.App.FocusedNode is Hex1b.EditorNode,
+        await auto.WaitUntilAsync(
+            _ => _state!.App.FocusedNode is Hex1b.EditorNode { State: var editorState }
+                && ReferenceEquals(editorState, _state.IlEditorState),
             description: "editor focused after Esc back");
         var cursorBeforeScroll = _state!.IlEditorState?.Cursor.Position.Value ?? -1;
 
@@ -765,7 +774,7 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         // first IL instruction). Per hex1b testing guide, poll on state rather
         // than Task.Delay — Linux/macOS CI rendered slower than Windows and
         // raced the down loop below.
-        await auto.KeyAsync(Hex1bKey.L, cts.Token);
+        await FocusIlEditorAsync(auto, cts.Token);
         await auto.WaitUntilAsync(_ =>
         {
             if (_state!.IlEditorState is null || _state.IlInstructions is null
@@ -1101,7 +1110,7 @@ public sealed class IlGoToDefinitionTests(SampleAssemblyFixture samples) : IDisp
         await auto.WaitUntilTextAsync("// Method: RichLibrary.IlNavigationFixture::CallExternal");
 
         // Focus editor and walk to the WriteLine call (PR #160's polling pattern).
-        await auto.KeyAsync(Hex1bKey.L, cts.Token);
+        await FocusIlEditorAsync(auto, cts.Token);
         await auto.WaitUntilAsync(_ =>
         {
             if (_state!.IlEditorState is null || _state.IlInstructions is null

--- a/tests/Dotsider.Tests/IlNavigationHelperTests.cs
+++ b/tests/Dotsider.Tests/IlNavigationHelperTests.cs
@@ -1,0 +1,67 @@
+using Dotsider.Core.Analysis.Models;
+using Dotsider.Views;
+using Hex1b.Documents;
+using Hex1b.Widgets;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests cursor mapping helpers for the IL editor.
+/// </summary>
+public sealed class IlNavigationHelperTests
+{
+    /// <summary>
+    /// Verifies a source comment line resolves to the following instruction's Source Link URL.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void GetSourceLinkUrlAtCursor_SourceCommentLine_ReturnsUrl()
+    {
+        const string url = "https://raw.githubusercontent.com/willibrandon/dotsider/abc/UserService.cs";
+        var editorState = CreateEditorState("// UserService.cs(1,1)-(1,2) [source link]\nIL_0000: nop");
+        var instructions = new[]
+        {
+            new IlInstruction(
+                0,
+                "nop",
+                "",
+                SequenceStartLine: 1,
+                SourceLinkUrl: url,
+                DisplayLine: 2)
+        };
+
+        var actual = IlNavigationHelper.GetSourceLinkUrlAtCursor(editorState, instructions);
+
+        Assert.Equal(url, actual);
+    }
+
+    /// <summary>
+    /// Verifies source comment lines do not resolve as instruction lines for go-to-definition.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void GetInstructionAtCursor_SourceCommentLine_ReturnsNull()
+    {
+        var editorState = CreateEditorState("// UserService.cs(1,1)-(1,2) [source link]\nIL_0000: call Foo::Bar");
+        var instructions = new[]
+        {
+            new IlInstruction(
+                0,
+                "call",
+                "Foo::Bar",
+                MetadataToken: 0x06000001,
+                SequenceStartLine: 1,
+                SourceLinkUrl: "https://example.test/UserService.cs",
+                DisplayLine: 2)
+        };
+
+        var actual = IlNavigationHelper.GetInstructionAtCursor(editorState, instructions, headerLineCount: 0);
+
+        Assert.Null(actual);
+    }
+
+    private static EditorState CreateEditorState(string text)
+    {
+        var editorState = new EditorState(new Hex1bDocument(text));
+        editorState.SetCursorPosition(new DocumentOffset(0));
+        return editorState;
+    }
+}

--- a/tests/Dotsider.Tests/IlNavigationHelperTests.cs
+++ b/tests/Dotsider.Tests/IlNavigationHelperTests.cs
@@ -35,6 +35,37 @@ public sealed class IlNavigationHelperTests
     }
 
     /// <summary>
+    /// Verifies a source comment line resolves the rendered Source Link marker range.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void GetSourceLinkMarkerRangeAtCursor_SourceCommentLine_ReturnsMarkerRange()
+    {
+        const string line = "// UserService.cs(1,1)-(1,2) [source link]";
+        var editorState = CreateEditorState($"{line}\nIL_0000: nop");
+        var instructions = new[]
+        {
+            new IlInstruction(
+                0,
+                "nop",
+                "",
+                SequenceStartLine: 1,
+                SourceLinkUrl: "https://example.test/UserService.cs",
+                DisplayLine: 2)
+        };
+
+        var actual = IlNavigationHelper.GetSourceLinkMarkerRangeAtCursor(editorState, instructions);
+
+        var markerStart = line.IndexOf(IlSourceLinkDecorationProvider.SourceLinkMarker, StringComparison.Ordinal);
+        Assert.NotNull(actual);
+        Assert.Equal(new DocumentPosition(1, markerStart + 1), actual.Value.Start);
+        Assert.Equal(
+            new DocumentPosition(
+                1,
+                markerStart + IlSourceLinkDecorationProvider.SourceLinkMarker.Length + 1),
+            actual.Value.End);
+    }
+
+    /// <summary>
     /// Verifies source comment lines do not resolve as instruction lines for go-to-definition.
     /// </summary>
     [Fact(Timeout = 30_000)]

--- a/tests/Dotsider.Tests/IlSourceLinkDecorationProviderTests.cs
+++ b/tests/Dotsider.Tests/IlSourceLinkDecorationProviderTests.cs
@@ -1,0 +1,71 @@
+using Dotsider.Core.Analysis.Models;
+using Dotsider.Views;
+using Hex1b;
+using Hex1b.Documents;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for Source Link marker decorations in the IL editor.
+/// </summary>
+public sealed class IlSourceLinkDecorationProviderTests
+{
+    /// <summary>
+    /// Verifies Source Link markers are underlined when the instruction has a resolved URL.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void GetDecorations_SourceLinkMarker_ReturnsUnderlineSpan()
+    {
+        var line = "// UserService.cs(1,1)-(1,2) [source link]";
+        var document = new Hex1bDocument($"{line}\nIL_0000: nop");
+        var provider = new IlSourceLinkDecorationProvider
+        {
+            Instructions =
+            [
+                new IlInstruction(
+                    0,
+                    "nop",
+                    "",
+                    SequenceStartLine: 1,
+                    SourceLinkUrl: "https://example.test/UserService.cs",
+                    DisplayLine: 2)
+            ]
+        };
+
+        var spans = provider.GetDecorations(1, 2, document);
+
+        var span = Assert.Single(spans);
+        var markerStart = line.IndexOf(IlSourceLinkDecorationProvider.SourceLinkMarker, StringComparison.Ordinal);
+        Assert.Equal(new DocumentPosition(1, markerStart + 1), span.Start);
+        Assert.Equal(new DocumentPosition(
+            1,
+            markerStart + IlSourceLinkDecorationProvider.SourceLinkMarker.Length + 1), span.End);
+        Assert.Equal(UnderlineStyle.Single, span.Decoration.UnderlineStyle);
+        Assert.Equal(12, span.Priority);
+    }
+
+    /// <summary>
+    /// Verifies markers without resolved Source Link URLs are not decorated.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void GetDecorations_NoSourceLinkUrl_ReturnsEmpty()
+    {
+        var document = new Hex1bDocument("// UserService.cs(1,1)-(1,2) [source link]\nIL_0000: nop");
+        var provider = new IlSourceLinkDecorationProvider
+        {
+            Instructions =
+            [
+                new IlInstruction(
+                    0,
+                    "nop",
+                    "",
+                    SequenceStartLine: 1,
+                    DisplayLine: 2)
+            ]
+        };
+
+        var spans = provider.GetDecorations(1, 2, document);
+
+        Assert.Empty(spans);
+    }
+}

--- a/tests/Dotsider.Tests/IlSyntaxDecorationProviderTests.cs
+++ b/tests/Dotsider.Tests/IlSyntaxDecorationProviderTests.cs
@@ -115,6 +115,23 @@ public class IlSyntaxDecorationProviderTests
     }
 
     /// <summary>
+    /// Verifies locals init line returns directive span.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void LocalsInitLine_ReturnsDirectiveSpan()
+    {
+        var line = "    .locals init (";
+        var doc = new Hex1bDocument(line);
+
+        var spans = _provider.GetDecorations(1, 1, doc);
+
+        var span = Assert.Single(spans);
+        Assert.Equal(IlColorizer.DirectiveColor, span.Decoration.Foreground);
+        Assert.Equal(5, span.Start.Column);
+        Assert.Equal(17, span.End.Column);
+    }
+
+    /// <summary>
     /// Verifies blank line no spans.
     /// </summary>
     [Fact(Timeout = 30_000)]

--- a/tests/Dotsider.Tests/PeMetadataViewTests.cs
+++ b/tests/Dotsider.Tests/PeMetadataViewTests.cs
@@ -287,6 +287,46 @@ public class PeMetadataViewTests(SampleAssemblyFixture samples) : IDisposable
     }
 
     /// <summary>
+    /// Verifies pe metadata navigate to debug directory.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_NavigateToDebugDirectory()
+    {
+        var (terminal, app) = CreateDotsiderApp();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
+
+        await auto.WaitUntilAsync(
+            s => s.InAlternateScreen && s.ContainsText("Sections"),
+            description: "PE metadata renders");
+
+        for (var expected = PeSubTabId.TypeDef; expected <= PeSubTabId.DebugDirectory; expected++)
+        {
+            await auto.KeyAsync(Hex1bKey.RightArrow, ct: cts.Token);
+            var expectedSubTab = expected;
+            await auto.WaitUntilAsync(
+                _ => _state!.PeSubTab == expectedSubTab,
+                description: $"PE sub-tab {expectedSubTab} selected");
+        }
+
+        await auto.WaitUntilAsync(
+            s => s.ContainsText("Debug Directory") && s.ContainsText("CodeView"),
+            description: "Debug Directory table renders");
+        await auto.EnterAsync(cts.Token);
+        await auto.WaitUntilAsync(
+            _ => _state!.PeDetailContent?.Contains("Debug Directory", StringComparison.Ordinal) == true,
+            description: "Debug Directory detail opens");
+
+        Assert.Equal(PeSubTabId.DebugDirectory, _state!.PeSubTab);
+        Assert.Contains("Payload:", _state.PeDetailContent);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
     /// Verifies pe metadata shows clr header fields.
     /// </summary>
     [Fact(Timeout = 30_000)]

--- a/tests/Dotsider.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Tests/SampleAssemblyFixture.cs
@@ -54,6 +54,10 @@ public class SampleAssemblyFixture : IAsyncLifetime
     /// Path to the built EmptyLib.dll sample assembly.
     /// </summary>
     public string EmptyLibDll { get; private set; } = null!;
+    /// <summary>
+    /// Path to the built EmbeddedSourceLib.dll sample assembly.
+    /// </summary>
+    public string EmbeddedSourceLibDll { get; private set; } = null!;
 
     /// <summary>
     /// Path to the built AppLocalRollForward.dll sample assembly. Reproduces the AppLocal
@@ -158,6 +162,7 @@ public class SampleAssemblyFixture : IAsyncLifetime
             BuildProject("samples/MinimalApi"),
             BuildProject("samples/NativeLib"),
             BuildProject("samples/EmptyLib"),
+            BuildProject("samples/EmbeddedSourceLib"),
             BuildProject("samples/Dotted.Name.App"),
             BuildProject("samples/AppLocalRollForward"),
         };
@@ -193,6 +198,7 @@ public class SampleAssemblyFixture : IAsyncLifetime
         RichLibraryV2Dll = SamplePath("RichLibraryV2", config, tfm, "RichLibrary.dll");
         NativeLibDll = SamplePath("NativeLib", config, tfm, "NativeLib.dll");
         EmptyLibDll = SamplePath("EmptyLib", config, tfm, "EmptyLib.dll");
+        EmbeddedSourceLibDll = SamplePath("EmbeddedSourceLib", config, tfm, "EmbeddedSourceLib.dll");
         AppLocalRollForwardDll = SamplePath(
             "AppLocalRollForward", config, tfm, "AppLocalRollForward.dll");
         DottedNameAppDll = SamplePath("Dotted.Name.App", config, tfm, "Dotted.Name.App.dll");
@@ -246,6 +252,8 @@ public class SampleAssemblyFixture : IAsyncLifetime
         // Verify critical paths exist
         Assert.True(File.Exists(HelloWorldDll), $"HelloWorld.dll not found at {HelloWorldDll}");
         Assert.True(File.Exists(RichLibraryDll), $"RichLibrary.dll not found at {RichLibraryDll}");
+        Assert.True(File.Exists(EmbeddedSourceLibDll),
+            $"EmbeddedSourceLib.dll not found at {EmbeddedSourceLibDll}");
         Assert.True(File.Exists(RichLibraryNupkg), $"RichLibrary.nupkg not found at {RichLibraryNupkg}");
         Assert.True(File.Exists(AppLocalRollForwardDll),
             $"AppLocalRollForward.dll not found at {AppLocalRollForwardDll}");

--- a/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
@@ -1,6 +1,7 @@
 using Dotsider.Views;
 using Hex1b;
 using Hex1b.Automation;
+using Hex1b.Documents;
 using Hex1b.Input;
 using Hex1b.Widgets;
 
@@ -1480,6 +1481,67 @@ public class StandardModeYankIntegrationTests(SampleAssemblyFixture samples) : I
         // Verify: no newline, no bleed into next line
         Assert.True(yankedText.Length > 0);
         Assert.DoesNotContain("\n", yankedText);
+
+        _cts!.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    /// <summary>
+    /// Verifies il inspector source link yank copies the resolved URL.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task IlInspector_SourceLinkUrlYank_CopiesResolvedUrl()
+    {
+        var (terminal, app, ct) = Launch(samples.RichLibraryDll);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var method = _state!.Analyzer.MethodDefs.First(m =>
+            m.DeclaringType == "RichLibrary.Services.UserService" && m.Name == "Add");
+        _state.NavigateToIlMethod(method);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(_ => _state.IlEditorState?.Document.GetText()
+                .Contains(IlSourceLinkDecorationProvider.SourceLinkMarker, StringComparison.Ordinal) == true,
+                TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Type("l")
+            .WaitUntil(_ => IsFocusedOnEditor(_state.IlEditorState), TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var documentText = _state.IlEditorState!.Document.GetText();
+        var markerOffset = documentText.IndexOf(
+            IlSourceLinkDecorationProvider.SourceLinkMarker,
+            StringComparison.Ordinal);
+        Assert.True(markerOffset >= 0, "Expected rendered IL to contain a Source Link marker.");
+
+        _state.IlEditorState.SetCursorPosition(new DocumentOffset(markerOffset));
+        _state.App.Invalidate();
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(_ => IlNavigationHelper.GetSourceLinkUrlAtCursor(
+                _state.IlEditorState,
+                _state.IlInstructions!) is not null,
+                TimeSpan.FromSeconds(5))
+            .Type("u")
+            .WaitUntil(snapshot => _clipboardAdapter!.ClipboardWrites.TryPeek(out _),
+                TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        Assert.True(_clipboardAdapter!.ClipboardWrites.TryDequeue(out var yankedText),
+            "CopyToClipboard should have emitted an OSC 52 sequence");
+        Assert.StartsWith("https://raw.githubusercontent.com/willibrandon/dotsider/", yankedText);
+        Assert.EndsWith("samples/RichLibrary/Services/UserService.cs", yankedText);
 
         _cts!.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }


### PR DESCRIPTION
Adds portable PDB discovery for sidecar and embedded symbols, including debug directory rows, sequence points, local names, Source Link mappings, and embedded source extraction. Text IL keeps source spans readable with `[source link]` markers, while JSON and MCP keep the full URL for tooling.

Surfaces this debug data in the General view, PE Metadata debug directory, IL inspector, CLI, diagnostics protocol, and MCP tools. Public docs and generated API docs were refreshed, and the embedded-source sample gives the behavior a focused fixture.

Validated with `dotnet build Dotsider.slnx --no-restore`, focused analyzer/CLI/MCP/Hex1b UI tests, and `dotnet test Dotsider.slnx --no-build`.

Fixes: #157