### PR TITLE
Detect Native AOT binaries and fill the metadata-free views

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Grab a standalone binary from [Releases](https://github.com/willibrandon/dotside
 
 ## What it does
 
-dotsider opens any .NET DLL or EXE and lets you explore it across 8 tabs. If you open an apphost `.exe` that has no .NET metadata, dotsider detects the missing metadata and offers to open the companion managed `.dll` instead. If you open a self-contained single-file executable, dotsider reads the bundle, extracts the entry assembly, and analyzes it directly — no unpacking needed.
+dotsider opens any .NET DLL or EXE and lets you explore it across 8 tabs. If you open an apphost `.exe` that has no .NET metadata, dotsider detects the missing metadata and offers to open the companion managed `.dll` instead. If you open a self-contained single-file executable, dotsider reads the bundle, extracts the entry assembly, and analyzes it directly — no unpacking needed. If you open a Native AOT executable, dotsider validates its embedded ReadyToRun header and shows the binary kind, toolchain format version, runtime version, native import/export/load-config tables, and frozen UTF-16 string literals.
 
 | Tab | What you see |
 |-----|-------------|
 | **1 General** | Assembly identity, target framework, architecture, dependency table. Press Enter on a reference to drill into it. |
-| **2 PE/Metadata** | COFF headers, CLR header, sections, TypeDefs, MethodDefs, AssemblyRefs, custom attributes, resources, and debug directory rows. Press `g` on a TypeDef or MethodDef to jump to its IL. |
+| **2 PE/Metadata** | COFF headers, CLR header, sections, TypeDefs, MethodDefs, AssemblyRefs, custom attributes, resources, debug directory, native imports, exports, and load config rows. Press `g` on a TypeDef or MethodDef to jump to its IL. |
 | **3 IL Inspector** | Namespace/Type/Method tree with IL disassembly. Portable PDBs add source spans, Source Link markers, and local names when available. Press `u` on a `[source link]` marker to copy its resolved URL. Press `Enter` or `gd` on a `call`, `ldfld`, `newobj`, etc. to go to the target — works across assemblies. Press `Esc` to go back. Press `x` to jump to the method body in the hex dump. |
-| **4 Strings** | User strings, metadata strings, and raw binary string scan with configurable minimum length. |
+| **4 Strings** | User strings, metadata strings, and raw ASCII and UTF-16 binary scans with configurable minimum length. |
 | **5 Hex Dump** | Hex editor with vi-style modal editing (read-only by default), byte category coloring, data interpretation panel, jump-to-offset, and vim navigation. |
 | **6 Dep Graph** | Visual dependency graph — your assembly at the root, references as nodes, edge weights by TypeRef count. Press Enter on a node to open that assembly. |
 | **7 Size Map** | Treemap of code size — Assembly > Namespace > Type > Method, sized by IL byte count. Click to drill in; Enter on a method leaf jumps to its IL. |

--- a/benchmarks/Dotsider.Benchmarks/BenchmarkHelpers.cs
+++ b/benchmarks/Dotsider.Benchmarks/BenchmarkHelpers.cs
@@ -73,6 +73,22 @@ internal static class BenchmarkHelpers
     }
 
     /// <summary>
+    /// Publishes a sample project with Native AOT. Cached per <paramref name="relativePath"/>.
+    /// </summary>
+    /// <param name="relativePath">Path relative to repo root (e.g. "samples/NativeAotConsole").</param>
+    /// <returns>The absolute path to the project directory.</returns>
+    internal static string PublishNativeAotSample(string relativePath)
+    {
+        var projectDir = Path.Combine(GetRepoRoot(), relativePath);
+        return BuildCache.GetOrAdd($"publish-aot:{relativePath}", _ =>
+        {
+            var rid = RuntimeInformation.RuntimeIdentifier;
+            RunDotNet(projectDir, $"publish -c Release -r {rid} -v q");
+            return projectDir;
+        });
+    }
+
+    /// <summary>
     /// Returns the platform-specific apphost extension (e.g. ".exe" on Windows, "" on Unix).
     /// </summary>
     internal static string ApphostExtension =>
@@ -105,6 +121,11 @@ internal static class BenchmarkHelpers
             RedirectStandardOutput = true,
             RedirectStandardError = true,
         };
+
+        // NoDefaultCurrentDirectoryInExePath breaks the ILCompiler's findvcvarsall →
+        // VsDevCmd toolchain discovery during Native AOT publish. Clear it for this
+        // process only (harmless for plain builds).
+        psi.Environment.Remove("NoDefaultCurrentDirectoryInExePath");
 
         var process = Process.Start(psi)
             ?? throw new InvalidOperationException($"Failed to start: dotnet {arguments}");

--- a/benchmarks/Dotsider.Benchmarks/NativeAotDetectorBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/NativeAotDetectorBenchmarks.cs
@@ -1,0 +1,59 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Benchmarks;
+
+/// <summary>
+/// Benchmarks for <see cref="NativeAotDetector"/>. The detector scans the whole file
+/// for the RTR signature and validates each candidate, so the cases cover a real
+/// Native AOT binary (hits a false-positive code immediate before the genuine header),
+/// a large ReadyToRun-compiled managed assembly (many rejected candidates, no match),
+/// and a native apphost (no candidates at all).
+/// </summary>
+[MemoryDiagnoser]
+public class NativeAotDetectorBenchmarks
+{
+    private byte[] _nativeAotBytes = null!;
+    private byte[] _coreLibBytes = null!;
+    private byte[] _apphostBytes = null!;
+
+    /// <summary>
+    /// Publishes the Native AOT sample, builds the apphost sample, and loads all
+    /// binaries into memory.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        BenchmarkHelpers.PublishNativeAotSample("samples/NativeAotConsole");
+        BenchmarkHelpers.BuildSample("samples/HelloWorld");
+
+        _nativeAotBytes = File.ReadAllBytes(
+            BenchmarkHelpers.GetPublishPath("samples/NativeAotConsole", "NativeAotConsole"));
+        _coreLibBytes = File.ReadAllBytes(Path.Combine(
+            RuntimeEnvironment.GetRuntimeDirectory(), "System.Private.CoreLib.dll"));
+        _apphostBytes = File.ReadAllBytes(BenchmarkHelpers.GetBuildPath(
+            "samples/HelloWorld", "HelloWorld" + BenchmarkHelpers.ApphostExtension));
+    }
+
+    /// <summary>
+    /// Full detection on a real Native AOT executable: signature scan, false-positive
+    /// rejection, header validation, and the runtime-version heuristic.
+    /// </summary>
+    [Benchmark(Description = "Detect NativeAOT exe (positive)")]
+    public NativeAotInfo? Detect_NativeAotExe() => NativeAotDetector.Detect(_nativeAotBytes);
+
+    /// <summary>
+    /// Worst-case negative: CoreLib is a large ReadyToRun image whose R2R headers and
+    /// code immediates all fail validation, so the scan walks the entire file.
+    /// </summary>
+    [Benchmark(Description = "Detect CoreLib (R2R negative)")]
+    public NativeAotInfo? Detect_CoreLib() => NativeAotDetector.Detect(_coreLibBytes);
+
+    /// <summary>
+    /// Native apphost negative: no RTR candidates, pure signature-scan throughput.
+    /// </summary>
+    [Benchmark(Description = "Detect apphost (negative)")]
+    public NativeAotInfo? Detect_Apphost() => NativeAotDetector.Detect(_apphostBytes);
+}

--- a/benchmarks/Dotsider.Benchmarks/PeDirectoryReaderBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/PeDirectoryReaderBenchmarks.cs
@@ -1,0 +1,78 @@
+using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Benchmarks;
+
+/// <summary>
+/// Benchmarks for <see cref="PeDirectoryReader"/> import, export, and load-config
+/// parsing against a real Native AOT executable (11 import modules) and CoreLib
+/// (a managed PE with a near-empty import surface).
+/// </summary>
+[MemoryDiagnoser]
+public class PeDirectoryReaderBenchmarks
+{
+    private FileStream _nativeAotStream = null!;
+    private FileStream _coreLibStream = null!;
+    private PEReader _nativeAotPe = null!;
+    private PEReader _coreLibPe = null!;
+
+    /// <summary>
+    /// Publishes the Native AOT sample and opens PE readers for reuse.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        BenchmarkHelpers.PublishNativeAotSample("samples/NativeAotConsole");
+
+        _nativeAotStream = File.OpenRead(
+            BenchmarkHelpers.GetPublishPath("samples/NativeAotConsole", "NativeAotConsole"));
+        _nativeAotPe = new PEReader(_nativeAotStream);
+
+        _coreLibStream = File.OpenRead(Path.Combine(
+            RuntimeEnvironment.GetRuntimeDirectory(), "System.Private.CoreLib.dll"));
+        _coreLibPe = new PEReader(_coreLibStream);
+    }
+
+    /// <summary>
+    /// Disposes the shared PE readers and streams.
+    /// </summary>
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _nativeAotPe.Dispose();
+        _coreLibPe.Dispose();
+        _nativeAotStream.Dispose();
+        _coreLibStream.Dispose();
+    }
+
+    /// <summary>
+    /// Walks the Native AOT import descriptors, thunk tables, and hint/name entries.
+    /// </summary>
+    [Benchmark(Description = "NativeAOT ReadImports")]
+    public IReadOnlyList<ImportedModuleInfo> NativeAot_ReadImports()
+        => PeDirectoryReader.ReadImports(_nativeAotPe);
+
+    /// <summary>
+    /// Reads the Native AOT export directory (typically empty for an executable).
+    /// </summary>
+    [Benchmark(Description = "NativeAOT ReadExports")]
+    public IReadOnlyList<ExportedFunctionInfo> NativeAot_ReadExports()
+        => PeDirectoryReader.ReadExports(_nativeAotPe);
+
+    /// <summary>
+    /// Parses the Native AOT load configuration directory including guard-flag decoding.
+    /// </summary>
+    [Benchmark(Description = "NativeAOT ReadLoadConfig")]
+    public LoadConfigInfo? NativeAot_ReadLoadConfig()
+        => PeDirectoryReader.ReadLoadConfig(_nativeAotPe);
+
+    /// <summary>
+    /// Walks CoreLib's import table — the managed-PE fast path.
+    /// </summary>
+    [Benchmark(Description = "CoreLib ReadImports")]
+    public IReadOnlyList<ImportedModuleInfo> CoreLib_ReadImports()
+        => PeDirectoryReader.ReadImports(_coreLibPe);
+}

--- a/benchmarks/Dotsider.Benchmarks/PeDirectoryReaderBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/PeDirectoryReaderBenchmarks.cs
@@ -1,4 +1,3 @@
-using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Dotsider.Core.Analysis;
@@ -7,72 +6,66 @@ using Dotsider.Core.Analysis.Models;
 namespace Dotsider.Benchmarks;
 
 /// <summary>
-/// Benchmarks for <see cref="PeDirectoryReader"/> import, export, and load-config
-/// parsing against a real Native AOT executable (11 import modules) and CoreLib
-/// (a managed PE with a near-empty import surface).
+/// Benchmarks for the native import/export/load-config readers, measured through the
+/// format-aware <see cref="AssemblyAnalyzer"/> properties so each platform exercises
+/// its own parser: PE directories on Windows, ELF dynamic tables on Linux, and Mach-O
+/// load commands on macOS. CoreLib gives a managed-PE reference point on every OS.
 /// </summary>
 [MemoryDiagnoser]
 public class PeDirectoryReaderBenchmarks
 {
-    private FileStream _nativeAotStream = null!;
-    private FileStream _coreLibStream = null!;
-    private PEReader _nativeAotPe = null!;
-    private PEReader _coreLibPe = null!;
+    private string _nativeAotPath = null!;
+    private string _coreLibPath = null!;
 
     /// <summary>
-    /// Publishes the Native AOT sample and opens PE readers for reuse.
+    /// Publishes the Native AOT sample and resolves the binary paths.
     /// </summary>
     [GlobalSetup]
     public void Setup()
     {
         BenchmarkHelpers.PublishNativeAotSample("samples/NativeAotConsole");
-
-        _nativeAotStream = File.OpenRead(
-            BenchmarkHelpers.GetPublishPath("samples/NativeAotConsole", "NativeAotConsole"));
-        _nativeAotPe = new PEReader(_nativeAotStream);
-
-        _coreLibStream = File.OpenRead(Path.Combine(
-            RuntimeEnvironment.GetRuntimeDirectory(), "System.Private.CoreLib.dll"));
-        _coreLibPe = new PEReader(_coreLibStream);
+        _nativeAotPath = BenchmarkHelpers.GetPublishPath("samples/NativeAotConsole", "NativeAotConsole");
+        _coreLibPath = Path.Combine(
+            RuntimeEnvironment.GetRuntimeDirectory(), "System.Private.CoreLib.dll");
     }
 
     /// <summary>
-    /// Disposes the shared PE readers and streams.
+    /// Reads the Native AOT import table in the platform's native format.
     /// </summary>
-    [GlobalCleanup]
-    public void Cleanup()
+    [Benchmark(Description = "NativeAOT Imports")]
+    public IReadOnlyList<ImportedModuleInfo> NativeAot_Imports()
     {
-        _nativeAotPe.Dispose();
-        _coreLibPe.Dispose();
-        _nativeAotStream.Dispose();
-        _coreLibStream.Dispose();
+        using var analyzer = new AssemblyAnalyzer(_nativeAotPath);
+        return analyzer.Imports;
     }
 
     /// <summary>
-    /// Walks the Native AOT import descriptors, thunk tables, and hint/name entries.
+    /// Reads the Native AOT export table in the platform's native format.
     /// </summary>
-    [Benchmark(Description = "NativeAOT ReadImports")]
-    public IReadOnlyList<ImportedModuleInfo> NativeAot_ReadImports()
-        => PeDirectoryReader.ReadImports(_nativeAotPe);
+    [Benchmark(Description = "NativeAOT Exports")]
+    public IReadOnlyList<ExportedFunctionInfo> NativeAot_Exports()
+    {
+        using var analyzer = new AssemblyAnalyzer(_nativeAotPath);
+        return analyzer.Exports;
+    }
 
     /// <summary>
-    /// Reads the Native AOT export directory (typically empty for an executable).
+    /// Reads the Native AOT load configuration (PE-only; empty on ELF and Mach-O).
     /// </summary>
-    [Benchmark(Description = "NativeAOT ReadExports")]
-    public IReadOnlyList<ExportedFunctionInfo> NativeAot_ReadExports()
-        => PeDirectoryReader.ReadExports(_nativeAotPe);
+    [Benchmark(Description = "NativeAOT LoadConfig")]
+    public LoadConfigInfo? NativeAot_LoadConfig()
+    {
+        using var analyzer = new AssemblyAnalyzer(_nativeAotPath);
+        return analyzer.LoadConfig;
+    }
 
     /// <summary>
-    /// Parses the Native AOT load configuration directory including guard-flag decoding.
+    /// Reads CoreLib's import table — the managed-PE reference point.
     /// </summary>
-    [Benchmark(Description = "NativeAOT ReadLoadConfig")]
-    public LoadConfigInfo? NativeAot_ReadLoadConfig()
-        => PeDirectoryReader.ReadLoadConfig(_nativeAotPe);
-
-    /// <summary>
-    /// Walks CoreLib's import table — the managed-PE fast path.
-    /// </summary>
-    [Benchmark(Description = "CoreLib ReadImports")]
-    public IReadOnlyList<ImportedModuleInfo> CoreLib_ReadImports()
-        => PeDirectoryReader.ReadImports(_coreLibPe);
+    [Benchmark(Description = "CoreLib Imports")]
+    public IReadOnlyList<ImportedModuleInfo> CoreLib_Imports()
+    {
+        using var analyzer = new AssemblyAnalyzer(_coreLibPath);
+        return analyzer.Imports;
+    }
 }

--- a/benchmarks/Dotsider.Benchmarks/StringExtractorBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/StringExtractorBenchmarks.cs
@@ -76,4 +76,19 @@ public class StringExtractorBenchmarks
     [Benchmark(Description = "Xml RawStrings")]
     public IReadOnlyList<StringEntry> Xml_RawStrings()
         => new StringExtractor(_xmlAnalyzer).ExtractRawStrings();
+
+    /// <summary>
+    /// Scans the CoreLib PE for raw UTF-16 strings — the parity-restarting pass
+    /// that surfaces frozen literals in Native AOT images.
+    /// </summary>
+    [Benchmark(Description = "CoreLib RawUtf16Strings")]
+    public IReadOnlyList<StringEntry> CoreLib_RawUtf16Strings()
+        => new StringExtractor(_coreLibAnalyzer).ExtractRawUtf16Strings();
+
+    /// <summary>
+    /// Scans the Xml PE for raw UTF-16 strings.
+    /// </summary>
+    [Benchmark(Description = "Xml RawUtf16Strings")]
+    public IReadOnlyList<StringEntry> Xml_RawUtf16Strings()
+        => new StringExtractor(_xmlAnalyzer).ExtractRawUtf16Strings();
 }

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -47,7 +47,7 @@ dotnet run --project benchmarks/Dotsider.Benchmarks -c Release -- --list flat
 | `McpToolBenchmarks` | MCP tool call round-trip and session discovery through in-process pipe transport |
 | `NativeAotDetectorBenchmarks` | ReadyToRun header scan + validation on a real Native AOT exe (positive with false-positive rejection), CoreLib (R2R negative full scan), and an apphost (no candidates) |
 | `NuGetPackageAnalyzerBenchmarks` | NuGet package construction and DLL extraction from standard (2 DLLs) and large (120+ entry) packages |
-| `PeDirectoryReaderBenchmarks` | Native import/export/load-config directory parsing on a Native AOT exe and CoreLib |
+| `PeDirectoryReaderBenchmarks` | Native import/export/load-config parsing on a Native AOT binary (PE, ELF, or Mach-O by platform) and CoreLib |
 | `RuntimeTracerDataRetrievalBenchmarks` | Ring buffer snapshot, summary aggregation, output materialization, and counter read with populated trace data |
 | `RuntimeTracerThroughputBenchmarks` | Data retrieval under concurrent event-processing load (lock contention, volatile reads) |
 | `RuntimeTracerWritePathBenchmarks` | Full write pipeline throughput: event collection, counter acquisition, and Start/Stop lifecycle with EventPipe connect latency |
@@ -212,10 +212,10 @@ The 8ms adaptive threshold (`HexDumpView` line 44) crosses at ~10MB on this mach
 
 | Benchmark | Mean | Allocated |
 |---|---|---|
-| NativeAOT ReadImports | — | — |
-| NativeAOT ReadExports | — | — |
-| NativeAOT ReadLoadConfig | — | — |
-| CoreLib ReadImports | — | — |
+| NativeAOT Imports | — | — |
+| NativeAOT Exports | — | — |
+| NativeAOT LoadConfig | — | — |
+| CoreLib Imports | — | — |
 
 #### RuntimeTracer — Data Retrieval (populated)
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -195,9 +195,9 @@ The 8ms adaptive threshold (`HexDumpView` line 44) crosses at ~10MB on this mach
 
 | Benchmark | Mean | Allocated |
 |---|---|---|
-| Detect NativeAOT exe (positive) | — | — |
-| Detect CoreLib (R2R negative) | — | — |
-| Detect apphost (negative) | — | — |
+| Detect NativeAOT exe (positive) | 63.80 μs | 4,752 B |
+| Detect CoreLib (R2R negative) | 470.87 μs | — |
+| Detect apphost (negative) | 3.63 μs | — |
 
 #### NuGetPackageAnalyzer
 
@@ -212,10 +212,10 @@ The 8ms adaptive threshold (`HexDumpView` line 44) crosses at ~10MB on this mach
 
 | Benchmark | Mean | Allocated |
 |---|---|---|
-| NativeAOT Imports | — | — |
-| NativeAOT Exports | — | — |
-| NativeAOT LoadConfig | — | — |
-| CoreLib Imports | — | — |
+| NativeAOT Imports | 127.4 μs | 1.20 MB |
+| NativeAOT Exports | 122.8 μs | 1.19 MB |
+| NativeAOT LoadConfig | 121.9 μs | 1.18 MB |
+| CoreLib Imports | 1.20 ms | 16.30 MB |
 
 #### RuntimeTracer — Data Retrieval (populated)
 
@@ -263,8 +263,8 @@ The 8ms adaptive threshold (`HexDumpView` line 44) crosses at ~10MB on this mach
 | Xml UserStrings | 62.56 μs | 375 KB |
 | Xml MetadataStrings | 1.02 ms | 1,519 KB |
 | Xml RawStrings | 14.97 ms | 3,962 KB |
-| CoreLib RawUtf16Strings | — | — |
-| Xml RawUtf16Strings | — | — |
+| CoreLib RawUtf16Strings | 26.99 ms | 689 KB |
+| Xml RawUtf16Strings | 15.05 ms | 613 KB |
 
 #### SizeAnalyzer
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -45,13 +45,15 @@ dotnet run --project benchmarks/Dotsider.Benchmarks -c Release -- --list flat
 | `ImplementationAssemblyResolverColdBenchmarks` | Cold-path reference-to-implementation resolution: known mappings, type forwarder chains, direct usable metadata |
 | `ImplementationAssemblyResolverWarmBenchmarks` | Warm-cache hit for implementation assembly resolution |
 | `McpToolBenchmarks` | MCP tool call round-trip and session discovery through in-process pipe transport |
+| `NativeAotDetectorBenchmarks` | ReadyToRun header scan + validation on a real Native AOT exe (positive with false-positive rejection), CoreLib (R2R negative full scan), and an apphost (no candidates) |
 | `NuGetPackageAnalyzerBenchmarks` | NuGet package construction and DLL extraction from standard (2 DLLs) and large (120+ entry) packages |
+| `PeDirectoryReaderBenchmarks` | Native import/export/load-config directory parsing on a Native AOT exe and CoreLib |
 | `RuntimeTracerDataRetrievalBenchmarks` | Ring buffer snapshot, summary aggregation, output materialization, and counter read with populated trace data |
 | `RuntimeTracerThroughputBenchmarks` | Data retrieval under concurrent event-processing load (lock contention, volatile reads) |
 | `RuntimeTracerWritePathBenchmarks` | Full write pipeline throughput: event collection, counter acquisition, and Start/Stop lifecycle with EventPipe connect latency |
 | `SingleFileBundleReaderBenchmarks` | Bundle signature scanning (file/span, positive/negative), manifest parsing, and full entry-assembly extraction |
 | `SizeAnalyzerBenchmarks` | `BuildSizeTree` full traversal |
-| `StringExtractorBenchmarks` | UserStrings, MetadataStrings, and RawStrings extraction |
+| `StringExtractorBenchmarks` | UserStrings, MetadataStrings, RawStrings, and RawUtf16Strings extraction |
 | `TreemapLayoutBenchmarks` | Squarified treemap rectangle computation for assembly size trees |
 
 ## Test Assemblies
@@ -189,6 +191,14 @@ The 8ms adaptive threshold (`HexDumpView` line 44) crosses at ~10MB on this mach
 | Direct usable (System.Private.Xml) | 36.25 μs | 10.80 KB |
 | Known mapping warm cache hit | 67.62 ns | — |
 
+#### NativeAotDetector
+
+| Benchmark | Mean | Allocated |
+|---|---|---|
+| Detect NativeAOT exe (positive) | — | — |
+| Detect CoreLib (R2R negative) | — | — |
+| Detect apphost (negative) | — | — |
+
 #### NuGetPackageAnalyzer
 
 | Benchmark | Mean | Allocated |
@@ -197,6 +207,15 @@ The 8ms adaptive threshold (`HexDumpView` line 44) crosses at ~10MB on this mach
 | OpenDll (CoreLib ~16MB) | 32.82 ms | 16,335 KB |
 | Construction (120+ entries) | 115.41 μs | 143.17 KB |
 | OpenDll from large package (CoreLib) | 30.35 ms | 16,434 KB |
+
+#### PeDirectoryReader
+
+| Benchmark | Mean | Allocated |
+|---|---|---|
+| NativeAOT ReadImports | — | — |
+| NativeAOT ReadExports | — | — |
+| NativeAOT ReadLoadConfig | — | — |
+| CoreLib ReadImports | — | — |
 
 #### RuntimeTracer — Data Retrieval (populated)
 
@@ -244,6 +263,8 @@ The 8ms adaptive threshold (`HexDumpView` line 44) crosses at ~10MB on this mach
 | Xml UserStrings | 62.56 μs | 375 KB |
 | Xml MetadataStrings | 1.02 ms | 1,519 KB |
 | Xml RawStrings | 14.97 ms | 3,962 KB |
+| CoreLib RawUtf16Strings | — | — |
+| Xml RawUtf16Strings | — | — |
 
 #### SizeAnalyzer
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -259,12 +259,18 @@ The 8ms adaptive threshold (`HexDumpView` line 44) crosses at ~10MB on this mach
 |---|---|---|
 | CoreLib UserStrings | 59.15 μs | 368 KB |
 | CoreLib MetadataStrings | 1.79 ms | 2,878 KB |
-| CoreLib RawStrings | 27.76 ms | 6,490 KB |
+| CoreLib RawStrings | 13.97 ms | 6,457 KB |
 | Xml UserStrings | 62.56 μs | 375 KB |
 | Xml MetadataStrings | 1.02 ms | 1,519 KB |
-| Xml RawStrings | 14.97 ms | 3,962 KB |
-| CoreLib RawUtf16Strings | 26.99 ms | 689 KB |
-| Xml RawUtf16Strings | 15.05 ms | 613 KB |
+| Xml RawStrings | 7.10 ms | 3,956 KB |
+| CoreLib RawUtf16Strings | 4.11 ms | 763 KB |
+| Xml RawUtf16Strings | 2.24 ms | 654 KB |
+
+The raw scans classify 64 bytes (or UTF-16 code units) per step into a printable
+bitmask with `Vector128` compares and walk run boundaries via bit scans, so SIMD cost
+stays fixed per block regardless of how dense printable bytes are. The ASCII scan is
+now bounded by materializing its ~6 MB of result strings, not by scanning; the UTF-16
+scan (one pass per byte parity) is 6.6× faster than the scalar baseline it replaced.
 
 #### SizeAnalyzer
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
@@ -101,6 +101,16 @@ The assembly version string, or null.
 public string? AssemblyVersion { get; }
 ```
 
+### BinaryKind
+
+Coarse classification of the analyzed binary.
+
+**Returns:** [BinaryKind](/api/dotsider.core.analysis.models.binarykind/)
+
+```csharp
+public BinaryKind BinaryKind { get; }
+```
+
 ### CanSaveInPlace
 
 Whether in-place hex save is supported. Returns `false` for bundle-backed analyzers
@@ -174,6 +184,17 @@ points to the bundle executable on disk. For file-backed analyzers, equals [File
 public string DisplayName { get; }
 ```
 
+### Exports
+
+Gets the native export table. Needs no CLR header; empty for non-PE files or
+when the image exports nothing.
+
+**Returns:** [IReadOnlyList\<ExportedFunctionInfo\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<ExportedFunctionInfo> Exports { get; }
+```
+
 ### FieldDefs
 
 Gets the FieldDef metadata table entries.
@@ -234,6 +255,17 @@ Gets whether a portable PDB was opened.
 public bool HasPortablePdb { get; }
 ```
 
+### Imports
+
+Gets the native import table (modules and imported functions). Needs no CLR
+header; empty for non-PE files.
+
+**Returns:** [IReadOnlyList\<ImportedModuleInfo\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<ImportedModuleInfo> Imports { get; }
+```
+
 ### IsBundleBacked
 
 Whether this analyzer was created from bytes extracted from a single-file bundle.
@@ -275,6 +307,16 @@ the bundle executable; for file-backed analyzers this is [FilePath](/api/dotside
 public string LaunchPath { get; }
 ```
 
+### LoadConfig
+
+Gets the parsed load configuration directory, or null when absent or not a PE.
+
+**Returns:** [LoadConfigInfo](/api/dotsider.core.analysis.models.loadconfiginfo/)
+
+```csharp
+public LoadConfigInfo? LoadConfig { get; }
+```
+
 ### MemberRefs
 
 Gets the MemberRef metadata table entries.
@@ -293,6 +335,19 @@ Gets the MethodDef metadata table entries.
 
 ```csharp
 public IReadOnlyList<MethodDefInfo> MethodDefs { get; }
+```
+
+### NativeAotInfo
+
+Facts from the embedded ReadyToRun header when this is a Native AOT binary,
+or null. Only probed for metadata-less files — a managed ReadyToRun assembly
+also embeds the header, but there it accompanies metadata rather than
+replacing it.
+
+**Returns:** [NativeAotInfo](/api/dotsider.core.analysis.models.nativeaotinfo/)
+
+```csharp
+public NativeAotInfo? NativeAotInfo { get; }
 ```
 
 ### PdbProvenance

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
@@ -186,8 +186,8 @@ public string DisplayName { get; }
 
 ### Exports
 
-Gets the native export table. Needs no CLR header; empty for non-PE files or
-when the image exports nothing.
+Gets the native export table: PE exports, or the defined global symbols of an
+ELF or Mach-O image. Needs no CLR header; empty when the image exports nothing.
 
 **Returns:** [IReadOnlyList\<ExportedFunctionInfo\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
 
@@ -257,8 +257,9 @@ public bool HasPortablePdb { get; }
 
 ### Imports
 
-Gets the native import table (modules and imported functions). Needs no CLR
-header; empty for non-PE files.
+Gets the native import table: PE import descriptors, ELF needed libraries and
+undefined dynamic symbols, or Mach-O loaded dylibs and undefined symbols.
+Needs no CLR header.
 
 **Returns:** [IReadOnlyList\<ImportedModuleInfo\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyLoader.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyLoader.md
@@ -1,6 +1,6 @@
 ---
 title: "AssemblyLoader"
-description: "Shared factory for opening assembly files. Handles apphosts (companion .dll redirect), single-file bundles (entry assembly extraction), and direct .dll/.exe loading. Returns an AssemblyOpenResult that preserves the distinction so callers can decide how to present each case (e.g. showing an apphost dialog)."
+description: "Shared factory for opening assembly files. Handles apphosts (companion .dll redirect), single-file bundles (entry assembly extraction), Native AOT binaries, and direct .dll/.exe loading. Returns an AssemblyOpenResult that preserves the distinction so callers can decide how to present each case (e.g. showing an apphost dialog)."
 slug: api/dotsider.core.analysis.assemblyloader
 sidebar:
   order: 0
@@ -11,9 +11,9 @@ sidebar:
 **Assembly:** Dotsider.Core.dll
 
 Shared factory for opening assembly files. Handles apphosts (companion .dll redirect),
-single-file bundles (entry assembly extraction), and direct .dll/.exe loading.
-Returns an [AssemblyOpenResult](/api/dotsider.core.analysis.models.assemblyopenresult/) that preserves the distinction so callers
-can decide how to present each case (e.g. showing an apphost dialog).
+single-file bundles (entry assembly extraction), Native AOT binaries, and direct
+.dll/.exe loading. Returns an [AssemblyOpenResult](/api/dotsider.core.analysis.models.assemblyopenresult/) that preserves the
+distinction so callers can decide how to present each case (e.g. showing an apphost dialog).
 
 ```csharp
 public static class AssemblyLoader
@@ -38,7 +38,8 @@ Opens an assembly from the given path, detecting apphosts and single-file bundle
 An [AssemblyOpenResult](/api/dotsider.core.analysis.models.assemblyopenresult/) describing the result:
 [Direct](/api/dotsider.core.analysis.models.assemblyopenresult.direct/) for regular assemblies,
 [ApphostWithCompanion](/api/dotsider.core.analysis.models.assemblyopenresult.apphostwithcompanion/) for native apphosts with a companion .dll,
-or [BundleEntry](/api/dotsider.core.analysis.models.assemblyopenresult.bundleentry/) for single-file bundles.
+[BundleEntry](/api/dotsider.core.analysis.models.assemblyopenresult.bundleentry/) for single-file bundles,
+or [NativeAot](/api/dotsider.core.analysis.models.assemblyopenresult.nativeaot/) for Native AOT compiled binaries.
 
 ```csharp
 public static AssemblyOpenResult Open(string filePath)

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-AssemblyOpenResult-Direct.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-AssemblyOpenResult-Direct.md
@@ -1,6 +1,6 @@
 ---
 title: "AssemblyOpenResult.Direct"
-description: "Direct load — the file is a .dll or .exe with metadata, or a native binary with no metadata (NativeAOT, unknown format)."
+description: "Direct load — the file is a .dll or .exe with metadata, or a native binary with no metadata and no ReadyToRun header (unknown format)."
 slug: api/dotsider.core.analysis.models.assemblyopenresult.direct
 sidebar:
   order: 1
@@ -11,7 +11,7 @@ sidebar:
 **Assembly:** Dotsider.Core.dll
 
 Direct load — the file is a .dll or .exe with metadata, or a native binary
-with no metadata (NativeAOT, unknown format).
+with no metadata and no ReadyToRun header (unknown format).
 
 ```csharp
 public sealed record AssemblyOpenResult.Direct : AssemblyOpenResult, IEquatable<AssemblyOpenResult>, IEquatable<AssemblyOpenResult.Direct>
@@ -31,7 +31,7 @@ public sealed record AssemblyOpenResult.Direct : AssemblyOpenResult, IEquatable<
 ### Direct(AssemblyAnalyzer)
 
 Direct load — the file is a .dll or .exe with metadata, or a native binary
-with no metadata (NativeAOT, unknown format).
+with no metadata and no ReadyToRun header (unknown format).
 
 **Parameters:**
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-AssemblyOpenResult-NativeAot.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-AssemblyOpenResult-NativeAot.md
@@ -1,0 +1,59 @@
+---
+title: "AssemblyOpenResult.NativeAot"
+description: "The file is a Native AOT compiled .NET binary: a valid PE, ELF, or Mach-O with no COR header whose image embeds a validated ReadyToRun header. No metadata is available, but PE structure, native import/export/load-config directories, and raw strings are."
+slug: api/dotsider.core.analysis.models.assemblyopenresult.nativeaot
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+The file is a Native AOT compiled .NET binary: a valid PE, ELF, or Mach-O
+with no COR header whose image embeds a validated ReadyToRun header. No
+metadata is available, but PE structure, native import/export/load-config
+directories, and raw strings are.
+
+```csharp
+public sealed record AssemblyOpenResult.NativeAot : AssemblyOpenResult, IEquatable<AssemblyOpenResult>, IEquatable<AssemblyOpenResult.NativeAot>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → [AssemblyOpenResult](/api/dotsider.core.analysis.models.assemblyopenresult/) → **AssemblyOpenResult.NativeAot**
+
+## Implements
+
+- [IEquatable\<AssemblyOpenResult\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+- [IEquatable\<NativeAot\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### NativeAot(AssemblyAnalyzer)
+
+The file is a Native AOT compiled .NET binary: a valid PE, ELF, or Mach-O
+with no COR header whose image embeds a validated ReadyToRun header. No
+metadata is available, but PE structure, native import/export/load-config
+directories, and raw strings are.
+
+**Parameters:**
+
+- `Analyzer` ([AssemblyAnalyzer](/api/dotsider.core.analysis.assemblyanalyzer/)): The analyzer for the Native AOT binary (no metadata).
+
+```csharp
+public NativeAot(AssemblyAnalyzer Analyzer)
+```
+
+## Properties
+
+### Analyzer
+
+The analyzer for the Native AOT binary (no metadata).
+
+**Returns:** [AssemblyAnalyzer](/api/dotsider.core.analysis.assemblyanalyzer/)
+
+```csharp
+public AssemblyAnalyzer Analyzer { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-BinaryKind.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-BinaryKind.md
@@ -1,0 +1,51 @@
+---
+title: "BinaryKind"
+description: "Coarse classification of an analyzed binary."
+slug: api/dotsider.core.analysis.models.binarykind
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+Coarse classification of an analyzed binary.
+
+```csharp
+public enum BinaryKind
+```
+
+## Fields
+
+### Managed
+
+A managed assembly with ECMA-335 metadata.
+
+**Returns:** [BinaryKind](/api/dotsider.core.analysis.models.binarykind/)
+
+```csharp
+Managed = 0
+```
+
+### Native
+
+A native binary with no CLR metadata and no ReadyToRun header (apphost, unknown format).
+
+**Returns:** [BinaryKind](/api/dotsider.core.analysis.models.binarykind/)
+
+```csharp
+Native = 2
+```
+
+### NativeAot
+
+A Native AOT compiled .NET binary: a native executable with no CLR metadata
+whose image embeds a validated ReadyToRun header.
+
+**Returns:** [BinaryKind](/api/dotsider.core.analysis.models.binarykind/)
+
+```csharp
+NativeAot = 1
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-ExportedFunctionInfo.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-ExportedFunctionInfo.md
@@ -1,0 +1,87 @@
+---
+title: "ExportedFunctionInfo"
+description: "A single entry in the PE export table."
+slug: api/dotsider.core.analysis.models.exportedfunctioninfo
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+A single entry in the PE export table.
+
+```csharp
+public sealed record ExportedFunctionInfo : IEquatable<ExportedFunctionInfo>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **ExportedFunctionInfo**
+
+## Implements
+
+- [IEquatable\<ExportedFunctionInfo\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### ExportedFunctionInfo(int, string?, int, string?)
+
+A single entry in the PE export table.
+
+**Parameters:**
+
+- `Ordinal` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The biased export ordinal (ordinal base applied).
+- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The exported name, or null for ordinal-only exports.
+- `Rva` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The RVA of the exported symbol, or of the forwarder string.
+- `ForwardedTo` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The forwarder target (e.g. "NTDLL.RtlAllocateHeap") when the export forwards to
+another module, or null for regular exports.
+
+```csharp
+public ExportedFunctionInfo(int Ordinal, string? Name, int Rva, string? ForwardedTo)
+```
+
+## Properties
+
+### ForwardedTo
+
+The forwarder target (e.g. "NTDLL.RtlAllocateHeap") when the export forwards to
+another module, or null for regular exports.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? ForwardedTo { get; init; }
+```
+
+### Name
+
+The exported name, or null for ordinal-only exports.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? Name { get; init; }
+```
+
+### Ordinal
+
+The biased export ordinal (ordinal base applied).
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int Ordinal { get; init; }
+```
+
+### Rva
+
+The RVA of the exported symbol, or of the forwarder string.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int Rva { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-ImportedFunctionInfo.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-ImportedFunctionInfo.md
@@ -1,0 +1,74 @@
+---
+title: "ImportedFunctionInfo"
+description: "A single function imported from a native module."
+slug: api/dotsider.core.analysis.models.importedfunctioninfo
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+A single function imported from a native module.
+
+```csharp
+public sealed record ImportedFunctionInfo : IEquatable<ImportedFunctionInfo>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **ImportedFunctionInfo**
+
+## Implements
+
+- [IEquatable\<ImportedFunctionInfo\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### ImportedFunctionInfo(string?, ushort?, ushort?)
+
+A single function imported from a native module.
+
+**Parameters:**
+
+- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The imported function name, or null for ordinal-only imports.
+- `Ordinal` ([Nullable\<UInt16\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The import ordinal, or null for named imports.
+- `Hint` ([Nullable\<UInt16\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The export-name-table hint for named imports, or null.
+
+```csharp
+public ImportedFunctionInfo(string? Name, ushort? Ordinal, ushort? Hint)
+```
+
+## Properties
+
+### Hint
+
+The export-name-table hint for named imports, or null.
+
+**Returns:** [Nullable\<UInt16\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)
+
+```csharp
+public ushort? Hint { get; init; }
+```
+
+### Name
+
+The imported function name, or null for ordinal-only imports.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? Name { get; init; }
+```
+
+### Ordinal
+
+The import ordinal, or null for named imports.
+
+**Returns:** [Nullable\<UInt16\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)
+
+```csharp
+public ushort? Ordinal { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-ImportedModuleInfo.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-ImportedModuleInfo.md
@@ -1,0 +1,63 @@
+---
+title: "ImportedModuleInfo"
+description: "A native module referenced by the PE import table, with the functions imported from it."
+slug: api/dotsider.core.analysis.models.importedmoduleinfo
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+A native module referenced by the PE import table, with the functions imported from it.
+
+```csharp
+public sealed record ImportedModuleInfo : IEquatable<ImportedModuleInfo>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **ImportedModuleInfo**
+
+## Implements
+
+- [IEquatable\<ImportedModuleInfo\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### ImportedModuleInfo(string, IReadOnlyList\<ImportedFunctionInfo\>)
+
+A native module referenced by the PE import table, with the functions imported from it.
+
+**Parameters:**
+
+- `ModuleName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The module file name (e.g. "KERNEL32.dll").
+- `Functions` ([IReadOnlyList\<ImportedFunctionInfo\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): The functions imported from the module.
+
+```csharp
+public ImportedModuleInfo(string ModuleName, IReadOnlyList<ImportedFunctionInfo> Functions)
+```
+
+## Properties
+
+### Functions
+
+The functions imported from the module.
+
+**Returns:** [IReadOnlyList\<ImportedFunctionInfo\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<ImportedFunctionInfo> Functions { get; init; }
+```
+
+### ModuleName
+
+The module file name (e.g. "KERNEL32.dll").
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string ModuleName { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-LoadConfigInfo.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-LoadConfigInfo.md
@@ -1,0 +1,168 @@
+---
+title: "LoadConfigInfo"
+description: "Parsed PE load configuration directory. Pointer-width fields are widened to UInt64 so a single record covers PE32 and PE32+ images. Fields beyond the directory's declared size are zero — real-world load configs are truncated at many historical lengths."
+slug: api/dotsider.core.analysis.models.loadconfiginfo
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+Parsed PE load configuration directory. Pointer-width fields are widened to
+[UInt64](https://learn.microsoft.com/dotnet/api/system.uint64) so a single record covers PE32 and PE32+ images. Fields
+beyond the directory's declared size are zero — real-world load configs are
+truncated at many historical lengths.
+
+```csharp
+public sealed record LoadConfigInfo : IEquatable<LoadConfigInfo>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **LoadConfigInfo**
+
+## Implements
+
+- [IEquatable\<LoadConfigInfo\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### LoadConfigInfo(uint, uint, ushort, ushort, ushort, ulong, ulong, ulong, ulong, uint, string)
+
+Parsed PE load configuration directory. Pointer-width fields are widened to
+[UInt64](https://learn.microsoft.com/dotnet/api/system.uint64) so a single record covers PE32 and PE32+ images. Fields
+beyond the directory's declared size are zero — real-world load configs are
+truncated at many historical lengths.
+
+**Parameters:**
+
+- `Size` ([UInt32](https://learn.microsoft.com/dotnet/api/system.uint32)): The declared size of the load configuration directory.
+- `TimeDateStamp` ([UInt32](https://learn.microsoft.com/dotnet/api/system.uint32)): The directory timestamp.
+- `MajorVersion` ([UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)): Major version number.
+- `MinorVersion` ([UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)): Minor version number.
+- `DependentLoadFlags` ([UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)): Default load flags applied when resolving DLL dependencies.
+- `SecurityCookie` ([UInt64](https://learn.microsoft.com/dotnet/api/system.uint64)): The VA of the /GS security cookie, or 0 when absent.
+- `SehHandlerCount` ([UInt64](https://learn.microsoft.com/dotnet/api/system.uint64)): Number of registered structured exception handlers (PE32 /SAFESEH).
+- `GuardCfCheckFunctionPointer` ([UInt64](https://learn.microsoft.com/dotnet/api/system.uint64)): The VA of the Control Flow Guard check-function pointer, or 0.
+- `GuardCfFunctionCount` ([UInt64](https://learn.microsoft.com/dotnet/api/system.uint64)): Number of entries in the Control Flow Guard function table.
+- `GuardFlags` ([UInt32](https://learn.microsoft.com/dotnet/api/system.uint32)): Raw Control Flow Guard flags.
+- `GuardFlagsDescription` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Decoded GuardFlags summary, or "(none)".
+
+```csharp
+public LoadConfigInfo(uint Size, uint TimeDateStamp, ushort MajorVersion, ushort MinorVersion, ushort DependentLoadFlags, ulong SecurityCookie, ulong SehHandlerCount, ulong GuardCfCheckFunctionPointer, ulong GuardCfFunctionCount, uint GuardFlags, string GuardFlagsDescription)
+```
+
+## Properties
+
+### DependentLoadFlags
+
+Default load flags applied when resolving DLL dependencies.
+
+**Returns:** [UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)
+
+```csharp
+public ushort DependentLoadFlags { get; init; }
+```
+
+### GuardCfCheckFunctionPointer
+
+The VA of the Control Flow Guard check-function pointer, or 0.
+
+**Returns:** [UInt64](https://learn.microsoft.com/dotnet/api/system.uint64)
+
+```csharp
+public ulong GuardCfCheckFunctionPointer { get; init; }
+```
+
+### GuardCfFunctionCount
+
+Number of entries in the Control Flow Guard function table.
+
+**Returns:** [UInt64](https://learn.microsoft.com/dotnet/api/system.uint64)
+
+```csharp
+public ulong GuardCfFunctionCount { get; init; }
+```
+
+### GuardFlags
+
+Raw Control Flow Guard flags.
+
+**Returns:** [UInt32](https://learn.microsoft.com/dotnet/api/system.uint32)
+
+```csharp
+public uint GuardFlags { get; init; }
+```
+
+### GuardFlagsDescription
+
+Decoded GuardFlags summary, or "(none)".
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string GuardFlagsDescription { get; init; }
+```
+
+### MajorVersion
+
+Major version number.
+
+**Returns:** [UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)
+
+```csharp
+public ushort MajorVersion { get; init; }
+```
+
+### MinorVersion
+
+Minor version number.
+
+**Returns:** [UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)
+
+```csharp
+public ushort MinorVersion { get; init; }
+```
+
+### SecurityCookie
+
+The VA of the /GS security cookie, or 0 when absent.
+
+**Returns:** [UInt64](https://learn.microsoft.com/dotnet/api/system.uint64)
+
+```csharp
+public ulong SecurityCookie { get; init; }
+```
+
+### SehHandlerCount
+
+Number of registered structured exception handlers (PE32 /SAFESEH).
+
+**Returns:** [UInt64](https://learn.microsoft.com/dotnet/api/system.uint64)
+
+```csharp
+public ulong SehHandlerCount { get; init; }
+```
+
+### Size
+
+The declared size of the load configuration directory.
+
+**Returns:** [UInt32](https://learn.microsoft.com/dotnet/api/system.uint32)
+
+```csharp
+public uint Size { get; init; }
+```
+
+### TimeDateStamp
+
+The directory timestamp.
+
+**Returns:** [UInt32](https://learn.microsoft.com/dotnet/api/system.uint32)
+
+```csharp
+public uint TimeDateStamp { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeAotInfo.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeAotInfo.md
@@ -1,0 +1,128 @@
+---
+title: "NativeAotInfo"
+description: "Facts extracted from the embedded ReadyToRun header of a Native AOT binary. Every Native AOT image embeds this header (signature \"RTR\\0\") so the runtime can locate its module sections; its presence with no COR header identifies the binary as Native AOT compiled .NET."
+slug: api/dotsider.core.analysis.models.nativeaotinfo
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+Facts extracted from the embedded ReadyToRun header of a Native AOT binary.
+Every Native AOT image embeds this header (signature "RTR\0") so the runtime can
+locate its module sections; its presence with no COR header identifies the binary
+as Native AOT compiled .NET.
+
+```csharp
+public sealed record NativeAotInfo : IEquatable<NativeAotInfo>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **NativeAotInfo**
+
+## Implements
+
+- [IEquatable\<NativeAotInfo\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### NativeAotInfo(int, ushort, ushort, uint, int, byte, string?)
+
+Facts extracted from the embedded ReadyToRun header of a Native AOT binary.
+Every Native AOT image embeds this header (signature "RTR\0") so the runtime can
+locate its module sections; its presence with no COR header identifies the binary
+as Native AOT compiled .NET.
+
+**Parameters:**
+
+- `HeaderOffset` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): File offset of the RTR signature.
+- `MajorVersion` ([UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)): ReadyToRun format major version — the ILC toolchain format version.
+- `MinorVersion` ([UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)): ReadyToRun format minor version.
+- `Flags` ([UInt32](https://learn.microsoft.com/dotnet/api/system.uint32)): Raw header flags.
+- `SectionCount` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): Number of module section entries following the header.
+- `EntrySize` ([Byte](https://learn.microsoft.com/dotnet/api/system.byte)): Size in bytes of each module section entry.
+- `RuntimeVersion` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Heuristically detected runtime version (e.g. "10.0.8"), or null when not found.
+Recovered from a version string the runtime pack embeds near a well-known error
+message; absence is normal for stripped or unusually linked binaries.
+
+```csharp
+public NativeAotInfo(int HeaderOffset, ushort MajorVersion, ushort MinorVersion, uint Flags, int SectionCount, byte EntrySize, string? RuntimeVersion)
+```
+
+## Properties
+
+### EntrySize
+
+Size in bytes of each module section entry.
+
+**Returns:** [Byte](https://learn.microsoft.com/dotnet/api/system.byte)
+
+```csharp
+public byte EntrySize { get; init; }
+```
+
+### Flags
+
+Raw header flags.
+
+**Returns:** [UInt32](https://learn.microsoft.com/dotnet/api/system.uint32)
+
+```csharp
+public uint Flags { get; init; }
+```
+
+### HeaderOffset
+
+File offset of the RTR signature.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int HeaderOffset { get; init; }
+```
+
+### MajorVersion
+
+ReadyToRun format major version — the ILC toolchain format version.
+
+**Returns:** [UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)
+
+```csharp
+public ushort MajorVersion { get; init; }
+```
+
+### MinorVersion
+
+ReadyToRun format minor version.
+
+**Returns:** [UInt16](https://learn.microsoft.com/dotnet/api/system.uint16)
+
+```csharp
+public ushort MinorVersion { get; init; }
+```
+
+### RuntimeVersion
+
+Heuristically detected runtime version (e.g. "10.0.8"), or null when not found.
+Recovered from a version string the runtime pack embeds near a well-known error
+message; absence is normal for stripped or unusually linked binaries.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? RuntimeVersion { get; init; }
+```
+
+### SectionCount
+
+Number of module section entries following the header.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int SectionCount { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-StringSource.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-StringSource.md
@@ -38,6 +38,17 @@ Raw printable character sequences extracted directly from the binary.
 RawBinary = 2
 ```
 
+### RawBinaryUtf16
+
+UTF-16LE printable character sequences extracted directly from the binary.
+This is how managed string literals freeze in Native AOT images.
+
+**Returns:** [StringSource](/api/dotsider.core.analysis.models.stringsource/)
+
+```csharp
+RawBinaryUtf16 = 3
+```
+
 ### UserStrings
 
 The #US (User Strings) metadata heap, containing string literals used in IL code.

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models.md
@@ -58,10 +58,21 @@ public sealed record AssemblyOpenResult.BundleEntry : AssemblyOpenResult, IEquat
 ### [AssemblyOpenResult.Direct](/api/dotsider.core.analysis.models.assemblyopenresult.direct/)
 
 Direct load — the file is a .dll or .exe with metadata, or a native binary
-with no metadata (NativeAOT, unknown format).
+with no metadata and no ReadyToRun header (unknown format).
 
 ```csharp
 public sealed record AssemblyOpenResult.Direct : AssemblyOpenResult, IEquatable<AssemblyOpenResult>, IEquatable<AssemblyOpenResult.Direct>
+```
+
+### [AssemblyOpenResult.NativeAot](/api/dotsider.core.analysis.models.assemblyopenresult.nativeaot/)
+
+The file is a Native AOT compiled .NET binary: a valid PE, ELF, or Mach-O
+with no COR header whose image embeds a validated ReadyToRun header. No
+metadata is available, but PE structure, native import/export/load-config
+directories, and raw strings are.
+
+```csharp
+public sealed record AssemblyOpenResult.NativeAot : AssemblyOpenResult, IEquatable<AssemblyOpenResult>, IEquatable<AssemblyOpenResult.NativeAot>
 ```
 
 ### [AssemblyRefInfo](/api/dotsider.core.analysis.models.assemblyrefinfo/)
@@ -207,6 +218,14 @@ Embedded source decoded from a portable PDB document.
 public sealed record EmbeddedSourceInfo : IEquatable<EmbeddedSourceInfo>
 ```
 
+### [ExportedFunctionInfo](/api/dotsider.core.analysis.models.exportedfunctioninfo/)
+
+A single entry in the PE export table.
+
+```csharp
+public sealed record ExportedFunctionInfo : IEquatable<ExportedFunctionInfo>
+```
+
 ### [FieldDefInfo](/api/dotsider.core.analysis.models.fielddefinfo/)
 
 Information about a field defined in the assembly's FieldDef metadata table.
@@ -335,6 +354,33 @@ A token kind that is recognized but not supported for navigation.
 public sealed record IlNavigationTarget.Unsupported : IlNavigationTarget, IEquatable<IlNavigationTarget>, IEquatable<IlNavigationTarget.Unsupported>
 ```
 
+### [ImportedFunctionInfo](/api/dotsider.core.analysis.models.importedfunctioninfo/)
+
+A single function imported from a native module.
+
+```csharp
+public sealed record ImportedFunctionInfo : IEquatable<ImportedFunctionInfo>
+```
+
+### [ImportedModuleInfo](/api/dotsider.core.analysis.models.importedmoduleinfo/)
+
+A native module referenced by the PE import table, with the functions imported from it.
+
+```csharp
+public sealed record ImportedModuleInfo : IEquatable<ImportedModuleInfo>
+```
+
+### [LoadConfigInfo](/api/dotsider.core.analysis.models.loadconfiginfo/)
+
+Parsed PE load configuration directory. Pointer-width fields are widened to
+[UInt64](https://learn.microsoft.com/dotnet/api/system.uint64) so a single record covers PE32 and PE32+ images. Fields
+beyond the directory's declared size are zero — real-world load configs are
+truncated at many historical lengths.
+
+```csharp
+public sealed record LoadConfigInfo : IEquatable<LoadConfigInfo>
+```
+
 ### [LoadedAssemblyEntry](/api/dotsider.core.analysis.models.loadedassemblyentry/)
 
 Per-loaded-identity entry interned in `LoadedAssemblyCache`. When two distinct requested
@@ -376,6 +422,17 @@ Information about a method defined in the assembly's MethodDef metadata table.
 
 ```csharp
 public sealed record MethodDefInfo : IEquatable<MethodDefInfo>
+```
+
+### [NativeAotInfo](/api/dotsider.core.analysis.models.nativeaotinfo/)
+
+Facts extracted from the embedded ReadyToRun header of a Native AOT binary.
+Every Native AOT image embeds this header (signature "RTR\0") so the runtime can
+locate its module sections; its presence with no COR header identifies the binary
+as Native AOT compiled .NET.
+
+```csharp
+public sealed record NativeAotInfo : IEquatable<NativeAotInfo>
 ```
 
 ### [NetFxBindingContext](/api/dotsider.core.analysis.models.netfxbindingcontext/)
@@ -552,6 +609,14 @@ Describes how an assembly in the dependency graph was located — or why it coul
 
 ```csharp
 public enum AssemblyProvenance
+```
+
+### [BinaryKind](/api/dotsider.core.analysis.models.binarykind/)
+
+Coarse classification of an analyzed binary.
+
+```csharp
+public enum BinaryKind
 ```
 
 ### [BundleFileType](/api/dotsider.core.analysis.models.bundlefiletype/)

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-NativeAotDetector.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-NativeAotDetector.md
@@ -1,0 +1,47 @@
+---
+title: "NativeAotDetector"
+description: "Detects Native AOT compiled .NET binaries by locating and validating the embedded ReadyToRun header. Every Native AOT image carries this header (signature \"RTR\\0\") so the runtime can find its module sections, but the signature bytes also occur as code immediates, so each candidate is validated against the field ranges the ILC toolchain actually emits before it is accepted."
+slug: api/dotsider.core.analysis.nativeaotdetector
+sidebar:
+  order: 0
+---
+
+**Namespace:** `Dotsider.Core.Analysis`
+
+**Assembly:** Dotsider.Core.dll
+
+Detects Native AOT compiled .NET binaries by locating and validating the embedded
+ReadyToRun header. Every Native AOT image carries this header (signature "RTR\0")
+so the runtime can find its module sections, but the signature bytes also occur as
+code immediates, so each candidate is validated against the field ranges the ILC
+toolchain actually emits before it is accepted.
+
+```csharp
+public static class NativeAotDetector
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **NativeAotDetector**
+
+## Methods
+
+### Detect(ReadOnlySpan\<byte\>)
+
+Probes the given binary image for a validated ReadyToRun header.
+
+**Parameters:**
+
+- `bytes` ([ReadOnlySpan\<Byte\>](https://learn.microsoft.com/dotnet/api/system.readonlyspan-1)): The raw bytes of the binary file.
+
+**Returns:** [NativeAotInfo](/api/dotsider.core.analysis.models.nativeaotinfo/)
+
+The extracted header facts when the image is a PE, ELF, or Mach-O binary
+containing a validated ReadyToRun header; otherwise null. Callers decide
+what the result means in combination with metadata presence — a managed
+R2R assembly also embeds this header, so probe only metadata-less files.
+
+```csharp
+public static NativeAotInfo? Detect(ReadOnlySpan<byte> bytes)
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-StringExtractor.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-StringExtractor.md
@@ -92,6 +92,27 @@ A list of string entries extracted from the raw binary.
 public IReadOnlyList<StringEntry> ExtractRawStrings(int minLength = 4)
 ```
 
+### ExtractRawUtf16Strings(int)
+
+Extracts printable UTF-16LE character sequences from the binary file. Scans for
+runs of little-endian code units in the printable ASCII range (0x20–0x7E stored
+as two bytes), which is how managed string literals freeze in Native AOT images.
+The scan restarts at every byte position, so runs at odd offsets are found too.
+Accepting the full BMP instead would drown the results in noise — most random
+16-bit values decode to a printable character.
+
+**Parameters:**
+
+- `minLength` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The minimum number of consecutive printable characters to consider a string.
+
+**Returns:** [IReadOnlyList\<StringEntry\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+A list of string entries extracted from the raw binary.
+
+```csharp
+public IReadOnlyList<StringEntry> ExtractRawUtf16Strings(int minLength = 4)
+```
+
 ### ExtractUserStrings()
 
 Extracts all user string literals from the #US metadata heap.

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis.md
@@ -46,9 +46,9 @@ public static class AssemblyIdentityFormat
 ### [AssemblyLoader](/api/dotsider.core.analysis.assemblyloader/)
 
 Shared factory for opening assembly files. Handles apphosts (companion .dll redirect),
-single-file bundles (entry assembly extraction), and direct .dll/.exe loading.
-Returns an [AssemblyOpenResult](/api/dotsider.core.analysis.models.assemblyopenresult/) that preserves the distinction so callers
-can decide how to present each case (e.g. showing an apphost dialog).
+single-file bundles (entry assembly extraction), Native AOT binaries, and direct
+.dll/.exe loading. Returns an [AssemblyOpenResult](/api/dotsider.core.analysis.models.assemblyopenresult/) that preserves the
+distinction so callers can decide how to present each case (e.g. showing an apphost dialog).
 
 ```csharp
 public static class AssemblyLoader
@@ -102,6 +102,18 @@ assemblies (e.g., System.Private.CoreLib) by probing for type forwarding.
 
 ```csharp
 public static class ImplementationAssemblyResolver
+```
+
+### [NativeAotDetector](/api/dotsider.core.analysis.nativeaotdetector/)
+
+Detects Native AOT compiled .NET binaries by locating and validating the embedded
+ReadyToRun header. Every Native AOT image carries this header (signature "RTR\0")
+so the runtime can find its module sections, but the signature bytes also occur as
+code immediates, so each candidate is validated against the field ranges the ILC
+toolchain actually emits before it is accepted.
+
+```csharp
+public static class NativeAotDetector
 ```
 
 ### [NetFxBinder](/api/dotsider.core.analysis.netfxbinder/)

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -11,7 +11,7 @@ Point dotsider at any .NET DLL or EXE:
 dotsider HelloWorld.dll
 ```
 
-You land on the **General** tab showing assembly identity, target framework, architecture, and the dependency table. If you open an apphost `.exe` that has no .NET metadata, dotsider offers to open the companion managed `.dll` instead — press `Enter` to switch or `Esc` to stay. If you open a self-contained single-file executable, dotsider reads the bundle and analyzes the entry assembly directly.
+You land on the **General** tab showing assembly identity, target framework, architecture, and the dependency table. If you open an apphost `.exe` that has no .NET metadata, dotsider offers to open the companion managed `.dll` instead — press `Enter` to switch or `Esc` to stay. If you open a self-contained single-file executable, dotsider reads the bundle and analyzes the entry assembly directly. If you open a Native AOT executable, dotsider recognizes its embedded ReadyToRun header and shows the binary kind, toolchain format version, runtime version, native import table, and frozen string literals.
 
 ![dotsider General tab](/demo.gif)
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -43,9 +43,12 @@ dotsider analyze MyLib.dll --json             # any of the above as JSON
 dotsider analyze MyLib.dll --types -o out.txt # write to file
 dotsider analyze MyApp.exe                    # apphost .exe → auto-redirects to MyApp.dll
 dotsider analyze MyApp                        # single-file bundle → extracts entry assembly
+dotsider analyze MyAotApp.exe                 # Native AOT → binary kind, RTR format, imports
 ```
 
 If the file is a native apphost with a companion `.dll`, `analyze` auto-redirects. If it's a self-contained single-file bundle, `analyze` extracts the entry assembly from the bundle. Both cases print a note to stderr.
+
+If the file is a Native AOT executable (a validated ReadyToRun header with no CLR metadata), the default output adds `Kind`, `RTR Format`, `Runtime`, and `Imports` lines, and JSON output gains `binaryKind` and `nativeAotInfo` fields. `--strings` falls back to the raw ASCII and UTF-16 scans, since AOT binaries have no metadata string heaps.
 
 When portable PDB data is available, default output reports where it came from, and `--il` includes source spans, local names, and Source Link markers. Use `--json` when you need the exact URLs. `--embedded-source` prints source embedded in the PDB.
 
@@ -57,6 +60,7 @@ When portable PDB data is available, default output reports where it came from, 
 | `--embedded-source <name>` | Print embedded source for a method |
 | `--deps` | Show assembly references |
 | `--strings` | Extract strings |
+| `-n`, `--min-len <n>` | Minimum length for raw string extraction (default: 4) |
 | `--fields` | List field definitions |
 | `--size` | Show size breakdown |
 | `--bundle` | Show single-file bundle manifest |

--- a/docs/src/content/docs/reference/mcp.md
+++ b/docs/src/content/docs/reference/mcp.md
@@ -77,6 +77,8 @@ Tools work in two modes:
 
 Single-file executables and native apphosts are handled transparently in direct mode — the server extracts the entry assembly from bundles and redirects apphosts to their companion DLLs, matching CLI and TUI behavior. Portable PDB data is exposed when present, including provenance, Source Link mappings, sequence points, and local names.
 
+Native AOT executables are recognized by their embedded ReadyToRun header: `get_assembly_info` reports `binaryKind` (`managed`, `nativeAot`, or `native`) and a `nativeAotInfo` object with the RTR format version, section count, and heuristically recovered runtime version. `extract_strings` returns `rawStrings` (ASCII) and `rawUtf16Strings` alongside the metadata heaps — for AOT binaries the raw scans are the only populated categories, and the UTF-16 scan is where frozen managed string literals appear.
+
 Session sockets are access-controlled. The socket directory and socket file are restricted to the current user on all platforms, connections are verified against the process owner, and a versioned protocol rejects mismatched clients. Concurrent connections are capped at four per session.
 
 ## Guided prompts

--- a/docs/src/content/docs/usage/general.md
+++ b/docs/src/content/docs/usage/general.md
@@ -13,6 +13,15 @@ The **General** tab (`1`) is the first thing you see when opening an assembly. I
 - **PDB summary** — whether portable debug information came from a sidecar, an embedded PDB, or was unavailable
 - **Dependency table** — all referenced assemblies with their versions
 
+## Native AOT binaries
+
+Opening a Native AOT executable adds a block below the standard fields. ILC strips ECMA-335 metadata, but every AOT image embeds a ReadyToRun header the runtime uses to find its module sections — dotsider validates that header and reports:
+
+- **Binary kind** — `Native AOT (.NET)`
+- **ILC / RTR format** — the ReadyToRun format version, section count, and header offset
+- **Runtime version** — recovered from a version string the runtime pack embeds; shown as `(not detected)` when the layout doesn't match (a heuristic, never a guess)
+- **Native imports** — module and function counts from the PE import table (the full table lives in the PE/Metadata tab)
+
 ## Text selection and copy
 
 The Assembly Info panel is a read-only editor. Click into it or press `Tab` to move focus there, then select text with click-drag or `Shift` + arrow keys. Press `y` to yank the selection to the clipboard.

--- a/docs/src/content/docs/usage/pe-metadata.md
+++ b/docs/src/content/docs/usage/pe-metadata.md
@@ -20,7 +20,7 @@ The **PE / Metadata** tab (`2`) exposes the raw structure of the Portable Execut
 - **Exports** — the native export table, including forwarders and ordinal-only exports
 - **Load Config** — the load configuration directory: security cookie, SEH handler count, and decoded Control Flow Guard flags
 
-The last three read PE data directories and need no CLR header, so they light up for native apphosts and Native AOT executables where the metadata tables are empty.
+Imports and Exports need no CLR header, so they light up for native apphosts and Native AOT executables where the metadata tables are empty. They read whichever native format the binary uses: PE import descriptors on Windows, ELF needed libraries and versioned dynamic symbols on Linux, and Mach-O loaded dylibs and two-level-namespace bindings on macOS. Load Config is a PE-only structure and stays empty on ELF and Mach-O.
 
 ## Text selection and copy
 

--- a/docs/src/content/docs/usage/pe-metadata.md
+++ b/docs/src/content/docs/usage/pe-metadata.md
@@ -16,6 +16,11 @@ The **PE / Metadata** tab (`2`) exposes the raw structure of the Portable Execut
 - **Custom attributes** — applied attributes with decoded arguments
 - **Resources** — embedded resources with names and sizes
 - **Debug Directory** — CodeView, embedded portable PDB, checksum, and reproducible-build entries
+- **Imports** — the native import table, one row per imported function with module, hint, and ordinal
+- **Exports** — the native export table, including forwarders and ordinal-only exports
+- **Load Config** — the load configuration directory: security cookie, SEH handler count, and decoded Control Flow Guard flags
+
+The last three read PE data directories and need no CLR header, so they light up for native apphosts and Native AOT executables where the metadata tables are empty.
 
 ## Text selection and copy
 

--- a/docs/src/content/docs/usage/strings.md
+++ b/docs/src/content/docs/usage/strings.md
@@ -5,11 +5,12 @@ description: User strings, metadata strings, and raw binary string scanning.
 
 ![Strings tab](../../../assets/screenshots/strings.png)
 
-The **Strings** tab (`4`) extracts text from three sources:
+The **Strings** tab (`4`) extracts text from four sources:
 
 - **User strings** — string literals from the `#US` metadata heap (the strings your code uses directly)
 - **Metadata strings** — type names, method names, namespace names from the `#Strings` heap
-- **Raw scan** — binary string extraction from the entire file, similar to the Unix `strings` command
+- **Raw scan** — ASCII string extraction from the entire file, similar to the Unix `strings` command
+- **Raw (UTF-16)** — UTF-16 string extraction from the entire file; managed string literals freeze as UTF-16 in Native AOT images, so this sub-tab is where an AOT binary's string constants appear
 
 ## Copy strings
 
@@ -17,10 +18,10 @@ Press `y` on a focused table row to copy the string value to the clipboard. Pres
 
 ## Minimum length
 
-Use the `--min-len` / `-n` flag to control the minimum length for the raw binary scan:
+Use the `--min-len` / `-n` flag to control the minimum length for both raw scans:
 
 ```
 dotsider MyApp.dll -n 8
 ```
 
-The default minimum is 4 characters. Increase it to reduce noise in large assemblies.
+The default minimum is 4 characters. Increase it to reduce noise in large assemblies. Inside the TUI, `+` and `-` adjust it live on either raw sub-tab.

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -35,6 +35,8 @@ public sealed class AssemblyAnalyzer : IDisposable
     private IReadOnlyList<DebugDirectoryInfo>? _debugDirectory;
     private SourceLinkInfo? _sourceLink;
     private string? _preferredRuntimePack;
+    private NativeAotInfo? _nativeAotInfo;
+    private bool _nativeAotProbed;
 
     /// <summary>
     /// Opens and analyzes the specified .NET assembly file.
@@ -78,6 +80,7 @@ public sealed class AssemblyAnalyzer : IDisposable
             // for hex dump; PE-specific analysis will be empty.
             _peReader?.Dispose();
             _peReader = null;
+            Architecture = GetNativeArchitecture(_rawBytes);
         }
         catch
         {
@@ -137,6 +140,7 @@ public sealed class AssemblyAnalyzer : IDisposable
         {
             _peReader?.Dispose();
             _peReader = null;
+            Architecture = GetNativeArchitecture(_rawBytes);
         }
         catch
         {
@@ -197,6 +201,33 @@ public sealed class AssemblyAnalyzer : IDisposable
 
     /// <summary>Whether the PE file contains .NET metadata.</summary>
     public bool HasMetadata => _metadataReader is not null;
+
+    /// <summary>
+    /// Facts from the embedded ReadyToRun header when this is a Native AOT binary,
+    /// or null. Only probed for metadata-less files — a managed ReadyToRun assembly
+    /// also embeds the header, but there it accompanies metadata rather than
+    /// replacing it.
+    /// </summary>
+    public NativeAotInfo? NativeAotInfo
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (!_nativeAotProbed)
+            {
+                _nativeAotInfo = HasMetadata ? null : NativeAotDetector.Detect(_rawBytes);
+                _nativeAotProbed = true;
+            }
+
+            return _nativeAotInfo;
+        }
+    }
+
+    /// <summary>Coarse classification of the analyzed binary.</summary>
+    public BinaryKind BinaryKind =>
+        HasMetadata ? BinaryKind.Managed
+        : NativeAotInfo is not null ? BinaryKind.NativeAot
+        : BinaryKind.Native;
 
     /// <summary>Portable PDB provenance for the analyzed assembly.</summary>
     public PdbProvenance PdbProvenance { get; private set; } =
@@ -641,6 +672,49 @@ public sealed class AssemblyAnalyzer : IDisposable
         // Mach-O: four known magic values (big/little endian, 32/64-bit)
         uint magic = (uint)(bytes[0] << 24 | bytes[1] << 16 | bytes[2] << 8 | bytes[3]);
         return magic is 0xFEEDFACE or 0xFEEDFACF or 0xCEFAEDFE or 0xCFFAEDFE;
+    }
+
+    /// <summary>
+    /// Reads the target architecture from an ELF or Mach-O header. The bytes have
+    /// already passed <see cref="IsNativeExecutable"/>.
+    /// </summary>
+    private static string GetNativeArchitecture(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < 8) return "Unknown";
+
+        // ELF: e_machine is a u16 at offset 18; EI_DATA at offset 5 selects endianness
+        if (bytes[0] == 0x7F && bytes[1] == 0x45 && bytes[2] == 0x4C && bytes[3] == 0x46)
+        {
+            if (bytes.Length < 20) return "Unknown";
+            var bigEndian = bytes[5] == 2;
+            int machine = bigEndian
+                ? bytes[18] << 8 | bytes[19]
+                : bytes[19] << 8 | bytes[18];
+            return machine switch
+            {
+                0x3E => "x64",
+                0xB7 => "ARM64",
+                0x03 => "x86",
+                0x28 => "ARM",
+                0xF3 => "RISC-V",
+                _ => "Unknown",
+            };
+        }
+
+        // Mach-O: cputype is an i32 at offset 4; 0xCxFAEDFE magics are byte-swapped
+        uint magic = (uint)(bytes[0] << 24 | bytes[1] << 16 | bytes[2] << 8 | bytes[3]);
+        var swapped = magic is 0xCEFAEDFE or 0xCFFAEDFE;
+        uint cpuType = swapped
+            ? (uint)(bytes[7] << 24 | bytes[6] << 16 | bytes[5] << 8 | bytes[4])
+            : (uint)(bytes[4] << 24 | bytes[5] << 16 | bytes[6] << 8 | bytes[7]);
+        return cpuType switch
+        {
+            0x01000007 => "x64",
+            0x0100000C => "ARM64",
+            0x00000007 => "x86",
+            0x0000000C => "ARM",
+            _ => "Unknown",
+        };
     }
 
     private void ReadAssemblyIdentity()

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -37,6 +37,10 @@ public sealed class AssemblyAnalyzer : IDisposable
     private string? _preferredRuntimePack;
     private NativeAotInfo? _nativeAotInfo;
     private bool _nativeAotProbed;
+    private IReadOnlyList<ImportedModuleInfo>? _imports;
+    private IReadOnlyList<ExportedFunctionInfo>? _exports;
+    private LoadConfigInfo? _loadConfig;
+    private bool _loadConfigProbed;
 
     /// <summary>
     /// Opens and analyzes the specified .NET assembly file.
@@ -282,6 +286,50 @@ public sealed class AssemblyAnalyzer : IDisposable
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
             return _debugDirectory ??= ReadDebugDirectory();
+        }
+    }
+
+    /// <summary>
+    /// Gets the native import table (modules and imported functions). Needs no CLR
+    /// header; empty for non-PE files.
+    /// </summary>
+    public IReadOnlyList<ImportedModuleInfo> Imports
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _imports ??= _peReader is null ? [] : PeDirectoryReader.ReadImports(_peReader);
+        }
+    }
+
+    /// <summary>
+    /// Gets the native export table. Needs no CLR header; empty for non-PE files or
+    /// when the image exports nothing.
+    /// </summary>
+    public IReadOnlyList<ExportedFunctionInfo> Exports
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _exports ??= _peReader is null ? [] : PeDirectoryReader.ReadExports(_peReader);
+        }
+    }
+
+    /// <summary>
+    /// Gets the parsed load configuration directory, or null when absent or not a PE.
+    /// </summary>
+    public LoadConfigInfo? LoadConfig
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (!_loadConfigProbed)
+            {
+                _loadConfig = _peReader is null ? null : PeDirectoryReader.ReadLoadConfig(_peReader);
+                _loadConfigProbed = true;
+            }
+
+            return _loadConfig;
         }
     }
 

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -290,28 +290,29 @@ public sealed class AssemblyAnalyzer : IDisposable
     }
 
     /// <summary>
-    /// Gets the native import table (modules and imported functions). Needs no CLR
-    /// header; empty for non-PE files.
+    /// Gets the native import table: PE import descriptors, ELF needed libraries and
+    /// undefined dynamic symbols, or Mach-O loaded dylibs and undefined symbols.
+    /// Needs no CLR header.
     /// </summary>
     public IReadOnlyList<ImportedModuleInfo> Imports
     {
         get
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            return _imports ??= _peReader is null ? [] : PeDirectoryReader.ReadImports(_peReader);
+            return _imports ??= ReadNativeImports();
         }
     }
 
     /// <summary>
-    /// Gets the native export table. Needs no CLR header; empty for non-PE files or
-    /// when the image exports nothing.
+    /// Gets the native export table: PE exports, or the defined global symbols of an
+    /// ELF or Mach-O image. Needs no CLR header; empty when the image exports nothing.
     /// </summary>
     public IReadOnlyList<ExportedFunctionInfo> Exports
     {
         get
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            return _exports ??= _peReader is null ? [] : PeDirectoryReader.ReadExports(_peReader);
+            return _exports ??= ReadNativeExports();
         }
     }
 
@@ -720,6 +721,22 @@ public sealed class AssemblyAnalyzer : IDisposable
         // Mach-O: four known magic values (big/little endian, 32/64-bit)
         uint magic = (uint)(bytes[0] << 24 | bytes[1] << 16 | bytes[2] << 8 | bytes[3]);
         return magic is 0xFEEDFACE or 0xFEEDFACF or 0xCEFAEDFE or 0xCFFAEDFE;
+    }
+
+    private IReadOnlyList<ImportedModuleInfo> ReadNativeImports()
+    {
+        if (_peReader is not null) return PeDirectoryReader.ReadImports(_peReader);
+        if (ElfImageReader.IsElf(_rawBytes)) return ElfImageReader.ReadImports(_rawBytes);
+        if (MachOImageReader.IsMachO(_rawBytes)) return MachOImageReader.ReadImports(_rawBytes);
+        return [];
+    }
+
+    private IReadOnlyList<ExportedFunctionInfo> ReadNativeExports()
+    {
+        if (_peReader is not null) return PeDirectoryReader.ReadExports(_peReader);
+        if (ElfImageReader.IsElf(_rawBytes)) return ElfImageReader.ReadExports(_rawBytes);
+        if (MachOImageReader.IsMachO(_rawBytes)) return MachOImageReader.ReadExports(_rawBytes);
+        return [];
     }
 
     /// <summary>

--- a/src/Dotsider.Core/Analysis/AssemblyLoader.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyLoader.cs
@@ -4,9 +4,9 @@ namespace Dotsider.Core.Analysis;
 
 /// <summary>
 /// Shared factory for opening assembly files. Handles apphosts (companion .dll redirect),
-/// single-file bundles (entry assembly extraction), and direct .dll/.exe loading.
-/// Returns an <see cref="AssemblyOpenResult"/> that preserves the distinction so callers
-/// can decide how to present each case (e.g. showing an apphost dialog).
+/// single-file bundles (entry assembly extraction), Native AOT binaries, and direct
+/// .dll/.exe loading. Returns an <see cref="AssemblyOpenResult"/> that preserves the
+/// distinction so callers can decide how to present each case (e.g. showing an apphost dialog).
 /// </summary>
 public static class AssemblyLoader
 {
@@ -18,7 +18,8 @@ public static class AssemblyLoader
     /// An <see cref="AssemblyOpenResult"/> describing the result:
     /// <see cref="AssemblyOpenResult.Direct"/> for regular assemblies,
     /// <see cref="AssemblyOpenResult.ApphostWithCompanion"/> for native apphosts with a companion .dll,
-    /// or <see cref="AssemblyOpenResult.BundleEntry"/> for single-file bundles.
+    /// <see cref="AssemblyOpenResult.BundleEntry"/> for single-file bundles,
+    /// or <see cref="AssemblyOpenResult.NativeAot"/> for Native AOT compiled binaries.
     /// </returns>
     public static AssemblyOpenResult Open(string filePath)
     {
@@ -44,7 +45,13 @@ public static class AssemblyLoader
             return new AssemblyOpenResult.BundleEntry(entryAnalyzer, filePath);
         }
 
-        // Native binary with no metadata (NativeAOT, unknown format)
+        // Validated ReadyToRun header with no COR header — Native AOT compiled .NET.
+        // Probed only after the bundle check: R2R assemblies inside a bundle also
+        // contain RTR signatures.
+        if (analyzer.NativeAotInfo is not null)
+            return new AssemblyOpenResult.NativeAot(analyzer);
+
+        // Native binary with no metadata (unknown format)
         return new AssemblyOpenResult.Direct(analyzer);
     }
 }

--- a/src/Dotsider.Core/Analysis/ElfImageReader.cs
+++ b/src/Dotsider.Core/Analysis/ElfImageReader.cs
@@ -1,0 +1,290 @@
+using System.Buffers.Binary;
+using System.Text;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Reads the dependency libraries and dynamic symbols of a 64-bit ELF image — the
+/// import/export analog of the PE data directories for Linux Native AOT output.
+/// Imports are the needed shared objects (each with the undefined symbols attributed
+/// to it via GNU version requirements); exports are the defined global symbols.
+/// Malformed images yield empty results rather than throwing.
+/// </summary>
+internal static class ElfImageReader
+{
+    private const int Elf64HeaderSize = 64;
+    private const int SectionHeaderSize = 64;
+    private const int SymbolSize = 24;
+    private const int MaxSymbols = 262_144;
+    private const int MaxStringLength = 4_096;
+
+    private const uint ShtDynSym = 11;
+    private const int StbGlobal = 1;
+    private const int StbWeak = 2;
+    private const ushort ShnUndef = 0;
+
+    /// <summary>Returns true if the bytes are a 64-bit ELF image.</summary>
+    internal static bool IsElf(ReadOnlySpan<byte> bytes) =>
+        bytes.Length >= Elf64HeaderSize
+        && bytes[0] == 0x7F && bytes[1] == (byte)'E' && bytes[2] == (byte)'L' && bytes[3] == (byte)'F'
+        && bytes[4] == 2; // ELFCLASS64
+
+    /// <summary>
+    /// Reads the needed shared libraries and the undefined symbols imported from each.
+    /// </summary>
+    internal static IReadOnlyList<ImportedModuleInfo> ReadImports(ReadOnlySpan<byte> bytes)
+    {
+        try
+        {
+            if (!IsElf(bytes)) return [];
+            var elf = ElfLayout.Parse(bytes);
+            if (elf is not { } layout) return [];
+
+            var modules = new Dictionary<string, List<ImportedFunctionInfo>>(StringComparer.Ordinal);
+
+            // Seed with the declared dependencies so libraries with no attributed
+            // symbols still appear.
+            foreach (var needed in layout.Needed)
+                modules.TryAdd(needed, []);
+
+            var symbolCount = layout.DynSym.Size / SymbolSize;
+            for (var i = 0; i < symbolCount && i < MaxSymbols; i++)
+            {
+                var symbolOffset = layout.DynSym.Offset + i * SymbolSize;
+                var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[symbolOffset..]);
+                var sectionIndex = BinaryPrimitives.ReadUInt16LittleEndian(bytes[(symbolOffset + 6)..]);
+                if (sectionIndex != ShnUndef) continue;
+
+                var name = ReadString(bytes, layout.DynStr.Offset, nameOffset);
+                if (string.IsNullOrEmpty(name)) continue;
+
+                var library = layout.ResolveVersionLibrary(bytes, i) ?? "(unversioned)";
+                if (!modules.TryGetValue(library, out var functions))
+                {
+                    functions = [];
+                    modules[library] = functions;
+                }
+
+                functions.Add(new ImportedFunctionInfo(name, Ordinal: null, Hint: null));
+            }
+
+            return [.. modules.Select(m => new ImportedModuleInfo(m.Key, m.Value))];
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>Reads the defined global and weak dynamic symbols (the exported symbols).</summary>
+    internal static IReadOnlyList<ExportedFunctionInfo> ReadExports(ReadOnlySpan<byte> bytes)
+    {
+        try
+        {
+            if (!IsElf(bytes)) return [];
+            var elf = ElfLayout.Parse(bytes);
+            if (elf is not { } layout) return [];
+
+            var exports = new List<ExportedFunctionInfo>();
+            var symbolCount = layout.DynSym.Size / SymbolSize;
+            for (var i = 0; i < symbolCount && i < MaxSymbols; i++)
+            {
+                var symbolOffset = layout.DynSym.Offset + i * SymbolSize;
+                var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[symbolOffset..]);
+                var info = bytes[symbolOffset + 4];
+                var sectionIndex = BinaryPrimitives.ReadUInt16LittleEndian(bytes[(symbolOffset + 6)..]);
+                var value = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(symbolOffset + 8)..]);
+                if (sectionIndex == ShnUndef) continue;
+
+                var bind = info >> 4;
+                if (bind != StbGlobal && bind != StbWeak) continue;
+
+                var name = ReadString(bytes, layout.DynStr.Offset, nameOffset);
+                if (string.IsNullOrEmpty(name)) continue;
+
+                exports.Add(new ExportedFunctionInfo(
+                    Ordinal: i, Name: name, Rva: (int)value, ForwardedTo: null));
+            }
+
+            return exports;
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            return [];
+        }
+    }
+
+    private static string? ReadString(ReadOnlySpan<byte> bytes, long tableOffset, uint offset)
+    {
+        var start = tableOffset + offset;
+        if (start < 0 || start >= bytes.Length) return null;
+
+        var slice = bytes[(int)start..];
+        var end = slice.IndexOf((byte)0);
+        if (end < 0) end = Math.Min(slice.Length, MaxStringLength);
+        if (end > MaxStringLength) return null;
+
+        return Encoding.UTF8.GetString(slice[..end]);
+    }
+
+    /// <summary>Resolved offsets of the dynamic symbol/string tables plus dependency data.</summary>
+    private readonly struct ElfLayout
+    {
+        private ElfLayout(
+            (int Offset, int Size) dynSym, (int Offset, int Size) dynStr,
+            int versionOffset, int versionNeedOffset, int versionNeedCount,
+            List<string> needed)
+        {
+            DynSym = dynSym;
+            DynStr = dynStr;
+            _versionOffset = versionOffset;
+            _versionNeedOffset = versionNeedOffset;
+            _versionNeedCount = versionNeedCount;
+            Needed = needed;
+        }
+
+        public (int Offset, int Size) DynSym { get; }
+        public (int Offset, int Size) DynStr { get; }
+        public List<string> Needed { get; }
+
+        private readonly int _versionOffset;
+        private readonly int _versionNeedOffset;
+        private readonly int _versionNeedCount;
+
+        /// <summary>
+        /// Parses the section headers to locate the dynamic tables and the dependency
+        /// libraries. Returns null when the image is not little-endian, lacks section
+        /// headers, or has no dynamic symbol table.
+        /// </summary>
+        public static ElfLayout? Parse(ReadOnlySpan<byte> bytes)
+        {
+            if (bytes[5] != 1) return null; // ELFDATA2LSB only
+
+            var sectionOffset = (long)BinaryPrimitives.ReadUInt64LittleEndian(bytes[40..]);
+            var sectionEntrySize = BinaryPrimitives.ReadUInt16LittleEndian(bytes[58..]);
+            var sectionCount = BinaryPrimitives.ReadUInt16LittleEndian(bytes[60..]);
+            var stringSectionIndex = BinaryPrimitives.ReadUInt16LittleEndian(bytes[62..]);
+            if (sectionOffset <= 0 || sectionEntrySize < SectionHeaderSize || sectionCount == 0)
+                return null;
+
+            var shStrTableOffset = (int)SectionField(bytes, sectionOffset, sectionEntrySize,
+                stringSectionIndex, offset: 24);
+
+            (int Offset, int Size) dynSym = default;
+            (int Offset, int Size) dynStr = default;
+            var versionOffset = 0;
+            var versionNeedOffset = 0;
+            var versionNeedCount = 0;
+
+            for (var i = 0; i < sectionCount; i++)
+            {
+                var header = sectionOffset + (long)i * sectionEntrySize;
+                var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)header..]);
+                var name = ReadString(bytes, shStrTableOffset, nameOffset);
+                var offset = (int)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 24)..]);
+                var size = (int)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 32)..]);
+
+                switch (name)
+                {
+                    case ".dynsym": dynSym = (offset, size); break;
+                    case ".dynstr": dynStr = (offset, size); break;
+                    case ".gnu.version": versionOffset = offset; break;
+                    case ".gnu.version_r":
+                        versionNeedOffset = offset;
+                        versionNeedCount = (int)BinaryPrimitives.ReadUInt32LittleEndian(
+                            bytes[(int)(header + 44)..]); // sh_info = number of Verneed entries
+                        break;
+                }
+            }
+
+            if (dynSym.Offset == 0 || dynStr.Offset == 0) return null;
+
+            var needed = ReadNeeded(bytes, sectionOffset, sectionEntrySize, sectionCount, dynStr.Offset);
+            return new ElfLayout(dynSym, dynStr, versionOffset, versionNeedOffset,
+                versionNeedCount, needed);
+        }
+
+        /// <summary>
+        /// Maps a dynamic symbol index to the library that provides its required version
+        /// via the <c>.gnu.version</c> and <c>.gnu.version_r</c> tables, or null when the
+        /// symbol carries no version requirement.
+        /// </summary>
+        public string? ResolveVersionLibrary(ReadOnlySpan<byte> bytes, int symbolIndex)
+        {
+            if (_versionOffset == 0 || _versionNeedOffset == 0) return null;
+
+            var versionIndex = BinaryPrimitives.ReadUInt16LittleEndian(
+                bytes[(_versionOffset + symbolIndex * 2)..]) & 0x7FFF;
+            if (versionIndex < 2) return null; // 0 = local, 1 = global, no requirement
+
+            var need = _versionNeedOffset;
+            for (var v = 0; v < _versionNeedCount; v++)
+            {
+                var count = BinaryPrimitives.ReadUInt16LittleEndian(bytes[(need + 2)..]);
+                // vn_file names the library; the aux entries below name its versions.
+                var fileOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(need + 4)..]);
+                var auxOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(need + 8)..]);
+                var nextOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(need + 12)..]);
+
+                var aux = need + (int)auxOffset;
+                for (var a = 0; a < count; a++)
+                {
+                    var other = BinaryPrimitives.ReadUInt16LittleEndian(bytes[(aux + 6)..]) & 0x7FFF;
+                    var auxNext = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(aux + 12)..]);
+
+                    if (other == versionIndex)
+                        return ReadString(bytes, DynStr.Offset, fileOffset);
+
+                    if (auxNext == 0) break;
+                    aux += (int)auxNext;
+                }
+
+                if (nextOffset == 0) break;
+                need += (int)nextOffset;
+            }
+
+            return null;
+        }
+
+        private static List<string> ReadNeeded(
+            ReadOnlySpan<byte> bytes, long sectionOffset, int sectionEntrySize,
+            int sectionCount, int dynStrOffset)
+        {
+            // Find the .dynamic section (SHT_DYNAMIC = 6) and read its DT_NEEDED entries.
+            const uint shtDynamic = 6;
+            var needed = new List<string>();
+            for (var i = 0; i < sectionCount; i++)
+            {
+                var header = sectionOffset + (long)i * sectionEntrySize;
+                var type = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)(header + 4)..]);
+                if (type != shtDynamic) continue;
+
+                var offset = (int)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 24)..]);
+                var size = (int)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 32)..]);
+                for (var p = offset; p + 16 <= offset + size; p += 16)
+                {
+                    var tag = (long)BinaryPrimitives.ReadUInt64LittleEndian(bytes[p..]);
+                    var value = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(p + 8)..]);
+                    if (tag == 0) break; // DT_NULL
+                    if (tag == 1) // DT_NEEDED
+                    {
+                        var name = ReadString(bytes, dynStrOffset, (uint)value);
+                        if (!string.IsNullOrEmpty(name)) needed.Add(name);
+                    }
+                }
+
+                break;
+            }
+
+            return needed;
+        }
+
+        private static ulong SectionField(
+            ReadOnlySpan<byte> bytes, long sectionOffset, int entrySize, int index, int offset)
+        {
+            var header = sectionOffset + (long)index * entrySize;
+            return BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + offset)..]);
+        }
+    }
+}

--- a/src/Dotsider.Core/Analysis/MachOImageReader.cs
+++ b/src/Dotsider.Core/Analysis/MachOImageReader.cs
@@ -1,0 +1,178 @@
+using System.Buffers.Binary;
+using System.Text;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Reads the linked dylibs and symbol table of a thin 64-bit Mach-O image — the
+/// import/export analog of the PE data directories for macOS Native AOT output.
+/// Imports are the loaded dylibs (each with the undefined external symbols bound to
+/// it through the two-level namespace library ordinal); exports are the defined
+/// external symbols. Fat archives and 32-bit images yield empty results.
+/// </summary>
+internal static class MachOImageReader
+{
+    private const uint Magic64LittleEndian = 0xFEEDFACF;
+    private const int HeaderSize = 32;
+    private const int NListSize = 16;
+    private const int MaxCommands = 4_096;
+    private const int MaxSymbols = 262_144;
+    private const int MaxStringLength = 4_096;
+
+    private const uint LcSymtab = 0x2;
+    private const uint LcLoadDylib = 0xC;
+    private const uint LcLoadWeakDylib = 0x80000018;
+    private const uint LcReexportDylib = 0x8000001F;
+    private const uint LcLoadUpwardDylib = 0x80000023;
+
+    private const byte NStab = 0xE0;
+    private const byte NType = 0x0E;
+    private const byte NExt = 0x01;
+    private const byte NUndef = 0x0;
+    private const byte NSect = 0xE;
+
+    /// <summary>Returns true if the bytes are a thin little-endian 64-bit Mach-O image.</summary>
+    internal static bool IsMachO(ReadOnlySpan<byte> bytes) =>
+        bytes.Length >= HeaderSize
+        && BinaryPrimitives.ReadUInt32LittleEndian(bytes) == Magic64LittleEndian;
+
+    /// <summary>Reads the loaded dylibs and the undefined external symbols bound to each.</summary>
+    internal static IReadOnlyList<ImportedModuleInfo> ReadImports(ReadOnlySpan<byte> bytes)
+    {
+        try
+        {
+            if (!IsMachO(bytes)) return [];
+            if (Parse(bytes) is not { } image) return [];
+
+            var modules = image.Dylibs
+                .Select(d => (Name: d, Functions: new List<ImportedFunctionInfo>()))
+                .ToList();
+
+            if (image.Symbols is { } symtab)
+            {
+                for (var i = 0; i < symtab.Count && i < MaxSymbols; i++)
+                {
+                    var entry = symtab.Offset + i * NListSize;
+                    var type = bytes[entry + 4];
+                    if ((type & NStab) != 0) continue;
+                    if ((type & NExt) == 0 || (type & NType) != NUndef) continue;
+
+                    var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[entry..]);
+                    var desc = BinaryPrimitives.ReadUInt16LittleEndian(bytes[(entry + 6)..]);
+                    var name = ReadString(bytes, symtab.StringOffset, nameOffset);
+                    if (string.IsNullOrEmpty(name)) continue;
+
+                    // Two-level namespace: high byte of n_desc is the 1-based dylib ordinal.
+                    var ordinal = (desc >> 8) & 0xFF;
+                    if (ordinal >= 1 && ordinal <= modules.Count)
+                        modules[ordinal - 1].Functions.Add(
+                            new ImportedFunctionInfo(name, Ordinal: null, Hint: null));
+                }
+            }
+
+            return [.. modules.Select(m => new ImportedModuleInfo(m.Name, m.Functions))];
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>Reads the defined external symbols (the exported symbols).</summary>
+    internal static IReadOnlyList<ExportedFunctionInfo> ReadExports(ReadOnlySpan<byte> bytes)
+    {
+        try
+        {
+            if (!IsMachO(bytes)) return [];
+            if (Parse(bytes) is not { Symbols: { } symtab }) return [];
+
+            var exports = new List<ExportedFunctionInfo>();
+            for (var i = 0; i < symtab.Count && i < MaxSymbols; i++)
+            {
+                var entry = symtab.Offset + i * NListSize;
+                var type = bytes[entry + 4];
+                if ((type & NStab) != 0) continue;
+                if ((type & NExt) == 0 || (type & NType) != NSect) continue;
+
+                var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[entry..]);
+                var value = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(entry + 8)..]);
+                var name = ReadString(bytes, symtab.StringOffset, nameOffset);
+                if (string.IsNullOrEmpty(name)) continue;
+
+                exports.Add(new ExportedFunctionInfo(
+                    Ordinal: i, Name: name, Rva: (int)value, ForwardedTo: null));
+            }
+
+            return exports;
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            return [];
+        }
+    }
+
+    private static MachOImage? Parse(ReadOnlySpan<byte> bytes)
+    {
+        var commandCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes[16..]);
+        if (commandCount > MaxCommands) return null;
+
+        var dylibs = new List<string>();
+        (int Offset, int Count, int StringOffset)? symbols = null;
+
+        var command = HeaderSize;
+        for (var i = 0; i < commandCount; i++)
+        {
+            if (command + 8 > bytes.Length) break;
+            var cmd = BinaryPrimitives.ReadUInt32LittleEndian(bytes[command..]);
+            var cmdSize = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 4)..]);
+            if (cmdSize < 8 || command + cmdSize > bytes.Length) break;
+
+            switch (cmd)
+            {
+                case LcLoadDylib or LcLoadWeakDylib or LcReexportDylib or LcLoadUpwardDylib:
+                {
+                    var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 8)..]);
+                    var name = ReadString(bytes, command, nameOffset);
+                    dylibs.Add(string.IsNullOrEmpty(name) ? "(unknown)" : ShortDylibName(name));
+                    break;
+                }
+
+                case LcSymtab:
+                {
+                    var symOffset = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 8)..]);
+                    var symCount = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 12)..]);
+                    var stringOffset = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 16)..]);
+                    symbols = (symOffset, symCount, stringOffset);
+                    break;
+                }
+            }
+
+            command += cmdSize;
+        }
+
+        return new MachOImage(dylibs, symbols);
+    }
+
+    private static string ShortDylibName(string path)
+    {
+        var slash = path.LastIndexOf('/');
+        return slash >= 0 && slash < path.Length - 1 ? path[(slash + 1)..] : path;
+    }
+
+    private static string? ReadString(ReadOnlySpan<byte> bytes, long tableOffset, uint offset)
+    {
+        var start = tableOffset + offset;
+        if (start < 0 || start >= bytes.Length) return null;
+
+        var slice = bytes[(int)start..];
+        var end = slice.IndexOf((byte)0);
+        if (end < 0) end = Math.Min(slice.Length, MaxStringLength);
+        if (end > MaxStringLength) return null;
+
+        return Encoding.UTF8.GetString(slice[..end]);
+    }
+
+    private readonly record struct MachOImage(
+        IReadOnlyList<string> Dylibs, (int Offset, int Count, int StringOffset)? Symbols);
+}

--- a/src/Dotsider.Core/Analysis/Models/AssemblyOpenResult.cs
+++ b/src/Dotsider.Core/Analysis/Models/AssemblyOpenResult.cs
@@ -9,10 +9,19 @@ public abstract record AssemblyOpenResult
 {
     /// <summary>
     /// Direct load — the file is a .dll or .exe with metadata, or a native binary
-    /// with no metadata (NativeAOT, unknown format).
+    /// with no metadata and no ReadyToRun header (unknown format).
     /// </summary>
     /// <param name="Analyzer">The analyzer for the opened file.</param>
     public sealed record Direct(AssemblyAnalyzer Analyzer) : AssemblyOpenResult;
+
+    /// <summary>
+    /// The file is a Native AOT compiled .NET binary: a valid PE, ELF, or Mach-O
+    /// with no COR header whose image embeds a validated ReadyToRun header. No
+    /// metadata is available, but PE structure, native import/export/load-config
+    /// directories, and raw strings are.
+    /// </summary>
+    /// <param name="Analyzer">The analyzer for the Native AOT binary (no metadata).</param>
+    public sealed record NativeAot(AssemblyAnalyzer Analyzer) : AssemblyOpenResult;
 
     /// <summary>
     /// The file is a native apphost with a companion managed .dll on disk.

--- a/src/Dotsider.Core/Analysis/Models/BinaryKind.cs
+++ b/src/Dotsider.Core/Analysis/Models/BinaryKind.cs
@@ -1,0 +1,19 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// Coarse classification of an analyzed binary.
+/// </summary>
+public enum BinaryKind
+{
+    /// <summary>A managed assembly with ECMA-335 metadata.</summary>
+    Managed,
+
+    /// <summary>
+    /// A Native AOT compiled .NET binary: a native executable with no CLR metadata
+    /// whose image embeds a validated ReadyToRun header.
+    /// </summary>
+    NativeAot,
+
+    /// <summary>A native binary with no CLR metadata and no ReadyToRun header (apphost, unknown format).</summary>
+    Native,
+}

--- a/src/Dotsider.Core/Analysis/Models/ExportedFunctionInfo.cs
+++ b/src/Dotsider.Core/Analysis/Models/ExportedFunctionInfo.cs
@@ -1,0 +1,14 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// A single entry in the PE export table.
+/// </summary>
+/// <param name="Ordinal">The biased export ordinal (ordinal base applied).</param>
+/// <param name="Name">The exported name, or null for ordinal-only exports.</param>
+/// <param name="Rva">The RVA of the exported symbol, or of the forwarder string.</param>
+/// <param name="ForwardedTo">
+/// The forwarder target (e.g. "NTDLL.RtlAllocateHeap") when the export forwards to
+/// another module, or null for regular exports.
+/// </param>
+public sealed record ExportedFunctionInfo(
+    int Ordinal, string? Name, int Rva, string? ForwardedTo);

--- a/src/Dotsider.Core/Analysis/Models/ImportedFunctionInfo.cs
+++ b/src/Dotsider.Core/Analysis/Models/ImportedFunctionInfo.cs
@@ -1,0 +1,9 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// A single function imported from a native module.
+/// </summary>
+/// <param name="Name">The imported function name, or null for ordinal-only imports.</param>
+/// <param name="Ordinal">The import ordinal, or null for named imports.</param>
+/// <param name="Hint">The export-name-table hint for named imports, or null.</param>
+public sealed record ImportedFunctionInfo(string? Name, ushort? Ordinal, ushort? Hint);

--- a/src/Dotsider.Core/Analysis/Models/ImportedModuleInfo.cs
+++ b/src/Dotsider.Core/Analysis/Models/ImportedModuleInfo.cs
@@ -1,0 +1,9 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// A native module referenced by the PE import table, with the functions imported from it.
+/// </summary>
+/// <param name="ModuleName">The module file name (e.g. "KERNEL32.dll").</param>
+/// <param name="Functions">The functions imported from the module.</param>
+public sealed record ImportedModuleInfo(
+    string ModuleName, IReadOnlyList<ImportedFunctionInfo> Functions);

--- a/src/Dotsider.Core/Analysis/Models/LoadConfigInfo.cs
+++ b/src/Dotsider.Core/Analysis/Models/LoadConfigInfo.cs
@@ -1,0 +1,31 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// Parsed PE load configuration directory. Pointer-width fields are widened to
+/// <see cref="ulong"/> so a single record covers PE32 and PE32+ images. Fields
+/// beyond the directory's declared size are zero — real-world load configs are
+/// truncated at many historical lengths.
+/// </summary>
+/// <param name="Size">The declared size of the load configuration directory.</param>
+/// <param name="TimeDateStamp">The directory timestamp.</param>
+/// <param name="MajorVersion">Major version number.</param>
+/// <param name="MinorVersion">Minor version number.</param>
+/// <param name="DependentLoadFlags">Default load flags applied when resolving DLL dependencies.</param>
+/// <param name="SecurityCookie">The VA of the /GS security cookie, or 0 when absent.</param>
+/// <param name="SehHandlerCount">Number of registered structured exception handlers (PE32 /SAFESEH).</param>
+/// <param name="GuardCfCheckFunctionPointer">The VA of the Control Flow Guard check-function pointer, or 0.</param>
+/// <param name="GuardCfFunctionCount">Number of entries in the Control Flow Guard function table.</param>
+/// <param name="GuardFlags">Raw Control Flow Guard flags.</param>
+/// <param name="GuardFlagsDescription">Decoded <paramref name="GuardFlags"/> summary, or "(none)".</param>
+public sealed record LoadConfigInfo(
+    uint Size,
+    uint TimeDateStamp,
+    ushort MajorVersion,
+    ushort MinorVersion,
+    ushort DependentLoadFlags,
+    ulong SecurityCookie,
+    ulong SehHandlerCount,
+    ulong GuardCfCheckFunctionPointer,
+    ulong GuardCfFunctionCount,
+    uint GuardFlags,
+    string GuardFlagsDescription);

--- a/src/Dotsider.Core/Analysis/Models/NativeAotInfo.cs
+++ b/src/Dotsider.Core/Analysis/Models/NativeAotInfo.cs
@@ -1,0 +1,27 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// Facts extracted from the embedded ReadyToRun header of a Native AOT binary.
+/// Every Native AOT image embeds this header (signature "RTR\0") so the runtime can
+/// locate its module sections; its presence with no COR header identifies the binary
+/// as Native AOT compiled .NET.
+/// </summary>
+/// <param name="HeaderOffset">File offset of the RTR signature.</param>
+/// <param name="MajorVersion">ReadyToRun format major version — the ILC toolchain format version.</param>
+/// <param name="MinorVersion">ReadyToRun format minor version.</param>
+/// <param name="Flags">Raw header flags.</param>
+/// <param name="SectionCount">Number of module section entries following the header.</param>
+/// <param name="EntrySize">Size in bytes of each module section entry.</param>
+/// <param name="RuntimeVersion">
+/// Heuristically detected runtime version (e.g. "10.0.8"), or null when not found.
+/// Recovered from a version string the runtime pack embeds near a well-known error
+/// message; absence is normal for stripped or unusually linked binaries.
+/// </param>
+public sealed record NativeAotInfo(
+    int HeaderOffset,
+    ushort MajorVersion,
+    ushort MinorVersion,
+    uint Flags,
+    int SectionCount,
+    byte EntrySize,
+    string? RuntimeVersion);

--- a/src/Dotsider.Core/Analysis/Models/StringSource.cs
+++ b/src/Dotsider.Core/Analysis/Models/StringSource.cs
@@ -18,5 +18,11 @@ public enum StringSource
     /// <summary>
     /// Raw printable character sequences extracted directly from the binary.
     /// </summary>
-    RawBinary
+    RawBinary,
+
+    /// <summary>
+    /// UTF-16LE printable character sequences extracted directly from the binary.
+    /// This is how managed string literals freeze in Native AOT images.
+    /// </summary>
+    RawBinaryUtf16
 }

--- a/src/Dotsider.Core/Analysis/NativeAotDetector.cs
+++ b/src/Dotsider.Core/Analysis/NativeAotDetector.cs
@@ -1,0 +1,144 @@
+using System.Buffers.Binary;
+using System.Text;
+using System.Text.RegularExpressions;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Detects Native AOT compiled .NET binaries by locating and validating the embedded
+/// ReadyToRun header. Every Native AOT image carries this header (signature "RTR\0")
+/// so the runtime can find its module sections, but the signature bytes also occur as
+/// code immediates, so each candidate is validated against the field ranges the ILC
+/// toolchain actually emits before it is accepted.
+/// </summary>
+public static partial class NativeAotDetector
+{
+    /// <summary>Fixed size of the ReadyToRun header before the section entries begin.</summary>
+    private const int HeaderSize = 16;
+
+    /// <summary>
+    /// The runtime pack embeds its version string immediately before this message;
+    /// the placement holds even for hand-linked binaries where other anchors move.
+    /// </summary>
+    private static ReadOnlySpan<byte> VersionAnchor =>
+        "Process is terminating due to StackOverflowException"u8;
+
+    /// <summary>Bytes to search before <see cref="VersionAnchor"/> for the version string.</summary>
+    private const int VersionWindowSize = 64;
+
+    /// <summary>
+    /// Probes the given binary image for a validated ReadyToRun header.
+    /// </summary>
+    /// <param name="bytes">The raw bytes of the binary file.</param>
+    /// <returns>
+    /// The extracted header facts when the image is a PE, ELF, or Mach-O binary
+    /// containing a validated ReadyToRun header; otherwise null. Callers decide
+    /// what the result means in combination with metadata presence — a managed
+    /// R2R assembly also embeds this header, so probe only metadata-less files.
+    /// </returns>
+    public static NativeAotInfo? Detect(ReadOnlySpan<byte> bytes)
+    {
+        if (!HasExecutableMagic(bytes)) return null;
+
+        ReadOnlySpan<byte> signature = [(byte)'R', (byte)'T', (byte)'R', 0];
+        var searchStart = 0;
+        while (searchStart < bytes.Length)
+        {
+            var index = bytes[searchStart..].IndexOf(signature);
+            if (index < 0) return null;
+
+            var candidate = searchStart + index;
+            if (ParseHeader(bytes, candidate) is { } info)
+                return info with { RuntimeVersion = DetectRuntimeVersion(bytes) };
+
+            searchStart = candidate + 1;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns true if the bytes start with a PE, ELF, or Mach-O magic number.
+    /// </summary>
+    private static bool HasExecutableMagic(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < 4) return false;
+
+        // PE: MZ
+        if (bytes[0] == (byte)'M' && bytes[1] == (byte)'Z') return true;
+
+        // ELF: \x7fELF
+        if (bytes[0] == 0x7F && bytes[1] == (byte)'E' && bytes[2] == (byte)'L' && bytes[3] == (byte)'F')
+            return true;
+
+        // Mach-O: four known magic values (big/little endian, 32/64-bit)
+        var magic = BinaryPrimitives.ReadUInt32BigEndian(bytes);
+        return magic is 0xFEEDFACE or 0xFEEDFACF or 0xCEFAEDFE or 0xCFFAEDFE;
+    }
+
+    /// <summary>
+    /// Validates a candidate header at <paramref name="offset"/> and extracts its fields.
+    /// Field ranges are deliberately tight: a real code-immediate collision observed in
+    /// ILC output passes the signature check but fails these.
+    /// </summary>
+    private static NativeAotInfo? ParseHeader(ReadOnlySpan<byte> bytes, int offset)
+    {
+        if (offset + HeaderSize + sizeof(int) > bytes.Length) return null;
+
+        var majorVersion = BinaryPrimitives.ReadUInt16LittleEndian(bytes[(offset + 4)..]);
+        if (majorVersion is < 1 or > 100) return null;
+
+        var minorVersion = BinaryPrimitives.ReadUInt16LittleEndian(bytes[(offset + 6)..]);
+        if (minorVersion > 100) return null;
+
+        var flags = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 8)..]);
+
+        var sectionCount = BinaryPrimitives.ReadUInt16LittleEndian(bytes[(offset + 12)..]);
+        if (sectionCount is 0 or > 1000) return null;
+
+        var entrySize = bytes[offset + 14];
+        if (entrySize is < 8 or > 64) return null;
+
+        var entryType = bytes[offset + 15];
+        if (entryType > 8) return null;
+
+        if (offset + HeaderSize + (long)sectionCount * entrySize > bytes.Length) return null;
+
+        // Native AOT module section ids live in the 200..999 range (StringTable = 200,
+        // GCStaticRegion = 201, readonly blob regions = 300..399) and entries are sorted,
+        // so the first id is always in range. Managed ReadyToRun images use ids around
+        // 100 with a different entry layout, so they fall out here and at the
+        // entry-size check above.
+        var firstSectionId = BinaryPrimitives.ReadInt32LittleEndian(bytes[(offset + HeaderSize)..]);
+        if (firstSectionId is < 200 or > 999) return null;
+
+        return new NativeAotInfo(
+            offset, majorVersion, minorVersion, flags, sectionCount, entrySize,
+            RuntimeVersion: null);
+    }
+
+    /// <summary>
+    /// Heuristically recovers the runtime version from the string the runtime pack
+    /// embeds immediately before its stack-overflow fatal message. Returns null when
+    /// the layout does not match — never guesses.
+    /// </summary>
+    private static string? DetectRuntimeVersion(ReadOnlySpan<byte> bytes)
+    {
+        var anchorIndex = bytes.IndexOf(VersionAnchor);
+        if (anchorIndex < 0) return null;
+
+        var windowStart = Math.Max(0, anchorIndex - VersionWindowSize);
+        var window = Encoding.Latin1.GetString(bytes[windowStart..anchorIndex]);
+
+        Match? last = null;
+        foreach (Match match in VersionRegex().Matches(window))
+            last = match;
+
+        return last?.Value;
+    }
+
+    /// <summary>Matches a three-part runtime version with an optional prerelease suffix.</summary>
+    [GeneratedRegex(@"\d+\.\d+\.\d+(-[0-9A-Za-z.]+)?")]
+    private static partial Regex VersionRegex();
+}

--- a/src/Dotsider.Core/Analysis/NativeAotDetector.cs
+++ b/src/Dotsider.Core/Analysis/NativeAotDetector.cs
@@ -18,14 +18,16 @@ public static partial class NativeAotDetector
     private const int HeaderSize = 16;
 
     /// <summary>
-    /// The runtime pack embeds its version string immediately before this message;
-    /// the placement holds even for hand-linked binaries where other anchors move.
+    /// The runtime pack embeds its version string near this message — the two live in
+    /// the same runtime object file, so linkers keep them close, but which side the
+    /// version lands on differs: immediately before on MSVC-linked PEs, a few hundred
+    /// bytes after on ELF images.
     /// </summary>
     private static ReadOnlySpan<byte> VersionAnchor =>
         "Process is terminating due to StackOverflowException"u8;
 
-    /// <summary>Bytes to search before <see cref="VersionAnchor"/> for the version string.</summary>
-    private const int VersionWindowSize = 64;
+    /// <summary>Bytes to search on each side of <see cref="VersionAnchor"/> for the version string.</summary>
+    private const int VersionWindowSize = 1024;
 
     /// <summary>
     /// Probes the given binary image for a validated ReadyToRun header.
@@ -120,8 +122,9 @@ public static partial class NativeAotDetector
 
     /// <summary>
     /// Heuristically recovers the runtime version from the string the runtime pack
-    /// embeds immediately before its stack-overflow fatal message. Returns null when
-    /// the layout does not match — never guesses.
+    /// embeds near its stack-overflow fatal message, taking the version-shaped match
+    /// closest to the anchor. Returns null when the layout does not match — never
+    /// guesses.
     /// </summary>
     private static string? DetectRuntimeVersion(ReadOnlySpan<byte> bytes)
     {
@@ -129,13 +132,23 @@ public static partial class NativeAotDetector
         if (anchorIndex < 0) return null;
 
         var windowStart = Math.Max(0, anchorIndex - VersionWindowSize);
-        var window = Encoding.Latin1.GetString(bytes[windowStart..anchorIndex]);
+        var windowEnd = Math.Min(bytes.Length, anchorIndex + VersionAnchor.Length + VersionWindowSize);
+        var window = Encoding.Latin1.GetString(bytes[windowStart..windowEnd]);
 
-        Match? last = null;
+        var anchorOffset = anchorIndex - windowStart;
+        Match? best = null;
+        var bestDistance = int.MaxValue;
         foreach (Match match in VersionRegex().Matches(window))
-            last = match;
+        {
+            var distance = Math.Abs(match.Index - anchorOffset);
+            if (distance < bestDistance)
+            {
+                best = match;
+                bestDistance = distance;
+            }
+        }
 
-        return last?.Value;
+        return best?.Value;
     }
 
     /// <summary>Matches a three-part runtime version with an optional prerelease suffix.</summary>

--- a/src/Dotsider.Core/Analysis/PeDirectoryReader.cs
+++ b/src/Dotsider.Core/Analysis/PeDirectoryReader.cs
@@ -1,0 +1,311 @@
+using System.Reflection.PortableExecutable;
+using System.Text;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Parses the PE import, export, and load configuration data directories, none of
+/// which <see cref="PEReader"/> exposes as structured data and none of which need a
+/// CLR header — they light up for apphosts, Native AOT binaries, and managed PEs
+/// alike. Malformed directories never throw; they yield empty results.
+/// </summary>
+internal static class PeDirectoryReader
+{
+    private const int MaxImportDescriptors = 4_096;
+    private const int MaxFunctionsPerModule = 65_536;
+    private const int MaxExports = 65_536;
+    private const int MaxStringLength = 4_096;
+
+    /// <summary>Named IMAGE_GUARD_* bits for the load-config flags summary.</summary>
+    private static readonly (uint Bit, string Name)[] GuardFlagNames =
+    [
+        (0x0000_0100, "CF Instrumented"),
+        (0x0000_0200, "CFW Instrumented"),
+        (0x0000_0400, "CF Function Table Present"),
+        (0x0000_0800, "Security Cookie Unused"),
+        (0x0000_1000, "Protect Delayload IAT"),
+        (0x0000_4000, "CF Export Suppression Info Present"),
+        (0x0000_8000, "CF Export Suppression Enabled"),
+        (0x0001_0000, "CF Long Jump Table Present"),
+        (0x0040_0000, "EH Continuation Table Present"),
+    ];
+
+    /// <summary>
+    /// Reads the import table: one entry per referenced module with its imported functions.
+    /// </summary>
+    internal static IReadOnlyList<ImportedModuleInfo> ReadImports(PEReader peReader)
+    {
+        try
+        {
+            var peHeader = peReader.PEHeaders.PEHeader;
+            if (peHeader is null) return [];
+
+            var directory = peHeader.ImportTableDirectory;
+            if (directory.RelativeVirtualAddress == 0 || directory.Size == 0) return [];
+
+            var is64Bit = peHeader.Magic == PEMagic.PE32Plus;
+            var modules = new List<ImportedModuleInfo>();
+
+            for (var i = 0; i < MaxImportDescriptors; i++)
+            {
+                // IMAGE_IMPORT_DESCRIPTOR: 20 bytes, all-zero entry terminates
+                var descriptor = GetReaderAt(peReader, directory.RelativeVirtualAddress + i * 20, 20);
+                if (descriptor is not { } d) break;
+
+                var importNameTableRva = d.ReadUInt32();
+                d.Offset += 8; // TimeDateStamp + ForwarderChain
+                var nameRva = d.ReadUInt32();
+                var importAddressTableRva = d.ReadUInt32();
+
+                if (importNameTableRva == 0 && nameRva == 0 && importAddressTableRva == 0) break;
+
+                var moduleName = ReadAsciiString(peReader, (int)nameRva);
+                if (moduleName is null) continue;
+
+                // Prefer the import name table; bound images may zero it out
+                var thunkRva = importNameTableRva != 0 ? importNameTableRva : importAddressTableRva;
+                modules.Add(new ImportedModuleInfo(
+                    moduleName, ReadThunks(peReader, (int)thunkRva, is64Bit)));
+            }
+
+            return modules;
+        }
+        catch (BadImageFormatException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Reads the export table, including ordinal-only exports and forwarders.
+    /// </summary>
+    internal static IReadOnlyList<ExportedFunctionInfo> ReadExports(PEReader peReader)
+    {
+        try
+        {
+            var peHeader = peReader.PEHeaders.PEHeader;
+            if (peHeader is null) return [];
+
+            var directory = peHeader.ExportTableDirectory;
+            if (directory.RelativeVirtualAddress == 0 || directory.Size == 0) return [];
+
+            // IMAGE_EXPORT_DIRECTORY: 40 bytes
+            if (GetReaderAt(peReader, directory.RelativeVirtualAddress, 40) is not { } d) return [];
+
+            d.Offset += 16; // Characteristics, TimeDateStamp, Major/MinorVersion, NameRVA
+            var ordinalBase = d.ReadUInt32();
+            var functionCount = d.ReadUInt32();
+            var nameCount = d.ReadUInt32();
+            var functionsRva = d.ReadUInt32();
+            var namesRva = d.ReadUInt32();
+            var nameOrdinalsRva = d.ReadUInt32();
+
+            if (functionCount is 0 or > MaxExports || nameCount > MaxExports) return [];
+
+            // Overlay the name and name-ordinal tables onto function indices
+            var namesByIndex = new Dictionary<uint, string>();
+            for (var i = 0u; i < nameCount; i++)
+            {
+                if (GetReaderAt(peReader, (int)(namesRva + i * 4), 4) is not { } nameReader) return [];
+                if (GetReaderAt(peReader, (int)(nameOrdinalsRva + i * 2), 2) is not { } ordinalReader)
+                    return [];
+
+                var name = ReadAsciiString(peReader, (int)nameReader.ReadUInt32());
+                if (name is not null)
+                    namesByIndex[ordinalReader.ReadUInt16()] = name;
+            }
+
+            var directoryStart = directory.RelativeVirtualAddress;
+            var directoryEnd = directoryStart + directory.Size;
+            var exports = new List<ExportedFunctionInfo>();
+
+            for (var i = 0u; i < functionCount; i++)
+            {
+                if (GetReaderAt(peReader, (int)(functionsRva + i * 4), 4) is not { } functionReader)
+                    return [];
+
+                var rva = (int)functionReader.ReadUInt32();
+                if (rva == 0) continue; // gap in the ordinal range
+
+                // A function RVA inside the export directory points at a forwarder string
+                var forwardedTo = rva >= directoryStart && rva < directoryEnd
+                    ? ReadAsciiString(peReader, rva)
+                    : null;
+
+                exports.Add(new ExportedFunctionInfo(
+                    (int)(ordinalBase + i),
+                    namesByIndex.GetValueOrDefault(i),
+                    rva,
+                    forwardedTo));
+            }
+
+            return exports;
+        }
+        catch (BadImageFormatException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Reads the load configuration directory. Each field is read only when it lies
+    /// within the directory's declared size, so truncated historical layouts parse cleanly.
+    /// </summary>
+    internal static LoadConfigInfo? ReadLoadConfig(PEReader peReader)
+    {
+        try
+        {
+            var peHeader = peReader.PEHeaders.PEHeader;
+            if (peHeader is null) return null;
+
+            var directory = peHeader.LoadConfigTableDirectory;
+            if (directory.RelativeVirtualAddress == 0 || directory.Size == 0) return null;
+
+            var block = peReader.GetSectionData(directory.RelativeVirtualAddress);
+            if (block.Length < 4) return null;
+
+            var reader = block.GetReader();
+            var declaredSize = reader.ReadUInt32();
+            var available = Math.Min(declaredSize == 0 ? (uint)directory.Size : declaredSize,
+                (uint)block.Length);
+
+            var is64Bit = peHeader.Magic == PEMagic.PE32Plus;
+
+            uint ReadU32At(int offset)
+            {
+                if (offset + 4 > available) return 0;
+                var r = block.GetReader();
+                r.Offset = offset;
+                return r.ReadUInt32();
+            }
+
+            ushort ReadU16At(int offset)
+            {
+                if (offset + 2 > available) return 0;
+                var r = block.GetReader();
+                r.Offset = offset;
+                return r.ReadUInt16();
+            }
+
+            ulong ReadPointerAt(int offset)
+            {
+                if (!is64Bit) return ReadU32At(offset);
+                if (offset + 8 > available) return 0;
+                var r = block.GetReader();
+                r.Offset = offset;
+                return r.ReadUInt64();
+            }
+
+            // Field offsets from IMAGE_LOAD_CONFIG_DIRECTORY32/64 (winnt.h)
+            var timeDateStamp = ReadU32At(4);
+            var majorVersion = ReadU16At(8);
+            var minorVersion = ReadU16At(10);
+            var dependentLoadFlags = ReadU16At(is64Bit ? 78 : 54);
+            var securityCookie = ReadPointerAt(is64Bit ? 88 : 60);
+            var sehHandlerCount = ReadPointerAt(is64Bit ? 104 : 68);
+            var guardCfCheckFunctionPointer = ReadPointerAt(is64Bit ? 112 : 72);
+            var guardCfFunctionCount = ReadPointerAt(is64Bit ? 136 : 84);
+            var guardFlags = ReadU32At(is64Bit ? 144 : 88);
+
+            return new LoadConfigInfo(
+                declaredSize, timeDateStamp, majorVersion, minorVersion,
+                dependentLoadFlags, securityCookie, sehHandlerCount,
+                guardCfCheckFunctionPointer, guardCfFunctionCount,
+                guardFlags, DescribeGuardFlags(guardFlags));
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Walks an import thunk table until its zero terminator, decoding ordinal and
+    /// hint/name imports.
+    /// </summary>
+    private static List<ImportedFunctionInfo> ReadThunks(
+        PEReader peReader, int thunkRva, bool is64Bit)
+    {
+        if (thunkRva == 0) return [];
+
+        var thunkSize = is64Bit ? 8 : 4;
+        var functions = new List<ImportedFunctionInfo>();
+
+        for (var i = 0; i < MaxFunctionsPerModule; i++)
+        {
+            if (GetReaderAt(peReader, thunkRva + i * thunkSize, thunkSize) is not { } d) break;
+
+            var thunk = is64Bit ? d.ReadUInt64() : d.ReadUInt32();
+            if (thunk == 0) break;
+
+            var ordinalBit = is64Bit ? 0x8000_0000_0000_0000UL : 0x8000_0000UL;
+            if ((thunk & ordinalBit) != 0)
+            {
+                functions.Add(new ImportedFunctionInfo(
+                    Name: null, Ordinal: (ushort)(thunk & 0xFFFF), Hint: null));
+                continue;
+            }
+
+            // IMAGE_IMPORT_BY_NAME: u16 hint followed by a NUL-terminated name
+            var byNameRva = (int)(thunk & 0x7FFF_FFFF);
+            if (GetReaderAt(peReader, byNameRva, 2) is not { } hintReader) continue;
+
+            var hint = hintReader.ReadUInt16();
+            var name = ReadAsciiString(peReader, byNameRva + 2);
+            if (name is not null)
+                functions.Add(new ImportedFunctionInfo(name, Ordinal: null, Hint: hint));
+        }
+
+        return functions;
+    }
+
+    /// <summary>
+    /// Returns a reader positioned at <paramref name="rva"/> when the RVA maps into a
+    /// section with at least <paramref name="minSize"/> bytes remaining; otherwise null.
+    /// </summary>
+    private static System.Reflection.Metadata.BlobReader? GetReaderAt(
+        PEReader peReader, int rva, int minSize)
+    {
+        if (rva <= 0) return null;
+
+        var block = peReader.GetSectionData(rva);
+        if (block.Length < minSize) return null;
+
+        return block.GetReader();
+    }
+
+    /// <summary>
+    /// Reads a NUL-terminated ASCII string at the given RVA, or null when the RVA is
+    /// unmapped or the string is unterminated within <see cref="MaxStringLength"/> chars.
+    /// </summary>
+    private static string? ReadAsciiString(PEReader peReader, int rva)
+    {
+        if (rva <= 0) return null;
+
+        var block = peReader.GetSectionData(rva);
+        if (block.Length == 0) return null;
+
+        var reader = block.GetReader();
+        var length = Math.Min(block.Length, MaxStringLength);
+        var builder = new StringBuilder();
+        for (var i = 0; i < length; i++)
+        {
+            var b = reader.ReadByte();
+            if (b == 0) return builder.ToString();
+            builder.Append((char)b);
+        }
+
+        return null;
+    }
+
+    /// <summary>Formats the named IMAGE_GUARD_* bits set in <paramref name="guardFlags"/>.</summary>
+    private static string DescribeGuardFlags(uint guardFlags)
+    {
+        var names = GuardFlagNames
+            .Where(f => (guardFlags & f.Bit) != 0)
+            .Select(f => f.Name)
+            .ToList();
+        return names.Count > 0 ? string.Join(", ", names) : "(none)";
+    }
+}

--- a/src/Dotsider.Core/Analysis/StringExtractor.cs
+++ b/src/Dotsider.Core/Analysis/StringExtractor.cs
@@ -1,4 +1,7 @@
+using System.Numerics;
 using System.Reflection.Metadata.Ecma335;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using System.Text;
 using Dotsider.Core.Analysis.Models;
 
@@ -120,34 +123,63 @@ public sealed class StringExtractor(AssemblyAnalyzer analyzer)
     {
         var bytes = analyzer.RawBytes.Span;
         var results = new List<StringEntry>();
-        var sb = new StringBuilder();
-        var startOffset = -1;
 
-        for (var i = 0; i < bytes.Length; i++)
+        var runStart = -1;
+        var position = 0;
+
+        void EmitRun(ReadOnlySpan<byte> data, int start, int end)
         {
-            var b = bytes[i];
-            if (b is >= 0x20 and <= 0x7E)
+            if (end - start < minLength) return;
+            results.Add(new StringEntry(
+                start, Encoding.ASCII.GetString(data[start..end]), StringSource.RawBinary));
+        }
+
+        // Printable bytes make up over a third of typical machine code, so runs start
+        // every few bytes and per-run vectorized searches pay their setup cost without
+        // covering ground. Classifying 64 bytes at a time into a bitmask keeps the
+        // SIMD work fixed per block, and run boundaries fall out of bit scans.
+        if (Vector128.IsHardwareAccelerated)
+        {
+            for (; position + 64 <= bytes.Length; position += 64)
             {
-                if (startOffset < 0) startOffset = i;
-                sb.Append((char)b);
-            }
-            else
-            {
-                if (sb.Length >= minLength)
+                var mask = PrintableMask64(bytes, position);
+                var bit = 0;
+                while (bit < 64)
                 {
-                    results.Add(new StringEntry(startOffset, sb.ToString(), StringSource.RawBinary));
+                    if (runStart < 0)
+                    {
+                        var remaining = mask >> bit;
+                        if (remaining == 0) break;
+                        bit += BitOperations.TrailingZeroCount(remaining);
+                        runStart = position + bit;
+                    }
+                    else
+                    {
+                        var remaining = ~mask >> bit;
+                        if (remaining == 0) break;
+                        bit += BitOperations.TrailingZeroCount(remaining);
+                        EmitRun(bytes, runStart, position + bit);
+                        runStart = -1;
+                    }
                 }
-
-                sb.Clear();
-                startOffset = -1;
             }
         }
 
-        // Handle trailing string
-        if (sb.Length >= minLength)
+        // Scalar tail; also the whole scan when SIMD is unavailable.
+        for (; position < bytes.Length; position++)
         {
-            results.Add(new StringEntry(startOffset, sb.ToString(), StringSource.RawBinary));
+            if (bytes[position] is >= 0x20 and <= 0x7E)
+            {
+                if (runStart < 0) runStart = position;
+            }
+            else if (runStart >= 0)
+            {
+                EmitRun(bytes, runStart, position);
+                runStart = -1;
+            }
         }
+
+        if (runStart >= 0) EmitRun(bytes, runStart, bytes.Length);
 
         return results;
     }
@@ -156,7 +188,7 @@ public sealed class StringExtractor(AssemblyAnalyzer analyzer)
     /// Extracts printable UTF-16LE character sequences from the binary file. Scans for
     /// runs of little-endian code units in the printable ASCII range (0x20–0x7E stored
     /// as two bytes), which is how managed string literals freeze in Native AOT images.
-    /// The scan restarts at every byte position, so runs at odd offsets are found too.
+    /// The file is scanned once per byte parity, so runs at odd offsets are found too.
     /// Accepting the full BMP instead would drown the results in noise — most random
     /// 16-bit values decode to a printable character.
     /// </summary>
@@ -165,42 +197,133 @@ public sealed class StringExtractor(AssemblyAnalyzer analyzer)
     public IReadOnlyList<StringEntry> ExtractRawUtf16Strings(int minLength = 4)
     {
         var bytes = analyzer.RawBytes.Span;
-        var results = new List<StringEntry>();
-        var sb = new StringBuilder();
-        var startOffset = -1;
+        var even = ScanUtf16Runs(bytes, parity: 0, minLength);
+        var odd = ScanUtf16Runs(bytes, parity: 1, minLength);
 
-        for (var i = 0; i + 1 < bytes.Length;)
+        // Qualifying runs of opposite parity never overlap — a code unit's zero high
+        // byte cannot also be another unit's printable low byte — so merging the two
+        // sorted passes yields entries in ascending offset order.
+        var results = new List<StringEntry>(even.Count + odd.Count);
+        int e = 0, o = 0;
+        while (e < even.Count || o < odd.Count)
         {
-            if (bytes[i] is >= 0x20 and <= 0x7E && bytes[i + 1] == 0)
-            {
-                if (startOffset < 0) startOffset = i;
-                sb.Append((char)bytes[i]);
-                i += 2;
-                continue;
-            }
-
-            if (sb.Length >= minLength)
-            {
-                results.Add(new StringEntry(startOffset, sb.ToString(), StringSource.RawBinaryUtf16));
-            }
-            else if (startOffset >= 0)
-            {
-                // A short run may hide a longer one starting inside it at the
-                // opposite parity; rewind to just past where it began.
-                i = startOffset;
-            }
-
-            sb.Clear();
-            startOffset = -1;
-            i++;
-        }
-
-        // Handle trailing string
-        if (sb.Length >= minLength)
-        {
-            results.Add(new StringEntry(startOffset, sb.ToString(), StringSource.RawBinaryUtf16));
+            if (o >= odd.Count || (e < even.Count && even[e].Offset < odd[o].Offset))
+                results.Add(even[e++]);
+            else
+                results.Add(odd[o++]);
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// Finds maximal runs of printable UTF-16LE code units starting at the given byte
+    /// parity. Reinterpreting the bytes as 16-bit units makes the printable-range test
+    /// a single comparison: a little-endian code unit in 0x20–0x7E has a printable low
+    /// byte and a zero high byte by construction.
+    /// </summary>
+    private static List<StringEntry> ScanUtf16Runs(ReadOnlySpan<byte> bytes, int parity, int minLength)
+    {
+        if (bytes.Length <= parity) return [];
+
+        var chars = MemoryMarshal.Cast<byte, char>(bytes[parity..]);
+        var units = MemoryMarshal.Cast<byte, ushort>(bytes[parity..]);
+        var results = new List<StringEntry>();
+
+        var runStart = -1;
+        var position = 0;
+
+        void EmitRun(ReadOnlySpan<char> data, int start, int end)
+        {
+            if (end - start < minLength) return;
+            results.Add(new StringEntry(
+                parity + start * 2, new string(data[start..end]), StringSource.RawBinaryUtf16));
+        }
+
+        if (Vector128.IsHardwareAccelerated)
+        {
+            for (; position + 64 <= units.Length; position += 64)
+            {
+                var mask = PrintableMask64(units, position);
+                var bit = 0;
+                while (bit < 64)
+                {
+                    if (runStart < 0)
+                    {
+                        var remaining = mask >> bit;
+                        if (remaining == 0) break;
+                        bit += BitOperations.TrailingZeroCount(remaining);
+                        runStart = position + bit;
+                    }
+                    else
+                    {
+                        var remaining = ~mask >> bit;
+                        if (remaining == 0) break;
+                        bit += BitOperations.TrailingZeroCount(remaining);
+                        EmitRun(chars, runStart, position + bit);
+                        runStart = -1;
+                    }
+                }
+            }
+        }
+
+        // Scalar tail; also the whole scan when SIMD is unavailable.
+        for (; position < units.Length; position++)
+        {
+            if (units[position] is >= 0x20 and <= 0x7E)
+            {
+                if (runStart < 0) runStart = position;
+            }
+            else if (runStart >= 0)
+            {
+                EmitRun(chars, runStart, position);
+                runStart = -1;
+            }
+        }
+
+        if (runStart >= 0) EmitRun(chars, runStart, units.Length);
+
+        return results;
+    }
+
+    /// <summary>
+    /// Classifies the 64 bytes at <paramref name="offset"/> into a bitmask where bit
+    /// <c>i</c> is set when byte <c>offset + i</c> is printable ASCII. The caller must
+    /// guarantee 64 bytes are available; the unsigned wraparound compare folds the
+    /// range test into one instruction.
+    /// </summary>
+    private static ulong PrintableMask64(ReadOnlySpan<byte> bytes, int offset)
+    {
+        var floor = Vector128.Create((byte)0x20);
+        var range = Vector128.Create((byte)(0x7E - 0x20));
+        var mask = 0UL;
+        for (var i = 0; i < 4; i++)
+        {
+            var block = Vector128.LoadUnsafe(in bytes[offset], (nuint)(i * 16));
+            var printable = Vector128.LessThanOrEqual(block - floor, range);
+            mask |= (ulong)printable.ExtractMostSignificantBits() << (i * 16);
+        }
+
+        return mask;
+    }
+
+    /// <summary>
+    /// Classifies the 64 UTF-16 code units at <paramref name="offset"/> into a bitmask
+    /// where bit <c>i</c> is set when unit <c>offset + i</c> is printable ASCII. The
+    /// caller must guarantee 64 units are available.
+    /// </summary>
+    private static ulong PrintableMask64(ReadOnlySpan<ushort> units, int offset)
+    {
+        var floor = Vector128.Create((ushort)0x20);
+        var range = Vector128.Create((ushort)(0x7E - 0x20));
+        var mask = 0UL;
+        for (var i = 0; i < 8; i++)
+        {
+            var block = Vector128.LoadUnsafe(in units[offset], (nuint)(i * 8));
+            var printable = Vector128.LessThanOrEqual(block - floor, range);
+            mask |= (ulong)printable.ExtractMostSignificantBits() << (i * 8);
+        }
+
+        return mask;
     }
 }

--- a/src/Dotsider.Core/Analysis/StringExtractor.cs
+++ b/src/Dotsider.Core/Analysis/StringExtractor.cs
@@ -151,4 +151,56 @@ public sealed class StringExtractor(AssemblyAnalyzer analyzer)
 
         return results;
     }
+
+    /// <summary>
+    /// Extracts printable UTF-16LE character sequences from the binary file. Scans for
+    /// runs of little-endian code units in the printable ASCII range (0x20–0x7E stored
+    /// as two bytes), which is how managed string literals freeze in Native AOT images.
+    /// The scan restarts at every byte position, so runs at odd offsets are found too.
+    /// Accepting the full BMP instead would drown the results in noise — most random
+    /// 16-bit values decode to a printable character.
+    /// </summary>
+    /// <param name="minLength">The minimum number of consecutive printable characters to consider a string.</param>
+    /// <returns>A list of string entries extracted from the raw binary.</returns>
+    public IReadOnlyList<StringEntry> ExtractRawUtf16Strings(int minLength = 4)
+    {
+        var bytes = analyzer.RawBytes.Span;
+        var results = new List<StringEntry>();
+        var sb = new StringBuilder();
+        var startOffset = -1;
+
+        for (var i = 0; i + 1 < bytes.Length;)
+        {
+            if (bytes[i] is >= 0x20 and <= 0x7E && bytes[i + 1] == 0)
+            {
+                if (startOffset < 0) startOffset = i;
+                sb.Append((char)bytes[i]);
+                i += 2;
+                continue;
+            }
+
+            if (sb.Length >= minLength)
+            {
+                results.Add(new StringEntry(startOffset, sb.ToString(), StringSource.RawBinaryUtf16));
+            }
+            else if (startOffset >= 0)
+            {
+                // A short run may hide a longer one starting inside it at the
+                // opposite parity; rewind to just past where it began.
+                i = startOffset;
+            }
+
+            sb.Clear();
+            startOffset = -1;
+            i++;
+        }
+
+        // Handle trailing string
+        if (sb.Length >= minLength)
+        {
+            results.Add(new StringEntry(startOffset, sb.ToString(), StringSource.RawBinaryUtf16));
+        }
+
+        return results;
+    }
 }

--- a/src/Dotsider.Mcp/Tools/AssemblyTools.cs
+++ b/src/Dotsider.Mcp/Tools/AssemblyTools.cs
@@ -33,6 +33,8 @@ public sealed partial class AssemblyTools(DotsiderSessionManager sessionManager)
                 analyzer.AssemblyName, analyzer.AssemblyVersion, analyzer.TargetFramework,
                 analyzer.Culture, analyzer.PublicKeyToken, analyzer.Architecture,
                 analyzer.HasMetadata,
+                analyzer.BinaryKind,
+                analyzer.NativeAotInfo,
                 analyzer.DisplayName,
                 analyzer.SourceBundlePath,
                 analyzer.IsBundleBacked,

--- a/src/Dotsider.Mcp/Tools/StringTools.cs
+++ b/src/Dotsider.Mcp/Tools/StringTools.cs
@@ -12,7 +12,9 @@ namespace Dotsider.Mcp.Tools;
 public sealed partial class StringTools(DotsiderSessionManager sessionManager)
 {
     /// <summary>
-    /// Extracts user strings, metadata strings, and raw binary strings from an assembly.
+    /// Extracts user strings, metadata strings, and raw binary strings (ASCII and
+    /// UTF-16) from an assembly. For metadata-less binaries such as Native AOT
+    /// executables the raw scans are the only populated categories.
     /// </summary>
     /// <param name="assemblyPath">Path to assembly file.</param>
     /// <param name="sessionId">PID of a running dotsider instance.</param>
@@ -20,7 +22,7 @@ public sealed partial class StringTools(DotsiderSessionManager sessionManager)
     /// <param name="minLength">Minimum length for raw string extraction (default: 4).</param>
     /// <param name="maxResults">Maximum number of results per category.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>JSON with UserStrings, MetadataStrings, and RawStrings arrays.</returns>
+    /// <returns>JSON with UserStrings, MetadataStrings, RawStrings, and RawUtf16Strings arrays.</returns>
     [McpServerTool(ReadOnly = true, OpenWorld = false)]
     public async partial Task<string> ExtractStrings(
         string? assemblyPath = null,
@@ -38,12 +40,14 @@ public sealed partial class StringTools(DotsiderSessionManager sessionManager)
             var user = extractor.ExtractUserStrings();
             var metadata = extractor.ExtractMetadataStrings();
             var raw = extractor.ExtractRawStrings(minLength ?? 4);
+            var rawUtf16 = extractor.ExtractRawUtf16Strings(minLength ?? 4);
 
             if (!string.IsNullOrEmpty(query))
             {
                 user = [.. user.Where(s => s.Value.Contains(query, StringComparison.OrdinalIgnoreCase))];
                 metadata = [.. metadata.Where(s => s.Value.Contains(query, StringComparison.OrdinalIgnoreCase))];
                 raw = [.. raw.Where(s => s.Value.Contains(query, StringComparison.OrdinalIgnoreCase))];
+                rawUtf16 = [.. rawUtf16.Where(s => s.Value.Contains(query, StringComparison.OrdinalIgnoreCase))];
             }
 
             var max = maxResults ?? int.MaxValue;
@@ -51,7 +55,8 @@ public sealed partial class StringTools(DotsiderSessionManager sessionManager)
             {
                 UserStrings = user.Take(max).ToList(),
                 MetadataStrings = metadata.Take(max).ToList(),
-                RawStrings = raw.Take(max).ToList()
+                RawStrings = raw.Take(max).ToList(),
+                RawUtf16Strings = rawUtf16.Take(max).ToList()
             }, DotsiderJsonOptions.Default);
         }
 

--- a/src/Dotsider.Mcp/Tools/ToolHelpers.cs
+++ b/src/Dotsider.Mcp/Tools/ToolHelpers.cs
@@ -60,6 +60,7 @@ internal static class ToolHelpers
         return result switch
         {
             AssemblyOpenResult.Direct(var a) => a,
+            AssemblyOpenResult.NativeAot(var aot) => aot,
             AssemblyOpenResult.ApphostWithCompanion(var host, var companion) =>
                 OpenCompanion(host, companion),
             AssemblyOpenResult.BundleEntry(var entry, _) => entry,

--- a/src/Dotsider/Commands/AnalyzeCommand.cs
+++ b/src/Dotsider/Commands/AnalyzeCommand.cs
@@ -137,6 +137,10 @@ internal static class AnalyzeCommand
                         analyzer = entry;
                         analyzedPath = bundle;
                         break;
+                    case AssemblyOpenResult.NativeAot(var aot):
+                        analyzer = aot;
+                        analyzedPath = filePath;
+                        break;
                     default:
                         analyzer = ((AssemblyOpenResult.Direct)result).Analyzer;
                         analyzedPath = filePath;

--- a/src/Dotsider/Commands/AnalyzeCommand.cs
+++ b/src/Dotsider/Commands/AnalyzeCommand.cs
@@ -45,6 +45,12 @@ internal static class AnalyzeCommand
         Description = "Extract strings from the assembly"
     };
 
+    private static readonly Option<int> s_minLenOption = new("--min-len", "-n")
+    {
+        Description = "Minimum length for raw string extraction (default: 4)",
+        DefaultValueFactory = _ => 4
+    };
+
     private static readonly Option<bool> s_sizeOption = new("--size")
     {
         Description = "Show size breakdown"
@@ -79,6 +85,7 @@ internal static class AnalyzeCommand
             s_embeddedSourceOption,
             s_depsOption,
             s_stringsOption,
+            s_minLenOption,
             s_sizeOption,
             s_fieldsOption,
             s_bundleOption,
@@ -193,7 +200,8 @@ internal static class AnalyzeCommand
                     return Task.FromResult(PrintDeps(analyzer, formatter));
 
                 if (parseResult.GetValue(s_stringsOption))
-                    return Task.FromResult(PrintStrings(analyzer, formatter));
+                    return Task.FromResult(PrintStrings(analyzer, formatter,
+                        parseResult.GetValue(s_minLenOption)));
 
                 if (parseResult.GetValue(s_sizeOption))
                     return Task.FromResult(PrintSize(analyzer, formatter));
@@ -224,7 +232,7 @@ internal static class AnalyzeCommand
             fmt.WriteJson(new
             {
                 a.FilePath, a.FileName, a.FileSize, a.AssemblyName, a.AssemblyVersion,
-                a.TargetFramework, a.Architecture, a.HasMetadata,
+                a.TargetFramework, a.Architecture, a.HasMetadata, a.BinaryKind, a.NativeAotInfo,
                 a.DisplayName, a.IsBundleBacked, a.SourceBundlePath, a.LaunchPath, a.CanSaveInPlace, a.PreferredRuntimePack,
                 a.PdbProvenance, a.SourceLink, a.DebugDirectory,
                 Types = a.TypeDefs, Methods = a.MethodDefs, References = a.AssemblyRefs
@@ -238,6 +246,14 @@ internal static class AnalyzeCommand
             fmt.WriteLine($"Version:    {a.AssemblyVersion ?? "(none)"}");
             fmt.WriteLine($"Framework:  {a.TargetFramework ?? "(none)"}");
             fmt.WriteLine($"Arch:       {a.Architecture}");
+            if (a.NativeAotInfo is { } aot)
+            {
+                fmt.WriteLine("Kind:       Native AOT (.NET)");
+                fmt.WriteLine($"RTR Format: v{aot.MajorVersion}.{aot.MinorVersion} ({aot.SectionCount} sections)");
+                fmt.WriteLine($"Runtime:    {aot.RuntimeVersion ?? "(not detected)"}");
+                fmt.WriteLine($"Imports:    {a.Imports.Count} modules, "
+                    + $"{a.Imports.Sum(m => m.Functions.Count)} functions");
+            }
             fmt.WriteLine($"PDB:        {a.PdbProvenance}");
             fmt.WriteLine($"SourceLink: {(a.SourceLink.IsPresent ? $"present, {a.SourceLink.Mappings.Count} mappings" : "not present")}");
             if (a.IsBundleBacked)
@@ -436,15 +452,25 @@ internal static class AnalyzeCommand
         return 0;
     }
 
-    private static int PrintStrings(AssemblyAnalyzer a, OutputFormatter fmt)
+    private static int PrintStrings(AssemblyAnalyzer a, OutputFormatter fmt, int minLength)
     {
         var extractor = new StringExtractor(a);
         var user = extractor.ExtractUserStrings();
         var metadata = extractor.ExtractMetadataStrings();
 
+        // Metadata-less binaries (Native AOT, apphosts) have no string heaps —
+        // fall back to the raw scans so --strings never comes back empty-handed.
+        var scanRaw = !a.HasMetadata;
+        IReadOnlyList<StringEntry> raw = scanRaw ? extractor.ExtractRawStrings(minLength) : [];
+        IReadOnlyList<StringEntry> rawUtf16 = scanRaw ? extractor.ExtractRawUtf16Strings(minLength) : [];
+
         if (fmt.JsonMode)
         {
-            fmt.WriteJson(new { UserStrings = user, MetadataStrings = metadata });
+            fmt.WriteJson(new
+            {
+                UserStrings = user, MetadataStrings = metadata,
+                RawStrings = raw, RawUtf16Strings = rawUtf16
+            });
             return 0;
         }
 
@@ -460,6 +486,21 @@ internal static class AnalyzeCommand
         {
             fmt.WriteLine($"Metadata Strings ({metadata.Count}):");
             foreach (var s in metadata)
+                fmt.WriteLine($"  [{s.Offset:X6}] {s.Value}");
+        }
+
+        if (raw.Count > 0)
+        {
+            fmt.WriteLine($"Raw Strings (ASCII) ({raw.Count}):");
+            foreach (var s in raw)
+                fmt.WriteLine($"  [{s.Offset:X6}] {s.Value}");
+            fmt.WriteLine("");
+        }
+
+        if (rawUtf16.Count > 0)
+        {
+            fmt.WriteLine($"Raw Strings (UTF-16) ({rawUtf16.Count}):");
+            foreach (var s in rawUtf16)
                 fmt.WriteLine($"  [{s.Offset:X6}] {s.Value}");
         }
 

--- a/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
+++ b/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
@@ -701,7 +701,7 @@ internal sealed class DotsiderDiagnosticsListener(
         if (state.IsNetFramework)
             return DotsiderResponse.Fail("Assembly targets .NET Framework; EventPipe requires .NET Core 3.0+");
 
-        if (!state.HasEntryPoint && !state.IsNativeAot)
+        if (!state.HasEntryPoint && !state.IsNativeBinary)
             return DotsiderResponse.Fail("Assembly has no entry point");
 
         if (state.Tracer?.ProcessState == TraceProcessState.Running)
@@ -948,6 +948,9 @@ internal sealed class DotsiderDiagnosticsListener(
                 {
                     case AssemblyOpenResult.Direct(var a):
                         s.PushAssemblyDirect(a);
+                        break;
+                    case AssemblyOpenResult.NativeAot(var aot):
+                        s.PushAssemblyDirect(aot);
                         break;
                     case AssemblyOpenResult.ApphostWithCompanion(var host, var companion):
                         host.Dispose();

--- a/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
+++ b/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
@@ -318,6 +318,8 @@ internal sealed class DotsiderDiagnosticsListener(
             a.PublicKeyToken,
             a.Architecture,
             a.HasMetadata,
+            a.BinaryKind,
+            a.NativeAotInfo,
             a.DisplayName,
             a.SourceBundlePath,
             a.IsBundleBacked,
@@ -545,6 +547,7 @@ internal sealed class DotsiderDiagnosticsListener(
         var user = extractor.ExtractUserStrings();
         var metadata = extractor.ExtractMetadataStrings();
         var raw = extractor.ExtractRawStrings(minLength);
+        var rawUtf16 = extractor.ExtractRawUtf16Strings(minLength);
 
         if (!string.IsNullOrEmpty(request.Query))
         {
@@ -554,6 +557,7 @@ internal sealed class DotsiderDiagnosticsListener(
             user = [.. user.Where(Match)];
             metadata = [.. metadata.Where(Match)];
             raw = [.. raw.Where(Match)];
+            rawUtf16 = [.. rawUtf16.Where(Match)];
         }
 
         var max = request.MaxResults ?? int.MaxValue;
@@ -561,7 +565,8 @@ internal sealed class DotsiderDiagnosticsListener(
         {
             UserStrings = user.Take(max),
             MetadataStrings = metadata.Take(max),
-            RawStrings = raw.Take(max)
+            RawStrings = raw.Take(max),
+            RawUtf16Strings = rawUtf16.Take(max)
         });
     }
 

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -581,7 +581,7 @@ public sealed class DotsiderApp(DotsiderState state)
                         : "Enter: Re-run";
                     hints.Add(s.Section(hint));
                 }
-                else if ((_state.HasEntryPoint || _state.IsNativeAot) && !_state.IsNetFramework)
+                else if ((_state.HasEntryPoint || _state.IsNativeBinary) && !_state.IsNetFramework)
                     hints.Add(s.Section("Enter: Launch"));
             }
 

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -28,6 +28,7 @@ public sealed class DotsiderState : IDisposable
         Analyzer = openResult switch
         {
             AssemblyOpenResult.Direct(var a) => a,
+            AssemblyOpenResult.NativeAot(var aot) => aot,
             AssemblyOpenResult.ApphostWithCompanion(var host, _) => host,
             AssemblyOpenResult.BundleEntry(var entry, _) => entry,
             _ => throw new InvalidOperationException($"Unknown open result: {openResult.GetType().Name}")
@@ -639,8 +640,14 @@ public sealed class DotsiderState : IDisposable
     /// <summary>Whether the assembly has a CLR entry point (executable, not library).</summary>
     public bool HasEntryPoint => Analyzer.ClrHeader is { EntryPointToken: > 0 };
 
-    /// <summary>Whether the assembly appears to be NativeAOT (no CLR metadata).</summary>
-    public bool IsNativeAot => !Analyzer.HasMetadata || Analyzer.ClrHeader is null;
+    /// <summary>
+    /// Whether the binary is Native AOT compiled .NET — a validated ReadyToRun
+    /// header with no CLR metadata.
+    /// </summary>
+    public bool IsNativeAot => Analyzer.BinaryKind == BinaryKind.NativeAot;
+
+    /// <summary>Whether the binary has no CLR metadata at all (Native AOT or unknown native).</summary>
+    public bool IsNativeBinary => !Analyzer.HasMetadata || Analyzer.ClrHeader is null;
 
     /// <summary>
     /// Whether the assembly targets .NET Framework (not .NET Core / .NET 5+). True when the

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -450,7 +450,7 @@ public sealed class DotsiderState : IDisposable
     /// <summary>The minimum string length filter for raw strings.</summary>
     public int StringsMinLength { get; set; } = 4;
 
-    /// <summary>The selected string source tab (0=User, 1=Metadata, 2=Raw).</summary>
+    /// <summary>The selected string source tab (0=User, 1=Metadata, 2=Raw, 3=Raw UTF-16).</summary>
     public int StringsSourceTab { get; set; }
 
     /// <summary>The focused string entry key in the strings table.</summary>
@@ -470,6 +470,12 @@ public sealed class DotsiderState : IDisposable
 
     /// <summary>The min length used for the cached raw strings.</summary>
     public int CachedRawStringsMinLength { get; set; } = -1;
+
+    /// <summary>Cached raw UTF-16 strings, invalidated when min length changes.</summary>
+    public IReadOnlyList<StringEntry>? CachedRawUtf16Strings { get; set; }
+
+    /// <summary>The min length used for the cached raw UTF-16 strings.</summary>
+    public int CachedRawUtf16StringsMinLength { get; set; } = -1;
 
     // --- Dependency Graph Tab State ---
 
@@ -1460,6 +1466,7 @@ public sealed class DotsiderState : IDisposable
         CachedUserStrings = null;
         CachedMetadataStrings = null;
         CachedRawStrings = null;
+        CachedRawUtf16Strings = null;
         CachedGraph = null;
         GraphNavigation = null;
         GraphBuildInProgress = false;
@@ -1522,6 +1529,7 @@ public sealed class DotsiderState : IDisposable
             StringsSubTabId.UserStrings => CachedUserStrings ??= StringExtractor.ExtractUserStrings(),
             StringsSubTabId.Metadata => CachedMetadataStrings ??= StringExtractor.ExtractMetadataStrings(),
             StringsSubTabId.RawBinary => GetCachedRawStrings(),
+            StringsSubTabId.RawBinaryUtf16 => GetCachedRawUtf16Strings(),
             _ => []
         };
 
@@ -1572,6 +1580,17 @@ public sealed class DotsiderState : IDisposable
         }
 
         return CachedRawStrings;
+    }
+
+    private IReadOnlyList<StringEntry> GetCachedRawUtf16Strings()
+    {
+        if (CachedRawUtf16Strings is null || CachedRawUtf16StringsMinLength != StringsMinLength)
+        {
+            CachedRawUtf16Strings = StringExtractor.ExtractRawUtf16Strings(StringsMinLength);
+            CachedRawUtf16StringsMinLength = StringsMinLength;
+        }
+
+        return CachedRawUtf16Strings;
     }
 
     /// <summary>

--- a/src/Dotsider/PeSubTabId.cs
+++ b/src/Dotsider/PeSubTabId.cs
@@ -29,6 +29,15 @@ public static class PeSubTabId
     /// <summary>Debug Directory sub-tab.</summary>
     public const int DebugDirectory = 7;
 
+    /// <summary>Imports sub-tab (native import table; needs no CLR header).</summary>
+    public const int Imports = 8;
+
+    /// <summary>Exports sub-tab (native export table; needs no CLR header).</summary>
+    public const int Exports = 9;
+
+    /// <summary>Load Config sub-tab (load configuration directory; needs no CLR header).</summary>
+    public const int LoadConfig = 10;
+
     /// <summary>Total number of PE/Metadata sub-tabs.</summary>
-    public const int Count = 8;
+    public const int Count = 11;
 }

--- a/src/Dotsider/Program.cs
+++ b/src/Dotsider/Program.cs
@@ -116,6 +116,9 @@ diffCommand.SetAction(async (parseResult, ct) =>
                 + $"Analyzing entry assembly {entry.FileName} instead.");
             leftAnalyzer = entry;
             break;
+        case AssemblyOpenResult.NativeAot(var aot):
+            leftAnalyzer = aot;
+            break;
         default:
             leftAnalyzer = ((AssemblyOpenResult.Direct)leftResult).Analyzer;
             break;
@@ -137,6 +140,9 @@ diffCommand.SetAction(async (parseResult, ct) =>
                 $"Note: {right.Name} is a single-file bundle. "
                 + $"Analyzing entry assembly {entry.FileName} instead.");
             rightAnalyzer = entry;
+            break;
+        case AssemblyOpenResult.NativeAot(var aot):
+            rightAnalyzer = aot;
             break;
         default:
             rightAnalyzer = ((AssemblyOpenResult.Direct)rightResult).Analyzer;

--- a/src/Dotsider/StringsSubTabId.cs
+++ b/src/Dotsider/StringsSubTabId.cs
@@ -14,6 +14,9 @@ public static class StringsSubTabId
     /// <summary>Raw Binary sub-tab.</summary>
     public const int RawBinary = 2;
 
+    /// <summary>Raw UTF-16 sub-tab.</summary>
+    public const int RawBinaryUtf16 = 3;
+
     /// <summary>Total number of Strings sub-tabs.</summary>
-    public const int Count = 3;
+    public const int Count = 4;
 }

--- a/src/Dotsider/Views/DynamicAnalysisView.cs
+++ b/src/Dotsider/Views/DynamicAnalysisView.cs
@@ -66,7 +66,7 @@ public static class DynamicAnalysisView
                 $"Detected target: {state.EffectiveTargetFrameworkDisplay}");
 
         // Library DLL — no entry point (but allow NativeAOT executables through)
-        if (!state.HasEntryPoint && !state.IsNativeAot)
+        if (!state.HasEntryPoint && !state.IsNativeBinary)
             return BuildMessageView(ctx,
                 "This assembly is a library (no entry point).",
                 "Dynamic analysis requires an executable assembly.",

--- a/src/Dotsider/Views/GeneralView.cs
+++ b/src/Dotsider/Views/GeneralView.cs
@@ -67,7 +67,8 @@ public static class GeneralView
         }
 
         // Build Assembly Info text for read-only editor
-        var infoText = string.Join("\n",
+        var infoLines = new List<string>
+        {
             $"  Assembly Name:    {analyzer.AssemblyName ?? "(none)"}",
             $"  Version:          {analyzer.AssemblyVersion ?? "(none)"}",
             $"  Target Framework: {state.EffectiveTargetFrameworkDisplay}",
@@ -81,7 +82,27 @@ public static class GeneralView
             $"  Read-Only:        {(analyzer.IsReadOnly ? "Yes" : "No")}",
             $"  Has Metadata:     {(analyzer.HasMetadata ? "Yes" : "No")}",
             $"  PDB:              {analyzer.PdbProvenance}",
-            $"  Source Link:      {(analyzer.SourceLink.IsPresent ? $"present, {analyzer.SourceLink.Mappings.Count} mappings" : "not present")}");
+            $"  Source Link:      {(analyzer.SourceLink.IsPresent ? $"present, {analyzer.SourceLink.Mappings.Count} mappings" : "not present")}",
+        };
+
+        if (analyzer.NativeAotInfo is { } aot)
+        {
+            var imports = analyzer.Imports;
+            infoLines.Add("");
+            infoLines.Add("  Binary Kind:      Native AOT (.NET)");
+            infoLines.Add($"  ILC / RTR Format: v{aot.MajorVersion}.{aot.MinorVersion} "
+                + $"({aot.SectionCount} sections @ 0x{aot.HeaderOffset:X})");
+            infoLines.Add($"  Runtime Version:  {aot.RuntimeVersion ?? "(not detected)"}");
+            infoLines.Add($"  Native Imports:   {imports.Count} modules, "
+                + $"{imports.Sum(m => m.Functions.Count)} functions");
+        }
+
+        var infoText = string.Join("\n", infoLines);
+
+        // Border chrome adds 2 rows. The AOT layout gets one more so the editor's
+        // horizontal scrollbar (long publish-dir PDB paths overflow the width)
+        // doesn't cover the last info line.
+        var infoHeight = infoLines.Count + (analyzer.NativeAotInfo is null ? 2 : 3);
 
         if (state.GeneralInfoEditorText != infoText)
         {
@@ -125,7 +146,7 @@ public static class GeneralView
                                 () => state.App.Invalidate());
                         })
                         .FillWidth().FillHeight())
-                ).Title(" Assembly Info ").FixedHeight(16)
+                ).Title(" Assembly Info ").FixedHeight(infoHeight)
             };
 
             // Search bar

--- a/src/Dotsider/Views/PeMetadataView.cs
+++ b/src/Dotsider/Views/PeMetadataView.cs
@@ -69,6 +69,12 @@ public static class PeMetadataView
                     PeSubTabId.Resources when analyzer.Resources.Count > 0 => analyzer.Resources[0].Name,
                     PeSubTabId.DebugDirectory when analyzer.DebugDirectory.Count > 0 =>
                         GetDebugDirectoryKey(analyzer.DebugDirectory[0]),
+                    PeSubTabId.Imports when GetImportRows(analyzer).Count > 0 =>
+                        GetImportRows(analyzer)[0].Key,
+                    PeSubTabId.Exports when analyzer.Exports.Count > 0 =>
+                        analyzer.Exports[0].Ordinal,
+                    PeSubTabId.LoadConfig when analyzer.LoadConfig is not null =>
+                        GetLoadConfigRows(analyzer.LoadConfig)[0].Field,
                     _ => null
                 };
         }
@@ -226,7 +232,13 @@ public static class PeMetadataView
                     tp.Tab("Resources", t => [BuildResourcesTable(t, state)])
                         .Selected(state.PeSubTab == PeSubTabId.Resources),
                     tp.Tab("Debug Directory", t => [BuildDebugDirectoryTable(t, state)])
-                        .Selected(state.PeSubTab == PeSubTabId.DebugDirectory)
+                        .Selected(state.PeSubTab == PeSubTabId.DebugDirectory),
+                    tp.Tab("Imports", t => [BuildImportsTable(t, state)])
+                        .Selected(state.PeSubTab == PeSubTabId.Imports),
+                    tp.Tab("Exports", t => [BuildExportsTable(t, state)])
+                        .Selected(state.PeSubTab == PeSubTabId.Exports),
+                    tp.Tab("Load Config", t => [BuildLoadConfigTable(t, state)])
+                        .Selected(state.PeSubTab == PeSubTabId.LoadConfig)
                 ])
                 .OnSelectionChanged(e =>
                 {
@@ -798,9 +810,162 @@ public static class PeMetadataView
                 r => $"{r.Name} {r.Visibility}").Select(r => (object)r.Name)],
             PeSubTabId.DebugDirectory => [.. ApplySearch(analyzer.DebugDirectory, query,
                 d => $"{d.Type} {d.Stamp:X8} {d.Payload}").Select(d => (object)GetDebugDirectoryKey(d))],
+            PeSubTabId.Imports => [.. ApplySearch(GetImportRows(analyzer), query,
+                r => $"{r.Module} {r.Function.Name}").Select(r => (object)r.Key)],
+            PeSubTabId.Exports => [.. ApplySearch(analyzer.Exports, query,
+                e => $"{e.Name} {e.Ordinal} {e.ForwardedTo}").Select(e => (object)e.Ordinal)],
+            PeSubTabId.LoadConfig when analyzer.LoadConfig is not null =>
+                [.. ApplySearch(GetLoadConfigRows(analyzer.LoadConfig), query,
+                    r => $"{r.Field} {r.Value}").Select(r => (object)r.Field)],
             _ => []
         };
     }
+
+    private static TableWidget<ImportRow> BuildImportsTable(
+        WidgetContext<VStackWidget> ctx, DotsiderState state)
+    {
+        var query = state.Search[TabId.PeMetadata].Query;
+        var data = ApplySearch(GetImportRows(state.Analyzer), query,
+            r => $"{r.Module} {r.Function.Name}");
+        state.Search[TabId.PeMetadata].SetMatchCount(data.Count);
+
+        return ctx.Table(data)
+            .RowKey(r => r.Key)
+            .Header(h =>
+            [
+                h.Cell("Module").Width(SizeHint.Fixed(24)),
+                h.Cell("Function").Width(SizeHint.Fill),
+                h.Cell("Hint").Width(SizeHint.Fixed(8)),
+                h.Cell("Ordinal").Width(SizeHint.Fixed(9))
+            ])
+            .Row((r, row, rs) =>
+            [
+                r.Cell(c => FocusHighlightCell(c, row.Module, query, true, rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c, ImportFunctionDisplay(row.Function), query, true, rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, c.Text(row.Function.Hint?.ToString() ?? ""), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, c.Text(row.Function.Ordinal?.ToString() ?? ""), rs.IsFocused))
+            ])
+            .Focus(state.PeDetailContent is not null || state.App.FocusedNode is EditorNode ? null : state.PeFocusedKey)
+            .OnFocusChanged(key => state.PeFocusedKey = key)
+            .OnRowActivated((_, row) =>
+            {
+                state.PeDetailContent = string.Join("\n",
+                    "Imported Function",
+                    $"Module: {row.Module}",
+                    $"Function: {ImportFunctionDisplay(row.Function)}",
+                    $"Hint: {row.Function.Hint?.ToString() ?? "(none)"}",
+                    $"Ordinal: {row.Function.Ordinal?.ToString() ?? "(imported by name)"}");
+                state.App.RequestFocus(node => node is EditorNode);
+                state.App.Invalidate();
+            })
+            .Compact().Fill();
+    }
+
+    private static TableWidget<ExportedFunctionInfo> BuildExportsTable(
+        WidgetContext<VStackWidget> ctx, DotsiderState state)
+    {
+        var query = state.Search[TabId.PeMetadata].Query;
+        var data = ApplySearch(state.Analyzer.Exports, query,
+            e => $"{e.Name} {e.Ordinal} {e.ForwardedTo}");
+        state.Search[TabId.PeMetadata].SetMatchCount(data.Count);
+
+        return ctx.Table(data)
+            .RowKey(e => e.Ordinal)
+            .Header(h =>
+            [
+                h.Cell("Ordinal").Width(SizeHint.Fixed(9)),
+                h.Cell("Name").Width(SizeHint.Fill),
+                h.Cell("RVA").Width(SizeHint.Fixed(12)),
+                h.Cell("Forwarded To").Width(SizeHint.Fixed(30))
+            ])
+            .Row((r, e, rs) =>
+            [
+                r.Cell(c => FocusStyle(c, c.Text(e.Ordinal.ToString()), rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c, e.Name ?? "(ordinal only)", query, true, rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{e.Rva:X8}"), rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c, e.ForwardedTo ?? "", query, true, rs.IsFocused))
+            ])
+            .Focus(state.PeDetailContent is not null || state.App.FocusedNode is EditorNode ? null : state.PeFocusedKey)
+            .OnFocusChanged(key => state.PeFocusedKey = key)
+            .OnRowActivated((_, e) =>
+            {
+                state.PeDetailContent = string.Join("\n",
+                    "Exported Function",
+                    $"Ordinal: {e.Ordinal}",
+                    $"Name: {e.Name ?? "(ordinal only)"}",
+                    $"RVA: 0x{e.Rva:X8}",
+                    $"Forwarded To: {e.ForwardedTo ?? "(not forwarded)"}");
+                state.App.RequestFocus(node => node is EditorNode);
+                state.App.Invalidate();
+            })
+            .Compact().Fill();
+    }
+
+    private static TableWidget<LoadConfigRow> BuildLoadConfigTable(
+        WidgetContext<VStackWidget> ctx, DotsiderState state)
+    {
+        var query = state.Search[TabId.PeMetadata].Query;
+        IReadOnlyList<LoadConfigRow> rows = state.Analyzer.LoadConfig is { } loadConfig
+            ? GetLoadConfigRows(loadConfig)
+            : [];
+        var data = ApplySearch(rows, query, r => $"{r.Field} {r.Value}");
+        state.Search[TabId.PeMetadata].SetMatchCount(data.Count);
+
+        return ctx.Table(data)
+            .RowKey(r => r.Field)
+            .Header(h =>
+            [
+                h.Cell("Field").Width(SizeHint.Fixed(28)),
+                h.Cell("Value").Width(SizeHint.Fill)
+            ])
+            .Row((r, row, rs) =>
+            [
+                r.Cell(c => FocusHighlightCell(c, row.Field, query, true, rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c, row.Value, query, true, rs.IsFocused))
+            ])
+            .Focus(state.PeDetailContent is not null || state.App.FocusedNode is EditorNode ? null : state.PeFocusedKey)
+            .OnFocusChanged(key => state.PeFocusedKey = key)
+            .OnRowActivated((_, row) =>
+            {
+                state.PeDetailContent = string.Join("\n",
+                    "Load Configuration",
+                    $"{row.Field}: {row.Value}");
+                state.App.RequestFocus(node => node is EditorNode);
+                state.App.Invalidate();
+            })
+            .Compact().Fill();
+    }
+
+    /// <summary>Flattens the import table into one row per imported function.</summary>
+    private static IReadOnlyList<ImportRow> GetImportRows(Core.Analysis.AssemblyAnalyzer analyzer) =>
+        [.. analyzer.Imports.SelectMany(m => m.Functions.Select(f =>
+            new ImportRow(m.ModuleName, f, $"{m.ModuleName}!{f.Name ?? $"#{f.Ordinal}"}")))];
+
+    /// <summary>Projects the load configuration into displayable field/value rows.</summary>
+    private static IReadOnlyList<LoadConfigRow> GetLoadConfigRows(LoadConfigInfo loadConfig) =>
+    [
+        new("Size", $"{loadConfig.Size} (0x{loadConfig.Size:X})"),
+        new("Timestamp", $"0x{loadConfig.TimeDateStamp:X8}"),
+        new("Version", $"{loadConfig.MajorVersion}.{loadConfig.MinorVersion}"),
+        new("Dependent Load Flags", $"0x{loadConfig.DependentLoadFlags:X4}"),
+        new("Security Cookie", loadConfig.SecurityCookie == 0
+            ? "(none)" : $"0x{loadConfig.SecurityCookie:X}"),
+        new("SEH Handler Count", loadConfig.SehHandlerCount.ToString()),
+        new("Guard CF Check Function", loadConfig.GuardCfCheckFunctionPointer == 0
+            ? "(none)" : $"0x{loadConfig.GuardCfCheckFunctionPointer:X}"),
+        new("Guard CF Function Count", loadConfig.GuardCfFunctionCount.ToString()),
+        new("Guard Flags", $"0x{loadConfig.GuardFlags:X8}"),
+        new("Guard Flags Decoded", loadConfig.GuardFlagsDescription),
+    ];
+
+    private static string ImportFunctionDisplay(ImportedFunctionInfo function) =>
+        function.Name ?? $"#{function.Ordinal}";
+
+    /// <summary>A single imported function flattened with its owning module.</summary>
+    private sealed record ImportRow(string Module, ImportedFunctionInfo Function, string Key);
+
+    /// <summary>A load-configuration field projected for table display.</summary>
+    private sealed record LoadConfigRow(string Field, string Value);
 
     private static string GetDebugDirectoryKey(DebugDirectoryInfo info) =>
         $"{info.Type}:{info.AddressOfRawData:X8}:{info.PointerToRawData:X8}";

--- a/src/Dotsider/Views/StringsView.cs
+++ b/src/Dotsider/Views/StringsView.cs
@@ -10,13 +10,15 @@ namespace Dotsider.Views;
 
 /// <summary>
 /// Builds the Strings tab (Tab 4), showing string entries extracted from the assembly
-/// across three sub-tabs: User Strings (#US), Metadata Strings (#Strings), and Raw Binary.
+/// across four sub-tabs: User Strings (#US), Metadata Strings (#Strings), Raw Binary,
+/// and Raw UTF-16.
 /// </summary>
 public static class StringsView
 {
     private static readonly Hex1bColor AddressColor = Hex1bColor.FromRgb(100, 100, 130);
     [ThreadStatic] private static bool s_yankFlash;
-    private static readonly string[] SourceTabs = ["User Strings (#US)", "Metadata (#Strings)", "Raw Binary"];
+    private static readonly string[] SourceTabs =
+        ["User Strings (#US)", "Metadata (#Strings)", "Raw Binary", "Raw (UTF-16)"];
 
     /// <summary>
     /// Builds the Strings view widget tree.
@@ -117,7 +119,7 @@ public static class StringsView
 
                 // Status line
                 var statusParts = new List<string> { $"{activeStrings.Count} strings" };
-                if (state.StringsSourceTab == StringsSubTabId.RawBinary)
+                if (state.StringsSourceTab is StringsSubTabId.RawBinary or StringsSubTabId.RawBinaryUtf16)
                 {
                     statusParts.Add($"Min length: {state.StringsMinLength}");
                 }
@@ -179,6 +181,7 @@ public static class StringsView
                 {
                     state.StringsMinLength++;
                     state.CachedRawStrings = null;
+                    state.CachedRawUtf16Strings = null;
                     state.App.Invalidate();
                 }, "Increase min length");
 
@@ -186,6 +189,7 @@ public static class StringsView
                 {
                     state.StringsMinLength++;
                     state.CachedRawStrings = null;
+                    state.CachedRawUtf16Strings = null;
                     state.App.Invalidate();
                 }, "Increase min length");
 
@@ -195,6 +199,7 @@ public static class StringsView
                     {
                         state.StringsMinLength--;
                         state.CachedRawStrings = null;
+                        state.CachedRawUtf16Strings = null;
                         state.App.Invalidate();
                     }
                 }, "Decrease min length");
@@ -205,6 +210,7 @@ public static class StringsView
                     {
                         state.StringsMinLength--;
                         state.CachedRawStrings = null;
+                        state.CachedRawUtf16Strings = null;
                         state.App.Invalidate();
                     }
                 }, "Decrease min length");

--- a/tests/Dotsider.Mcp.Tests/AssemblyToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/AssemblyToolsTests.cs
@@ -283,6 +283,54 @@ public class AssemblyToolsTests(SampleAssemblyFixture samples) : McpServerTestBa
     }
 
     /// <summary>
+    /// get_assembly_info reports a Native AOT executable's binary kind and
+    /// ReadyToRun header facts.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task GetAssemblyInfo_NativeAot_ReportsBinaryKindAndRtr()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync("get_assembly_info",
+            new Dictionary<string, object?> { ["assemblyPath"] = samples.NativeAotConsoleExe },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+        Assert.Equal("nativeAot", json.GetProperty("binaryKind").GetString());
+        var aotInfo = json.GetProperty("nativeAotInfo");
+        Assert.True(aotInfo.GetProperty("majorVersion").GetInt32() >= 1);
+        Assert.True(aotInfo.GetProperty("sectionCount").GetInt32() >= 1);
+        Assert.False(json.GetProperty("hasMetadata").GetBoolean());
+    }
+
+    /// <summary>
+    /// get_assembly_info reports a managed assembly's binary kind as managed with
+    /// no Native AOT info attached.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task GetAssemblyInfo_Managed_ReportsManagedKind()
+    {
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync("get_assembly_info",
+            new Dictionary<string, object?> { ["assemblyPath"] = samples.RichLibraryDll },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+        Assert.Equal("managed", json.GetProperty("binaryKind").GetString());
+        Assert.False(json.TryGetProperty("nativeAotInfo", out _));
+    }
+
+    /// <summary>
     /// A self-contained apphost is reported as bundle-backed with an in-bundle display name.
     /// </summary>
     [Fact(Timeout = 30_000)]

--- a/tests/Dotsider.Mcp.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Mcp.Tests/SampleAssemblyFixture.cs
@@ -50,6 +50,10 @@ public class SampleAssemblyFixture : IAsyncLifetime
     /// Path to the published self-contained single-file apphost used by bundle tests.
     /// </summary>
     public string SelfContainedConsoleExe { get; private set; } = null!;
+    /// <summary>
+    /// Path to the published NativeAOT sample executable, or null when not built.
+    /// </summary>
+    public string? NativeAotConsoleExe { get; private set; }
 
     /// <summary>
     /// Builds all sample projects once per collection and resolves their output paths.
@@ -68,6 +72,7 @@ public class SampleAssemblyFixture : IAsyncLifetime
         await BuildProject("samples/EmptyLib");
         await BuildProject("samples/MinimalApi");
         await PublishSelfContainedProject("samples/SelfContainedConsole");
+        await PublishNativeAotProject("samples/NativeAotConsole");
 
         const string config = "Debug";
         const string tfm = "net10.0";
@@ -88,12 +93,18 @@ public class SampleAssemblyFixture : IAsyncLifetime
         SelfContainedConsoleExe = Path.Combine(_repoRoot, "samples", "SelfContainedConsole",
             "bin", "Release", tfm, rid, "publish", $"SelfContainedConsole{apphostExt}");
 
+        NativeAotConsoleExe = Path.Combine(_repoRoot, "samples", "NativeAotConsole",
+            "bin", "Release", tfm, rid, "publish", $"NativeAotConsole{apphostExt}");
+
         Assert.True(File.Exists(HelloWorldDll), $"HelloWorld.dll not found at {HelloWorldDll}");
         Assert.True(File.Exists(HelloWorldExe), $"HelloWorld apphost not found at {HelloWorldExe}");
         Assert.True(File.Exists(RichLibraryDll), $"RichLibrary.dll not found at {RichLibraryDll}");
         Assert.True(File.Exists(RichLibraryNupkg), $"RichLibrary.nupkg not found at {RichLibraryNupkg}");
         Assert.True(File.Exists(MinimalApiDll), $"MinimalApi.dll not found at {MinimalApiDll}");
         Assert.True(File.Exists(SelfContainedConsoleExe), $"SelfContainedConsole not found at {SelfContainedConsoleExe}");
+
+        if (!File.Exists(NativeAotConsoleExe))
+            NativeAotConsoleExe = null;
     }
 
     /// <summary>
@@ -215,6 +226,72 @@ public class SampleAssemblyFixture : IAsyncLifetime
                 WorkingDirectory = projectDir,
                 UseShellExecute = false,
             };
+
+            var process = Process.Start(psi)!;
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode != 0)
+                throw new InvalidOperationException(
+                    $"dotnet publish failed for {relativePath} (exit {process.ExitCode})");
+        }
+        finally
+        {
+            lockFile.Dispose();
+        }
+    }
+
+    private async Task PublishNativeAotProject(string relativePath)
+    {
+        var rid = RuntimeInformation.RuntimeIdentifier;
+        var apphostExt = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
+        var expectedOutput = Path.Combine(_repoRoot, relativePath,
+            "bin", "Release", "net10.0", rid, "publish",
+            $"{Path.GetFileName(relativePath)}{apphostExt}");
+
+        // Skip if Dotsider.Tests already published
+        if (File.Exists(expectedOutput))
+            return;
+
+        var lockName = "dotsider-build-" + relativePath.Replace('/', '-').Replace('\\', '-') + ".lock";
+        var lockPath = Path.Combine(Path.GetTempPath(), lockName);
+
+        FileStream lockFile;
+        while (true)
+        {
+            try
+            {
+                lockFile = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                break;
+            }
+            catch (IOException)
+            {
+                await Task.Delay(200);
+            }
+        }
+
+        try
+        {
+            // Re-check after acquiring lock
+            if (File.Exists(expectedOutput))
+            {
+                lockFile.Dispose();
+                return;
+            }
+
+            var projectDir = Path.Combine(_repoRoot, relativePath);
+            var psi = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"publish -c Release -r {rid} -v q",
+                WorkingDirectory = projectDir,
+                UseShellExecute = false,
+            };
+
+            // NoDefaultCurrentDirectoryInExePath breaks the ILCompiler's
+            // findvcvarsall → VsDevCmd toolchain discovery (vswhere.exe
+            // is not resolved from the current directory inside FOR /F).
+            // Clear it for this process only.
+            psi.Environment.Remove("NoDefaultCurrentDirectoryInExePath");
 
             var process = Process.Start(psi)!;
             await process.WaitForExitAsync();

--- a/tests/Dotsider.Mcp.Tests/StringToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/StringToolsTests.cs
@@ -83,4 +83,56 @@ public class StringToolsTests(SampleAssemblyFixture samples) : McpServerTestBase
             Assert.True(user.GetArrayLength() <= 2);
         }
     }
+
+    /// <summary>
+    /// extract_strings on a Native AOT executable returns raw ASCII and raw UTF-16
+    /// strings even though the metadata heaps are absent.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task ExtractStrings_NativeAot_ReturnsRawAndUtf16()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "extract_strings",
+            new Dictionary<string, object?>
+            {
+                ["assemblyPath"] = samples.NativeAotConsoleExe,
+                ["minLength"] = 8,
+                ["maxResults"] = 50
+            },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+        Assert.Empty(json.GetProperty("userStrings").EnumerateArray());
+        Assert.True(json.GetProperty("rawStrings").GetArrayLength() > 0);
+        Assert.True(json.GetProperty("rawUtf16Strings").GetArrayLength() > 0);
+    }
+
+    /// <summary>
+    /// extract_strings always includes the rawUtf16Strings category for managed
+    /// assemblies too.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task ExtractStrings_Managed_HasRawUtf16Field()
+    {
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "extract_strings",
+            new Dictionary<string, object?> { ["assemblyPath"] = samples.RichLibraryDll },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+        Assert.True(json.TryGetProperty("rawUtf16Strings", out _));
+    }
 }

--- a/tests/Dotsider.Tests/AssemblyLoaderTests.cs
+++ b/tests/Dotsider.Tests/AssemblyLoaderTests.cs
@@ -78,15 +78,42 @@ public sealed class AssemblyLoaderTests(SampleAssemblyFixture samples)
         direct.Analyzer.Dispose();
     }
 
-    /// <summary>Verifies that a NativeAOT exe returns a Direct result without metadata.</summary>
+    /// <summary>Verifies that a NativeAOT exe returns a NativeAot result without metadata.</summary>
     [Fact(Timeout = 30_000)]
-    public void Open_NativeAotExe_ReturnsDirect()
+    public void Open_NativeAotExe_ReturnsNativeAot()
     {
         Assert.NotNull(samples.NativeAotConsoleExe);
         var result = AssemblyLoader.Open(samples.NativeAotConsoleExe!);
-        Assert.IsType<AssemblyOpenResult.Direct>(result);
+        Assert.IsType<AssemblyOpenResult.NativeAot>(result);
+        var aot = (AssemblyOpenResult.NativeAot)result;
+        Assert.False(aot.Analyzer.HasMetadata);
+        Assert.NotNull(aot.Analyzer.NativeAotInfo);
+        Assert.Equal(BinaryKind.NativeAot, aot.Analyzer.BinaryKind);
+        aot.Analyzer.Dispose();
+    }
+
+    /// <summary>
+    /// Verifies that a single-file bundle is never classified as Native AOT even though
+    /// the ReadyToRun assemblies inside it contain RTR signatures — the bundle check
+    /// runs before the Native AOT probe.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Open_SingleFileBundle_NotClassifiedAsNativeAot()
+    {
+        Assert.NotNull(samples.SelfContainedConsoleExe);
+        var result = AssemblyLoader.Open(samples.SelfContainedConsoleExe!);
+        Assert.IsType<AssemblyOpenResult.BundleEntry>(result);
+        ((AssemblyOpenResult.BundleEntry)result).EntryAnalyzer.Dispose();
+    }
+
+    /// <summary>Verifies that a managed DLL is classified as Managed.</summary>
+    [Fact(Timeout = 30_000)]
+    public void Open_ManagedDll_HasManagedBinaryKind()
+    {
+        var result = AssemblyLoader.Open(samples.RichLibraryDll);
         var direct = (AssemblyOpenResult.Direct)result;
-        Assert.False(direct.Analyzer.HasMetadata);
+        Assert.Equal(BinaryKind.Managed, direct.Analyzer.BinaryKind);
+        Assert.Null(direct.Analyzer.NativeAotInfo);
         direct.Analyzer.Dispose();
     }
 }

--- a/tests/Dotsider.Tests/NativeAotDetectorTests.cs
+++ b/tests/Dotsider.Tests/NativeAotDetectorTests.cs
@@ -211,6 +211,34 @@ public class NativeAotDetectorTests(SampleAssemblyFixture samples)
     }
 
     /// <summary>
+    /// Verifies the runtime-version heuristic finds a version placed after the
+    /// anchor message and prefers the match nearest to it — the ELF layout, where
+    /// the version lands a few hundred bytes past the anchor instead of
+    /// immediately before it as in MSVC-linked PEs.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Detect_VersionAfterAnchor_NearestMatchWins()
+    {
+        var bytes = new byte[8192];
+        bytes[0] = 0x7F;
+        bytes[1] = (byte)'E';
+        bytes[2] = (byte)'L';
+        bytes[3] = (byte)'F';
+        WriteHeader(bytes, offset: 512, majorVersion: 16, minorVersion: 0,
+            sectionCount: 33, entrySize: 24, entryType: 1, firstSectionId: 201);
+
+        var anchor = "Process is terminating due to StackOverflowException"u8;
+        anchor.CopyTo(bytes.AsSpan(4096));
+        "1.2.3"u8.CopyTo(bytes.AsSpan(4096 + anchor.Length + 700)); // decoy, farther away
+        "10.0.5"u8.CopyTo(bytes.AsSpan(4096 + anchor.Length + 200));
+
+        var result = NativeAotDetector.Detect(bytes);
+
+        Assert.NotNull(result);
+        Assert.Equal("10.0.5", result.RuntimeVersion);
+    }
+
+    /// <summary>
     /// Writes a ReadyToRun-shaped header into a buffer at the given offset.
     /// </summary>
     private static void WriteHeader(byte[] bytes, int offset, ushort majorVersion,

--- a/tests/Dotsider.Tests/NativeAotDetectorTests.cs
+++ b/tests/Dotsider.Tests/NativeAotDetectorTests.cs
@@ -1,0 +1,230 @@
+using System.Buffers.Binary;
+using Dotsider.Core.Analysis;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for the Native AOT detector.
+/// </summary>
+[Collection("SampleAssemblies")]
+public class NativeAotDetectorTests(SampleAssemblyFixture samples)
+{
+    /// <summary>
+    /// Verifies detect on a Native AOT executable returns a validated header.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Detect_NativeAotExe_ReturnsValidatedHeader()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        var result = NativeAotDetector.Detect(File.ReadAllBytes(samples.NativeAotConsoleExe!));
+
+        Assert.NotNull(result);
+        Assert.True(result.HeaderOffset > 0);
+        Assert.InRange(result.MajorVersion, (ushort)1, (ushort)100);
+        Assert.InRange(result.SectionCount, 1, 1000);
+        Assert.InRange(result.EntrySize, (byte)8, (byte)64);
+    }
+
+    /// <summary>
+    /// Verifies detect on a Native AOT executable recovers the runtime version.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Detect_NativeAotExe_FindsRuntimeVersion()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        var result = NativeAotDetector.Detect(File.ReadAllBytes(samples.NativeAotConsoleExe!));
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.RuntimeVersion);
+        Assert.Matches(@"^\d+\.\d+\.\d+", result.RuntimeVersion);
+    }
+
+    /// <summary>
+    /// Verifies detect on a managed assembly returns null.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Detect_ManagedDll_ReturnsNull()
+    {
+        var result = NativeAotDetector.Detect(File.ReadAllBytes(samples.RichLibraryDll));
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Verifies detect on a native apphost executable returns null.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Detect_ApphostExe_ReturnsNull()
+    {
+        var result = NativeAotDetector.Detect(File.ReadAllBytes(samples.HelloWorldExe));
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Verifies a signature match with implausible header fields is rejected.
+    /// The field values replicate a real code-immediate collision observed in
+    /// ILC-generated machine code.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Detect_FakeRtrSignatureFailsValidation_ReturnsNull()
+    {
+        var bytes = new byte[512];
+        bytes[0] = (byte)'M';
+        bytes[1] = (byte)'Z';
+        WriteHeader(bytes, offset: 64, majorVersion: 35649, minorVersion: 18937,
+            sectionCount: 18650, entrySize: 139, entryType: 233, firstSectionId: 15041807);
+
+        Assert.Null(NativeAotDetector.Detect(bytes));
+    }
+
+    /// <summary>
+    /// Verifies a well-formed synthetic header is accepted.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Detect_SyntheticValidHeader_ReturnsInfo()
+    {
+        var bytes = new byte[4096];
+        bytes[0] = (byte)'M';
+        bytes[1] = (byte)'Z';
+        WriteHeader(bytes, offset: 128, majorVersion: 16, minorVersion: 0,
+            sectionCount: 33, entrySize: 24, entryType: 1, firstSectionId: 201);
+
+        var result = NativeAotDetector.Detect(bytes);
+
+        Assert.NotNull(result);
+        Assert.Equal(128, result.HeaderOffset);
+        Assert.Equal(16, result.MajorVersion);
+        Assert.Equal(33, result.SectionCount);
+        Assert.Equal(24, result.EntrySize);
+        Assert.Null(result.RuntimeVersion);
+    }
+
+    /// <summary>
+    /// Verifies a header whose section entries would run past the end of the
+    /// file is rejected.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Detect_TruncatedHeader_ReturnsNull()
+    {
+        var bytes = new byte[160];
+        bytes[0] = (byte)'M';
+        bytes[1] = (byte)'Z';
+
+        // 33 entries of 24 bytes need 792 bytes past the header; only 16 exist.
+        WriteHeader(bytes, offset: 128, majorVersion: 16, minorVersion: 0,
+            sectionCount: 33, entrySize: 24, entryType: 1, firstSectionId: 201);
+
+        Assert.Null(NativeAotDetector.Detect(bytes));
+    }
+
+    /// <summary>
+    /// Verifies bytes without a PE, ELF, or Mach-O magic are rejected even when
+    /// they contain a well-formed header.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Detect_NoExecutableMagic_ReturnsNull()
+    {
+        var bytes = new byte[4096];
+        WriteHeader(bytes, offset: 128, majorVersion: 16, minorVersion: 0,
+            sectionCount: 33, entrySize: 24, entryType: 1, firstSectionId: 201);
+
+        Assert.Null(NativeAotDetector.Detect(bytes));
+    }
+
+    /// <summary>
+    /// Verifies the scan skips an invalid candidate and accepts a later valid
+    /// header, mirroring real binaries where a code immediate precedes the
+    /// genuine header.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Detect_FalsePositiveBeforeRealHeader_FindsRealHeader()
+    {
+        var bytes = new byte[8192];
+        bytes[0] = (byte)'M';
+        bytes[1] = (byte)'Z';
+        WriteHeader(bytes, offset: 256, majorVersion: 35649, minorVersion: 18937,
+            sectionCount: 18650, entrySize: 139, entryType: 233, firstSectionId: 15041807);
+        WriteHeader(bytes, offset: 2048, majorVersion: 16, minorVersion: 0,
+            sectionCount: 33, entrySize: 24, entryType: 1, firstSectionId: 201);
+
+        var result = NativeAotDetector.Detect(bytes);
+
+        Assert.NotNull(result);
+        Assert.Equal(2048, result.HeaderOffset);
+    }
+
+    /// <summary>
+    /// Verifies that corrupting the real header's version field in a copy of the
+    /// real Native AOT binary makes detection fail — validation, not just the
+    /// signature, is load-bearing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Detect_NativeAotExe_CorruptedHeader_ReturnsNull()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        var bytes = File.ReadAllBytes(samples.NativeAotConsoleExe!);
+        var info = NativeAotDetector.Detect(bytes);
+        Assert.NotNull(info);
+
+        BinaryPrimitives.WriteUInt16LittleEndian(bytes.AsSpan(info.HeaderOffset + 4), 35649);
+
+        Assert.Null(NativeAotDetector.Detect(bytes));
+    }
+
+    /// <summary>
+    /// Verifies the real Native AOT binary truncated just past its header start
+    /// is rejected because the section entries no longer fit.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Detect_NativeAotExe_TruncatedAtHeader_ReturnsNull()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        var bytes = File.ReadAllBytes(samples.NativeAotConsoleExe!);
+        var info = NativeAotDetector.Detect(bytes);
+        Assert.NotNull(info);
+
+        Assert.Null(NativeAotDetector.Detect(bytes.AsSpan(0, info.HeaderOffset + 20)));
+    }
+
+    /// <summary>
+    /// Verifies a self-contained single-file bundle is not classified as Native AOT
+    /// even though the ReadyToRun assemblies inside it contain RTR signatures.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Detect_SelfContainedBundle_ReturnsNull()
+    {
+        Assert.SkipWhen(samples.SelfContainedConsoleExe is null,
+            "Self-contained sample was not built");
+
+        var result = NativeAotDetector.Detect(File.ReadAllBytes(samples.SelfContainedConsoleExe!));
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Writes a ReadyToRun-shaped header into a buffer at the given offset.
+    /// </summary>
+    private static void WriteHeader(byte[] bytes, int offset, ushort majorVersion,
+        ushort minorVersion, ushort sectionCount, byte entrySize, byte entryType,
+        int firstSectionId)
+    {
+        var span = bytes.AsSpan(offset);
+        "RTR\0"u8.CopyTo(span);
+        BinaryPrimitives.WriteUInt16LittleEndian(span[4..], majorVersion);
+        BinaryPrimitives.WriteUInt16LittleEndian(span[6..], minorVersion);
+        BinaryPrimitives.WriteUInt32LittleEndian(span[8..], 0);
+        BinaryPrimitives.WriteUInt16LittleEndian(span[12..], sectionCount);
+        span[14] = entrySize;
+        span[15] = entryType;
+        BinaryPrimitives.WriteInt32LittleEndian(span[16..], firstSectionId);
+    }
+}

--- a/tests/Dotsider.Tests/PeDirectoryReaderTests.cs
+++ b/tests/Dotsider.Tests/PeDirectoryReaderTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
 
 namespace Dotsider.Tests;
@@ -17,6 +18,9 @@ public class PeDirectoryReaderTests(SampleAssemblyFixture samples)
     [Fact(Timeout = 30_000)]
     public void Imports_ApphostExe_ContainsKernel32()
     {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "apphost is a PE with an import table only on Windows");
+
         using var analyzer = new AssemblyAnalyzer(samples.HelloWorldExe);
 
         var imports = analyzer.Imports;
@@ -33,6 +37,8 @@ public class PeDirectoryReaderTests(SampleAssemblyFixture samples)
     [Fact(Timeout = 30_000)]
     public void Imports_NativeAotExe_ContainsMultipleModules()
     {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Native AOT output is a PE with an import table only on Windows");
         Assert.SkipWhen(samples.NativeAotConsoleExe is null,
             "NativeAOT sample was not built");
 
@@ -104,6 +110,8 @@ public class PeDirectoryReaderTests(SampleAssemblyFixture samples)
     [Fact(Timeout = 30_000)]
     public void LoadConfig_NativeAotExe_HasSecurityCookie()
     {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "the load configuration directory exists only in Windows PE output");
         Assert.SkipWhen(samples.NativeAotConsoleExe is null,
             "NativeAOT sample was not built");
 
@@ -123,6 +131,9 @@ public class PeDirectoryReaderTests(SampleAssemblyFixture samples)
     [Fact(Timeout = 30_000)]
     public void LoadConfig_ApphostExe_Parses()
     {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "the load configuration directory exists only in Windows PE output");
+
         using var analyzer = new AssemblyAnalyzer(samples.HelloWorldExe);
 
         var loadConfig = analyzer.LoadConfig;

--- a/tests/Dotsider.Tests/PeDirectoryReaderTests.cs
+++ b/tests/Dotsider.Tests/PeDirectoryReaderTests.cs
@@ -5,40 +5,44 @@ using Dotsider.Core.Analysis;
 namespace Dotsider.Tests;
 
 /// <summary>
-/// Tests for the PE import/export/load-config directory parsers, exercised through
-/// the public <see cref="AssemblyAnalyzer"/> properties against real sample binaries,
-/// plus a synthetic PE for export shapes (forwarders, ordinal-only) no sample produces.
+/// Tests for the native import/export/load-config readers, exercised through the public
+/// <see cref="AssemblyAnalyzer"/> properties against real sample binaries. Each CI OS
+/// publishes its own-format Native AOT binary, so the import/export cases cover PE on
+/// Windows, ELF on Linux, and Mach-O on macOS. A synthetic PE covers export shapes
+/// (forwarders, ordinal-only) that no sample produces.
 /// </summary>
 [Collection("SampleAssemblies")]
 public class PeDirectoryReaderTests(SampleAssemblyFixture samples)
 {
+    /// <summary>The core system library name expected in the import table of the running OS.</summary>
+    private static string CoreImportLibrary =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "kernel32"
+        : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "libSystem"
+        : "libc";
+
     /// <summary>
-    /// Verifies the apphost executable's import table contains kernel32.
+    /// Verifies the apphost executable's import table lists the platform's core system library.
     /// </summary>
     [Fact(Timeout = 30_000)]
-    public void Imports_ApphostExe_ContainsKernel32()
+    public void Imports_ApphostExe_ContainsCoreLibrary()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "apphost is a PE with an import table only on Windows");
-
         using var analyzer = new AssemblyAnalyzer(samples.HelloWorldExe);
 
         var imports = analyzer.Imports;
 
         Assert.NotEmpty(imports);
         Assert.Contains(imports, m =>
-            m.ModuleName.Contains("kernel32", StringComparison.OrdinalIgnoreCase));
-        Assert.All(imports, m => Assert.NotEmpty(m.Functions));
+            m.ModuleName.Contains(CoreImportLibrary, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
-    /// Verifies the Native AOT executable imports multiple modules with named functions.
+    /// Verifies the Native AOT executable imports the platform's core system library
+    /// with named functions attributed to it (PE thunks, ELF versioned symbols, or
+    /// Mach-O two-level-namespace bindings).
     /// </summary>
     [Fact(Timeout = 30_000)]
-    public void Imports_NativeAotExe_ContainsMultipleModules()
+    public void Imports_NativeAotExe_ContainsCoreLibraryWithFunctions()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Native AOT output is a PE with an import table only on Windows");
         Assert.SkipWhen(samples.NativeAotConsoleExe is null,
             "NativeAOT sample was not built");
 
@@ -46,7 +50,10 @@ public class PeDirectoryReaderTests(SampleAssemblyFixture samples)
 
         var imports = analyzer.Imports;
 
-        Assert.True(imports.Count >= 2);
+        Assert.NotEmpty(imports);
+        Assert.Contains(imports, m =>
+            m.ModuleName.Contains(CoreImportLibrary, StringComparison.OrdinalIgnoreCase));
+
         var named = imports.SelectMany(m => m.Functions).Where(f => f.Name is not null).ToList();
         Assert.NotEmpty(named);
         Assert.All(named, f => Assert.Null(f.Ordinal));
@@ -104,14 +111,34 @@ public class PeDirectoryReaderTests(SampleAssemblyFixture samples)
     }
 
     /// <summary>
-    /// Verifies the Native AOT executable's load configuration parses with a
-    /// security cookie present.
+    /// Verifies the Native AOT executable exports parse without error. An ELF image
+    /// exports its runtime debug header; a Windows PE executable typically exports
+    /// nothing, which is equally valid.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Exports_NativeAotExe_WellFormed()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        using var analyzer = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+
+        var exports = analyzer.Exports;
+
+        Assert.NotNull(exports);
+        Assert.All(exports, e => Assert.False(string.IsNullOrEmpty(e.Name)));
+    }
+
+    /// <summary>
+    /// Verifies the Native AOT executable's load configuration parses with a security
+    /// cookie on Windows, where the PE load configuration directory exists. The
+    /// directory is a PE-only structure with no ELF or Mach-O equivalent.
     /// </summary>
     [Fact(Timeout = 30_000)]
     public void LoadConfig_NativeAotExe_HasSecurityCookie()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "the load configuration directory exists only in Windows PE output");
+            "the load configuration directory is a PE-only structure");
         Assert.SkipWhen(samples.NativeAotConsoleExe is null,
             "NativeAOT sample was not built");
 
@@ -126,13 +153,14 @@ public class PeDirectoryReaderTests(SampleAssemblyFixture samples)
     }
 
     /// <summary>
-    /// Verifies the apphost executable's load configuration parses.
+    /// Verifies the apphost executable's load configuration parses on Windows. The
+    /// directory is a PE-only structure with no ELF or Mach-O equivalent.
     /// </summary>
     [Fact(Timeout = 30_000)]
     public void LoadConfig_ApphostExe_Parses()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "the load configuration directory exists only in Windows PE output");
+            "the load configuration directory is a PE-only structure");
 
         using var analyzer = new AssemblyAnalyzer(samples.HelloWorldExe);
 

--- a/tests/Dotsider.Tests/PeDirectoryReaderTests.cs
+++ b/tests/Dotsider.Tests/PeDirectoryReaderTests.cs
@@ -1,0 +1,266 @@
+using System.Reflection.PortableExecutable;
+using Dotsider.Core.Analysis;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for the PE import/export/load-config directory parsers, exercised through
+/// the public <see cref="AssemblyAnalyzer"/> properties against real sample binaries,
+/// plus a synthetic PE for export shapes (forwarders, ordinal-only) no sample produces.
+/// </summary>
+[Collection("SampleAssemblies")]
+public class PeDirectoryReaderTests(SampleAssemblyFixture samples)
+{
+    /// <summary>
+    /// Verifies the apphost executable's import table contains kernel32.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Imports_ApphostExe_ContainsKernel32()
+    {
+        using var analyzer = new AssemblyAnalyzer(samples.HelloWorldExe);
+
+        var imports = analyzer.Imports;
+
+        Assert.NotEmpty(imports);
+        Assert.Contains(imports, m =>
+            m.ModuleName.Contains("kernel32", StringComparison.OrdinalIgnoreCase));
+        Assert.All(imports, m => Assert.NotEmpty(m.Functions));
+    }
+
+    /// <summary>
+    /// Verifies the Native AOT executable imports multiple modules with named functions.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Imports_NativeAotExe_ContainsMultipleModules()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        using var analyzer = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+
+        var imports = analyzer.Imports;
+
+        Assert.True(imports.Count >= 2);
+        var named = imports.SelectMany(m => m.Functions).Where(f => f.Name is not null).ToList();
+        Assert.NotEmpty(named);
+        Assert.All(named, f => Assert.Null(f.Ordinal));
+    }
+
+    /// <summary>
+    /// Verifies a managed DLL parses without errors — its import table is empty or tiny.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Imports_ManagedDll_WellFormed()
+    {
+        using var analyzer = new AssemblyAnalyzer(samples.RichLibraryDll);
+
+        var imports = analyzer.Imports;
+
+        Assert.NotNull(imports);
+        Assert.All(imports, m => Assert.False(string.IsNullOrEmpty(m.ModuleName)));
+    }
+
+    /// <summary>
+    /// Verifies export parsing on real samples never throws — the samples export nothing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Exports_RealSamples_WellFormed()
+    {
+        using var apphost = new AssemblyAnalyzer(samples.HelloWorldExe);
+        using var managed = new AssemblyAnalyzer(samples.RichLibraryDll);
+
+        Assert.NotNull(apphost.Exports);
+        Assert.NotNull(managed.Exports);
+    }
+
+    /// <summary>
+    /// Verifies named, forwarded, and ordinal-only exports parse from a synthetic PE.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Exports_SyntheticPe_ParsesNamedForwarderAndOrdinalOnly()
+    {
+        using var peReader = new PEReader(new MemoryStream(BuildExportTestPe()));
+
+        var exports = PeDirectoryReader.ReadExports(peReader);
+
+        Assert.Equal(3, exports.Count);
+
+        var alpha = Assert.Single(exports, e => e.Name == "Alpha");
+        Assert.Equal(5, alpha.Ordinal);
+        Assert.Null(alpha.ForwardedTo);
+
+        var beta = Assert.Single(exports, e => e.Name == "Beta");
+        Assert.Equal(6, beta.Ordinal);
+        Assert.Equal("NTDLL.RtlAllocateHeap", beta.ForwardedTo);
+
+        var ordinalOnly = Assert.Single(exports, e => e.Name is null);
+        Assert.Equal(7, ordinalOnly.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies the Native AOT executable's load configuration parses with a
+    /// security cookie present.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void LoadConfig_NativeAotExe_HasSecurityCookie()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        using var analyzer = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+
+        var loadConfig = analyzer.LoadConfig;
+
+        Assert.NotNull(loadConfig);
+        Assert.True(loadConfig.Size > 0);
+        Assert.NotEqual(0UL, loadConfig.SecurityCookie);
+        Assert.False(string.IsNullOrEmpty(loadConfig.GuardFlagsDescription));
+    }
+
+    /// <summary>
+    /// Verifies the apphost executable's load configuration parses.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void LoadConfig_ApphostExe_Parses()
+    {
+        using var analyzer = new AssemblyAnalyzer(samples.HelloWorldExe);
+
+        var loadConfig = analyzer.LoadConfig;
+
+        Assert.NotNull(loadConfig);
+        Assert.True(loadConfig.Size > 0);
+    }
+
+    /// <summary>
+    /// Verifies an import directory pointing outside every section yields an empty
+    /// result rather than throwing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Imports_UnmappedDirectory_ReturnsEmpty()
+    {
+        using var peReader = new PEReader(
+            new MemoryStream(BuildExportTestPe(importDirRva: 0x5000, importDirSize: 0x100)));
+
+        Assert.Empty(PeDirectoryReader.ReadImports(peReader));
+    }
+
+    /// <summary>
+    /// Verifies all directory properties degrade gracefully for a non-PE native binary.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NonPe_AllDirectories_Empty()
+    {
+        var elfBytes = new byte[128];
+        elfBytes[0] = 0x7F;
+        elfBytes[1] = (byte)'E';
+        elfBytes[2] = (byte)'L';
+        elfBytes[3] = (byte)'F';
+
+        using var analyzer = new AssemblyAnalyzer(elfBytes, "fake.so");
+
+        Assert.Empty(analyzer.Imports);
+        Assert.Empty(analyzer.Exports);
+        Assert.Null(analyzer.LoadConfig);
+    }
+
+    /// <summary>
+    /// Builds a minimal valid PE32+ image with one .edata section holding an export
+    /// directory: "Alpha" (ordinal 5), a forwarder "Beta" (ordinal 6), and an
+    /// ordinal-only export (ordinal 7).
+    /// </summary>
+    private static byte[] BuildExportTestPe(int importDirRva = 0, int importDirSize = 0)
+    {
+        var image = new byte[0x400];
+        var w = new SpanWriter(image);
+
+        // DOS header
+        w.U16(0x0000, 0x5A4D); // MZ
+        w.U32(0x003C, 0x80);   // e_lfanew
+
+        // PE signature + COFF header
+        w.U32(0x0080, 0x00004550);        // "PE\0\0"
+        w.U16(0x0084, 0x8664);            // Machine: x64
+        w.U16(0x0086, 1);                 // NumberOfSections
+        w.U16(0x0090, 240);               // SizeOfOptionalHeader
+        w.U16(0x0092, 0x2022);            // Characteristics: EXE | LARGE_ADDRESS_AWARE | DLL
+
+        // Optional header (PE32+) at 0x98
+        w.U16(0x0098, 0x020B);            // Magic
+        w.U32(0x0098 + 0x14, 0x1000);     // BaseOfCode
+        w.U64(0x0098 + 0x18, 0x1_8000_0000); // ImageBase
+        w.U32(0x0098 + 0x20, 0x1000);     // SectionAlignment
+        w.U32(0x0098 + 0x24, 0x200);      // FileAlignment
+        w.U16(0x0098 + 0x28, 6);          // MajorOSVersion
+        w.U16(0x0098 + 0x30, 6);          // MajorSubsystemVersion
+        w.U32(0x0098 + 0x38, 0x2000);     // SizeOfImage
+        w.U32(0x0098 + 0x3C, 0x200);      // SizeOfHeaders
+        w.U16(0x0098 + 0x44, 3);          // Subsystem: console
+        w.U64(0x0098 + 0x48, 0x100000);   // SizeOfStackReserve
+        w.U64(0x0098 + 0x50, 0x1000);     // SizeOfStackCommit
+        w.U64(0x0098 + 0x58, 0x100000);   // SizeOfHeapReserve
+        w.U64(0x0098 + 0x60, 0x1000);     // SizeOfHeapCommit
+        w.U32(0x0098 + 0x6C, 16);         // NumberOfRvaAndSizes
+
+        // Data directories at optional+0x70: [0] export, [1] import
+        w.U32(0x0098 + 0x70, 0x1000);     // export RVA
+        w.U32(0x0098 + 0x74, 0xC0);       // export size
+        w.U32(0x0098 + 0x78, (uint)importDirRva);
+        w.U32(0x0098 + 0x7C, (uint)importDirSize);
+
+        // Section table at 0x188: ".edata", RVA 0x1000, file 0x200, 0x200 bytes
+        "edata"u8.CopyTo(image.AsSpan(0x0189)); // ".edata" with leading dot
+        image[0x0188] = (byte)'.';
+        w.U32(0x0188 + 0x08, 0x200);      // VirtualSize
+        w.U32(0x0188 + 0x0C, 0x1000);     // VirtualAddress
+        w.U32(0x0188 + 0x10, 0x200);      // SizeOfRawData
+        w.U32(0x0188 + 0x14, 0x200);      // PointerToRawData
+        w.U32(0x0188 + 0x24, 0x40000040); // INITIALIZED_DATA | READ
+
+        // Export directory at file 0x200 (RVA 0x1000)
+        const int S = 0x200;              // file offset of section; RVA = offset - S + 0x1000
+        w.U32(S + 0x0C, 0x1060);          // NameRVA -> "TestLib.dll"
+        w.U32(S + 0x10, 5);               // OrdinalBase
+        w.U32(S + 0x14, 3);               // NumberOfFunctions
+        w.U32(S + 0x18, 2);               // NumberOfNames
+        w.U32(S + 0x1C, 0x1028);          // AddressOfFunctions
+        w.U32(S + 0x20, 0x1034);          // AddressOfNames
+        w.U32(S + 0x24, 0x103C);          // AddressOfNameOrdinals
+
+        // Function RVAs: [0]=Alpha code (outside dir), [1]=forwarder (inside dir), [2]=ordinal-only
+        w.U32(S + 0x28, 0x1100);
+        w.U32(S + 0x2C, 0x10A0);
+        w.U32(S + 0x30, 0x1110);
+
+        // Name pointer table + name ordinal table
+        w.U32(S + 0x34, 0x1070);          // -> "Alpha"
+        w.U32(S + 0x38, 0x1078);          // -> "Beta"
+        w.U16(S + 0x3C, 0);               // Alpha -> function index 0
+        w.U16(S + 0x3E, 1);               // Beta -> function index 1
+
+        // Strings
+        "TestLib.dll"u8.CopyTo(image.AsSpan(S + 0x60));
+        "Alpha"u8.CopyTo(image.AsSpan(S + 0x70));
+        "Beta"u8.CopyTo(image.AsSpan(S + 0x78));
+        "NTDLL.RtlAllocateHeap"u8.CopyTo(image.AsSpan(S + 0xA0));
+
+        return image;
+    }
+
+    /// <summary>Little-endian field writer over an in-memory PE image.</summary>
+    private readonly ref struct SpanWriter(Span<byte> span)
+    {
+        private readonly Span<byte> _span = span;
+
+        /// <summary>Writes a little-endian 16-bit value at the given offset.</summary>
+        public void U16(int offset, ushort value) =>
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(_span[offset..], value);
+
+        /// <summary>Writes a little-endian 32-bit value at the given offset.</summary>
+        public void U32(int offset, uint value) =>
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(_span[offset..], value);
+
+        /// <summary>Writes a little-endian 64-bit value at the given offset.</summary>
+        public void U64(int offset, ulong value) =>
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(_span[offset..], value);
+    }
+}

--- a/tests/Dotsider.Tests/PeMetadataViewTests.cs
+++ b/tests/Dotsider.Tests/PeMetadataViewTests.cs
@@ -718,15 +718,20 @@ public class PeMetadataViewTests(SampleAssemblyFixture samples) : IDisposable
         await runTask;
     }
 
+    /// <summary>The core system library name shown in the import table of the running OS.</summary>
+    private static string CoreImportLibrary =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "kernel32"
+        : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "libSystem"
+        : "libc";
+
     /// <summary>
     /// Verifies the Imports sub-tab shows the native import table for a Native AOT
-    /// executable.
+    /// executable — PE imports on Windows, ELF needed libraries on Linux, Mach-O
+    /// dylibs on macOS.
     /// </summary>
     [Fact(Timeout = 30_000)]
     public async Task PeMetadata_NativeAot_ImportsTab_ShowsModules()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Native AOT output is a PE with an import table only on Windows");
         Assert.SkipWhen(samples.NativeAotConsoleExe is null,
             "NativeAOT sample was not built");
 
@@ -746,17 +751,28 @@ public class PeMetadataViewTests(SampleAssemblyFixture samples) : IDisposable
                 .WaitUntil(_ => _state!.PeSubTab == expected, TimeSpan.FromSeconds(10));
         }
 
+        // Wait for the first module's name to render (casing varies by platform, so
+        // drive the on-screen match from the actual module name).
         await builder
-            .WaitUntil(s => s.ContainsText("KERNEL32") || s.ContainsText("kernel32"),
-                TimeSpan.FromSeconds(10))
+            .WaitUntil(_ => _state!.Analyzer.Imports.Count > 0, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText(FirstModulePrefix()), TimeSpan.FromSeconds(10))
             .Build()
             .ApplyAsync(terminal, cts.Token);
 
         Assert.Equal(PeSubTabId.Imports, _state!.PeSubTab);
         Assert.NotEmpty(_state.Analyzer.Imports);
+        Assert.Contains(_state.Analyzer.Imports, m =>
+            m.ModuleName.Contains(CoreImportLibrary, StringComparison.OrdinalIgnoreCase));
 
         cts.Cancel();
         await runTask;
+    }
+
+    private string FirstModulePrefix()
+    {
+        var name = _state!.Analyzer.Imports[0].ModuleName;
+        // The Module column is 24 cells wide; match a prefix that fits without truncation.
+        return name.Length <= 20 ? name : name[..20];
     }
 
     /// <summary>
@@ -765,8 +781,6 @@ public class PeMetadataViewTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public async Task PeMetadata_NativeAot_ImportsDetailPopup_OpensOnEnter()
     {
-        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Native AOT output is a PE with an import table only on Windows");
         Assert.SkipWhen(samples.NativeAotConsoleExe is null,
             "NativeAOT sample was not built");
 
@@ -806,7 +820,7 @@ public class PeMetadataViewTests(SampleAssemblyFixture samples) : IDisposable
     public async Task PeMetadata_NativeAot_LoadConfigTab_ShowsFields()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "the load configuration directory exists only in Windows PE output");
+            "the load configuration directory is a PE-only structure");
         Assert.SkipWhen(samples.NativeAotConsoleExe is null,
             "NativeAOT sample was not built");
 

--- a/tests/Dotsider.Tests/PeMetadataViewTests.cs
+++ b/tests/Dotsider.Tests/PeMetadataViewTests.cs
@@ -16,7 +16,7 @@ public class PeMetadataViewTests(SampleAssemblyFixture samples) : IDisposable
     private Hex1bApp? _hex1bApp;
     private DotsiderState? _state;
 
-    private (Hex1bTerminal terminal, Hex1bApp app) CreateDotsiderApp()
+    private (Hex1bTerminal terminal, Hex1bApp app) CreateDotsiderApp(string? assemblyPath = null)
     {
         _workload = new Hex1bAppWorkloadAdapter();
         _terminal = Hex1bTerminal.CreateBuilder()
@@ -28,7 +28,7 @@ public class PeMetadataViewTests(SampleAssemblyFixture samples) : IDisposable
         _hex1bApp = new Hex1bApp(
             ctx =>
             {
-                _state ??= new DotsiderState(_hex1bApp!, samples.RichLibraryDll)
+                _state ??= new DotsiderState(_hex1bApp!, assemblyPath ?? samples.RichLibraryDll)
                 {
                     CurrentTab = TabId.PeMetadata
                 };
@@ -712,6 +712,154 @@ public class PeMetadataViewTests(SampleAssemblyFixture samples) : IDisposable
         Assert.Contains("Token: 0x", content);
         Assert.Contains("Signature:", content);
         Assert.Contains("RVA: 0x", content);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Verifies the Imports sub-tab shows the native import table for a Native AOT
+    /// executable.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_NativeAot_ImportsTab_ShowsModules()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        var (terminal, app) = CreateDotsiderApp(samples.NativeAotConsoleExe);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        var builder = new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Sections"), TimeSpan.FromSeconds(10));
+        for (var target = 1; target <= PeSubTabId.Imports; target++)
+        {
+            var expected = target;
+            builder = builder
+                .Key(Hex1bKey.RightArrow)
+                .WaitUntil(_ => _state!.PeSubTab == expected, TimeSpan.FromSeconds(10));
+        }
+
+        await builder
+            .WaitUntil(s => s.ContainsText("KERNEL32") || s.ContainsText("kernel32"),
+                TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(PeSubTabId.Imports, _state!.PeSubTab);
+        Assert.NotEmpty(_state.Analyzer.Imports);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Verifies the Imports detail popup opens on Enter for a Native AOT executable.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_NativeAot_ImportsDetailPopup_OpensOnEnter()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        var (terminal, app) = CreateDotsiderApp(samples.NativeAotConsoleExe);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        var builder = new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Sections"), TimeSpan.FromSeconds(10));
+        for (var target = 1; target <= PeSubTabId.Imports; target++)
+        {
+            var expected = target;
+            builder = builder
+                .Key(Hex1bKey.RightArrow)
+                .WaitUntil(_ => _state!.PeSubTab == expected, TimeSpan.FromSeconds(10));
+        }
+
+        await builder
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.PeDetailContent is not null, TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Contains("Imported Function", _state!.PeDetailContent!);
+        Assert.Contains("Module:", _state.PeDetailContent!);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Verifies the Load Config sub-tab shows parsed fields for a Native AOT executable.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_NativeAot_LoadConfigTab_ShowsFields()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        var (terminal, app) = CreateDotsiderApp(samples.NativeAotConsoleExe);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        var builder = new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Sections"), TimeSpan.FromSeconds(10));
+        for (var target = 1; target <= PeSubTabId.LoadConfig; target++)
+        {
+            var expected = target;
+            builder = builder
+                .Key(Hex1bKey.RightArrow)
+                .WaitUntil(_ => _state!.PeSubTab == expected, TimeSpan.FromSeconds(10));
+        }
+
+        await builder
+            .WaitUntil(s => s.ContainsText("Security Cookie"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(PeSubTabId.LoadConfig, _state!.PeSubTab);
+        Assert.NotNull(_state.Analyzer.LoadConfig);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Verifies a managed DLL can navigate through the Imports, Exports, and Load
+    /// Config sub-tabs without crashing even when they are empty.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_ManagedDll_NewSubTabs_NoCrash()
+    {
+        var (terminal, app) = CreateDotsiderApp();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        var builder = new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Sections"), TimeSpan.FromSeconds(10));
+        for (var target = 1; target <= PeSubTabId.LoadConfig; target++)
+        {
+            var expected = target;
+            builder = builder
+                .Key(Hex1bKey.RightArrow)
+                .WaitUntil(_ => _state!.PeSubTab == expected, TimeSpan.FromSeconds(10));
+        }
+
+        await builder
+            .WaitUntil(s => s.ContainsText("Load Config"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(PeSubTabId.LoadConfig, _state!.PeSubTab);
 
         cts.Cancel();
         await runTask;

--- a/tests/Dotsider.Tests/PeMetadataViewTests.cs
+++ b/tests/Dotsider.Tests/PeMetadataViewTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
@@ -724,6 +725,8 @@ public class PeMetadataViewTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public async Task PeMetadata_NativeAot_ImportsTab_ShowsModules()
     {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Native AOT output is a PE with an import table only on Windows");
         Assert.SkipWhen(samples.NativeAotConsoleExe is null,
             "NativeAOT sample was not built");
 
@@ -762,6 +765,8 @@ public class PeMetadataViewTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public async Task PeMetadata_NativeAot_ImportsDetailPopup_OpensOnEnter()
     {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Native AOT output is a PE with an import table only on Windows");
         Assert.SkipWhen(samples.NativeAotConsoleExe is null,
             "NativeAOT sample was not built");
 
@@ -800,6 +805,8 @@ public class PeMetadataViewTests(SampleAssemblyFixture samples) : IDisposable
     [Fact(Timeout = 30_000)]
     public async Task PeMetadata_NativeAot_LoadConfigTab_ShowsFields()
     {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "the load configuration directory exists only in Windows PE output");
         Assert.SkipWhen(samples.NativeAotConsoleExe is null,
             "NativeAOT sample was not built");
 

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -3040,6 +3040,37 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
     }
 
     /// <summary>
+    /// Verifies the General tab shows the Native AOT info block (binary kind,
+    /// ReadyToRun format version, runtime version, native import summary) for a
+    /// Native AOT executable.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task General_NativeAot_ShowsAotInfo()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        var (terminal, app) = CreateDotsiderApp(samples.NativeAotConsoleExe!);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Native AOT (.NET)"), TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("ILC / RTR Format"), TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Native Imports"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.True(_state!.IsNativeAot);
+        Assert.NotNull(_state.Analyzer.NativeAotInfo);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
     /// Disposes test resources created during the run.
     /// </summary>
     public void Dispose()

--- a/tests/Dotsider.Tests/StringExtractorTests.cs
+++ b/tests/Dotsider.Tests/StringExtractorTests.cs
@@ -245,4 +245,79 @@ public class StringExtractorTests(SampleAssemblyFixture samples)
 
         Assert.NotNull(strings);
     }
+
+    /// <summary>
+    /// Verifies the UTF-16 raw scan finds frozen managed string literals in a
+    /// Native AOT binary (the DOTNET_ environment variable names the runtime reads).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NativeAot_ExtractRawUtf16Strings_FindsFrozenLiterals()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        using var a = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        var extractor = new StringExtractor(a);
+
+        var strings = extractor.ExtractRawUtf16Strings(minLength: 8);
+
+        Assert.NotEmpty(strings);
+        Assert.Contains(strings, s => s.Value.Contains("DOTNET_", StringComparison.Ordinal));
+        Assert.All(strings, s => Assert.Equal(StringSource.RawBinaryUtf16, s.Source));
+    }
+
+    /// <summary>
+    /// Verifies the UTF-16 raw scan honors the minimum length.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ExtractRawUtf16Strings_RespectsMinLength()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var extractor = new StringExtractor(a);
+
+        var strings = extractor.ExtractRawUtf16Strings(minLength: 16);
+
+        Assert.All(strings, s => Assert.True(s.Value.Length >= 16));
+    }
+
+    /// <summary>
+    /// Verifies UTF-16 entries carry offsets inside the file.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ExtractRawUtf16Strings_HaveValidOffsets()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var extractor = new StringExtractor(a);
+
+        var strings = extractor.ExtractRawUtf16Strings();
+
+        Assert.All(strings, s => Assert.InRange(s.Offset, 0, (int)a.FileSize - 1));
+    }
+
+    /// <summary>
+    /// Verifies a UTF-16 run at an odd byte offset is found — UTF-16 data sits at
+    /// arbitrary alignments in real binaries.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ExtractRawUtf16Strings_OddOffsetRun_Found()
+    {
+        var bytes = new byte[64];
+        bytes[0] = 0x7F;
+        bytes[1] = (byte)'E';
+        bytes[2] = (byte)'L';
+        bytes[3] = (byte)'F';
+
+        // "Hello" as UTF-16LE starting at odd offset 7
+        var text = "Hello"u8;
+        for (var i = 0; i < text.Length; i++)
+            bytes[7 + i * 2] = text[i];
+
+        using var a = new AssemblyAnalyzer(bytes, "fake.so");
+        var extractor = new StringExtractor(a);
+
+        var strings = extractor.ExtractRawUtf16Strings(minLength: 5);
+
+        var entry = Assert.Single(strings, s => s.Value == "Hello");
+        Assert.Equal(7, entry.Offset);
+    }
 }

--- a/tests/Dotsider.Tests/StringsViewTests.cs
+++ b/tests/Dotsider.Tests/StringsViewTests.cs
@@ -305,6 +305,79 @@ public class StringsViewTests(SampleAssemblyFixture samples) : IDisposable
     }
 
     /// <summary>
+    /// Verifies the fourth sub-tab (Raw UTF-16) renders and becomes active.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Strings_NavigateToRawUtf16_Renders()
+    {
+        var (terminal, app) = CreateDotsiderApp();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        var builder = new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("User Strings"), TimeSpan.FromSeconds(10));
+        for (var target = 1; target <= StringsSubTabId.RawBinaryUtf16; target++)
+        {
+            var expected = target;
+            builder = builder
+                .Key(Hex1bKey.RightArrow)
+                .WaitUntil(_ => _state!.StringsSourceTab == expected, TimeSpan.FromSeconds(10));
+        }
+
+        await builder
+            .WaitUntil(s => s.ContainsText("Raw (UTF-16)"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(StringsSubTabId.RawBinaryUtf16, _state!.StringsSourceTab);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Verifies changing min length on the Raw UTF-16 sub-tab invalidates and
+    /// rebuilds its cache with the new minimum.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Strings_MinLengthChange_InvalidatesUtf16Cache()
+    {
+        var (terminal, app) = CreateDotsiderApp();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        var builder = new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("User Strings"), TimeSpan.FromSeconds(10));
+        for (var target = 1; target <= StringsSubTabId.RawBinaryUtf16; target++)
+        {
+            var expected = target;
+            builder = builder
+                .Key(Hex1bKey.RightArrow)
+                .WaitUntil(_ => _state!.StringsSourceTab == expected, TimeSpan.FromSeconds(10));
+        }
+
+        await builder
+            .WaitUntil(_ => _state!.CachedRawUtf16StringsMinLength == _state.StringsMinLength,
+                TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.OemPlus)
+            .WaitUntil(_ => _state!.StringsMinLength == 5
+                && _state.CachedRawUtf16StringsMinLength == 5,
+                TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(5, _state!.StringsMinLength);
+        Assert.NotNull(_state.CachedRawUtf16Strings);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
     /// Disposes test resources created during the run.
     /// </summary>
     public void Dispose()


### PR DESCRIPTION
Opening a Native AOT executable used to leave most tabs empty because every reader keyed off ECMA-335 metadata, and ILC strips that out. The binary still identifies itself: every AOT image embeds a ReadyToRun header so the runtime can find its module sections, and its presence with no COR header is the classification signal.

The new detector scans for the RTR signature and validates each candidate against the field ranges ILC actually emits — the signature alone collides with code immediates, and the test binaries contain a real collision that the validation rejects. The first section id check (200..999) also keeps managed ReadyToRun images out, since R2R uses ids around 100 with a different entry layout. The runtime version comes from the version string the runtime pack embeds next to its stack-overflow message; the two live in the same runtime object file so the linker keeps them close, but the version lands just before the message on MSVC-linked PEs and a few hundred bytes after it on ELF, so the search takes the nearest version-shaped match on either side. When nothing matches, the output says "(not detected)" rather than guessing.

AssemblyLoader gains a NativeAot open-result kind, probed after the bundle check because R2R assemblies inside a bundle carry RTR signatures too. General shows the binary kind, RTR format version, runtime version, and an import summary. PE/Metadata gains Imports, Exports, and Load Config sub-tabs.

Imports and Exports read whichever native format the binary uses, so they work on every platform, not just Windows. On Windows the walker parses PE import descriptors and the export directory — thunk tables, ordinal imports, forwarded exports — from the RVA/size pairs PEReader leaves unparsed. On Linux it reads the ELF needed libraries and attributes each undefined dynamic symbol to its library through the GNU version requirements. On macOS it reads the Mach-O loaded dylibs and the two-level-namespace bindings. Load Config is a PE-only structure with no ELF or Mach-O equivalent, so that sub-tab stays empty off Windows. None of the readers throw on malformed input; they return empty.

Strings gains a Raw (UTF-16) sub-tab, which is where managed string literals appear in AOT images since they freeze as UTF-16. The analyze CLI picks up --min-len and falls back to the raw scans when there is no metadata instead of printing nothing, and the session protocol and MCP tools carry the same fields.

Tests run against the real sample fixtures wherever one exists. The import and export cases are format-aware and run against each CI runner's own-format binary, so Windows exercises PE, Linux exercises ELF, and macOS exercises Mach-O. The detector's corruption and truncation cases operate on copies of the real AOT binary's bytes, and a synthetic PE covers export shapes (forwarders, ordinal-only) that no sample produces. Benchmarks cover the detector's full-file scans, the format-aware import/export readers, and the UTF-16 scan — with baselines recorded in the benchmarks README on the M4 Pro machine the other numbers use.

Verified against a standard dotnet publish output, a hand-linked static-library binary, and a Linux ELF publish; all report kind, format version, runtime, and imports where they previously showed nothing.

Fixes: #174
