### PR TITLE
Size Map and Dep Graph for Native AOT via mstat and DGML

### DIFF
--- a/benchmarks/Dotsider.Benchmarks/DgmlReaderBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/DgmlReaderBenchmarks.cs
@@ -1,0 +1,58 @@
+using BenchmarkDotNet.Attributes;
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Benchmarks;
+
+/// <summary>
+/// Benchmarks for <see cref="DgmlReader"/> and <see cref="DgmlGraph.PathToRoot(string)"/>
+/// against the real dependency graphs the NativeAotConsole sample publishes. The codegen
+/// graph is the smaller of the two; the scan graph roughly doubles the node count.
+/// </summary>
+[MemoryDiagnoser]
+public class DgmlReaderBenchmarks
+{
+    private string _codegenPath = null!;
+    private string _scanPath = null!;
+    private DgmlGraph _graph = null!;
+    private string _deepLabel = null!;
+
+    /// <summary>
+    /// Publishes the Native AOT sample (cached across benchmark classes), locates the DGML
+    /// sidecars, and picks a deep method node for the chain query.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        BenchmarkHelpers.PublishNativeAotSample("samples/NativeAotConsole");
+        var exe = BenchmarkHelpers.GetPublishPath("samples/NativeAotConsole", "NativeAotConsole");
+        var dir = Path.GetDirectoryName(exe)!;
+        _codegenPath = Path.Combine(dir, "NativeAotConsole.codegen.dgml.xml");
+        _scanPath = Path.Combine(dir, "NativeAotConsole.scan.dgml.xml");
+        if (!File.Exists(_codegenPath) || !File.Exists(_scanPath))
+            throw new InvalidOperationException($"DGML sidecars not found next to {exe}");
+
+        _graph = DgmlReader.Read(_codegenPath)
+            ?? throw new InvalidOperationException("codegen DGML failed to parse");
+
+        // The last compiled method is as far from the roots as the report gets.
+        var mstat = MstatReader.Read(Path.Combine(dir, "NativeAotConsole.mstat"))
+            ?? throw new InvalidOperationException("mstat failed to parse");
+        _deepLabel = mstat.Methods.Last(m => m.NodeName is not null && _graph.FindNodeByLabel(m.NodeName) is not null).NodeName!;
+    }
+
+    /// <summary>Streams and indexes the codegen dependency graph.</summary>
+    /// <returns>The parsed graph, returned so the JIT cannot elide the work.</returns>
+    [Benchmark(Description = "Read codegen DGML")]
+    public DgmlGraph? ReadCodegen() => DgmlReader.Read(_codegenPath);
+
+    /// <summary>Streams and indexes the larger scan dependency graph.</summary>
+    /// <returns>The parsed graph, returned so the JIT cannot elide the work.</returns>
+    [Benchmark(Description = "Read scan DGML")]
+    public DgmlGraph? ReadScan() => DgmlReader.Read(_scanPath);
+
+    /// <summary>Walks a deep method node back to a dependency root.</summary>
+    /// <returns>The chain, returned so the JIT cannot elide the work.</returns>
+    [Benchmark(Description = "PathToRoot on a deep method node")]
+    public IReadOnlyList<DgmlPathStep> PathToRootDeepNode() => _graph.PathToRoot(_deepLabel);
+}

--- a/benchmarks/Dotsider.Benchmarks/MstatReaderBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/MstatReaderBenchmarks.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Benchmarks;
+
+/// <summary>
+/// Benchmarks for <see cref="MstatReader"/> against the real size report the NativeAotConsole
+/// sample publishes. The read decodes every IL stream, resolves every token, and reads every
+/// node name from the <c>.names</c> section.
+/// </summary>
+[MemoryDiagnoser]
+public class MstatReaderBenchmarks
+{
+    private string _mstatPath = null!;
+
+    /// <summary>
+    /// Publishes the Native AOT sample (cached across benchmark classes) and locates the
+    /// mstat sidecar next to the executable.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        BenchmarkHelpers.PublishNativeAotSample("samples/NativeAotConsole");
+        var exe = BenchmarkHelpers.GetPublishPath("samples/NativeAotConsole", "NativeAotConsole");
+        _mstatPath = Path.Combine(Path.GetDirectoryName(exe)!, "NativeAotConsole.mstat");
+        if (!File.Exists(_mstatPath))
+            throw new InvalidOperationException($"mstat sidecar not found at {_mstatPath}");
+    }
+
+    /// <summary>Reads and fully decodes the sample's mstat report.</summary>
+    /// <returns>The decoded report, returned so the JIT cannot elide the work.</returns>
+    [Benchmark(Description = "Read NativeAotConsole.mstat")]
+    public MstatData? ReadMstat() => MstatReader.Read(_mstatPath);
+}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -36,6 +36,7 @@ dotnet run --project benchmarks/Dotsider.Benchmarks -c Release -- --list flat
 | `AssemblyAnalyzerBenchmarks` | Constructor (file and byte[]), lazy metadata properties (TypeDefs, MethodDefs, AssemblyRefs, TypeRefs, MemberRefs, FieldDefs, CustomAttributes, Resources, Sections), token resolution, and 7-step assembly resolution chain (app-local, NuGet deps.json, runtime directory, source bundle, host bundle, adjacent bundles, shared framework) |
 | `AssemblyDifferBenchmarks` | Dictionary-based O(n) diff of two assemblies by type, method, and reference with normalized IL body comparison |
 | `DependencyGraphBuilderBenchmarks` | Full transitive assembly dependency closure — BFS walk that resolves each AssemblyRef by full identity, opens it, and recurses (CoreLib has no outbound refs so this is pure builder overhead; Xml walks its full BCL/runtime-pack closure) |
+| `DgmlReaderBenchmarks` | ILC dependency-graph parsing (codegen and scan DGML sidecars) and a root-chain walk from a deep method node |
 | `DotNetRuntimeLocatorColdBenchmarks` | Cold-path .NET runtime discovery: base path + shared framework resolution with cache cleared |
 | `DotNetRuntimeLocatorWarmBenchmarks` | Warm-cache ConcurrentDictionary hit for shared framework lookup |
 | `HexSearchBenchmarks` | `FindBytePattern` with short, long, and no-match patterns against real assemblies |
@@ -45,6 +46,7 @@ dotnet run --project benchmarks/Dotsider.Benchmarks -c Release -- --list flat
 | `ImplementationAssemblyResolverColdBenchmarks` | Cold-path reference-to-implementation resolution: known mappings, type forwarder chains, direct usable metadata |
 | `ImplementationAssemblyResolverWarmBenchmarks` | Warm-cache hit for implementation assembly resolution |
 | `McpToolBenchmarks` | MCP tool call round-trip and session discovery through in-process pipe transport |
+| `MstatReaderBenchmarks` | Full ILC size-report decode: IL stream walk, token resolution with assembly attribution, and .names section reads |
 | `NativeAotDetectorBenchmarks` | ReadyToRun header scan + validation on a real Native AOT exe (positive with false-positive rejection), CoreLib (R2R negative full scan), and an apphost (no candidates) |
 | `NuGetPackageAnalyzerBenchmarks` | NuGet package construction and DLL extraction from standard (2 DLLs) and large (120+ entry) packages |
 | `PeDirectoryReaderBenchmarks` | Native import/export/load-config parsing on a Native AOT binary (PE, ELF, or Mach-O by platform) and CoreLib |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -128,6 +128,16 @@ Identity and distinct benchmarks are worst-case: every method matches, forcing n
 
 The builder now produces a full transitive closure: every AssemblyRef is resolved by full identity, opened, and recursed into. CoreLib has no outbound refs so its graph is a single root node (the baseline reflects pure BFS + layout overhead). Xml refs most of the BCL, so its closure walks ~dozens of additional assemblies — each one opened via `AssemblyAnalyzer`, which dominates both time and allocation. The prior 8 μs baseline measured only the root's direct-ref star without any resolution or traversal; the new number is the cost of doing the thing the name actually claims.
 
+#### DgmlReader
+
+| Benchmark | Mean | Allocated |
+|---|---|---|
+| Read codegen DGML | 7.06 ms | 6.86 MB |
+| Read scan DGML | 15.88 ms | 12.63 MB |
+| PathToRoot on a deep method node | 118.3 ns | 648 B |
+
+Reads parse the NativeAotConsole sample's ILC dependency-graph sidecars (the scan graph roughly doubles the codegen graph's node count) and build the label and edge indexes. `PathToRoot` is a pure index walk, so chain queries from the UI are effectively free once the graph is loaded.
+
 #### DotNetRuntimeLocator
 
 | Benchmark | Mean | Allocated |
@@ -194,6 +204,14 @@ The 8ms adaptive threshold (`HexDumpView` line 44) crosses at ~10MB on this mach
 | Direct usable (System.Private.Xml) | 36.25 μs | 10.80 KB |
 | Known mapping warm cache hit | 67.62 ns | — |
 
+#### MstatReader
+
+| Benchmark | Mean | Allocated |
+|---|---|---|
+| Read NativeAotConsole.mstat | 764.7 μs | 2.73 MB |
+
+One read fully decodes the sample's ILC size report: walks the IL stream for every type, method, and blob row, resolves every token with assembly attribution, and reads every node name from the `.names` section.
+
 #### NativeAotDetector
 
 | Benchmark | Mean | Allocated |
@@ -224,9 +242,9 @@ The 8ms adaptive threshold (`HexDumpView` line 44) crosses at ~10MB on this mach
 
 | Benchmark | Mean | Allocated |
 |---|---|---|
-| ReadyToRun sections | — | — |
-| Frozen strings | — | — |
-| Recovered types | — | — |
+| ReadyToRun sections | 194.9 μs | 1.19 MB |
+| Frozen strings | 257.3 μs | 1.34 MB |
+| Recovered types | 240.5 μs | 1.33 MB |
 
 #### RuntimeTracer — Data Retrieval (populated)
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
@@ -172,6 +172,32 @@ Gets the PE debug directory entries.
 public IReadOnlyList<DebugDirectoryInfo> DebugDirectory { get; }
 ```
 
+### Dgml
+
+The ILC dependency graph found next to a Native AOT binary, or null when this is not
+a Native AOT binary or no readable DGML sidecar sits beside it. Graphs run to
+hundreds of thousands of links, so touch this only when a dependency question is
+actually being asked. The value is assigned before the probed flag, so a rare
+concurrent first read costs at most a second parse of immutable data.
+
+**Returns:** [DgmlGraph](/api/dotsider.core.analysis.models.dgmlgraph/)
+
+```csharp
+public DgmlGraph? Dgml { get; }
+```
+
+### DgmlPath
+
+The path of the DGML sidecar next to a Native AOT binary — the codegen graph when
+present (its node names match the mstat's exactly), else the scan graph — or null
+when this is not a Native AOT binary or neither file is present.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? DgmlPath { get; }
+```
+
 ### DisplayName
 
 Logical display name for the analyzed artifact. For bundle-backed analyzers this is
@@ -349,6 +375,30 @@ Gets the MethodDef metadata table entries.
 
 ```csharp
 public IReadOnlyList<MethodDefInfo> MethodDefs { get; }
+```
+
+### Mstat
+
+The ILC size report found next to a Native AOT binary, or null when this is not a
+Native AOT binary or no readable `.mstat` sidecar sits beside it. The value is
+assigned before the probed flag, so a rare concurrent first read costs at most a
+second parse of immutable data.
+
+**Returns:** [MstatData](/api/dotsider.core.analysis.models.mstatdata/)
+
+```csharp
+public MstatData? Mstat { get; }
+```
+
+### MstatPath
+
+The path of the `.mstat` sidecar next to a Native AOT binary, or null when this
+is not a Native AOT binary or the file is absent.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? MstatPath { get; }
 ```
 
 ### NativeAotInfo

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-DgmlReader.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-DgmlReader.md
@@ -1,0 +1,63 @@
+---
+title: "DgmlReader"
+description: "Reads an ILC dependency-graph DGML file, emitted when publishing a Native AOT project with IlcGenerateDgmlFile. The format is a DirectedGraph document of nodes (id and label) and links (source depends on target, with a reason). Node labels equal the node names an mstat size report stores (MstatReader), which is how sizes join to dependency chains. Parsing streams the XML — the graphs run to hundreds of thousands of links — and never throws: unreadable files return null, and malformed nodes or links are skipped."
+slug: api/dotsider.core.analysis.dgmlreader
+sidebar:
+  order: 0
+---
+
+**Namespace:** `Dotsider.Core.Analysis`
+
+**Assembly:** Dotsider.Core.dll
+
+Reads an ILC dependency-graph DGML file, emitted when publishing a Native AOT project with
+`IlcGenerateDgmlFile`. The format is a `DirectedGraph` document of nodes (id and
+label) and links (source depends on target, with a reason). Node labels equal the node
+names an mstat size report stores ([MstatReader](/api/dotsider.core.analysis.mstatreader/)), which is how sizes join to
+dependency chains.
+
+Parsing streams the XML — the graphs run to hundreds of thousands of links — and never
+throws: unreadable files return null, and malformed nodes or links are skipped.
+
+```csharp
+public static class DgmlReader
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **DgmlReader**
+
+## Methods
+
+### Read(Stream)
+
+Reads a dependency graph from a stream. The stream is left open.
+
+**Parameters:**
+
+- `stream` ([Stream](https://learn.microsoft.com/dotnet/api/system.io.stream)): A readable stream positioned at the start of the document.
+
+**Returns:** [DgmlGraph](/api/dotsider.core.analysis.models.dgmlgraph/)
+
+The graph, or null when the content is not a DGML document.
+
+```csharp
+public static DgmlGraph? Read(Stream stream)
+```
+
+### Read(string)
+
+Reads a dependency graph from a file.
+
+**Parameters:**
+
+- `filePath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The path of the `.dgml.xml` file.
+
+**Returns:** [DgmlGraph](/api/dotsider.core.analysis.models.dgmlgraph/)
+
+The graph, or null when the file is missing or is not a DGML document.
+
+```csharp
+public static DgmlGraph? Read(string filePath)
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-AssemblyProvenance.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-AssemblyProvenance.md
@@ -62,6 +62,17 @@ fail-fast (the CLR does not fall back to probing in this case), distinct from ge
 CodeBaseMissing = 13
 ```
 
+### CompiledIntoNativeImage
+
+Compiled into a Native AOT image: the node comes from the binary's mstat size report
+or native import table rather than an on-disk assembly, so there is no file to open.
+
+**Returns:** [AssemblyProvenance](/api/dotsider.core.analysis.models.assemblyprovenance/)
+
+```csharp
+CompiledIntoNativeImage = 14
+```
+
 ### FrameworkRuntimeDirectory
 
 Resolved from the .NET Framework runtime directory at

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-DgmlGraph.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-DgmlGraph.md
@@ -1,0 +1,93 @@
+---
+title: "DgmlGraph"
+description: "An ILC dependency graph read from a DGML file, with the reverse index needed to answer \"why is this in my binary\": a breadth-first walk from any node toward its dependers ends at a root — a node nothing depends on — and the chain back down is the explanation."
+slug: api/dotsider.core.analysis.models.dgmlgraph
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+An ILC dependency graph read from a DGML file, with the reverse index needed to answer
+"why is this in my binary": a breadth-first walk from any node toward its dependers ends
+at a root — a node nothing depends on — and the chain back down is the explanation.
+
+```csharp
+public sealed class DgmlGraph
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **DgmlGraph**
+
+## Properties
+
+### Links
+
+The graph's edges; each source depends on its target.
+
+**Returns:** [IReadOnlyList\<DgmlLink\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<DgmlLink> Links { get; }
+```
+
+### Nodes
+
+The graph's nodes.
+
+**Returns:** [IReadOnlyList\<DgmlNode\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<DgmlNode> Nodes { get; }
+```
+
+## Methods
+
+### FindNodeByLabel(string)
+
+Finds the node with the given label, or null when no node carries it. When labels
+repeat, the first node wins.
+
+**Parameters:**
+
+- `label` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The node name to look up — for an mstat entry, its `NodeName`.
+
+**Returns:** [DgmlNode](/api/dotsider.core.analysis.models.dgmlnode/)
+
+```csharp
+public DgmlNode? FindNodeByLabel(string label)
+```
+
+### PathToRoot(int)
+
+Walks from the node to a root and returns the chain root-first, ending at the queried
+node. Empty when the id is unknown.
+
+**Parameters:**
+
+- `nodeId` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The node id to explain.
+
+**Returns:** [IReadOnlyList\<DgmlPathStep\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<DgmlPathStep> PathToRoot(int nodeId)
+```
+
+### PathToRoot(string)
+
+Walks from the labeled node to a root and returns the chain root-first, ending at the
+queried node. Empty when the label is unknown.
+
+**Parameters:**
+
+- `label` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The node name to explain.
+
+**Returns:** [IReadOnlyList\<DgmlPathStep\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<DgmlPathStep> PathToRoot(string label)
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-DgmlLink.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-DgmlLink.md
@@ -1,0 +1,76 @@
+---
+title: "DgmlLink"
+description: "One edge of an ILC dependency graph: the source node depends on the target node, so the target is in the binary because the source needed it."
+slug: api/dotsider.core.analysis.models.dgmllink
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+One edge of an ILC dependency graph: the source node depends on the target node, so the
+target is in the binary because the source needed it.
+
+```csharp
+public sealed record DgmlLink : IEquatable<DgmlLink>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **DgmlLink**
+
+## Implements
+
+- [IEquatable\<DgmlLink\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### DgmlLink(int, int, string?)
+
+One edge of an ILC dependency graph: the source node depends on the target node, so the
+target is in the binary because the source needed it.
+
+**Parameters:**
+
+- `SourceId` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The depender's node id.
+- `TargetId` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The dependee's node id.
+- `Reason` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The compiler's explanation for the dependency, or null when it gave none.
+
+```csharp
+public DgmlLink(int SourceId, int TargetId, string? Reason)
+```
+
+## Properties
+
+### Reason
+
+The compiler's explanation for the dependency, or null when it gave none.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? Reason { get; init; }
+```
+
+### SourceId
+
+The depender's node id.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int SourceId { get; init; }
+```
+
+### TargetId
+
+The dependee's node id.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int TargetId { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-DgmlNode.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-DgmlNode.md
@@ -1,0 +1,65 @@
+---
+title: "DgmlNode"
+description: "One node of an ILC dependency graph. The label is the compiler's node name — the same string an mstat size entry stores as its NodeName, which is how the two files join."
+slug: api/dotsider.core.analysis.models.dgmlnode
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+One node of an ILC dependency graph. The label is the compiler's node name — the same
+string an mstat size entry stores as its `NodeName`, which is how the two files join.
+
+```csharp
+public sealed record DgmlNode : IEquatable<DgmlNode>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **DgmlNode**
+
+## Implements
+
+- [IEquatable\<DgmlNode\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### DgmlNode(int, string)
+
+One node of an ILC dependency graph. The label is the compiler's node name — the same
+string an mstat size entry stores as its `NodeName`, which is how the two files join.
+
+**Parameters:**
+
+- `Id` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The node id, unique within the graph.
+- `Label` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The node name.
+
+```csharp
+public DgmlNode(int Id, string Label)
+```
+
+## Properties
+
+### Id
+
+The node id, unique within the graph.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int Id { get; init; }
+```
+
+### Label
+
+The node name.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Label { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-DgmlPathStep.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-DgmlPathStep.md
@@ -1,0 +1,67 @@
+---
+title: "DgmlPathStep"
+description: "One step of a root-to-node dependency chain — the answer to \"why is this in my binary,\" read top-down: the root kept the second step, which kept the third, and so on to the node that was asked about."
+slug: api/dotsider.core.analysis.models.dgmlpathstep
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+One step of a root-to-node dependency chain — the answer to "why is this in my binary,"
+read top-down: the root kept the second step, which kept the third, and so on to the node
+that was asked about.
+
+```csharp
+public sealed record DgmlPathStep : IEquatable<DgmlPathStep>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **DgmlPathStep**
+
+## Implements
+
+- [IEquatable\<DgmlPathStep\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### DgmlPathStep(string, string?)
+
+One step of a root-to-node dependency chain — the answer to "why is this in my binary,"
+read top-down: the root kept the second step, which kept the third, and so on to the node
+that was asked about.
+
+**Parameters:**
+
+- `Label` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The node name at this step.
+- `Reason` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Why the previous step depends on this one, or null on the root step.
+
+```csharp
+public DgmlPathStep(string Label, string? Reason)
+```
+
+## Properties
+
+### Label
+
+The node name at this step.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Label { get; init; }
+```
+
+### Reason
+
+Why the previous step depends on this one, or null on the root step.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? Reason { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-GraphNode.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-GraphNode.md
@@ -29,7 +29,7 @@ public sealed record GraphNode : IEquatable<GraphNode>
 
 ## Constructors
 
-### GraphNode(string, string, string?, string, string?, bool, int, bool)
+### GraphNode(string, string, string?, string, string?, bool, int, bool, GraphNodeKind)
 
 A node in the transitive assembly dependency graph. Topology only — layout coordinates
 and rendered labels are the responsibility of the view layer, which projects the visible
@@ -53,9 +53,11 @@ Zero for the root; one for direct references; greater for transitive references.
 probe produced any candidate and the case where a probe produced a simple-name match whose
 manifest identity did not match — the latter is further distinguished by the node's
 navigation-context provenance.
+- `Kind` ([GraphNodeKind](/api/dotsider.core.analysis.models.graphnodekind/)): What the node represents. Defaults to [Assembly](/api/dotsider.core.analysis.models.graphnodekind.assembly/) and is omitted
+from serialized output at that default, so managed graph JSON is unchanged.
 
 ```csharp
-public GraphNode(string Id, string Name, string? Version, string Culture, string? PublicKeyToken, bool IsRoot, int Depth, bool Unresolved)
+public GraphNode(string Id, string Name, string? Version, string Culture, string? PublicKeyToken, bool IsRoot, int Depth, bool Unresolved, GraphNodeKind Kind = GraphNodeKind.Assembly)
 ```
 
 ## Properties
@@ -102,6 +104,18 @@ Whether this is the analyzed assembly (the root of the graph).
 
 ```csharp
 public bool IsRoot { get; init; }
+```
+
+### Kind
+
+What the node represents. Defaults to [Assembly](/api/dotsider.core.analysis.models.graphnodekind.assembly/) and is omitted
+from serialized output at that default, so managed graph JSON is unchanged.
+
+**Returns:** [GraphNodeKind](/api/dotsider.core.analysis.models.graphnodekind/)
+
+```csharp
+[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+public GraphNodeKind Kind { get; init; }
 ```
 
 ### Name

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-GraphNodeKind.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-GraphNodeKind.md
@@ -1,0 +1,41 @@
+---
+title: "GraphNodeKind"
+description: "What a dependency-graph node represents. Managed graphs contain only assemblies; the Native AOT graph adds the binary's native import modules."
+slug: api/dotsider.core.analysis.models.graphnodekind
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+What a dependency-graph node represents. Managed graphs contain only assemblies; the
+Native AOT graph adds the binary's native import modules.
+
+```csharp
+public enum GraphNodeKind
+```
+
+## Fields
+
+### Assembly
+
+A managed assembly, identified by its full assembly identity.
+
+**Returns:** [GraphNodeKind](/api/dotsider.core.analysis.models.graphnodekind/)
+
+```csharp
+Assembly = 0
+```
+
+### NativeImport
+
+A native module the binary imports (for example `kernel32.dll`).
+
+**Returns:** [GraphNodeKind](/api/dotsider.core.analysis.models.graphnodekind/)
+
+```csharp
+NativeImport = 1
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatBlob.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatBlob.md
@@ -1,0 +1,69 @@
+---
+title: "MstatBlob"
+description: "One named global data region from an ILC size report — embedded metadata, hydration tables, dispatch maps, and the like. Blob names come from the compiler's node type names (for example Metadata or InterfaceDispatchMap), with same-named regions summed into one entry."
+slug: api/dotsider.core.analysis.models.mstatblob
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+One named global data region from an ILC size report — embedded metadata, hydration
+tables, dispatch maps, and the like. Blob names come from the compiler's node type names
+(for example `Metadata` or `InterfaceDispatchMap`), with same-named regions
+summed into one entry.
+
+```csharp
+public sealed record MstatBlob : IEquatable<MstatBlob>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **MstatBlob**
+
+## Implements
+
+- [IEquatable\<MstatBlob\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### MstatBlob(string, int)
+
+One named global data region from an ILC size report — embedded metadata, hydration
+tables, dispatch maps, and the like. Blob names come from the compiler's node type names
+(for example `Metadata` or `InterfaceDispatchMap`), with same-named regions
+summed into one entry.
+
+**Parameters:**
+
+- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The region name.
+- `Size` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The total size in bytes across all regions with this name.
+
+```csharp
+public MstatBlob(string Name, int Size)
+```
+
+## Properties
+
+### Name
+
+The region name.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Name { get; init; }
+```
+
+### Size
+
+The total size in bytes across all regions with this name.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int Size { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatData.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatData.md
@@ -1,0 +1,157 @@
+---
+title: "MstatData"
+description: "The contents of an ILC size report (.mstat), produced by publishing a Native AOT project with IlcGenerateMstatFile. The file is itself a valid ECMA-335 assembly whose assembly version carries the format version and whose data lives in IL streams; this record is the decoded result. Sections absent from older format versions are empty lists."
+slug: api/dotsider.core.analysis.models.mstatdata
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+The contents of an ILC size report (`.mstat`), produced by publishing a Native AOT
+project with `IlcGenerateMstatFile`. The file is itself a valid ECMA-335 assembly whose
+assembly version carries the format version and whose data lives in IL streams; this record
+is the decoded result. Sections absent from older format versions are empty lists.
+
+```csharp
+public sealed record MstatData : IEquatable<MstatData>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **MstatData**
+
+## Implements
+
+- [IEquatable\<MstatData\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### MstatData(int, int, IReadOnlyList\<AssemblyRefInfo\>, IReadOnlyList\<MstatMethod\>, IReadOnlyList\<MstatType\>, IReadOnlyList\<MstatBlob\>, IReadOnlyList\<MstatRvaField\>, IReadOnlyList\<MstatFrozenObject\>, IReadOnlyList\<MstatManifestResource\>, IReadOnlyList\<MstatDeduplicatedMethod\>)
+
+The contents of an ILC size report (`.mstat`), produced by publishing a Native AOT
+project with `IlcGenerateMstatFile`. The file is itself a valid ECMA-335 assembly whose
+assembly version carries the format version and whose data lives in IL streams; this record
+is the decoded result. Sections absent from older format versions are empty lists.
+
+**Parameters:**
+
+- `FormatMajorVersion` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The format major version (1 = .NET 7, 2 = .NET 8+).
+- `FormatMinorVersion` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The format minor version (2.1 adds RVA field, frozen object, and resource detail; 2.2 adds deduplicated methods).
+- `Assemblies` ([IReadOnlyList\<AssemblyRefInfo\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): The managed assemblies the report references, in AssemblyRef table order.
+- `Methods` ([IReadOnlyList\<MstatMethod\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Every compiled method body with its code, GC info, and EH info sizes.
+- `Types` ([IReadOnlyList\<MstatType\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Every constructed MethodTable with its size.
+- `Blobs` ([IReadOnlyList\<MstatBlob\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Global data regions (metadata, dehydrated data, hydration tables) by name.
+- `RvaFields` ([IReadOnlyList\<MstatRvaField\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Field RVA data entries (format 2.1+); their bytes also appear in Blobs for back-compat.
+- `FrozenObjects` ([IReadOnlyList\<MstatFrozenObject\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Frozen object entries (format 2.1+); their bytes also appear in Blobs for back-compat.
+- `ManifestResources` ([IReadOnlyList\<MstatManifestResource\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Embedded manifest resources (format 2.1+); their bytes also appear in Blobs for back-compat.
+- `DeduplicatedMethods` ([IReadOnlyList\<MstatDeduplicatedMethod\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Method bodies folded into an identical original (format 2.2+).
+
+```csharp
+public MstatData(int FormatMajorVersion, int FormatMinorVersion, IReadOnlyList<AssemblyRefInfo> Assemblies, IReadOnlyList<MstatMethod> Methods, IReadOnlyList<MstatType> Types, IReadOnlyList<MstatBlob> Blobs, IReadOnlyList<MstatRvaField> RvaFields, IReadOnlyList<MstatFrozenObject> FrozenObjects, IReadOnlyList<MstatManifestResource> ManifestResources, IReadOnlyList<MstatDeduplicatedMethod> DeduplicatedMethods)
+```
+
+## Properties
+
+### Assemblies
+
+The managed assemblies the report references, in AssemblyRef table order.
+
+**Returns:** [IReadOnlyList\<AssemblyRefInfo\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<AssemblyRefInfo> Assemblies { get; init; }
+```
+
+### Blobs
+
+Global data regions (metadata, dehydrated data, hydration tables) by name.
+
+**Returns:** [IReadOnlyList\<MstatBlob\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<MstatBlob> Blobs { get; init; }
+```
+
+### DeduplicatedMethods
+
+Method bodies folded into an identical original (format 2.2+).
+
+**Returns:** [IReadOnlyList\<MstatDeduplicatedMethod\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<MstatDeduplicatedMethod> DeduplicatedMethods { get; init; }
+```
+
+### FormatMajorVersion
+
+The format major version (1 = .NET 7, 2 = .NET 8+).
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int FormatMajorVersion { get; init; }
+```
+
+### FormatMinorVersion
+
+The format minor version (2.1 adds RVA field, frozen object, and resource detail; 2.2 adds deduplicated methods).
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int FormatMinorVersion { get; init; }
+```
+
+### FrozenObjects
+
+Frozen object entries (format 2.1+); their bytes also appear in Blobs for back-compat.
+
+**Returns:** [IReadOnlyList\<MstatFrozenObject\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<MstatFrozenObject> FrozenObjects { get; init; }
+```
+
+### ManifestResources
+
+Embedded manifest resources (format 2.1+); their bytes also appear in Blobs for back-compat.
+
+**Returns:** [IReadOnlyList\<MstatManifestResource\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<MstatManifestResource> ManifestResources { get; init; }
+```
+
+### Methods
+
+Every compiled method body with its code, GC info, and EH info sizes.
+
+**Returns:** [IReadOnlyList\<MstatMethod\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<MstatMethod> Methods { get; init; }
+```
+
+### RvaFields
+
+Field RVA data entries (format 2.1+); their bytes also appear in Blobs for back-compat.
+
+**Returns:** [IReadOnlyList\<MstatRvaField\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<MstatRvaField> RvaFields { get; init; }
+```
+
+### Types
+
+Every constructed MethodTable with its size.
+
+**Returns:** [IReadOnlyList\<MstatType\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<MstatType> Types { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatDeduplicatedMethod.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatDeduplicatedMethod.md
@@ -1,0 +1,65 @@
+---
+title: "MstatDeduplicatedMethod"
+description: "One method-body fold from an ILC size report (format 2.2+): the compiler emitted a single body and pointed these identical methods at it, so only the original contributes size."
+slug: api/dotsider.core.analysis.models.mstatdeduplicatedmethod
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+One method-body fold from an ILC size report (format 2.2+): the compiler emitted a single
+body and pointed these identical methods at it, so only the original contributes size.
+
+```csharp
+public sealed record MstatDeduplicatedMethod : IEquatable<MstatDeduplicatedMethod>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **MstatDeduplicatedMethod**
+
+## Implements
+
+- [IEquatable\<MstatDeduplicatedMethod\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### MstatDeduplicatedMethod(string, IReadOnlyList\<string\>)
+
+One method-body fold from an ILC size report (format 2.2+): the compiler emitted a single
+body and pointed these identical methods at it, so only the original contributes size.
+
+**Parameters:**
+
+- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The original method's display name, including its declaring type.
+- `TargetNames` ([IReadOnlyList\<String\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): The dependency-graph node names of the methods folded into the original.
+
+```csharp
+public MstatDeduplicatedMethod(string Name, IReadOnlyList<string> TargetNames)
+```
+
+## Properties
+
+### Name
+
+The original method's display name, including its declaring type.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Name { get; init; }
+```
+
+### TargetNames
+
+The dependency-graph node names of the methods folded into the original.
+
+**Returns:** [IReadOnlyList\<String\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<string> TargetNames { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatFrozenObject.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatFrozenObject.md
@@ -1,0 +1,102 @@
+---
+title: "MstatFrozenObject"
+description: "One frozen object from an ILC size report (format 2.1+) — an object allocated at compile time and baked into the image, most commonly a string literal. For back-compat these bytes are also summed into the ArrayOfFrozenObjects blob entry."
+slug: api/dotsider.core.analysis.models.mstatfrozenobject
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+One frozen object from an ILC size report (format 2.1+) — an object allocated at compile
+time and baked into the image, most commonly a string literal. For back-compat these bytes
+are also summed into the `ArrayOfFrozenObjects` blob entry.
+
+```csharp
+public sealed record MstatFrozenObject : IEquatable<MstatFrozenObject>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **MstatFrozenObject**
+
+## Implements
+
+- [IEquatable\<MstatFrozenObject\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### MstatFrozenObject(string, string, int, string?, string?)
+
+One frozen object from an ILC size report (format 2.1+) — an object allocated at compile
+time and baked into the image, most commonly a string literal. For back-compat these bytes
+are also summed into the `ArrayOfFrozenObjects` blob entry.
+
+**Parameters:**
+
+- `TypeName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The frozen object's type display name (for example `System.String`).
+- `AssemblyName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The simple name of the assembly that defines the object's type.
+- `Size` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The object size in bytes, including its object header.
+- `NodeName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The compiler's dependency-graph node name; joins to the DGML node `Label`.
+- `OwningType` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The type whose static data serialized this object, or null when the object is not a
+serialized static (string literals report null).
+
+```csharp
+public MstatFrozenObject(string TypeName, string AssemblyName, int Size, string? NodeName, string? OwningType)
+```
+
+## Properties
+
+### AssemblyName
+
+The simple name of the assembly that defines the object's type.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string AssemblyName { get; init; }
+```
+
+### NodeName
+
+The compiler's dependency-graph node name; joins to the DGML node `Label`.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? NodeName { get; init; }
+```
+
+### OwningType
+
+The type whose static data serialized this object, or null when the object is not a
+serialized static (string literals report null).
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? OwningType { get; init; }
+```
+
+### Size
+
+The object size in bytes, including its object header.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int Size { get; init; }
+```
+
+### TypeName
+
+The frozen object's type display name (for example `System.String`).
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string TypeName { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatManifestResource.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatManifestResource.md
@@ -1,0 +1,76 @@
+---
+title: "MstatManifestResource"
+description: "One embedded manifest resource from an ILC size report (format 2.1+). For back-compat these bytes are also summed into the ResourceData blob entry."
+slug: api/dotsider.core.analysis.models.mstatmanifestresource
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+One embedded manifest resource from an ILC size report (format 2.1+). For back-compat
+these bytes are also summed into the `ResourceData` blob entry.
+
+```csharp
+public sealed record MstatManifestResource : IEquatable<MstatManifestResource>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **MstatManifestResource**
+
+## Implements
+
+- [IEquatable\<MstatManifestResource\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### MstatManifestResource(string, string, int)
+
+One embedded manifest resource from an ILC size report (format 2.1+). For back-compat
+these bytes are also summed into the `ResourceData` blob entry.
+
+**Parameters:**
+
+- `AssemblyName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The simple name of the assembly the resource was embedded in.
+- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The resource name.
+- `Size` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The resource size in bytes.
+
+```csharp
+public MstatManifestResource(string AssemblyName, string Name, int Size)
+```
+
+## Properties
+
+### AssemblyName
+
+The simple name of the assembly the resource was embedded in.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string AssemblyName { get; init; }
+```
+
+### Name
+
+The resource name.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Name { get; init; }
+```
+
+### Size
+
+The resource size in bytes.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int Size { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatMethod.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatMethod.md
@@ -1,0 +1,137 @@
+---
+title: "MstatMethod"
+description: "One compiled method body from an ILC size report. Sizes are bytes of native artifact, not IL: ILC compiles each body once, so the sum over all methods is the code contribution to the binary."
+slug: api/dotsider.core.analysis.models.mstatmethod
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+One compiled method body from an ILC size report. Sizes are bytes of native artifact, not
+IL: ILC compiles each body once, so the sum over all methods is the code contribution to
+the binary.
+
+```csharp
+public sealed record MstatMethod : IEquatable<MstatMethod>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **MstatMethod**
+
+## Implements
+
+- [IEquatable\<MstatMethod\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### MstatMethod(string, string, string, string, int, int, int, string?)
+
+One compiled method body from an ILC size report. Sizes are bytes of native artifact, not
+IL: ILC compiles each body once, so the sum over all methods is the code contribution to
+the binary.
+
+**Parameters:**
+
+- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The method name, with generic arguments rendered when instantiated.
+- `DeclaringType` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The declaring type's display name, including namespace.
+- `Namespace` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The declaring type's namespace, or an empty string for the global namespace.
+- `AssemblyName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The simple name of the assembly the method was compiled from.
+- `Size` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The native code size in bytes.
+- `GcInfoSize` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The GC info size in bytes.
+- `EhInfoSize` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The exception-handling info size in bytes, or 0 when the method has none.
+- `NodeName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The compiler's dependency-graph node name (format 2.0+), or null in 1.x reports. The same
+string appears as the node `Label` in the DGML graphs `IlcGenerateDgmlFile` emits,
+which is how a size entry joins to its dependency chain.
+
+```csharp
+public MstatMethod(string Name, string DeclaringType, string Namespace, string AssemblyName, int Size, int GcInfoSize, int EhInfoSize, string? NodeName)
+```
+
+## Properties
+
+### AssemblyName
+
+The simple name of the assembly the method was compiled from.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string AssemblyName { get; init; }
+```
+
+### DeclaringType
+
+The declaring type's display name, including namespace.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string DeclaringType { get; init; }
+```
+
+### EhInfoSize
+
+The exception-handling info size in bytes, or 0 when the method has none.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int EhInfoSize { get; init; }
+```
+
+### GcInfoSize
+
+The GC info size in bytes.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int GcInfoSize { get; init; }
+```
+
+### Name
+
+The method name, with generic arguments rendered when instantiated.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Name { get; init; }
+```
+
+### Namespace
+
+The declaring type's namespace, or an empty string for the global namespace.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Namespace { get; init; }
+```
+
+### NodeName
+
+The compiler's dependency-graph node name (format 2.0+), or null in 1.x reports. The same
+string appears as the node `Label` in the DGML graphs `IlcGenerateDgmlFile` emits,
+which is how a size entry joins to its dependency chain.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? NodeName { get; init; }
+```
+
+### Size
+
+The native code size in bytes.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int Size { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatRvaField.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatRvaField.md
@@ -1,0 +1,91 @@
+---
+title: "MstatRvaField"
+description: "One field-RVA data entry from an ILC size report (format 2.1+) — the initial data of a field mapped directly into the image, typically compiler-generated arrays behind collection expressions and ReadOnlySpan literals. For back-compat these bytes are also summed into the FieldRvaData blob entry."
+slug: api/dotsider.core.analysis.models.mstatrvafield
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+One field-RVA data entry from an ILC size report (format 2.1+) — the initial data of a
+field mapped directly into the image, typically compiler-generated arrays behind
+collection expressions and `ReadOnlySpan` literals. For back-compat these bytes are
+also summed into the `FieldRvaData` blob entry.
+
+```csharp
+public sealed record MstatRvaField : IEquatable<MstatRvaField>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **MstatRvaField**
+
+## Implements
+
+- [IEquatable\<MstatRvaField\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### MstatRvaField(string, string, int, string?)
+
+One field-RVA data entry from an ILC size report (format 2.1+) — the initial data of a
+field mapped directly into the image, typically compiler-generated arrays behind
+collection expressions and `ReadOnlySpan` literals. For back-compat these bytes are
+also summed into the `FieldRvaData` blob entry.
+
+**Parameters:**
+
+- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The field's display name, including its declaring type.
+- `AssemblyName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The simple name of the assembly that defines the field.
+- `Size` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The RVA data size in bytes.
+- `NodeName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The compiler's dependency-graph node name; joins to the DGML node `Label`.
+
+```csharp
+public MstatRvaField(string Name, string AssemblyName, int Size, string? NodeName)
+```
+
+## Properties
+
+### AssemblyName
+
+The simple name of the assembly that defines the field.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string AssemblyName { get; init; }
+```
+
+### Name
+
+The field's display name, including its declaring type.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Name { get; init; }
+```
+
+### NodeName
+
+The compiler's dependency-graph node name; joins to the DGML node `Label`.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? NodeName { get; init; }
+```
+
+### Size
+
+The RVA data size in bytes.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int Size { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatType.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-MstatType.md
@@ -1,0 +1,100 @@
+---
+title: "MstatType"
+description: "One constructed type from an ILC size report. The size is the type's MethodTable data — the runtime type structure — not the code of its methods, which is reported per method."
+slug: api/dotsider.core.analysis.models.mstattype
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+One constructed type from an ILC size report. The size is the type's MethodTable data —
+the runtime type structure — not the code of its methods, which is reported per method.
+
+```csharp
+public sealed record MstatType : IEquatable<MstatType>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **MstatType**
+
+## Implements
+
+- [IEquatable\<MstatType\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### MstatType(string, string, string, int, string?)
+
+One constructed type from an ILC size report. The size is the type's MethodTable data —
+the runtime type structure — not the code of its methods, which is reported per method.
+
+**Parameters:**
+
+- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The type's display name, with generic arguments rendered when instantiated.
+- `Namespace` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The type's namespace, or an empty string for the global namespace.
+- `AssemblyName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The simple name of the assembly that defines the type.
+- `Size` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32)): The MethodTable size in bytes.
+- `NodeName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The compiler's dependency-graph node name (format 2.0+), or null in 1.x reports; joins to
+the DGML node `Label`.
+
+```csharp
+public MstatType(string Name, string Namespace, string AssemblyName, int Size, string? NodeName)
+```
+
+## Properties
+
+### AssemblyName
+
+The simple name of the assembly that defines the type.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string AssemblyName { get; init; }
+```
+
+### Name
+
+The type's display name, with generic arguments rendered when instantiated.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Name { get; init; }
+```
+
+### Namespace
+
+The type's namespace, or an empty string for the global namespace.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Namespace { get; init; }
+```
+
+### NodeName
+
+The compiler's dependency-graph node name (format 2.0+), or null in 1.x reports; joins to
+the DGML node `Label`.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? NodeName { get; init; }
+```
+
+### Size
+
+The MethodTable size in bytes.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public int Size { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SizeNode.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SizeNode.md
@@ -1,6 +1,6 @@
 ---
 title: "SizeNode"
-description: "A node in the size treemap hierarchy. Can be assembly, namespace, type, or method."
+description: "A node in the size treemap hierarchy. Can be assembly, namespace, type, or method — or, for Native AOT trees, a data category and its entries."
 slug: api/dotsider.core.analysis.models.sizenode
 sidebar:
   order: 1
@@ -10,7 +10,8 @@ sidebar:
 
 **Assembly:** Dotsider.Core.dll
 
-A node in the size treemap hierarchy. Can be assembly, namespace, type, or method.
+A node in the size treemap hierarchy. Can be assembly, namespace, type, or method — or,
+for Native AOT trees, a data category and its entries.
 
 ```csharp
 public sealed record SizeNode : IEquatable<SizeNode>
@@ -26,9 +27,10 @@ public sealed record SizeNode : IEquatable<SizeNode>
 
 ## Constructors
 
-### SizeNode(string, string, long, SizeNodeKind, IReadOnlyList\<SizeNode\>)
+### SizeNode(string, string, long, SizeNodeKind, IReadOnlyList\<SizeNode\>, string?)
 
-A node in the size treemap hierarchy. Can be assembly, namespace, type, or method.
+A node in the size treemap hierarchy. Can be assembly, namespace, type, or method — or,
+for Native AOT trees, a data category and its entries.
 
 **Parameters:**
 
@@ -37,12 +39,27 @@ A node in the size treemap hierarchy. Can be assembly, namespace, type, or metho
 - `Size` ([Int64](https://learn.microsoft.com/dotnet/api/system.int64)): Size in bytes attributed to this node.
 - `Kind` ([SizeNodeKind](/api/dotsider.core.analysis.models.sizenodekind/)): The granularity level of this node.
 - `Children` ([IReadOnlyList\<SizeNode\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Child nodes in the hierarchy.
+- `AotNodeName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The ILC dependency-graph node name behind this entry, or null outside Native AOT trees.
+The name matches a DGML node label, which is what makes "why is this in my binary"
+answerable for the node.
 
 ```csharp
-public SizeNode(string Name, string FullPath, long Size, SizeNodeKind Kind, IReadOnlyList<SizeNode> Children)
+public SizeNode(string Name, string FullPath, long Size, SizeNodeKind Kind, IReadOnlyList<SizeNode> Children, string? AotNodeName = null)
 ```
 
 ## Properties
+
+### AotNodeName
+
+The ILC dependency-graph node name behind this entry, or null outside Native AOT trees.
+The name matches a DGML node label, which is what makes "why is this in my binary"
+answerable for the node.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? AotNodeName { get; init; }
+```
 
 ### Children
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SizeNodeKind.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SizeNodeKind.md
@@ -1,6 +1,6 @@
 ---
 title: "SizeNodeKind"
-description: "The granularity level of a SizeNode in the size breakdown tree."
+description: "The granularity level of a SizeNode in the size breakdown tree. The kinds beyond Method appear only in Native AOT trees built from an mstat report."
 slug: api/dotsider.core.analysis.models.sizenodekind
 sidebar:
   order: 1
@@ -10,7 +10,8 @@ sidebar:
 
 **Assembly:** Dotsider.Core.dll
 
-The granularity level of a [SizeNode](/api/dotsider.core.analysis.models.sizenode/) in the size breakdown tree.
+The granularity level of a [SizeNode](/api/dotsider.core.analysis.models.sizenode/) in the size breakdown tree. The kinds
+beyond [Method](/api/dotsider.core.analysis.models.sizenodekind.method/) appear only in Native AOT trees built from an mstat report.
 
 ```csharp
 public enum SizeNodeKind
@@ -28,6 +29,36 @@ Root node representing an entire assembly.
 Assembly = 0
 ```
 
+### Blob
+
+A named global data region of a Native AOT binary.
+
+**Returns:** [SizeNodeKind](/api/dotsider.core.analysis.models.sizenodekind/)
+
+```csharp
+Blob = 5
+```
+
+### Category
+
+Grouping node for a Native AOT data category (blobs, frozen objects, and the like).
+
+**Returns:** [SizeNodeKind](/api/dotsider.core.analysis.models.sizenodekind/)
+
+```csharp
+Category = 4
+```
+
+### FrozenObject
+
+An object frozen into a Native AOT binary at compile time.
+
+**Returns:** [SizeNodeKind](/api/dotsider.core.analysis.models.sizenodekind/)
+
+```csharp
+FrozenObject = 7
+```
+
 ### Method
 
 Node representing a method within a type.
@@ -38,6 +69,16 @@ Node representing a method within a type.
 Method = 3
 ```
 
+### MethodTable
+
+A type's runtime MethodTable data in a Native AOT binary.
+
+**Returns:** [SizeNodeKind](/api/dotsider.core.analysis.models.sizenodekind/)
+
+```csharp
+MethodTable = 6
+```
+
 ### Namespace
 
 Node representing a namespace within an assembly.
@@ -46,6 +87,26 @@ Node representing a namespace within an assembly.
 
 ```csharp
 Namespace = 1
+```
+
+### Resource
+
+A manifest resource embedded in a Native AOT binary.
+
+**Returns:** [SizeNodeKind](/api/dotsider.core.analysis.models.sizenodekind/)
+
+```csharp
+Resource = 9
+```
+
+### RvaField
+
+A field's RVA data mapped into a Native AOT binary.
+
+**Returns:** [SizeNodeKind](/api/dotsider.core.analysis.models.sizenodekind/)
+
+```csharp
+RvaField = 8
 ```
 
 ### Type

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models.md
@@ -194,6 +194,44 @@ metadata consumed by the TUI ([NavigationById](/api/dotsider.core.analysis.model
 public sealed record DependencyGraphResult : IEquatable<DependencyGraphResult>
 ```
 
+### [DgmlGraph](/api/dotsider.core.analysis.models.dgmlgraph/)
+
+An ILC dependency graph read from a DGML file, with the reverse index needed to answer
+"why is this in my binary": a breadth-first walk from any node toward its dependers ends
+at a root — a node nothing depends on — and the chain back down is the explanation.
+
+```csharp
+public sealed class DgmlGraph
+```
+
+### [DgmlLink](/api/dotsider.core.analysis.models.dgmllink/)
+
+One edge of an ILC dependency graph: the source node depends on the target node, so the
+target is in the binary because the source needed it.
+
+```csharp
+public sealed record DgmlLink : IEquatable<DgmlLink>
+```
+
+### [DgmlNode](/api/dotsider.core.analysis.models.dgmlnode/)
+
+One node of an ILC dependency graph. The label is the compiler's node name — the same
+string an mstat size entry stores as its `NodeName`, which is how the two files join.
+
+```csharp
+public sealed record DgmlNode : IEquatable<DgmlNode>
+```
+
+### [DgmlPathStep](/api/dotsider.core.analysis.models.dgmlpathstep/)
+
+One step of a root-to-node dependency chain — the answer to "why is this in my binary,"
+read top-down: the root kept the second step, which kept the third, and so on to the node
+that was asked about.
+
+```csharp
+public sealed record DgmlPathStep : IEquatable<DgmlPathStep>
+```
+
 ### [DiffEntry\<T\>](/api/dotsider.core.analysis.models.diffentry-1/)
 
 A single diff entry wrapping an item from either side.
@@ -424,6 +462,86 @@ Information about a method defined in the assembly's MethodDef metadata table.
 public sealed record MethodDefInfo : IEquatable<MethodDefInfo>
 ```
 
+### [MstatBlob](/api/dotsider.core.analysis.models.mstatblob/)
+
+One named global data region from an ILC size report — embedded metadata, hydration
+tables, dispatch maps, and the like. Blob names come from the compiler's node type names
+(for example `Metadata` or `InterfaceDispatchMap`), with same-named regions
+summed into one entry.
+
+```csharp
+public sealed record MstatBlob : IEquatable<MstatBlob>
+```
+
+### [MstatData](/api/dotsider.core.analysis.models.mstatdata/)
+
+The contents of an ILC size report (`.mstat`), produced by publishing a Native AOT
+project with `IlcGenerateMstatFile`. The file is itself a valid ECMA-335 assembly whose
+assembly version carries the format version and whose data lives in IL streams; this record
+is the decoded result. Sections absent from older format versions are empty lists.
+
+```csharp
+public sealed record MstatData : IEquatable<MstatData>
+```
+
+### [MstatDeduplicatedMethod](/api/dotsider.core.analysis.models.mstatdeduplicatedmethod/)
+
+One method-body fold from an ILC size report (format 2.2+): the compiler emitted a single
+body and pointed these identical methods at it, so only the original contributes size.
+
+```csharp
+public sealed record MstatDeduplicatedMethod : IEquatable<MstatDeduplicatedMethod>
+```
+
+### [MstatFrozenObject](/api/dotsider.core.analysis.models.mstatfrozenobject/)
+
+One frozen object from an ILC size report (format 2.1+) — an object allocated at compile
+time and baked into the image, most commonly a string literal. For back-compat these bytes
+are also summed into the `ArrayOfFrozenObjects` blob entry.
+
+```csharp
+public sealed record MstatFrozenObject : IEquatable<MstatFrozenObject>
+```
+
+### [MstatManifestResource](/api/dotsider.core.analysis.models.mstatmanifestresource/)
+
+One embedded manifest resource from an ILC size report (format 2.1+). For back-compat
+these bytes are also summed into the `ResourceData` blob entry.
+
+```csharp
+public sealed record MstatManifestResource : IEquatable<MstatManifestResource>
+```
+
+### [MstatMethod](/api/dotsider.core.analysis.models.mstatmethod/)
+
+One compiled method body from an ILC size report. Sizes are bytes of native artifact, not
+IL: ILC compiles each body once, so the sum over all methods is the code contribution to
+the binary.
+
+```csharp
+public sealed record MstatMethod : IEquatable<MstatMethod>
+```
+
+### [MstatRvaField](/api/dotsider.core.analysis.models.mstatrvafield/)
+
+One field-RVA data entry from an ILC size report (format 2.1+) — the initial data of a
+field mapped directly into the image, typically compiler-generated arrays behind
+collection expressions and `ReadOnlySpan` literals. For back-compat these bytes are
+also summed into the `FieldRvaData` blob entry.
+
+```csharp
+public sealed record MstatRvaField : IEquatable<MstatRvaField>
+```
+
+### [MstatType](/api/dotsider.core.analysis.models.mstattype/)
+
+One constructed type from an ILC size report. The size is the type's MethodTable data —
+the runtime type structure — not the code of its methods, which is reported per method.
+
+```csharp
+public sealed record MstatType : IEquatable<MstatType>
+```
+
 ### [NativeAotInfo](/api/dotsider.core.analysis.models.nativeaotinfo/)
 
 Facts extracted from the embedded ReadyToRun header of a Native AOT binary.
@@ -559,7 +677,8 @@ public sealed record SequencePointInfo : IEquatable<SequencePointInfo>
 
 ### [SizeNode](/api/dotsider.core.analysis.models.sizenode/)
 
-A node in the size treemap hierarchy. Can be assembly, namespace, type, or method.
+A node in the size treemap hierarchy. Can be assembly, namespace, type, or method — or,
+for Native AOT trees, a data category and its entries.
 
 ```csharp
 public sealed record SizeNode : IEquatable<SizeNode>
@@ -655,6 +774,15 @@ Describes the kind of difference detected between two assembly elements.
 public enum DiffKind
 ```
 
+### [GraphNodeKind](/api/dotsider.core.analysis.models.graphnodekind/)
+
+What a dependency-graph node represents. Managed graphs contain only assemblies; the
+Native AOT graph adds the binary's native import modules.
+
+```csharp
+public enum GraphNodeKind
+```
+
 ### [MemberRefKind](/api/dotsider.core.analysis.models.memberrefkind/)
 
 Distinguishes whether a MemberRef entry refers to a method or a field.
@@ -708,7 +836,8 @@ public enum PolicyLayer
 
 ### [SizeNodeKind](/api/dotsider.core.analysis.models.sizenodekind/)
 
-The granularity level of a [SizeNode](/api/dotsider.core.analysis.models.sizenode/) in the size breakdown tree.
+The granularity level of a [SizeNode](/api/dotsider.core.analysis.models.sizenode/) in the size breakdown tree. The kinds
+beyond [Method](/api/dotsider.core.analysis.models.sizenodekind.method/) appear only in Native AOT trees built from an mstat report.
 
 ```csharp
 public enum SizeNodeKind

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-MstatReader.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-MstatReader.md
@@ -1,0 +1,66 @@
+---
+title: "MstatReader"
+description: "Reads an ILC size report (.mstat), the file IlcGenerateMstatFile emits when publishing a Native AOT project. The report is itself a valid ECMA-335 assembly: its assembly version carries the format version, and its data is encoded as IL instruction streams in global methods named Methods, Types, Blobs, and (in newer formats) RvaFields, FrozenObjects, ManifestResources, and DeduplicatedMethods. Format 2.0+ also stores each entry's dependency-graph node name in a custom .names PE section; those names equal the node labels in the DGML graphs IlcGenerateDgmlFile emits, which is how sizes join to dependency chains. Malformed input never throws: unreadable files return null, and a truncated IL stream yields the entries parsed before the damage."
+slug: api/dotsider.core.analysis.mstatreader
+sidebar:
+  order: 0
+---
+
+**Namespace:** `Dotsider.Core.Analysis`
+
+**Assembly:** Dotsider.Core.dll
+
+Reads an ILC size report (`.mstat`), the file `IlcGenerateMstatFile` emits when
+publishing a Native AOT project. The report is itself a valid ECMA-335 assembly: its
+assembly version carries the format version, and its data is encoded as IL instruction
+streams in global methods named `Methods`, `Types`, `Blobs`, and (in newer
+formats) `RvaFields`, `FrozenObjects`, `ManifestResources`, and
+`DeduplicatedMethods`. Format 2.0+ also stores each entry's dependency-graph node name
+in a custom `.names` PE section; those names equal the node labels in the DGML graphs
+`IlcGenerateDgmlFile` emits, which is how sizes join to dependency chains.
+
+Malformed input never throws: unreadable files return null, and a truncated IL stream
+yields the entries parsed before the damage.
+
+```csharp
+public static class MstatReader
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **MstatReader**
+
+## Methods
+
+### Read(Stream)
+
+Reads an ILC size report from a stream. The stream is left open.
+
+**Parameters:**
+
+- `stream` ([Stream](https://learn.microsoft.com/dotnet/api/system.io.stream)): A readable, seekable stream positioned at the start of the file.
+
+**Returns:** [MstatData](/api/dotsider.core.analysis.models.mstatdata/)
+
+The decoded report, or null when the content is not an mstat.
+
+```csharp
+public static MstatData? Read(Stream stream)
+```
+
+### Read(string)
+
+Reads an ILC size report from a file.
+
+**Parameters:**
+
+- `filePath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The path of the `.mstat` file.
+
+**Returns:** [MstatData](/api/dotsider.core.analysis.models.mstatdata/)
+
+The decoded report, or null when the file is missing or is not an mstat.
+
+```csharp
+public static MstatData? Read(string filePath)
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-SizeAnalyzer.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-SizeAnalyzer.md
@@ -1,6 +1,6 @@
 ---
 title: "SizeAnalyzer"
-description: "Computes IL code size per method and builds a hierarchical size tree for treemap visualization."
+description: "Computes IL code size per method and builds a hierarchical size tree for treemap visualization. For a Native AOT binary with an mstat sidecar the tree is built from the compiler's size report instead: native code and MethodTable bytes per assembly, namespace, type, and method, plus the binary's data categories."
 slug: api/dotsider.core.analysis.sizeanalyzer
 sidebar:
   order: 0
@@ -11,7 +11,9 @@ sidebar:
 **Assembly:** Dotsider.Core.dll
 
 Computes IL code size per method and builds a hierarchical size tree
-for treemap visualization.
+for treemap visualization. For a Native AOT binary with an mstat sidecar the tree is
+built from the compiler's size report instead: native code and MethodTable bytes per
+assembly, namespace, type, and method, plus the binary's data categories.
 
 ```csharp
 public static class SizeAnalyzer

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis.md
@@ -70,6 +70,21 @@ public topology plus internal navigation metadata consumed only by the TUI.
 public static class DependencyGraphBuilder
 ```
 
+### [DgmlReader](/api/dotsider.core.analysis.dgmlreader/)
+
+Reads an ILC dependency-graph DGML file, emitted when publishing a Native AOT project with
+`IlcGenerateDgmlFile`. The format is a `DirectedGraph` document of nodes (id and
+label) and links (source depends on target, with a reason). Node labels equal the node
+names an mstat size report stores ([MstatReader](/api/dotsider.core.analysis.mstatreader/)), which is how sizes join to
+dependency chains.
+
+Parsing streams the XML — the graphs run to hundreds of thousands of links — and never
+throws: unreadable files return null, and malformed nodes or links are skipped.
+
+```csharp
+public static class DgmlReader
+```
+
 ### [DotNetRuntimeLocator](/api/dotsider.core.analysis.dotnetruntimelocator/)
 
 Discovers system .NET installations and resolves shared framework assembly paths.
@@ -102,6 +117,24 @@ assemblies (e.g., System.Private.CoreLib) by probing for type forwarding.
 
 ```csharp
 public static class ImplementationAssemblyResolver
+```
+
+### [MstatReader](/api/dotsider.core.analysis.mstatreader/)
+
+Reads an ILC size report (`.mstat`), the file `IlcGenerateMstatFile` emits when
+publishing a Native AOT project. The report is itself a valid ECMA-335 assembly: its
+assembly version carries the format version, and its data is encoded as IL instruction
+streams in global methods named `Methods`, `Types`, `Blobs`, and (in newer
+formats) `RvaFields`, `FrozenObjects`, `ManifestResources`, and
+`DeduplicatedMethods`. Format 2.0+ also stores each entry's dependency-graph node name
+in a custom `.names` PE section; those names equal the node labels in the DGML graphs
+`IlcGenerateDgmlFile` emits, which is how sizes join to dependency chains.
+
+Malformed input never throws: unreadable files return null, and a truncated IL stream
+yields the entries parsed before the damage.
+
+```csharp
+public static class MstatReader
 ```
 
 ### [NativeAotDetector](/api/dotsider.core.analysis.nativeaotdetector/)
@@ -173,7 +206,9 @@ public static class SingleFileBundleReader
 ### [SizeAnalyzer](/api/dotsider.core.analysis.sizeanalyzer/)
 
 Computes IL code size per method and builds a hierarchical size tree
-for treemap visualization.
+for treemap visualization. For a Native AOT binary with an mstat sidecar the tree is
+built from the compiler's size report instead: native code and MethodTable bytes per
+assembly, namespace, type, and method, plus the binary's data categories.
 
 ```csharp
 public static class SizeAnalyzer

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -44,11 +44,14 @@ dotsider analyze MyLib.dll --types -o out.txt # write to file
 dotsider analyze MyApp.exe                    # apphost .exe → auto-redirects to MyApp.dll
 dotsider analyze MyApp                        # single-file bundle → extracts entry assembly
 dotsider analyze MyAotApp.exe                 # Native AOT → binary kind, RTR format, imports
+dotsider analyze MyAotApp.exe --why System.Text.Json.JsonSerializer  # AOT dependency chain
 ```
 
 If the file is a native apphost with a companion `.dll`, `analyze` auto-redirects. If it's a self-contained single-file bundle, `analyze` extracts the entry assembly from the bundle. Both cases print a note to stderr.
 
 If the file is a Native AOT executable (a validated ReadyToRun header with no CLR metadata), the default output adds `Kind`, `RTR Format`, `Runtime`, `Imports`, `R2R`, `Recovered`, and `Frozen` lines, and JSON output gains `binaryKind`, `nativeAotInfo`, `readyToRunSections`, `recoveredTypeCount`, and `frozenStringCount`. `--types` falls back to the types recovered from the embedded metadata, `--strings` adds the raw ASCII and UTF-16 scans plus the frozen string literals, since AOT binaries have no metadata string heaps.
+
+With the ILC sidecars next to the binary (publish with `IlcGenerateMstatFile` and `IlcGenerateDgmlFile`, then copy the `.mstat` and `.codegen.dgml.xml` out of `obj/.../native/`), `--size` prints the compiler's own per-assembly breakdown with the binary's data categories, `--deps` shows the compiled-in assemblies and native import modules, and `--why <name>` prints the dependency chain that kept a type or method in the binary — root first, one step per line with the compiler's reason. Names match exactly first, then by unambiguous substring.
 
 When portable PDB data is available, default output reports where it came from, and `--il` includes source spans, local names, and Source Link markers. Use `--json` when you need the exact URLs. `--embedded-source` prints source embedded in the PDB.
 
@@ -63,6 +66,7 @@ When portable PDB data is available, default output reports where it came from, 
 | `-n`, `--min-len <n>` | Minimum length for raw string extraction (default: 4) |
 | `--fields` | List field definitions |
 | `--size` | Show size breakdown |
+| `--why <name>` | Explain why a type or method is in a Native AOT binary |
 | `--bundle` | Show single-file bundle manifest |
 | `--json` | Output as JSON |
 | `-o`, `--output <file>` | Write output to a file |

--- a/docs/src/content/docs/reference/keyboard.md
+++ b/docs/src/content/docs/reference/keyboard.md
@@ -41,6 +41,16 @@ description: All keyboard shortcuts for navigating dotsider.
 | `u` | Copy Source Link URL from a `[source link]` marker |
 | `l` | Focus the IL disassembly editor |
 
+## Size Map tab
+
+| Key | Action |
+|-----|--------|
+| `←` / `→` | Move selection across the current level |
+| `Enter` / click | Drill into a region; on a managed method leaf, jump to its IL |
+| `Esc` / right-click | Go up one level |
+| `w` | Why is this in the binary — dependency chain popup (Native AOT with DGML sidecar) |
+| `s` | Toggle size formatting |
+
 ## Hex Dump tab — Normal mode
 
 | Key | Action |

--- a/docs/src/content/docs/usage/dep-graph.md
+++ b/docs/src/content/docs/usage/dep-graph.md
@@ -18,6 +18,12 @@ Identity is keyed on the full `(name, version, culture, public key token)` tuple
 
 References that cannot be located on disk or inside a bundle render as leaf nodes prefixed with `?`. When a probe produces a file whose simple name matches but whose manifest identity does not, the node renders with a `!` prefix and the graph does not expand from the mismatched file — the closure stays honest about what it actually contains. A `↪` prefix marks a node where binding policy rewrote the requested version; a `×` prefix marks a configured `<codeBase>` whose `href` does not exist on disk.
 
+## Native AOT binaries
+
+ILC folds every managed assembly into the image, so a Native AOT binary carries no AssemblyRef table to walk. With the mstat and DGML sidecars next to the binary (see [Size Map](/usage/size-map/#native-aot-binaries) for the publish properties), the graph shows what the compiler saw instead: one node per compiled-in assembly, edges aggregated from the compiler's dependency graph and weighted by how many dependencies cross each assembly pair, and the binary's native import modules (`kernel32.dll` and friends) at depth 1 weighted by imported function count.
+
+Assembly nodes keep their full identity, so `f` filters framework assemblies as usual. `Enter` explains that the assembly was compiled into the native image — there is no separate file to open. Without sidecars the graph shows the root plus its native imports, the only dependency facts the binary itself records.
+
 ## .NET Framework targets
 
 For a .NET Framework root, resolution walks the framework binder rather than the .NET Core probe chain: framework unification, `app.config` and `machine.config` `<bindingRedirect>` entries, publisher-policy assemblies in the GAC, the GAC itself, the framework runtime directory, configured `<codeBase>` hrefs, then the application base and `<probing privatePath>`. Nodes are keyed on the bound identity, so two upstream references at different versions that both redirect to the same loaded version collapse onto a single node.

--- a/docs/src/content/docs/usage/size-map.md
+++ b/docs/src/content/docs/usage/size-map.md
@@ -17,3 +17,16 @@ The **Size Map** tab (`7`) shows a treemap of IL code size:
 Click or press `Enter` on any region to drill into it. When you reach a method leaf, pressing `Enter` jumps to its IL disassembly in tab 3.
 
 This is useful for finding unexpectedly large methods or identifying which parts of your codebase contribute the most to assembly size.
+
+## Native AOT binaries
+
+For a Native AOT binary the treemap is built from the compiler's own size report instead of IL. Publish with two properties and copy the outputs next to the executable — ILC writes them to the native intermediate directory (`obj/.../native/`), not the publish folder:
+
+```xml
+<IlcGenerateMstatFile>true</IlcGenerateMstatFile>
+<IlcGenerateDgmlFile>true</IlcGenerateDgmlFile>
+```
+
+With the `.mstat` beside the binary the tree shows every assembly ILC compiled in, drilling through namespaces and types to native method sizes (code plus GC and exception info). Each type carries an explicit `MethodTable` leaf for its runtime type structure, and category regions sit beside the assemblies: `Blobs` for global data like embedded metadata and dispatch maps, `Frozen Objects` for compile-time allocated objects (mostly string literals), `RVA Fields` for data mapped straight into the image, and `Resources` for embedded manifest resources.
+
+With the `.codegen.dgml.xml` beside the binary too, press `w` on any method, type, or frozen object to see why it is in the binary: the chain of dependencies from a root down to the node, each step annotated with the compiler's reason. `Esc` dismisses the chain.

--- a/samples/NativeAotConsole/NativeAotConsole.csproj
+++ b/samples/NativeAotConsole/NativeAotConsole.csproj
@@ -6,7 +6,23 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <PublishAot>true</PublishAot>
+    <IlcGenerateMstatFile>true</IlcGenerateMstatFile>
+    <IlcGenerateDgmlFile>true</IlcGenerateDgmlFile>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <!-- ILC writes the size report and dependency graphs to the native intermediate
+       directory; copy them next to the published binary so sidecar probing finds them.
+       Each copy is Exists-guarded: an SDK that stops producing a file degrades to
+       "sidecar absent" rather than a failed publish. -->
+  <Target Name="CopyAotSidecarsToPublish" AfterTargets="Publish">
+    <ItemGroup>
+      <_AotSidecar Include="$(NativeIntermediateOutputPath)$(TargetName).mstat" />
+      <_AotSidecar Include="$(NativeIntermediateOutputPath)$(TargetName).codegen.dgml.xml" />
+      <_AotSidecar Include="$(NativeIntermediateOutputPath)$(TargetName).scan.dgml.xml" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_AotSidecar)" DestinationFolder="$(PublishDir)"
+          Condition="Exists('%(_AotSidecar.Identity)')" SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -46,6 +46,10 @@ public sealed class AssemblyAnalyzer : IDisposable
     private IReadOnlyList<RtrSection>? _readyToRunSections;
     private IReadOnlyList<StringEntry>? _frozenStrings;
     private IReadOnlyList<RecoveredType>? _recoveredTypes;
+    private MstatData? _mstat;
+    private bool _mstatProbed;
+    private DgmlGraph? _dgml;
+    private bool _dgmlProbed;
 
     /// <summary>
     /// Opens and analyzes the specified .NET assembly file.
@@ -297,6 +301,84 @@ public sealed class AssemblyAnalyzer : IDisposable
 
             return _recoveredTypes;
         }
+    }
+
+    /// <summary>
+    /// The ILC size report found next to a Native AOT binary, or null when this is not a
+    /// Native AOT binary or no readable <c>.mstat</c> sidecar sits beside it. The value is
+    /// assigned before the probed flag, so a rare concurrent first read costs at most a
+    /// second parse of immutable data.
+    /// </summary>
+    public MstatData? Mstat
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (!_mstatProbed)
+            {
+                _mstat = MstatPath is { } path ? MstatReader.Read(path) : null;
+                _mstatProbed = true;
+            }
+
+            return _mstat;
+        }
+    }
+
+    /// <summary>
+    /// The path of the <c>.mstat</c> sidecar next to a Native AOT binary, or null when this
+    /// is not a Native AOT binary or the file is absent.
+    /// </summary>
+    public string? MstatPath =>
+        BinaryKind == BinaryKind.NativeAot ? FindSidecar(".mstat") : null;
+
+    /// <summary>
+    /// The ILC dependency graph found next to a Native AOT binary, or null when this is not
+    /// a Native AOT binary or no readable DGML sidecar sits beside it. Graphs run to
+    /// hundreds of thousands of links, so touch this only when a dependency question is
+    /// actually being asked. The value is assigned before the probed flag, so a rare
+    /// concurrent first read costs at most a second parse of immutable data.
+    /// </summary>
+    public DgmlGraph? Dgml
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (!_dgmlProbed)
+            {
+                _dgml = DgmlPath is { } path ? DgmlReader.Read(path) : null;
+                _dgmlProbed = true;
+            }
+
+            return _dgml;
+        }
+    }
+
+    /// <summary>
+    /// The path of the DGML sidecar next to a Native AOT binary — the codegen graph when
+    /// present (its node names match the mstat's exactly), else the scan graph — or null
+    /// when this is not a Native AOT binary or neither file is present.
+    /// </summary>
+    public string? DgmlPath =>
+        BinaryKind == BinaryKind.NativeAot
+            ? FindSidecar(".codegen.dgml.xml") ?? FindSidecar(".scan.dgml.xml")
+            : null;
+
+    /// <summary>
+    /// Probes for a sidecar next to the analyzed binary: the binary's extension is replaced
+    /// (or the suffix appended for extensionless Linux and macOS binaries) and the file must
+    /// exist in the same directory.
+    /// </summary>
+    private string? FindSidecar(string suffix)
+    {
+        var directory = Path.GetDirectoryName(FilePath);
+        if (string.IsNullOrEmpty(directory)) return null;
+
+        var stem = Path.GetFileName(FilePath);
+        if (stem.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            stem = stem[..^4];
+
+        var candidate = Path.Combine(directory, stem + suffix);
+        return File.Exists(candidate) ? candidate : null;
     }
 
     /// <summary>

--- a/src/Dotsider.Core/Analysis/DependencyGraphBuilder.cs
+++ b/src/Dotsider.Core/Analysis/DependencyGraphBuilder.cs
@@ -23,6 +23,9 @@ public static class DependencyGraphBuilder
     /// <returns>The computed nodes, edges, and per-node navigation metadata.</returns>
     public static DependencyGraphResult Build(AssemblyAnalyzer analyzer)
     {
+        if (analyzer.BinaryKind == BinaryKind.NativeAot)
+            return BuildForNativeAot(analyzer);
+
         var byId = new Dictionary<string, GraphNode>(StringComparer.Ordinal);
         var edges = new List<GraphEdge>();
         var navById = new Dictionary<string, GraphNavigationContext>(StringComparer.Ordinal);
@@ -133,6 +136,206 @@ public static class DependencyGraphBuilder
 
         return new DependencyGraphResult(orderedNodes, edges, navById);
     }
+
+    /// <summary>
+    /// Builds the graph of a Native AOT binary. ILC folds every managed assembly into the
+    /// image, so nodes come from the mstat sidecar's assembly list (the app's own entry is
+    /// the root) with edges aggregated from the DGML dependency graph: each link whose two
+    /// endpoints attribute to different assemblies counts toward that assembly pair. The
+    /// binary's native import modules join at depth 1. Without sidecars the graph is the
+    /// root plus the import star — the only dependency facts the binary itself records.
+    /// </summary>
+    private static DependencyGraphResult BuildForNativeAot(AssemblyAnalyzer analyzer)
+    {
+        var nodes = new List<GraphNode>();
+        var edges = new List<GraphEdge>();
+        var navById = new Dictionary<string, GraphNavigationContext>(StringComparer.Ordinal);
+
+        var rootIdentity = IdentityFromAnalyzer(analyzer);
+        var mstat = analyzer.Mstat;
+
+        // The mstat lists the app's own assembly among its references; promote that identity
+        // to the root so the graph is keyed on real assembly identity when available.
+        var stem = Path.GetFileNameWithoutExtension(analyzer.FileName);
+        var appIdentity = mstat?.Assemblies.FirstOrDefault(
+            a => string.Equals(a.Name, stem, StringComparison.OrdinalIgnoreCase));
+        if (appIdentity is not null) rootIdentity = appIdentity;
+
+        var rootId = AssemblyIdentityFormat.Format(
+            rootIdentity.Name, rootIdentity.Version, rootIdentity.Culture, rootIdentity.PublicKeyToken);
+        nodes.Add(new GraphNode(
+            Id: rootId,
+            Name: rootIdentity.Name,
+            Version: NullIfEmpty(rootIdentity.Version),
+            Culture: string.IsNullOrEmpty(rootIdentity.Culture) ? "neutral" : rootIdentity.Culture,
+            PublicKeyToken: rootIdentity.PublicKeyToken,
+            IsRoot: true,
+            Depth: 0,
+            Unresolved: false));
+        navById[rootId] = AotNavigationContext(analyzer, AssemblyProvenance.Root, isFramework: false);
+
+        if (mstat is not null)
+        {
+            var idByAssemblyName = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [rootIdentity.Name] = rootId,
+            };
+
+            foreach (var assembly in mstat.Assemblies)
+            {
+                if (ReferenceEquals(assembly, appIdentity)) continue;
+                var id = AssemblyIdentityFormat.Format(
+                    assembly.Name, assembly.Version, assembly.Culture, assembly.PublicKeyToken);
+                if (!idByAssemblyName.TryAdd(assembly.Name, id)) continue;
+
+                nodes.Add(new GraphNode(
+                    Id: id,
+                    Name: assembly.Name,
+                    Version: NullIfEmpty(assembly.Version),
+                    Culture: string.IsNullOrEmpty(assembly.Culture) ? "neutral" : assembly.Culture,
+                    PublicKeyToken: assembly.PublicKeyToken,
+                    IsRoot: false,
+                    Depth: 1,
+                    Unresolved: false));
+                navById[id] = AotNavigationContext(
+                    analyzer, AssemblyProvenance.CompiledIntoNativeImage,
+                    isFramework: AssemblyAnalyzer.IsFrameworkAssembly(
+                        AssemblyProvenance.CompiledIntoNativeImage, assembly,
+                        analyzer.TargetFramework, analyzer.PreferredRuntimePack));
+            }
+
+            AggregateDgmlEdges(analyzer, mstat, idByAssemblyName, rootId, nodes, edges);
+        }
+
+        // Native import modules: the exe's own dependency facts, present with or without
+        // sidecars, at depth 1 off the root. Edge weight = imported function count.
+        foreach (var module in analyzer.Imports)
+        {
+            var id = $"native:{module.ModuleName.ToLowerInvariant()}";
+            if (navById.ContainsKey(id)) continue;
+
+            nodes.Add(new GraphNode(
+                Id: id,
+                Name: module.ModuleName,
+                Version: null,
+                Culture: "neutral",
+                PublicKeyToken: null,
+                IsRoot: false,
+                Depth: 1,
+                Unresolved: false,
+                Kind: GraphNodeKind.NativeImport));
+            navById[id] = AotNavigationContext(
+                analyzer, AssemblyProvenance.CompiledIntoNativeImage, isFramework: false);
+            edges.Add(new GraphEdge(rootId, id, module.Functions.Count));
+        }
+
+        var ordered = nodes
+            .OrderBy(n => n.Depth)
+            .ThenBy(n => n.Kind)
+            .ThenBy(n => n.Id, StringComparer.Ordinal)
+            .ToList();
+        return new DependencyGraphResult(ordered, edges, navById);
+    }
+
+    /// <summary>
+    /// Aggregates DGML links to assembly-pair edges: each link whose endpoints join (via the
+    /// mstat node names) to entries of two different assemblies increments that pair's count.
+    /// Depths then follow from a BFS over the aggregated edges so the layout bands read as
+    /// dependency layers rather than a flat row.
+    /// </summary>
+    private static void AggregateDgmlEdges(
+        AssemblyAnalyzer analyzer,
+        MstatData mstat,
+        Dictionary<string, string> idByAssemblyName,
+        string rootId,
+        List<GraphNode> nodes,
+        List<GraphEdge> edges)
+    {
+        if (analyzer.Dgml is not { } dgml) return;
+
+        // mstat node name -> owning assembly's node id.
+        var assemblyByNodeName = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var method in mstat.Methods)
+        {
+            if (method.NodeName is { } n && idByAssemblyName.TryGetValue(method.AssemblyName, out var id))
+                assemblyByNodeName.TryAdd(n, id);
+        }
+
+        foreach (var type in mstat.Types)
+        {
+            if (type.NodeName is { } n && idByAssemblyName.TryGetValue(type.AssemblyName, out var id))
+                assemblyByNodeName.TryAdd(n, id);
+        }
+
+        var labelById = new Dictionary<int, string>(dgml.Nodes.Count);
+        foreach (var node in dgml.Nodes)
+            labelById.TryAdd(node.Id, node.Label);
+
+        var counts = new Dictionary<(string Source, string Target), int>();
+        foreach (var link in dgml.Links)
+        {
+            if (!labelById.TryGetValue(link.SourceId, out var sourceLabel)
+                || !labelById.TryGetValue(link.TargetId, out var targetLabel)
+                || !assemblyByNodeName.TryGetValue(sourceLabel, out var sourceAssembly)
+                || !assemblyByNodeName.TryGetValue(targetLabel, out var targetAssembly)
+                || sourceAssembly == targetAssembly)
+            {
+                continue;
+            }
+
+            counts.TryGetValue((sourceAssembly, targetAssembly), out var count);
+            counts[(sourceAssembly, targetAssembly)] = count + 1;
+        }
+
+        foreach (var ((source, target), count) in counts.OrderBy(kvp => kvp.Key.Source, StringComparer.Ordinal))
+            edges.Add(new GraphEdge(source, target, count));
+
+        // Re-derive depths from the aggregated topology, keeping every assembly reachable:
+        // anything the BFS cannot reach from the root stays at depth 1.
+        var depths = new Dictionary<string, int>(StringComparer.Ordinal) { [rootId] = 0 };
+        var queue = new Queue<string>();
+        queue.Enqueue(rootId);
+        var adjacency = edges
+            .GroupBy(e => e.SourceId)
+            .ToDictionary(g => g.Key, g => g.Select(e => e.TargetId).ToList(), StringComparer.Ordinal);
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (!adjacency.TryGetValue(current, out var children)) continue;
+            foreach (var child in children)
+            {
+                if (depths.ContainsKey(child)) continue;
+                depths[child] = depths[current] + 1;
+                queue.Enqueue(child);
+            }
+        }
+
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            if (nodes[i].Kind == GraphNodeKind.Assembly
+                && depths.TryGetValue(nodes[i].Id, out var depth)
+                && nodes[i].Depth != depth)
+            {
+                nodes[i] = nodes[i] with { Depth = depth };
+            }
+        }
+    }
+
+    /// <summary>
+    /// The navigation context of a Native AOT graph node: nothing to open (the assembly was
+    /// compiled into the image), so Enter degrades to an explanatory message.
+    /// </summary>
+    private static GraphNavigationContext AotNavigationContext(
+        AssemblyAnalyzer analyzer, AssemblyProvenance provenance, bool isFramework) =>
+        new(
+            Resolved: null,
+            ReferencingFilePath: analyzer.FilePath,
+            ReferencingBundlePath: null,
+            ReferencingTargetFramework: analyzer.TargetFramework,
+            ReferencingPreferredRuntimePack: analyzer.PreferredRuntimePack,
+            Provenance: provenance,
+            IsFrameworkAssembly: isFramework,
+            CandidateProbePath: null);
 
     private static AssemblyResolution ResolveOnce(
         AssemblyAnalyzer parent,

--- a/src/Dotsider.Core/Analysis/DgmlReader.cs
+++ b/src/Dotsider.Core/Analysis/DgmlReader.cs
@@ -1,0 +1,92 @@
+using System.Xml;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Reads an ILC dependency-graph DGML file, emitted when publishing a Native AOT project with
+/// <c>IlcGenerateDgmlFile</c>. The format is a <c>DirectedGraph</c> document of nodes (id and
+/// label) and links (source depends on target, with a reason). Node labels equal the node
+/// names an mstat size report stores (<see cref="MstatReader"/>), which is how sizes join to
+/// dependency chains.
+///
+/// Parsing streams the XML — the graphs run to hundreds of thousands of links — and never
+/// throws: unreadable files return null, and malformed nodes or links are skipped.
+/// </summary>
+public static class DgmlReader
+{
+    /// <summary>
+    /// Reads a dependency graph from a file.
+    /// </summary>
+    /// <param name="filePath">The path of the <c>.dgml.xml</c> file.</param>
+    /// <returns>The graph, or null when the file is missing or is not a DGML document.</returns>
+    public static DgmlGraph? Read(string filePath)
+    {
+        try
+        {
+            using var stream = File.OpenRead(filePath);
+            return Read(stream);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Reads a dependency graph from a stream. The stream is left open.
+    /// </summary>
+    /// <param name="stream">A readable stream positioned at the start of the document.</param>
+    /// <returns>The graph, or null when the content is not a DGML document.</returns>
+    public static DgmlGraph? Read(Stream stream)
+    {
+        try
+        {
+            var settings = new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Prohibit,
+                IgnoreWhitespace = true,
+                IgnoreComments = true,
+                CloseInput = false,
+            };
+            using var reader = XmlReader.Create(stream, settings);
+
+            // The root element must be DirectedGraph; namespace is accepted but not required.
+            if (reader.MoveToContent() != XmlNodeType.Element || reader.LocalName != "DirectedGraph")
+                return null;
+
+            var nodes = new List<DgmlNode>();
+            var links = new List<DgmlLink>();
+            while (reader.Read())
+            {
+                if (reader.NodeType != XmlNodeType.Element) continue;
+
+                if (reader.LocalName == "Node")
+                {
+                    if (int.TryParse(reader.GetAttribute("Id"), out var id))
+                        nodes.Add(new DgmlNode(id, reader.GetAttribute("Label") ?? ""));
+                }
+                else if (reader.LocalName == "Link")
+                {
+                    if (int.TryParse(reader.GetAttribute("Source"), out var source)
+                        && int.TryParse(reader.GetAttribute("Target"), out var target))
+                    {
+                        var reason = reader.GetAttribute("Reason");
+                        links.Add(new DgmlLink(source, target,
+                            string.IsNullOrEmpty(reason) ? null : reason));
+                    }
+                }
+            }
+
+            return new DgmlGraph(nodes, links);
+        }
+        catch (XmlException)
+        {
+            return null;
+        }
+        catch (Exception ex) when (ex is IOException or InvalidOperationException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Dotsider.Core/Analysis/Models/AssemblyProvenance.cs
+++ b/src/Dotsider.Core/Analysis/Models/AssemblyProvenance.cs
@@ -73,4 +73,10 @@ public enum AssemblyProvenance
     /// <see cref="Unresolved"/> so the UI can surface the configured href to the user.
     /// </summary>
     CodeBaseMissing,
+
+    /// <summary>
+    /// Compiled into a Native AOT image: the node comes from the binary's mstat size report
+    /// or native import table rather than an on-disk assembly, so there is no file to open.
+    /// </summary>
+    CompiledIntoNativeImage,
 }

--- a/src/Dotsider.Core/Analysis/Models/DgmlGraph.cs
+++ b/src/Dotsider.Core/Analysis/Models/DgmlGraph.cs
@@ -1,0 +1,131 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// An ILC dependency graph read from a DGML file, with the reverse index needed to answer
+/// "why is this in my binary": a breadth-first walk from any node toward its dependers ends
+/// at a root — a node nothing depends on — and the chain back down is the explanation.
+/// </summary>
+public sealed class DgmlGraph
+{
+    private readonly Dictionary<int, int> _indexById;
+    private readonly Dictionary<string, int> _indexByLabel;
+    private readonly int[] _incomingStarts;
+    private readonly int[] _incomingLinks;
+
+    internal DgmlGraph(IReadOnlyList<DgmlNode> nodes, IReadOnlyList<DgmlLink> links)
+    {
+        Nodes = nodes;
+        Links = links;
+
+        _indexById = new Dictionary<int, int>(nodes.Count);
+        _indexByLabel = new Dictionary<string, int>(nodes.Count, StringComparer.Ordinal);
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            _indexById.TryAdd(nodes[i].Id, i);
+            _indexByLabel.TryAdd(nodes[i].Label, i);
+        }
+
+        // CSR-style reverse adjacency: for each node, the indices of its incoming links.
+        // Links with endpoints that resolve to no node are kept in Links but not indexed.
+        var counts = new int[nodes.Count + 1];
+        foreach (var link in links)
+        {
+            if (_indexById.TryGetValue(link.TargetId, out var target) && _indexById.ContainsKey(link.SourceId))
+                counts[target + 1]++;
+        }
+
+        for (var i = 1; i < counts.Length; i++)
+            counts[i] += counts[i - 1];
+
+        _incomingStarts = counts;
+        _incomingLinks = new int[counts[^1]];
+        var cursor = new int[nodes.Count];
+        for (var i = 0; i < links.Count; i++)
+        {
+            if (_indexById.TryGetValue(links[i].TargetId, out var target) && _indexById.ContainsKey(links[i].SourceId))
+                _incomingLinks[_incomingStarts[target] + cursor[target]++] = i;
+        }
+    }
+
+    /// <summary>The graph's nodes.</summary>
+    public IReadOnlyList<DgmlNode> Nodes { get; }
+
+    /// <summary>The graph's edges; each source depends on its target.</summary>
+    public IReadOnlyList<DgmlLink> Links { get; }
+
+    /// <summary>
+    /// Finds the node with the given label, or null when no node carries it. When labels
+    /// repeat, the first node wins.
+    /// </summary>
+    /// <param name="label">The node name to look up — for an mstat entry, its <c>NodeName</c>.</param>
+    public DgmlNode? FindNodeByLabel(string label) =>
+        _indexByLabel.TryGetValue(label, out var index) ? Nodes[index] : null;
+
+    /// <summary>
+    /// Walks from the labeled node to a root and returns the chain root-first, ending at the
+    /// queried node. Empty when the label is unknown.
+    /// </summary>
+    /// <param name="label">The node name to explain.</param>
+    public IReadOnlyList<DgmlPathStep> PathToRoot(string label) =>
+        _indexByLabel.TryGetValue(label, out var index) ? PathToRootCore(index) : [];
+
+    /// <summary>
+    /// Walks from the node to a root and returns the chain root-first, ending at the queried
+    /// node. Empty when the id is unknown.
+    /// </summary>
+    /// <param name="nodeId">The node id to explain.</param>
+    public IReadOnlyList<DgmlPathStep> PathToRoot(int nodeId) =>
+        _indexById.TryGetValue(nodeId, out var index) ? PathToRootCore(index) : [];
+
+    private List<DgmlPathStep> PathToRootCore(int start)
+    {
+        // BFS toward dependers, so the first root reached gives a shortest chain. next[n]
+        // remembers which node n leads back down to, and via which link, for reconstruction.
+        var visited = new HashSet<int> { start };
+        var next = new Dictionary<int, (int Child, int Link)>();
+        var queue = new Queue<int>();
+        queue.Enqueue(start);
+
+        var root = -1;
+        while (queue.Count > 0)
+        {
+            var node = queue.Dequeue();
+            if (InDegree(node) == 0)
+            {
+                root = node;
+                break;
+            }
+
+            for (var i = _incomingStarts[node]; i < _incomingStarts[node + 1]; i++)
+            {
+                var link = _incomingLinks[i];
+                var depender = _indexById[Links[link].SourceId];
+                if (!visited.Add(depender)) continue;
+                next[depender] = (node, link);
+                queue.Enqueue(depender);
+            }
+        }
+
+        if (root < 0)
+        {
+            // Every depender chain loops back on itself; report the node alone.
+            return [new DgmlPathStep(Nodes[start].Label, null)];
+        }
+
+        var steps = new List<DgmlPathStep> { new(Nodes[root].Label, null) };
+        var current = root;
+        while (current != start)
+        {
+            var (child, link) = next[current];
+            steps.Add(new DgmlPathStep(Nodes[child].Label, NormalizeReason(Links[link].Reason)));
+            current = child;
+        }
+
+        return steps;
+    }
+
+    private int InDegree(int node) => _incomingStarts[node + 1] - _incomingStarts[node];
+
+    private static string? NormalizeReason(string? reason) =>
+        string.IsNullOrEmpty(reason) ? null : reason;
+}

--- a/src/Dotsider.Core/Analysis/Models/DgmlLink.cs
+++ b/src/Dotsider.Core/Analysis/Models/DgmlLink.cs
@@ -1,0 +1,13 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// One edge of an ILC dependency graph: the source node depends on the target node, so the
+/// target is in the binary because the source needed it.
+/// </summary>
+/// <param name="SourceId">The depender's node id.</param>
+/// <param name="TargetId">The dependee's node id.</param>
+/// <param name="Reason">The compiler's explanation for the dependency, or null when it gave none.</param>
+public sealed record DgmlLink(
+    int SourceId,
+    int TargetId,
+    string? Reason);

--- a/src/Dotsider.Core/Analysis/Models/DgmlNode.cs
+++ b/src/Dotsider.Core/Analysis/Models/DgmlNode.cs
@@ -1,0 +1,11 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// One node of an ILC dependency graph. The label is the compiler's node name — the same
+/// string an mstat size entry stores as its <c>NodeName</c>, which is how the two files join.
+/// </summary>
+/// <param name="Id">The node id, unique within the graph.</param>
+/// <param name="Label">The node name.</param>
+public sealed record DgmlNode(
+    int Id,
+    string Label);

--- a/src/Dotsider.Core/Analysis/Models/DgmlPathStep.cs
+++ b/src/Dotsider.Core/Analysis/Models/DgmlPathStep.cs
@@ -1,0 +1,12 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// One step of a root-to-node dependency chain — the answer to "why is this in my binary,"
+/// read top-down: the root kept the second step, which kept the third, and so on to the node
+/// that was asked about.
+/// </summary>
+/// <param name="Label">The node name at this step.</param>
+/// <param name="Reason">Why the previous step depends on this one, or null on the root step.</param>
+public sealed record DgmlPathStep(
+    string Label,
+    string? Reason);

--- a/src/Dotsider.Core/Analysis/Models/GraphNode.cs
+++ b/src/Dotsider.Core/Analysis/Models/GraphNode.cs
@@ -29,6 +29,10 @@ namespace Dotsider.Core.Analysis.Models;
 /// manifest identity did not match — the latter is further distinguished by the node's
 /// navigation-context provenance.
 /// </param>
+/// <param name="Kind">
+/// What the node represents. Defaults to <see cref="GraphNodeKind.Assembly"/> and is omitted
+/// from serialized output at that default, so managed graph JSON is unchanged.
+/// </param>
 public sealed record GraphNode(
     string Id,
     string Name,
@@ -37,4 +41,7 @@ public sealed record GraphNode(
     string? PublicKeyToken,
     bool IsRoot,
     int Depth,
-    bool Unresolved);
+    bool Unresolved,
+    [property: System.Text.Json.Serialization.JsonIgnore(
+        Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    GraphNodeKind Kind = GraphNodeKind.Assembly);

--- a/src/Dotsider.Core/Analysis/Models/GraphNodeKind.cs
+++ b/src/Dotsider.Core/Analysis/Models/GraphNodeKind.cs
@@ -1,0 +1,14 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// What a dependency-graph node represents. Managed graphs contain only assemblies; the
+/// Native AOT graph adds the binary's native import modules.
+/// </summary>
+public enum GraphNodeKind
+{
+    /// <summary>A managed assembly, identified by its full assembly identity.</summary>
+    Assembly,
+
+    /// <summary>A native module the binary imports (for example <c>kernel32.dll</c>).</summary>
+    NativeImport
+}

--- a/src/Dotsider.Core/Analysis/Models/MstatBlob.cs
+++ b/src/Dotsider.Core/Analysis/Models/MstatBlob.cs
@@ -1,0 +1,13 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// One named global data region from an ILC size report — embedded metadata, hydration
+/// tables, dispatch maps, and the like. Blob names come from the compiler's node type names
+/// (for example <c>Metadata</c> or <c>InterfaceDispatchMap</c>), with same-named regions
+/// summed into one entry.
+/// </summary>
+/// <param name="Name">The region name.</param>
+/// <param name="Size">The total size in bytes across all regions with this name.</param>
+public sealed record MstatBlob(
+    string Name,
+    int Size);

--- a/src/Dotsider.Core/Analysis/Models/MstatData.cs
+++ b/src/Dotsider.Core/Analysis/Models/MstatData.cs
@@ -1,0 +1,29 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// The contents of an ILC size report (<c>.mstat</c>), produced by publishing a Native AOT
+/// project with <c>IlcGenerateMstatFile</c>. The file is itself a valid ECMA-335 assembly whose
+/// assembly version carries the format version and whose data lives in IL streams; this record
+/// is the decoded result. Sections absent from older format versions are empty lists.
+/// </summary>
+/// <param name="FormatMajorVersion">The format major version (1 = .NET 7, 2 = .NET 8+).</param>
+/// <param name="FormatMinorVersion">The format minor version (2.1 adds RVA field, frozen object, and resource detail; 2.2 adds deduplicated methods).</param>
+/// <param name="Assemblies">The managed assemblies the report references, in AssemblyRef table order.</param>
+/// <param name="Methods">Every compiled method body with its code, GC info, and EH info sizes.</param>
+/// <param name="Types">Every constructed MethodTable with its size.</param>
+/// <param name="Blobs">Global data regions (metadata, dehydrated data, hydration tables) by name.</param>
+/// <param name="RvaFields">Field RVA data entries (format 2.1+); their bytes also appear in <paramref name="Blobs"/> for back-compat.</param>
+/// <param name="FrozenObjects">Frozen object entries (format 2.1+); their bytes also appear in <paramref name="Blobs"/> for back-compat.</param>
+/// <param name="ManifestResources">Embedded manifest resources (format 2.1+); their bytes also appear in <paramref name="Blobs"/> for back-compat.</param>
+/// <param name="DeduplicatedMethods">Method bodies folded into an identical original (format 2.2+).</param>
+public sealed record MstatData(
+    int FormatMajorVersion,
+    int FormatMinorVersion,
+    IReadOnlyList<AssemblyRefInfo> Assemblies,
+    IReadOnlyList<MstatMethod> Methods,
+    IReadOnlyList<MstatType> Types,
+    IReadOnlyList<MstatBlob> Blobs,
+    IReadOnlyList<MstatRvaField> RvaFields,
+    IReadOnlyList<MstatFrozenObject> FrozenObjects,
+    IReadOnlyList<MstatManifestResource> ManifestResources,
+    IReadOnlyList<MstatDeduplicatedMethod> DeduplicatedMethods);

--- a/src/Dotsider.Core/Analysis/Models/MstatDeduplicatedMethod.cs
+++ b/src/Dotsider.Core/Analysis/Models/MstatDeduplicatedMethod.cs
@@ -1,0 +1,11 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// One method-body fold from an ILC size report (format 2.2+): the compiler emitted a single
+/// body and pointed these identical methods at it, so only the original contributes size.
+/// </summary>
+/// <param name="Name">The original method's display name, including its declaring type.</param>
+/// <param name="TargetNames">The dependency-graph node names of the methods folded into the original.</param>
+public sealed record MstatDeduplicatedMethod(
+    string Name,
+    IReadOnlyList<string> TargetNames);

--- a/src/Dotsider.Core/Analysis/Models/MstatFrozenObject.cs
+++ b/src/Dotsider.Core/Analysis/Models/MstatFrozenObject.cs
@@ -1,0 +1,21 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// One frozen object from an ILC size report (format 2.1+) — an object allocated at compile
+/// time and baked into the image, most commonly a string literal. For back-compat these bytes
+/// are also summed into the <c>ArrayOfFrozenObjects</c> blob entry.
+/// </summary>
+/// <param name="TypeName">The frozen object's type display name (for example <c>System.String</c>).</param>
+/// <param name="AssemblyName">The simple name of the assembly that defines the object's type.</param>
+/// <param name="Size">The object size in bytes, including its object header.</param>
+/// <param name="NodeName">The compiler's dependency-graph node name; joins to the DGML node <c>Label</c>.</param>
+/// <param name="OwningType">
+/// The type whose static data serialized this object, or null when the object is not a
+/// serialized static (string literals report null).
+/// </param>
+public sealed record MstatFrozenObject(
+    string TypeName,
+    string AssemblyName,
+    int Size,
+    string? NodeName,
+    string? OwningType);

--- a/src/Dotsider.Core/Analysis/Models/MstatManifestResource.cs
+++ b/src/Dotsider.Core/Analysis/Models/MstatManifestResource.cs
@@ -1,0 +1,13 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// One embedded manifest resource from an ILC size report (format 2.1+). For back-compat
+/// these bytes are also summed into the <c>ResourceData</c> blob entry.
+/// </summary>
+/// <param name="AssemblyName">The simple name of the assembly the resource was embedded in.</param>
+/// <param name="Name">The resource name.</param>
+/// <param name="Size">The resource size in bytes.</param>
+public sealed record MstatManifestResource(
+    string AssemblyName,
+    string Name,
+    int Size);

--- a/src/Dotsider.Core/Analysis/Models/MstatMethod.cs
+++ b/src/Dotsider.Core/Analysis/Models/MstatMethod.cs
@@ -1,0 +1,28 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// One compiled method body from an ILC size report. Sizes are bytes of native artifact, not
+/// IL: ILC compiles each body once, so the sum over all methods is the code contribution to
+/// the binary.
+/// </summary>
+/// <param name="Name">The method name, with generic arguments rendered when instantiated.</param>
+/// <param name="DeclaringType">The declaring type's display name, including namespace.</param>
+/// <param name="Namespace">The declaring type's namespace, or an empty string for the global namespace.</param>
+/// <param name="AssemblyName">The simple name of the assembly the method was compiled from.</param>
+/// <param name="Size">The native code size in bytes.</param>
+/// <param name="GcInfoSize">The GC info size in bytes.</param>
+/// <param name="EhInfoSize">The exception-handling info size in bytes, or 0 when the method has none.</param>
+/// <param name="NodeName">
+/// The compiler's dependency-graph node name (format 2.0+), or null in 1.x reports. The same
+/// string appears as the node <c>Label</c> in the DGML graphs <c>IlcGenerateDgmlFile</c> emits,
+/// which is how a size entry joins to its dependency chain.
+/// </param>
+public sealed record MstatMethod(
+    string Name,
+    string DeclaringType,
+    string Namespace,
+    string AssemblyName,
+    int Size,
+    int GcInfoSize,
+    int EhInfoSize,
+    string? NodeName);

--- a/src/Dotsider.Core/Analysis/Models/MstatRvaField.cs
+++ b/src/Dotsider.Core/Analysis/Models/MstatRvaField.cs
@@ -1,0 +1,17 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// One field-RVA data entry from an ILC size report (format 2.1+) — the initial data of a
+/// field mapped directly into the image, typically compiler-generated arrays behind
+/// collection expressions and <c>ReadOnlySpan</c> literals. For back-compat these bytes are
+/// also summed into the <c>FieldRvaData</c> blob entry.
+/// </summary>
+/// <param name="Name">The field's display name, including its declaring type.</param>
+/// <param name="AssemblyName">The simple name of the assembly that defines the field.</param>
+/// <param name="Size">The RVA data size in bytes.</param>
+/// <param name="NodeName">The compiler's dependency-graph node name; joins to the DGML node <c>Label</c>.</param>
+public sealed record MstatRvaField(
+    string Name,
+    string AssemblyName,
+    int Size,
+    string? NodeName);

--- a/src/Dotsider.Core/Analysis/Models/MstatType.cs
+++ b/src/Dotsider.Core/Analysis/Models/MstatType.cs
@@ -1,0 +1,20 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// One constructed type from an ILC size report. The size is the type's MethodTable data —
+/// the runtime type structure — not the code of its methods, which is reported per method.
+/// </summary>
+/// <param name="Name">The type's display name, with generic arguments rendered when instantiated.</param>
+/// <param name="Namespace">The type's namespace, or an empty string for the global namespace.</param>
+/// <param name="AssemblyName">The simple name of the assembly that defines the type.</param>
+/// <param name="Size">The MethodTable size in bytes.</param>
+/// <param name="NodeName">
+/// The compiler's dependency-graph node name (format 2.0+), or null in 1.x reports; joins to
+/// the DGML node <c>Label</c>.
+/// </param>
+public sealed record MstatType(
+    string Name,
+    string Namespace,
+    string AssemblyName,
+    int Size,
+    string? NodeName);

--- a/src/Dotsider.Core/Analysis/Models/SizeNode.cs
+++ b/src/Dotsider.Core/Analysis/Models/SizeNode.cs
@@ -1,16 +1,23 @@
 namespace Dotsider.Core.Analysis.Models;
 
 /// <summary>
-/// A node in the size treemap hierarchy. Can be assembly, namespace, type, or method.
+/// A node in the size treemap hierarchy. Can be assembly, namespace, type, or method — or,
+/// for Native AOT trees, a data category and its entries.
 /// </summary>
 /// <param name="Name">Display name for this node.</param>
 /// <param name="FullPath">Fully qualified path from root (e.g., <c>Assembly/Namespace/Type</c>).</param>
 /// <param name="Size">Size in bytes attributed to this node.</param>
 /// <param name="Kind">The granularity level of this node.</param>
 /// <param name="Children">Child nodes in the hierarchy.</param>
+/// <param name="AotNodeName">
+/// The ILC dependency-graph node name behind this entry, or null outside Native AOT trees.
+/// The name matches a DGML node label, which is what makes "why is this in my binary"
+/// answerable for the node.
+/// </param>
 public sealed record SizeNode(
     string Name,
     string FullPath,
     long Size,
     SizeNodeKind Kind,
-    IReadOnlyList<SizeNode> Children);
+    IReadOnlyList<SizeNode> Children,
+    string? AotNodeName = null);

--- a/src/Dotsider.Core/Analysis/Models/SizeNodeKind.cs
+++ b/src/Dotsider.Core/Analysis/Models/SizeNodeKind.cs
@@ -1,7 +1,8 @@
 namespace Dotsider.Core.Analysis.Models;
 
 /// <summary>
-/// The granularity level of a <see cref="SizeNode"/> in the size breakdown tree.
+/// The granularity level of a <see cref="SizeNode"/> in the size breakdown tree. The kinds
+/// beyond <see cref="Method"/> appear only in Native AOT trees built from an mstat report.
 /// </summary>
 public enum SizeNodeKind
 {
@@ -15,5 +16,23 @@ public enum SizeNodeKind
     Type,
 
     /// <summary>Node representing a method within a type.</summary>
-    Method
+    Method,
+
+    /// <summary>Grouping node for a Native AOT data category (blobs, frozen objects, and the like).</summary>
+    Category,
+
+    /// <summary>A named global data region of a Native AOT binary.</summary>
+    Blob,
+
+    /// <summary>A type's runtime MethodTable data in a Native AOT binary.</summary>
+    MethodTable,
+
+    /// <summary>An object frozen into a Native AOT binary at compile time.</summary>
+    FrozenObject,
+
+    /// <summary>A field's RVA data mapped into a Native AOT binary.</summary>
+    RvaField,
+
+    /// <summary>A manifest resource embedded in a Native AOT binary.</summary>
+    Resource
 }

--- a/src/Dotsider.Core/Analysis/MstatReader.cs
+++ b/src/Dotsider.Core/Analysis/MstatReader.cs
@@ -1,0 +1,557 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Reads an ILC size report (<c>.mstat</c>), the file <c>IlcGenerateMstatFile</c> emits when
+/// publishing a Native AOT project. The report is itself a valid ECMA-335 assembly: its
+/// assembly version carries the format version, and its data is encoded as IL instruction
+/// streams in global methods named <c>Methods</c>, <c>Types</c>, <c>Blobs</c>, and (in newer
+/// formats) <c>RvaFields</c>, <c>FrozenObjects</c>, <c>ManifestResources</c>, and
+/// <c>DeduplicatedMethods</c>. Format 2.0+ also stores each entry's dependency-graph node name
+/// in a custom <c>.names</c> PE section; those names equal the node labels in the DGML graphs
+/// <c>IlcGenerateDgmlFile</c> emits, which is how sizes join to dependency chains.
+///
+/// Malformed input never throws: unreadable files return null, and a truncated IL stream
+/// yields the entries parsed before the damage.
+/// </summary>
+public static class MstatReader
+{
+    /// <summary>
+    /// Reads an ILC size report from a file.
+    /// </summary>
+    /// <param name="filePath">The path of the <c>.mstat</c> file.</param>
+    /// <returns>The decoded report, or null when the file is missing or is not an mstat.</returns>
+    public static MstatData? Read(string filePath)
+    {
+        try
+        {
+            using var stream = File.OpenRead(filePath);
+            return Read(stream);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Reads an ILC size report from a stream. The stream is left open.
+    /// </summary>
+    /// <param name="stream">A readable, seekable stream positioned at the start of the file.</param>
+    /// <returns>The decoded report, or null when the content is not an mstat.</returns>
+    public static MstatData? Read(Stream stream)
+    {
+        try
+        {
+            using var pe = new PEReader(stream, PEStreamOptions.PrefetchEntireImage | PEStreamOptions.LeaveOpen);
+            if (!pe.HasMetadata) return null;
+
+            var mr = pe.GetMetadataReader();
+            var version = mr.GetAssemblyDefinition().Version;
+            // Build/Revision are unset sentinels (65535); only Major.Minor carry the format.
+            if (version.Major is not (1 or 2)) return null;
+
+            var streams = FindGlobalMethodStreams(pe, mr);
+            if (streams.Count == 0) return null;
+
+            var resolver = new EntityResolver(mr);
+            var names = FindNamesSection(pe);
+            var hasNames = version.Major >= 2;
+
+            return new MstatData(
+                version.Major,
+                version.Minor,
+                ReadAssemblyRefs(mr),
+                ReadMethods(streams, resolver, names, hasNames),
+                ReadTypes(streams, resolver, names, hasNames),
+                ReadBlobs(streams, mr),
+                ReadRvaFields(streams, resolver, names),
+                ReadFrozenObjects(streams, resolver, names),
+                ReadManifestResources(streams, mr),
+                ReadDeduplicatedMethods(streams, resolver, names));
+        }
+        catch
+        {
+            // Not a PE, no metadata, or damaged beyond the lenient per-stream recovery.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Collects the IL of the report's global methods — the methods on <c>&lt;Module&gt;</c>
+    /// (always TypeDef row 1) whose names identify data streams.
+    /// </summary>
+    private static Dictionary<string, byte[]> FindGlobalMethodStreams(PEReader pe, MetadataReader mr)
+    {
+        var streams = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        if (mr.TypeDefinitions.Count == 0) return streams;
+
+        var moduleType = mr.GetTypeDefinition(MetadataTokens.TypeDefinitionHandle(1));
+        foreach (var handle in moduleType.GetMethods())
+        {
+            var method = mr.GetMethodDefinition(handle);
+            var name = mr.GetString(method.Name);
+            if (name is not ("Methods" or "Types" or "Blobs" or "RvaFields" or "FrozenObjects"
+                or "ManifestResources" or "DeduplicatedMethods"))
+            {
+                continue;
+            }
+
+            if (method.RelativeVirtualAddress == 0) continue;
+            var il = pe.GetMethodBody(method.RelativeVirtualAddress).GetILBytes();
+            if (il is not null) streams[name] = il;
+        }
+
+        return streams;
+    }
+
+    /// <summary>
+    /// Locates the custom <c>.names</c> PE section that holds length-prefixed UTF-8 node
+    /// names in format 2.0+, or null when the section is absent.
+    /// </summary>
+    private static PEMemoryBlock? FindNamesSection(PEReader pe)
+    {
+        foreach (var section in pe.PEHeaders.SectionHeaders)
+        {
+            if (section.Name == ".names")
+                return pe.GetSectionData(section.VirtualAddress);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reads the node name at a byte offset into the <c>.names</c> section, or null when the
+    /// offset is out of range or the section is absent.
+    /// </summary>
+    private static string? ReadName(PEMemoryBlock? names, int offset)
+    {
+        if (names is not { } block || offset < 0 || offset >= block.Length) return null;
+        try
+        {
+            var reader = block.GetReader();
+            reader.Offset = offset;
+            return reader.ReadSerializedString();
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+    }
+
+    private static List<AssemblyRefInfo> ReadAssemblyRefs(MetadataReader mr)
+    {
+        var result = new List<AssemblyRefInfo>();
+        foreach (var handle in mr.AssemblyReferences)
+        {
+            var ar = mr.GetAssemblyReference(handle);
+            var culture = mr.GetString(ar.Culture);
+            if (string.IsNullOrEmpty(culture)) culture = "neutral";
+
+            var pkt = mr.GetBlobBytes(ar.PublicKeyOrToken);
+            result.Add(new AssemblyRefInfo(
+                mr.GetString(ar.Name),
+                ar.Version.ToString(),
+                culture,
+                pkt.Length > 0 ? Convert.ToHexStringLower(pkt) : null));
+        }
+
+        return result;
+    }
+
+    private static List<MstatMethod> ReadMethods(
+        Dictionary<string, byte[]> streams, EntityResolver resolver,
+        PEMemoryBlock? names, bool hasNames)
+    {
+        var result = new List<MstatMethod>();
+        if (!streams.TryGetValue("Methods", out var il)) return result;
+
+        var cursor = new IlCursor(il);
+        var nameOffset = 0;
+        while (cursor.TryReadToken(out var token)
+            && cursor.TryReadInt(out var size)
+            && cursor.TryReadInt(out var gcInfoSize)
+            && cursor.TryReadInt(out var ehInfoSize)
+            && (!hasNames || cursor.TryReadInt(out nameOffset)))
+        {
+            var method = resolver.ResolveMethod(token);
+            result.Add(new MstatMethod(
+                method.Name, method.Type.Display, method.Type.Namespace, method.Type.AssemblyName,
+                size, gcInfoSize, ehInfoSize,
+                hasNames ? ReadName(names, nameOffset) : null));
+        }
+
+        return result;
+    }
+
+    private static List<MstatType> ReadTypes(
+        Dictionary<string, byte[]> streams, EntityResolver resolver,
+        PEMemoryBlock? names, bool hasNames)
+    {
+        var result = new List<MstatType>();
+        if (!streams.TryGetValue("Types", out var il)) return result;
+
+        var cursor = new IlCursor(il);
+        var nameOffset = 0;
+        while (cursor.TryReadToken(out var token)
+            && cursor.TryReadInt(out var size)
+            && (!hasNames || cursor.TryReadInt(out nameOffset)))
+        {
+            var type = resolver.ResolveType(token);
+            result.Add(new MstatType(
+                type.Display, type.Namespace, type.AssemblyName, size,
+                hasNames ? ReadName(names, nameOffset) : null));
+        }
+
+        return result;
+    }
+
+    private static List<MstatBlob> ReadBlobs(Dictionary<string, byte[]> streams, MetadataReader mr)
+    {
+        var result = new List<MstatBlob>();
+        if (!streams.TryGetValue("Blobs", out var il)) return result;
+
+        var cursor = new IlCursor(il);
+        while (cursor.TryReadUserString(mr, out var name) && cursor.TryReadInt(out var size))
+            result.Add(new MstatBlob(name, size));
+
+        return result;
+    }
+
+    private static List<MstatRvaField> ReadRvaFields(
+        Dictionary<string, byte[]> streams, EntityResolver resolver, PEMemoryBlock? names)
+    {
+        var result = new List<MstatRvaField>();
+        if (!streams.TryGetValue("RvaFields", out var il)) return result;
+
+        var cursor = new IlCursor(il);
+        while (cursor.TryReadToken(out var token)
+            && cursor.TryReadInt(out var size)
+            && cursor.TryReadInt(out var nameOffset))
+        {
+            var field = resolver.ResolveMethod(token); // MemberRef: same shape as a method ref
+            result.Add(new MstatRvaField(
+                $"{field.Type.Display}::{field.Name}", field.Type.AssemblyName, size,
+                ReadName(names, nameOffset)));
+        }
+
+        return result;
+    }
+
+    private static List<MstatFrozenObject> ReadFrozenObjects(
+        Dictionary<string, byte[]> streams, EntityResolver resolver, PEMemoryBlock? names)
+    {
+        var result = new List<MstatFrozenObject>();
+        if (!streams.TryGetValue("FrozenObjects", out var il)) return result;
+
+        var cursor = new IlCursor(il);
+        while (cursor.TryReadToken(out var token)
+            && cursor.TryReadInt(out var size)
+            && cursor.TryReadInt(out var nameOffset))
+        {
+            // The fourth element is always present: an owning-type token for serialized
+            // statics, or a zero constant for everything else (string literals).
+            string? owningType = null;
+            if (cursor.TryReadToken(out var ownerToken))
+                owningType = resolver.ResolveType(ownerToken).Display;
+            else if (!cursor.TryReadInt(out _))
+                break;
+
+            var type = resolver.ResolveType(token);
+            result.Add(new MstatFrozenObject(
+                type.Display, type.AssemblyName, size, ReadName(names, nameOffset), owningType));
+        }
+
+        return result;
+    }
+
+    private static List<MstatManifestResource> ReadManifestResources(
+        Dictionary<string, byte[]> streams, MetadataReader mr)
+    {
+        var result = new List<MstatManifestResource>();
+        if (!streams.TryGetValue("ManifestResources", out var il)) return result;
+
+        var cursor = new IlCursor(il);
+        while (cursor.TryReadInt(out var assemblyToken)
+            && cursor.TryReadUserString(mr, out var name)
+            && cursor.TryReadInt(out var size))
+        {
+            var assembly = "";
+            var handle = MetadataTokens.EntityHandle(assemblyToken);
+            if (handle.Kind == HandleKind.AssemblyReference && !handle.IsNil)
+                assembly = mr.GetString(mr.GetAssemblyReference((AssemblyReferenceHandle)handle).Name);
+
+            result.Add(new MstatManifestResource(assembly, name, size));
+        }
+
+        return result;
+    }
+
+    private static List<MstatDeduplicatedMethod> ReadDeduplicatedMethods(
+        Dictionary<string, byte[]> streams, EntityResolver resolver, PEMemoryBlock? names)
+    {
+        var result = new List<MstatDeduplicatedMethod>();
+        if (!streams.TryGetValue("DeduplicatedMethods", out var il)) return result;
+
+        var cursor = new IlCursor(il);
+        while (cursor.TryReadToken(out var token) && cursor.TryReadInt(out var count))
+        {
+            var method = resolver.ResolveMethod(token);
+            var targets = new List<string>(count);
+            for (var i = 0; i < count; i++)
+            {
+                if (!cursor.TryReadToken(out _) || !cursor.TryReadInt(out var nameOffset))
+                    return result;
+                if (ReadName(names, nameOffset) is { } target) targets.Add(target);
+            }
+
+            result.Add(new MstatDeduplicatedMethod($"{method.Type.Display}::{method.Name}", targets));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// A forward-only reader over an mstat IL stream. Each Try method consumes its element or
+    /// returns false without advancing, so a truncated or unexpected stream ends the walk with
+    /// every fully-parsed entry retained.
+    /// </summary>
+    private struct IlCursor(byte[] il)
+    {
+        private readonly byte[] _il = il;
+        private int _pos;
+
+        /// <summary>Reads any ldc.i4 form.</summary>
+        public bool TryReadInt(out int value)
+        {
+            value = 0;
+            if (_pos >= _il.Length) return false;
+
+            switch (_il[_pos])
+            {
+                case 0x15: // ldc.i4.m1
+                    value = -1;
+                    _pos += 1;
+                    return true;
+                case >= 0x16 and <= 0x1E: // ldc.i4.0 .. ldc.i4.8
+                    value = _il[_pos] - 0x16;
+                    _pos += 1;
+                    return true;
+                case 0x1F when _pos + 1 < _il.Length: // ldc.i4.s
+                    value = (sbyte)_il[_pos + 1];
+                    _pos += 2;
+                    return true;
+                case 0x20 when _pos + 4 < _il.Length: // ldc.i4
+                    value = BitConverter.ToInt32(_il, _pos + 1);
+                    _pos += 5;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public bool TryReadToken(out int token)
+        {
+            token = 0;
+            if (_pos + 4 >= _il.Length || _il[_pos] != 0xD0) return false; // ldtoken
+            token = BitConverter.ToInt32(_il, _pos + 1);
+            _pos += 5;
+            return true;
+        }
+
+        public bool TryReadUserString(MetadataReader mr, out string value)
+        {
+            value = "";
+            if (_pos + 4 >= _il.Length || _il[_pos] != 0x72) return false; // ldstr
+            var token = BitConverter.ToInt32(_il, _pos + 1);
+            _pos += 5;
+            value = mr.GetUserString(MetadataTokens.UserStringHandle(token));
+            return true;
+        }
+    }
+
+    /// <summary>The display name, namespace, and defining assembly of a resolved type.</summary>
+    private readonly record struct TypeAttribution(string Display, string Namespace, string AssemblyName)
+    {
+        public static readonly TypeAttribution Unknown = new("?", "", "");
+    }
+
+    /// <summary>A resolved method or field reference: its name and its declaring type.</summary>
+    private readonly record struct MemberAttribution(string Name, TypeAttribution Type);
+
+    /// <summary>
+    /// Resolves mstat entity tokens to display names with assembly attribution. Types resolve
+    /// through TypeRef chains (nested types walk to the outermost scope's AssemblyRef) or
+    /// TypeSpec signatures, where a constructed type attributes to its outermost named type —
+    /// <c>List&lt;MyType&gt;</c> belongs to the collections assembly no matter what it holds.
+    /// </summary>
+    private sealed class EntityResolver(MetadataReader mr) : ISignatureTypeProvider<TypeAttribution, object?>
+    {
+        private readonly MetadataReader _mr = mr;
+
+        public MemberAttribution ResolveMethod(int token)
+        {
+            var handle = MetadataTokens.EntityHandle(token);
+            try
+            {
+                switch (handle.Kind)
+                {
+                    case HandleKind.MemberReference:
+                        return ResolveMemberRef((MemberReferenceHandle)handle);
+
+                    case HandleKind.MethodSpecification:
+                        var spec = _mr.GetMethodSpecification((MethodSpecificationHandle)handle);
+                        if (spec.Method.Kind != HandleKind.MemberReference)
+                            return new MemberAttribution("?", TypeAttribution.Unknown);
+                        var member = ResolveMemberRef((MemberReferenceHandle)spec.Method);
+                        var args = spec.DecodeSignature(this, null);
+                        return member with { Name = $"{member.Name}<{Join(args)}>" };
+
+                    default:
+                        return new MemberAttribution("?", TypeAttribution.Unknown);
+                }
+            }
+            catch (BadImageFormatException)
+            {
+                return new MemberAttribution("?", TypeAttribution.Unknown);
+            }
+        }
+
+        public TypeAttribution ResolveType(int token)
+        {
+            var handle = MetadataTokens.EntityHandle(token);
+            try
+            {
+                return handle.Kind switch
+                {
+                    HandleKind.TypeReference => ResolveTypeRef((TypeReferenceHandle)handle),
+                    HandleKind.TypeSpecification =>
+                        _mr.GetTypeSpecification((TypeSpecificationHandle)handle).DecodeSignature(this, null),
+                    _ => TypeAttribution.Unknown,
+                };
+            }
+            catch (BadImageFormatException)
+            {
+                return TypeAttribution.Unknown;
+            }
+        }
+
+        private MemberAttribution ResolveMemberRef(MemberReferenceHandle handle)
+        {
+            var member = _mr.GetMemberReference(handle);
+            var type = member.Parent.Kind switch
+            {
+                HandleKind.TypeReference => ResolveTypeRef((TypeReferenceHandle)member.Parent),
+                HandleKind.TypeSpecification =>
+                    _mr.GetTypeSpecification((TypeSpecificationHandle)member.Parent).DecodeSignature(this, null),
+                _ => TypeAttribution.Unknown,
+            };
+            return new MemberAttribution(_mr.GetString(member.Name), type);
+        }
+
+        private TypeAttribution ResolveTypeRef(TypeReferenceHandle handle)
+        {
+            var tr = _mr.GetTypeReference(handle);
+            var name = _mr.GetString(tr.Name);
+
+            if (tr.ResolutionScope.Kind == HandleKind.TypeReference)
+            {
+                // Nested type: namespace and assembly come from the outermost type.
+                var outer = ResolveTypeRef((TypeReferenceHandle)tr.ResolutionScope);
+                return outer with { Display = $"{outer.Display}/{name}" };
+            }
+
+            var ns = _mr.GetString(tr.Namespace);
+            var assembly = tr.ResolutionScope.Kind == HandleKind.AssemblyReference
+                ? _mr.GetString(_mr.GetAssemblyReference((AssemblyReferenceHandle)tr.ResolutionScope).Name)
+                : "";
+            return new TypeAttribution(ns.Length > 0 ? $"{ns}.{name}" : name, ns, assembly);
+        }
+
+        private static string Join(ImmutableArray<TypeAttribution> args) =>
+            string.Join(", ", args.Select(a => a.Display));
+
+        // ISignatureTypeProvider — display composition; attribution follows the named type.
+
+        TypeAttribution ISimpleTypeProvider<TypeAttribution>.GetPrimitiveType(PrimitiveTypeCode typeCode)
+        {
+            var display = typeCode switch
+            {
+                PrimitiveTypeCode.Void => "void",
+                PrimitiveTypeCode.Boolean => "bool",
+                PrimitiveTypeCode.Char => "char",
+                PrimitiveTypeCode.SByte => "sbyte",
+                PrimitiveTypeCode.Byte => "byte",
+                PrimitiveTypeCode.Int16 => "short",
+                PrimitiveTypeCode.UInt16 => "ushort",
+                PrimitiveTypeCode.Int32 => "int",
+                PrimitiveTypeCode.UInt32 => "uint",
+                PrimitiveTypeCode.Int64 => "long",
+                PrimitiveTypeCode.UInt64 => "ulong",
+                PrimitiveTypeCode.Single => "float",
+                PrimitiveTypeCode.Double => "double",
+                PrimitiveTypeCode.String => "string",
+                PrimitiveTypeCode.Object => "object",
+                PrimitiveTypeCode.IntPtr => "nint",
+                PrimitiveTypeCode.UIntPtr => "nuint",
+                PrimitiveTypeCode.TypedReference => "TypedReference",
+                _ => typeCode.ToString(),
+            };
+            return new TypeAttribution(display, "System", "");
+        }
+
+        TypeAttribution ISimpleTypeProvider<TypeAttribution>.GetTypeFromDefinition(
+            MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+        {
+            var td = reader.GetTypeDefinition(handle);
+            var name = reader.GetString(td.Name);
+            var ns = reader.GetString(td.Namespace);
+            return new TypeAttribution(ns.Length > 0 ? $"{ns}.{name}" : name, ns, "");
+        }
+
+        TypeAttribution ISimpleTypeProvider<TypeAttribution>.GetTypeFromReference(
+            MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) =>
+            ResolveTypeRef(handle);
+
+        TypeAttribution ISignatureTypeProvider<TypeAttribution, object?>.GetTypeFromSpecification(
+            MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind) =>
+            reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+
+        TypeAttribution IConstructedTypeProvider<TypeAttribution>.GetGenericInstantiation(
+            TypeAttribution genericType, ImmutableArray<TypeAttribution> typeArguments) =>
+            genericType with { Display = $"{genericType.Display}<{Join(typeArguments)}>" };
+
+        TypeAttribution ISZArrayTypeProvider<TypeAttribution>.GetSZArrayType(TypeAttribution elementType) =>
+            elementType with { Display = $"{elementType.Display}[]" };
+
+        TypeAttribution IConstructedTypeProvider<TypeAttribution>.GetArrayType(
+            TypeAttribution elementType, ArrayShape shape) =>
+            elementType with { Display = $"{elementType.Display}[{new string(',', shape.Rank - 1)}]" };
+
+        TypeAttribution IConstructedTypeProvider<TypeAttribution>.GetByReferenceType(TypeAttribution elementType) =>
+            elementType with { Display = $"ref {elementType.Display}" };
+
+        TypeAttribution IConstructedTypeProvider<TypeAttribution>.GetPointerType(TypeAttribution elementType) =>
+            elementType with { Display = $"{elementType.Display}*" };
+
+        TypeAttribution ISignatureTypeProvider<TypeAttribution, object?>.GetGenericMethodParameter(
+            object? genericContext, int index) => new($"!!{index}", "", "");
+
+        TypeAttribution ISignatureTypeProvider<TypeAttribution, object?>.GetGenericTypeParameter(
+            object? genericContext, int index) => new($"!{index}", "", "");
+
+        TypeAttribution ISignatureTypeProvider<TypeAttribution, object?>.GetModifiedType(
+            TypeAttribution modifier, TypeAttribution unmodifiedType, bool isRequired) => unmodifiedType;
+
+        TypeAttribution ISignatureTypeProvider<TypeAttribution, object?>.GetPinnedType(
+            TypeAttribution elementType) => elementType;
+
+        TypeAttribution ISignatureTypeProvider<TypeAttribution, object?>.GetFunctionPointerType(
+            MethodSignature<TypeAttribution> signature) => new("fnptr", "", "");
+    }
+}

--- a/src/Dotsider.Core/Analysis/SizeAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/SizeAnalyzer.cs
@@ -4,7 +4,9 @@ namespace Dotsider.Core.Analysis;
 
 /// <summary>
 /// Computes IL code size per method and builds a hierarchical size tree
-/// for treemap visualization.
+/// for treemap visualization. For a Native AOT binary with an mstat sidecar the tree is
+/// built from the compiler's size report instead: native code and MethodTable bytes per
+/// assembly, namespace, type, and method, plus the binary's data categories.
 /// </summary>
 public static class SizeAnalyzer
 {
@@ -15,6 +17,9 @@ public static class SizeAnalyzer
     /// <returns>The root <see cref="SizeNode"/> representing the entire assembly.</returns>
     public static SizeNode BuildSizeTree(AssemblyAnalyzer analyzer)
     {
+        if (analyzer.BinaryKind == BinaryKind.NativeAot && analyzer.Mstat is { } mstat)
+            return BuildAotSizeTree(analyzer, mstat);
+
         // Get method sizes
         var methodSizes = new List<(MethodDefInfo Method, long Size)>();
         foreach (var method in analyzer.MethodDefs)
@@ -95,4 +100,159 @@ public static class SizeAnalyzer
             SizeNodeKind.Assembly,
             [.. namespaceNodes.OrderByDescending(n => n.Size)]);
     }
+
+    /// <summary>
+    /// Builds the size tree of a Native AOT binary from its mstat report: one subtree per
+    /// contributing assembly (namespace &gt; type &gt; method, with each type's MethodTable as
+    /// an explicit leaf so sums stay exact) beside category nodes for the binary's data
+    /// regions. Method sizes include code, GC info, and EH info.
+    /// </summary>
+    private static SizeNode BuildAotSizeTree(AssemblyAnalyzer analyzer, MstatData mstat)
+    {
+        var roots = new List<SizeNode>();
+        roots.AddRange(BuildAssemblyNodes(mstat));
+
+        // The 2.1+ detail sections re-report bytes that older readers found in these blob
+        // buckets; showing both would double-count, so each bucket yields to its detail
+        // section when that section has entries.
+        var excluded = new HashSet<string>(StringComparer.Ordinal);
+        if (mstat.FrozenObjects.Count > 0) excluded.Add("ArrayOfFrozenObjects");
+        if (mstat.RvaFields.Count > 0) excluded.Add("FieldRvaData");
+        if (mstat.ManifestResources.Count > 0) excluded.Add("ResourceData");
+
+        var blobs = mstat.Blobs
+            .Where(b => b.Size > 0 && !excluded.Contains(b.Name))
+            .OrderByDescending(b => b.Size)
+            .Select(b => new SizeNode(b.Name, $"Blobs/{b.Name}", b.Size, SizeNodeKind.Blob, []))
+            .ToList();
+        if (blobs.Count > 0)
+            roots.Add(new SizeNode("Blobs", "Blobs", blobs.Sum(b => b.Size), SizeNodeKind.Category, blobs));
+
+        var frozen = mstat.FrozenObjects
+            .Where(f => f.Size > 0)
+            .OrderByDescending(f => f.Size)
+            .Select((f, i) => new SizeNode(
+                f.TypeName, f.NodeName ?? $"Frozen Objects/{f.TypeName}#{i}", f.Size,
+                SizeNodeKind.FrozenObject, [], f.NodeName))
+            .ToList();
+        if (frozen.Count > 0)
+            roots.Add(new SizeNode("Frozen Objects", "Frozen Objects", frozen.Sum(f => f.Size), SizeNodeKind.Category, frozen));
+
+        var rvaFields = mstat.RvaFields
+            .Where(f => f.Size > 0)
+            .OrderByDescending(f => f.Size)
+            .Select(f => new SizeNode(
+                f.Name, f.NodeName ?? $"RVA Fields/{f.Name}", f.Size, SizeNodeKind.RvaField, [], f.NodeName))
+            .ToList();
+        if (rvaFields.Count > 0)
+            roots.Add(new SizeNode("RVA Fields", "RVA Fields", rvaFields.Sum(f => f.Size), SizeNodeKind.Category, rvaFields));
+
+        var resources = mstat.ManifestResources
+            .Where(r => r.Size > 0)
+            .OrderByDescending(r => r.Size)
+            .Select(r => new SizeNode(r.Name, $"Resources/{r.Name}", r.Size, SizeNodeKind.Resource, []))
+            .ToList();
+        if (resources.Count > 0)
+            roots.Add(new SizeNode("Resources", "Resources", resources.Sum(r => r.Size), SizeNodeKind.Category, resources));
+
+        return new SizeNode(
+            analyzer.FileName,
+            analyzer.FileName,
+            roots.Sum(n => n.Size),
+            SizeNodeKind.Assembly,
+            [.. roots.OrderByDescending(n => n.Size)]);
+    }
+
+    /// <summary>
+    /// Groups mstat methods and types into assembly &gt; namespace &gt; type subtrees. A type
+    /// node's children are its methods plus a MethodTable leaf carrying the type's runtime
+    /// structure size and dependency-graph node name.
+    /// </summary>
+    private static List<SizeNode> BuildAssemblyNodes(MstatData mstat)
+    {
+        var methodsByType = mstat.Methods
+            .GroupBy(m => (m.AssemblyName, m.DeclaringType))
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        // Two constructed types can render to the same display name; fold them into one
+        // MethodTable entry, keeping the first node name for the why-chain join.
+        var typesByKey = new Dictionary<(string Assembly, string Type), (long Size, string? NodeName, string Namespace)>();
+        foreach (var t in mstat.Types)
+        {
+            var key = (t.AssemblyName, t.Name);
+            typesByKey[key] = typesByKey.TryGetValue(key, out var existing)
+                ? (existing.Size + t.Size, existing.NodeName, existing.Namespace)
+                : (t.Size, t.NodeName, t.Namespace);
+        }
+
+        // A type can appear with methods but no MethodTable, or the reverse; join over both.
+        var typeKeys = methodsByType.Keys.Union(typesByKey.Keys);
+
+        var assemblies = new Dictionary<string, Dictionary<string, List<SizeNode>>>(StringComparer.Ordinal);
+        foreach (var (assemblyName, typeName) in typeKeys)
+        {
+            var children = new List<SizeNode>();
+
+            var ns = "";
+            if (typesByKey.TryGetValue((assemblyName, typeName), out var methodTable))
+            {
+                ns = methodTable.Namespace;
+                if (methodTable.Size > 0)
+                {
+                    children.Add(new SizeNode(
+                        "MethodTable", $"{assemblyName}/{typeName}::MethodTable",
+                        methodTable.Size, SizeNodeKind.MethodTable, [], methodTable.NodeName));
+                }
+            }
+
+            if (methodsByType.TryGetValue((assemblyName, typeName), out var methods))
+            {
+                ns = methods[0].Namespace;
+                children.AddRange(methods
+                    .Select(m => (Method: m, Total: (long)m.Size + m.GcInfoSize + m.EhInfoSize))
+                    .Where(m => m.Total > 0)
+                    .OrderByDescending(m => m.Total)
+                    .Select(m => new SizeNode(
+                        m.Method.Name, $"{assemblyName}/{typeName}::{m.Method.Name}",
+                        m.Total, SizeNodeKind.Method, [], m.Method.NodeName)));
+            }
+
+            if (children.Count == 0) continue;
+
+            var typeNode = new SizeNode(
+                StripNamespace(typeName, ns), $"{assemblyName}/{typeName}",
+                children.Sum(c => c.Size), SizeNodeKind.Type,
+                [.. children.OrderByDescending(c => c.Size)]);
+
+            var namespaces = assemblies.TryGetValue(assemblyName, out var existing)
+                ? existing
+                : assemblies[assemblyName] = new Dictionary<string, List<SizeNode>>(StringComparer.Ordinal);
+            var nsKey = string.IsNullOrEmpty(ns) ? "(global)" : ns;
+            (namespaces.TryGetValue(nsKey, out var list) ? list : namespaces[nsKey] = []).Add(typeNode);
+        }
+
+        var result = new List<SizeNode>(assemblies.Count);
+        foreach (var (assemblyName, namespaces) in assemblies)
+        {
+            var namespaceNodes = namespaces
+                .Select(kvp => new SizeNode(
+                    kvp.Key, $"{assemblyName}/{kvp.Key}",
+                    kvp.Value.Sum(t => t.Size), SizeNodeKind.Namespace,
+                    [.. kvp.Value.OrderByDescending(t => t.Size)]))
+                .OrderByDescending(n => n.Size)
+                .ToList();
+
+            result.Add(new SizeNode(
+                assemblyName, assemblyName,
+                namespaceNodes.Sum(n => n.Size), SizeNodeKind.Assembly, namespaceNodes));
+        }
+
+        return result;
+    }
+
+    /// <summary>Strips the namespace prefix from a namespace-qualified type display name.</summary>
+    private static string StripNamespace(string typeName, string ns) =>
+        ns.Length > 0 && typeName.StartsWith(ns + ".", StringComparison.Ordinal)
+            ? typeName[(ns.Length + 1)..]
+            : typeName;
 }

--- a/src/Dotsider.Core/README.md
+++ b/src/Dotsider.Core/README.md
@@ -10,8 +10,10 @@ Core library for .NET assembly analysis. Provides analyzers, models, and the dia
 | `IlDisassembler` | Disassembles method bodies into IL instruction sequences |
 | `IlNavigationResolver` | Resolves metadata tokens from IL instructions to `IlNavigationTarget` records (file path, type/method, member kind) for go-to-definition |
 | `StringExtractor` | Extracts user strings, metadata strings, and raw binary strings from an assembly |
-| `SizeAnalyzer` | Builds a hierarchical size tree (namespace → type → method) by IL byte size |
-| `DependencyGraphBuilder` | Generates a dependency graph (nodes and edges) from assembly references; routes through `NetFxBinder` for .NET Framework roots so nodes are keyed on the *bound* identity (post-redirect) |
+| `SizeAnalyzer` | Builds a hierarchical size tree (namespace → type → method) by IL byte size; for Native AOT binaries with an mstat sidecar the tree comes from the compiler's size report instead, with per-assembly subtrees and data categories |
+| `DependencyGraphBuilder` | Generates a dependency graph (nodes and edges) from assembly references; routes through `NetFxBinder` for .NET Framework roots so nodes are keyed on the *bound* identity (post-redirect). Native AOT binaries graph the compiled-in assemblies (mstat × DGML join) plus native import modules |
+| `MstatReader` | Decodes an ILC size report (`.mstat`) — a valid ECMA-335 assembly whose data lives in IL streams — into per-method, per-type, blob, frozen object, RVA field, and resource sizes with assembly attribution and dependency-graph node names |
+| `DgmlReader` | Streams an ILC dependency-graph DGML file into a `DgmlGraph` whose `PathToRoot` answers "why is this in my binary" — node labels equal mstat node names, joining the two files |
 | `AssemblyDiffer` | Compares two assemblies and reports added, removed, and changed types, methods, and references. Method body comparison uses normalized IL instruction walks with semantic token resolution, deep local signature decoding, and exception region analysis |
 | `RuntimeTracer` | Launches a .NET process with EventPipe tracing for JIT, GC, exception, and counter events |
 | `NuGetPackageAnalyzer` | Reads `.nupkg` files for package metadata and DLL listing |
@@ -37,6 +39,8 @@ All models live in `Analysis/Models/` and are plain records or enums suitable fo
 **Portable PDB:** `PdbProvenance`, `PdbProvenanceKind`, `SourceLinkInfo`, `SourceLinkMapping`, `EmbeddedSourceInfo`
 
 **Size:** `SizeNode`, `SizeNodeKind`
+
+**Native AOT sidecars:** `MstatData`, `MstatMethod`, `MstatType`, `MstatBlob`, `MstatRvaField`, `MstatFrozenObject`, `MstatManifestResource`, `MstatDeduplicatedMethod`, `DgmlGraph`, `DgmlNode`, `DgmlLink`, `DgmlPathStep`
 
 **Strings:** `StringEntry`, `StringSource`
 
@@ -87,11 +91,11 @@ The diagnostics protocol enables communication between the dotsider TUI and exte
 | `get-method-debug-info` | TypeName, MethodName | Portable PDB sequence points and local names for a method |
 | `get-source-link` | — | Source Link mappings decoded from the portable PDB |
 | `search-il-opcodes` | Query, MaxResults? | Find methods containing an opcode |
-| `get-size-tree` | — | Hierarchical size tree |
+| `get-size-tree` | — | Hierarchical size tree (AOT-aware: mstat-backed for Native AOT binaries) |
 | `get-largest-methods` | MaxResults? | Top methods by IL size |
 | `get-strings` | Query?, MinLength?, MaxResults? | User, metadata, and binary strings |
 | `get-assembly-refs` | — | Assembly references |
-| `get-dependency-graph` | — | Dependency graph nodes and edges |
+| `get-dependency-graph` | — | Dependency graph nodes and edges (AOT-aware: compiled-in assemblies and native imports) |
 | `get-type-refs` | — | Type references |
 | `diff` | LeftPath, RightPath | Assembly comparison |
 | `is-bundle` | AssemblyPath | Check if a file is a single-file bundle |

--- a/src/Dotsider/Commands/AnalyzeCommand.cs
+++ b/src/Dotsider/Commands/AnalyzeCommand.cs
@@ -56,6 +56,11 @@ internal static class AnalyzeCommand
         Description = "Show size breakdown"
     };
 
+    private static readonly Option<string?> s_whyOption = new("--why")
+    {
+        Description = "Explain why a type or method is in a Native AOT binary (requires mstat and DGML sidecars)"
+    };
+
     private static readonly Option<bool> s_fieldsOption = new("--fields")
     {
         Description = "List field definitions"
@@ -87,6 +92,7 @@ internal static class AnalyzeCommand
             s_stringsOption,
             s_minLenOption,
             s_sizeOption,
+            s_whyOption,
             s_fieldsOption,
             s_bundleOption,
             s_outputOption
@@ -205,6 +211,9 @@ internal static class AnalyzeCommand
 
                 if (parseResult.GetValue(s_sizeOption))
                     return Task.FromResult(PrintSize(analyzer, formatter));
+
+                if (parseResult.GetValue(s_whyOption) is { } whyTarget)
+                    return Task.FromResult(PrintWhy(analyzer, whyTarget, formatter));
 
                 if (parseResult.GetValue(s_fieldsOption))
                     return Task.FromResult(PrintFields(analyzer, formatter));
@@ -564,6 +573,85 @@ internal static class AnalyzeCommand
 
         foreach (var child in node.Children.OrderByDescending(c => c.Size).Take(20))
             PrintSizeNode(child, fmt, indent + 1);
+    }
+
+    private static int PrintWhy(AssemblyAnalyzer a, string target, OutputFormatter fmt)
+    {
+        if (a.BinaryKind != BinaryKind.NativeAot || a.Mstat is not { } mstat)
+        {
+            Console.Error.WriteLine(
+                "Error: --why requires a Native AOT binary with an mstat sidecar next to it "
+                + "(publish with IlcGenerateMstatFile)");
+            return 1;
+        }
+
+        if (a.Dgml is not { } dgml)
+        {
+            Console.Error.WriteLine(
+                "Error: --why requires a DGML sidecar next to the binary "
+                + "(publish with IlcGenerateDgmlFile and keep the *.codegen.dgml.xml beside it)");
+            return 1;
+        }
+
+        // Exact display-name match wins; otherwise fall back to a case-insensitive
+        // substring search and require it to be unambiguous.
+        var candidates = mstat.Methods
+            .Where(m => m.NodeName is not null)
+            .Select(m => (Display: $"{m.DeclaringType}::{m.Name}", NodeName: m.NodeName!))
+            .Concat(mstat.Types
+                .Where(t => t.NodeName is not null)
+                .Select(t => (Display: t.Name, NodeName: t.NodeName!)))
+            .ToList();
+
+        var matches = candidates
+            .Where(c => string.Equals(c.Display, target, StringComparison.Ordinal))
+            .ToList();
+        if (matches.Count == 0)
+        {
+            matches = [.. candidates
+                .Where(c => c.Display.Contains(target, StringComparison.OrdinalIgnoreCase))];
+        }
+
+        if (matches.Count == 0)
+        {
+            Console.Error.WriteLine($"Error: no compiled type or method matches '{target}'");
+            return 1;
+        }
+
+        if (matches.Count > 1)
+        {
+            Console.Error.WriteLine($"Error: '{target}' is ambiguous ({matches.Count} matches):");
+            foreach (var candidate in matches.Take(10))
+                Console.Error.WriteLine($"  {candidate.Display}");
+            if (matches.Count > 10)
+                Console.Error.WriteLine($"  ... and {matches.Count - 10} more");
+            return 1;
+        }
+
+        var (display, nodeName) = matches[0];
+        var chain = dgml.PathToRoot(nodeName);
+        if (chain.Count == 0)
+        {
+            Console.Error.WriteLine($"Error: '{display}' is not present in the DGML dependency graph");
+            return 1;
+        }
+
+        if (fmt.JsonMode)
+        {
+            fmt.WriteJson(new { Target = display, NodeName = nodeName, Chain = chain });
+            return 0;
+        }
+
+        fmt.WriteLine($"Why is {display} in the binary? (root first)");
+        fmt.WriteLine("");
+        for (var i = 0; i < chain.Count; i++)
+        {
+            fmt.WriteLine($"{i + 1,3}. {chain[i].Label}");
+            if (chain[i].Reason is { } reason)
+                fmt.WriteLine($"     reason: {reason}");
+        }
+
+        return 0;
     }
 
     private static int PrintFields(AssemblyAnalyzer a, OutputFormatter fmt)

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -375,7 +375,8 @@ public sealed class DotsiderApp(DotsiderState state)
             if ((hasBackTarget || hasIlSelection) && !sizeMapUsesEsc && !dynamicFilterActive
                 && !currentSearch.IsActive && !_state.HexJumpDialogOpen && !hexInsertMode
                 && !_state.ApphostDialogOpen && !_state.DynamicEditingArgs
-                && _state.PeDetailContent is null && _state.StringsDetailContent is null)
+                && _state.PeDetailContent is null && _state.StringsDetailContent is null
+                && _state.SizeMapWhyContent is null)
             {
                 bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(VimReset(_ =>
                 {
@@ -599,6 +600,10 @@ public sealed class DotsiderApp(DotsiderState state)
             if (_state.CurrentTab is 0 or 1 or 6) // General, PE/Metadata, Size Map
                 hints.Add(s.Section(_state.HumanReadableSizes ? "s: Sizes (dec)" : "s: Sizes (hex)"));
 
+            // w: Why hint — AOT size map entries can explain their dependency chain
+            if (_state.CurrentTab == TabId.SizeMap && _state.IsNativeAot)
+                hints.Add(s.Section("w: Why"));
+
             // y: Yank hint — show when yankable content exists
             var yankable = _state.CurrentTab switch
             {
@@ -796,6 +801,9 @@ public sealed class DotsiderApp(DotsiderState state)
         state.CachedSizeTree = null;
         state.TreemapCurrentLevel = null;
         state.TreemapBreadcrumb.Clear();
+        state.SizeMapWhyContent = null;
+        state.SizeMapWhyEditorState = null;
+        state.SizeMapWhyEditorText = null;
         state.IlSelectedMethod = null;
         state.IlSelectedField = null;
         state.IlEditorMethod = null;

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -146,6 +146,9 @@ public sealed class DotsiderState : IDisposable
     /// <summary>The item being shown in the detail popup, or null.</summary>
     public string? PeDetailContent { get; set; }
 
+    /// <summary>The why-chain shown in the Size Map popup, or null when the popup is closed.</summary>
+    public string? SizeMapWhyContent { get; set; }
+
     /// <summary>The focused row key in the current PE metadata table.</summary>
     public object? PeFocusedKey { get; set; }
 
@@ -358,6 +361,15 @@ public sealed class DotsiderState : IDisposable
 
     /// <summary>Yank flash decoration provider for the PE detail popup editor.</summary>
     public IlYankDecorationProvider PeDetailYankProvider { get; } = new();
+
+    /// <summary>Read-only editor for the Size Map why-chain popup overlay.</summary>
+    public EditorState? SizeMapWhyEditorState { get; set; }
+
+    /// <summary>Source text used to build <see cref="SizeMapWhyEditorState"/>, for staleness detection.</summary>
+    public string? SizeMapWhyEditorText { get; set; }
+
+    /// <summary>Yank flash decoration provider for the why-chain popup editor.</summary>
+    public IlYankDecorationProvider SizeMapWhyYankProvider { get; } = new();
 
     /// <summary>Read-only editor for the Strings detail popup overlay.</summary>
     public EditorState? StringsDetailEditorState { get; set; }
@@ -1416,6 +1428,7 @@ public sealed class DotsiderState : IDisposable
         PeSubTab = 0;
         PeFocusedKey = null;
         PeDetailContent = null;
+        SizeMapWhyContent = null;
         SetIlFocusedTreeKey(null);
         IlSelectedMethod = null;
         IlSelectedField = null;
@@ -1461,6 +1474,8 @@ public sealed class DotsiderState : IDisposable
         DataInterpEditorText = null;
         PeDetailEditorState = null;
         PeDetailEditorText = null;
+        SizeMapWhyEditorState = null;
+        SizeMapWhyEditorText = null;
         StringsDetailEditorState = null;
         StringsDetailEditorText = null;
         StringsSourceTab = 0;

--- a/src/Dotsider/Views/DependencyGraphView.cs
+++ b/src/Dotsider/Views/DependencyGraphView.cs
@@ -19,6 +19,7 @@ public static class DependencyGraphView
 {
     private static readonly Hex1bColor RootColor = Hex1bColor.FromRgb(0, 200, 180);
     private static readonly Hex1bColor RefColor = Hex1bColor.FromRgb(100, 130, 180);
+    private static readonly Hex1bColor NativeImportColor = Hex1bColor.FromRgb(150, 120, 170);
     private static readonly Hex1bColor UnresolvedColor = Hex1bColor.FromRgb(120, 100, 100);
     private static readonly Hex1bColor EdgeColor = Hex1bColor.FromRgb(80, 80, 100);
     private static readonly Hex1bColor HighlightColor = Hex1bColor.FromRgb(255, 220, 100);
@@ -277,6 +278,8 @@ public static class DependencyGraphView
                                     $"{node.Name}: identity mismatch against {nctx.CandidateProbePath ?? "(unknown)"}",
                                 AssemblyProvenance.CodeBaseMissing =>
                                     $"{node.Name}: codeBase href not found: {nctx.CandidateProbePath ?? "(unknown)"}",
+                                AssemblyProvenance.CompiledIntoNativeImage =>
+                                    $"{node.Name}: compiled into the native image; no file to open",
                                 _ => $"{node.Name}: not resolvable",
                             };
                             state.App.Invalidate();
@@ -446,7 +449,9 @@ public static class DependencyGraphView
 
         var isMatch = hasQuery && node.Name.Contains(query!, StringComparison.OrdinalIgnoreCase);
         Hex1bColor baseColor = node.Unresolved ? UnresolvedColor
-            : node.IsRoot ? RootColor : RefColor;
+            : node.IsRoot ? RootColor
+            : node.Kind == GraphNodeKind.NativeImport ? NativeImportColor
+            : RefColor;
         var bg = isHovered ? HighlightColor
             : isMatch ? baseColor
             : hasQuery ? HighlightHelper.DimColor

--- a/src/Dotsider/Views/SizeTreemapView.cs
+++ b/src/Dotsider/Views/SizeTreemapView.cs
@@ -1,6 +1,7 @@
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
+using Hex1b.Documents;
 using Hex1b.Input;
 using Hex1b.Surfaces;
 using Hex1b.Theming;
@@ -71,7 +72,17 @@ public static class SizeTreemapView
             : null;
         }
 
-        return ctx.VStack(outer =>
+        // Build the why-chain popup editor state when its content changes
+        if (state.SizeMapWhyContent is not null && state.SizeMapWhyEditorText != state.SizeMapWhyContent)
+        {
+            state.SizeMapWhyEditorText = state.SizeMapWhyContent;
+            state.SizeMapWhyEditorState = new EditorState(new Hex1bDocument(state.SizeMapWhyContent)) { IsReadOnly = true };
+        }
+
+        return ctx.ZStack(z =>
+        [
+            // Layer 0: Main content
+            z.VStack(outer =>
         {
             var widgets = new List<Hex1bWidget>
             {
@@ -143,9 +154,11 @@ public static class SizeTreemapView
                     state.TreemapHoveredNode = null;
                     state.App.Invalidate();
                 }
-                else if (drillTarget is { Kind: SizeNodeKind.Method, FullPath: var fullPath })
+                else if (drillTarget is { Kind: SizeNodeKind.Method, FullPath: var fullPath }
+                    && state.Analyzer.HasMetadata)
                 {
-                    // Leaf method node — navigate to IL Inspector
+                    // Leaf method node — navigate to IL Inspector. Native AOT leaves carry
+                    // no metadata token, so the jump is metadata-only.
                     // FullPath format: "DeclaringType::MethodName@0xTOKEN"
                     var atIdx = fullPath.LastIndexOf('@');
                     if (atIdx > 0 && fullPath.Length > atIdx + 3
@@ -159,9 +172,22 @@ public static class SizeTreemapView
                 }
             }).InputBindings(bindings =>
             {
-                // Esc pops the treemap breadcrumb (when no search is active)
+                // Esc dismisses the why popup first, then pops the treemap breadcrumb
+                // (when no search is active)
                 var treemapSearch = state.Search[TabId.SizeMap];
-                if (!treemapSearch.IsActive && state.TreemapBreadcrumb.Count > 0)
+                if (!treemapSearch.IsActive && state.SizeMapWhyContent is not null)
+                {
+                    bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
+                    {
+                        state.VimPending = VimMotionState.Idle;
+                        state.SizeMapWhyContent = null;
+                        state.SizeMapWhyEditorText = null;
+                        state.SizeMapWhyEditorState = null;
+                        state.RequestContentFocus();
+                        state.App.Invalidate();
+                    }, "Dismiss why");
+                }
+                else if (!treemapSearch.IsActive && state.TreemapBreadcrumb.Count > 0)
                 {
                     bindings.Key(Hex1bKey.Escape).Global().OverridesCapture().Action(_ =>
                     {
@@ -171,6 +197,25 @@ public static class SizeTreemapView
                         state.App.Invalidate();
                     }, "Go up");
                 }
+
+                // w explains why the targeted node is in a Native AOT binary: the chain of
+                // dependencies from a root, joined through the node name the mstat recorded.
+                bindings.Key(Hex1bKey.W).Action(_ =>
+                {
+                    var target = state.TreemapHoveredNode;
+                    if (target is null && state.TreemapMatchIndex >= 0
+                        && state.TreemapMatchIndex < matchingItems.Count)
+                        target = currentLevel.Children[matchingItems[state.TreemapMatchIndex]];
+                    if (target is null && state.TreemapSelectedIndex >= 0
+                        && state.TreemapSelectedIndex < currentLevel.Children.Count)
+                        target = currentLevel.Children[state.TreemapSelectedIndex];
+                    if (target?.AotNodeName is null) return;
+
+                    state.SizeMapWhyContent = state.Analyzer.Dgml is { } dgml
+                        ? FormatWhyChain(dgml, target)
+                        : $"{target.FullPath}\n\nNo DGML dependency graph next to the binary.\nPublish with IlcGenerateDgmlFile and keep the\n*.codegen.dgml.xml beside the executable.";
+                    state.App.Invalidate();
+                }, "Why in binary");
 
                 bindings.Mouse(MouseButton.Right).Action(_ =>
                 {
@@ -232,7 +277,73 @@ public static class SizeTreemapView
                 }
             }, "Esc");
         })
-        .Fill();
+        .Fill(),
+
+            // Layer 1: Why-chain popup overlay (read-only editor for selection + yank)
+            state.SizeMapWhyContent is not null && state.SizeMapWhyEditorState is not null
+                ? z.Backdrop(
+                    z.Border(
+                        z.ThemePanel(t => t
+                            .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
+                            .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
+                        z.Editor(state.SizeMapWhyEditorState)
+                            .ViewRenderer(InfoEditorViewRenderer.Instance)
+                            .Decorations(new InfoLabelDecorationProvider())
+                            .Decorations(state.SizeMapWhyYankProvider)
+                            .InputBindings(bindings =>
+                            {
+                                TextObjectHelper.ConfigureReadOnlyEditorBindings(
+                                    bindings,
+                                    state.SizeMapWhyEditorState!,
+                                    () => state.VimPending,
+                                    () => state.VimPendingEditor,
+                                    () => state.VimPendingCursorOffset,
+                                    () => state.VimPendingTimestamp,
+                                    (s, e, o) => { state.VimPending = s; state.VimPendingEditor = e; state.VimPendingCursorOffset = o; state.VimPendingTimestamp = DateTime.UtcNow; },
+                                    state.PerformEditorYank,
+                                    () => state.App.Invalidate());
+                            })
+                            .FillWidth().FillHeight())
+                    ).Title(" Why in binary ").FixedWidth(100).FixedHeight(20)
+                ).OnClickAway(() =>
+                {
+                    state.SizeMapWhyContent = null;
+                    state.SizeMapWhyEditorText = null;
+                    state.SizeMapWhyEditorState = null;
+                    state.RequestContentFocus();
+                    state.App.Invalidate();
+                })
+                : null
+        ]).Fill();
+    }
+
+    /// <summary>
+    /// Formats the root-to-node dependency chain for the why popup: the root kept step 2,
+    /// step 2 kept step 3, and so on down to the node that was asked about.
+    /// </summary>
+    private static string FormatWhyChain(DgmlGraph dgml, SizeNode target)
+    {
+        var path = dgml.PathToRoot(target.AotNodeName!);
+        if (path.Count == 0)
+        {
+            return $"{target.FullPath}\n\nNot present in the DGML dependency graph. The scan\ngraph can differ from the compiled output; publish\nwith the codegen graph next to the binary for an\nexact join.";
+        }
+
+        var lines = new List<string>
+        {
+            target.FullPath,
+            "",
+            "Kept by (root first):",
+            "",
+        };
+        for (var i = 0; i < path.Count; i++)
+        {
+            lines.Add($"{i + 1,3}. {path[i].Label}");
+            if (path[i].Reason is { } reason)
+                lines.Add($"     reason: {reason}");
+        }
+
+        return string.Join('\n', lines);
     }
 
     private static string BuildBreadcrumb(DotsiderState state)

--- a/tests/Dotsider.Mcp.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Mcp.Tests/SampleAssemblyFixture.cs
@@ -56,6 +56,18 @@ public class SampleAssemblyFixture : IAsyncLifetime
     public string? NativeAotConsoleExe { get; private set; }
 
     /// <summary>
+    /// Path to the ILC size report published next to the NativeAOT sample, or null when the
+    /// publish did not produce one.
+    /// </summary>
+    public string? NativeAotConsoleMstat { get; private set; }
+
+    /// <summary>
+    /// Path to the ILC dependency-graph DGML published next to the NativeAOT sample (codegen
+    /// preferred, scan fallback), or null when the publish did not produce one.
+    /// </summary>
+    public string? NativeAotConsoleDgml { get; private set; }
+
+    /// <summary>
     /// Builds all sample projects once per collection and resolves their output paths.
     /// </summary>
     public async ValueTask InitializeAsync()
@@ -105,6 +117,18 @@ public class SampleAssemblyFixture : IAsyncLifetime
 
         if (!File.Exists(NativeAotConsoleExe))
             NativeAotConsoleExe = null;
+
+        if (NativeAotConsoleExe is not null)
+        {
+            var aotPublishDir = Path.GetDirectoryName(NativeAotConsoleExe)!;
+            var mstat = Path.Combine(aotPublishDir, "NativeAotConsole.mstat");
+            NativeAotConsoleMstat = File.Exists(mstat) ? mstat : null;
+            var codegenDgml = Path.Combine(aotPublishDir, "NativeAotConsole.codegen.dgml.xml");
+            var scanDgml = Path.Combine(aotPublishDir, "NativeAotConsole.scan.dgml.xml");
+            NativeAotConsoleDgml = File.Exists(codegenDgml) ? codegenDgml
+                : File.Exists(scanDgml) ? scanDgml
+                : null;
+        }
     }
 
     /// <summary>
@@ -244,12 +268,16 @@ public class SampleAssemblyFixture : IAsyncLifetime
     {
         var rid = RuntimeInformation.RuntimeIdentifier;
         var apphostExt = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
-        var expectedOutput = Path.Combine(_repoRoot, relativePath,
-            "bin", "Release", "net10.0", rid, "publish",
+        var publishDir = Path.Combine(_repoRoot, relativePath,
+            "bin", "Release", "net10.0", rid, "publish");
+        var expectedOutput = Path.Combine(publishDir,
             $"{Path.GetFileName(relativePath)}{apphostExt}");
+        // The mstat sidecar joins the up-to-date check so a publish that predates sidecar
+        // emission republishes once instead of leaving sidecar tests skipping forever.
+        var expectedMstat = Path.Combine(publishDir, $"{Path.GetFileName(relativePath)}.mstat");
 
         // Skip if Dotsider.Tests already published
-        if (File.Exists(expectedOutput))
+        if (File.Exists(expectedOutput) && File.Exists(expectedMstat))
             return;
 
         var lockName = "dotsider-build-" + relativePath.Replace('/', '-').Replace('\\', '-') + ".lock";
@@ -272,7 +300,7 @@ public class SampleAssemblyFixture : IAsyncLifetime
         try
         {
             // Re-check after acquiring lock
-            if (File.Exists(expectedOutput))
+            if (File.Exists(expectedOutput) && File.Exists(expectedMstat))
             {
                 lockFile.Dispose();
                 return;

--- a/tests/Dotsider.Mcp.Tests/SizeToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/SizeToolsTests.cs
@@ -74,4 +74,29 @@ public class SizeToolsTests(SampleAssemblyFixture samples) : McpServerTestBase
         var methods = JsonSerializer.Deserialize<JsonElement>(text);
         Assert.True(methods.GetArrayLength() <= 20);
     }
+
+    /// <summary>
+    /// get_size_breakdown on a Native AOT binary with an mstat sidecar returns the AOT tree:
+    /// assembly subtrees plus category nodes, not an empty root.
+    /// </summary>
+    [Fact]
+    public async Task GetSizeBreakdown_NativeAot_ReturnsAotTree()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "get_size_breakdown",
+            new Dictionary<string, object?> { ["assemblyPath"] = samples.NativeAotConsoleExe },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var tree = JsonSerializer.Deserialize<JsonElement>(text);
+        Assert.True(tree.GetProperty("size").GetInt64() > 0);
+        Assert.Contains("category", text);
+        Assert.Contains("System.Private.CoreLib", text);
+    }
 }

--- a/tests/Dotsider.Tests/AssemblyAnalyzerTests.cs
+++ b/tests/Dotsider.Tests/AssemblyAnalyzerTests.cs
@@ -844,6 +844,108 @@ public class AssemblyAnalyzerTests(SampleAssemblyFixture samples)
         Assert.Throws<ObjectDisposedException>(() => a.ResolveToken(token));
     }
 
+    /// <summary>
+    /// Verifies the analyzer finds and parses the mstat and DGML sidecars published next to
+    /// the Native AOT sample, preferring the codegen graph.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Sidecars_NativeAotExe_ProbeAndParse()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        using var a = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+
+        Assert.Equal(samples.NativeAotConsoleMstat, a.MstatPath);
+        Assert.NotNull(a.Mstat);
+        Assert.NotEmpty(a.Mstat.Methods);
+
+        if (samples.NativeAotConsoleDgml is not null)
+        {
+            Assert.Equal(samples.NativeAotConsoleDgml, a.DgmlPath);
+            Assert.NotNull(a.Dgml);
+            Assert.NotEmpty(a.Dgml.Nodes);
+        }
+    }
+
+    /// <summary>
+    /// Verifies an AOT binary with no sidecars beside it probes to null without throwing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Sidecars_NativeAotExeWithoutSidecars_ReturnNull()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        var dir = Directory.CreateTempSubdirectory("dotsider-nosidecar-");
+        try
+        {
+            var exeCopy = Path.Combine(dir.FullName, Path.GetFileName(samples.NativeAotConsoleExe!));
+            File.Copy(samples.NativeAotConsoleExe!, exeCopy);
+            using var a = new AssemblyAnalyzer(exeCopy);
+
+            Assert.Null(a.MstatPath);
+            Assert.Null(a.Mstat);
+            Assert.Null(a.DgmlPath);
+            Assert.Null(a.Dgml);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a managed assembly never probes for sidecars, even when a stray mstat sits
+    /// next to it — the binary-kind gate short-circuits first.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Sidecars_ManagedAssemblyWithStrayMstat_ReturnsNull()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var dir = Directory.CreateTempSubdirectory("dotsider-stray-");
+        try
+        {
+            var dllCopy = Path.Combine(dir.FullName, "RichLibrary.dll");
+            File.Copy(samples.RichLibraryDll, dllCopy);
+            File.Copy(samples.NativeAotConsoleMstat!, Path.Combine(dir.FullName, "RichLibrary.mstat"));
+            using var a = new AssemblyAnalyzer(dllCopy);
+
+            Assert.Null(a.MstatPath);
+            Assert.Null(a.Mstat);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a corrupt sidecar reads as null rather than throwing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Sidecars_CorruptMstat_ReturnsNull()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        var dir = Directory.CreateTempSubdirectory("dotsider-corrupt-");
+        try
+        {
+            var name = Path.GetFileName(samples.NativeAotConsoleExe!);
+            var exeCopy = Path.Combine(dir.FullName, name);
+            File.Copy(samples.NativeAotConsoleExe!, exeCopy);
+            var stem = name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ? name[..^4] : name;
+            File.WriteAllBytes(Path.Combine(dir.FullName, stem + ".mstat"), [0xDE, 0xAD]);
+            using var a = new AssemblyAnalyzer(exeCopy);
+
+            Assert.NotNull(a.MstatPath);
+            Assert.Null(a.Mstat);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
     private static MethodDefInfo FindMethod(AssemblyAnalyzer analyzer, string typeName, string methodName)
     {
         var method = analyzer.MethodDefs.FirstOrDefault(m =>

--- a/tests/Dotsider.Tests/CliTests.cs
+++ b/tests/Dotsider.Tests/CliTests.cs
@@ -558,6 +558,71 @@ public class CliTests(SampleAssemblyFixture fixture)
         Assert.DoesNotContain("aotNodeName", stdout);
     }
 
+    /// <summary>
+    /// Verifies <c>analyze --why</c> prints the root-first dependency chain for a compiled
+    /// method when both sidecars are present.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_Why_KnownType_PrintsChain()
+    {
+        Assert.SkipWhen(fixture.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+        Assert.SkipWhen(fixture.NativeAotConsoleDgml is null, "DGML sidecar was not produced");
+
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.NativeAotConsoleExe!, "--why", "Program");
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("in the binary? (root first)", stdout);
+        Assert.Contains("1.", stdout);
+    }
+
+    /// <summary>
+    /// Verifies <c>analyze --why --json</c> emits the chain as structured steps.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_Why_Json_EmitsChainSteps()
+    {
+        Assert.SkipWhen(fixture.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+        Assert.SkipWhen(fixture.NativeAotConsoleDgml is null, "DGML sidecar was not produced");
+
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.NativeAotConsoleExe!, "--why", "Program", "--json");
+
+        Assert.Equal(0, exitCode);
+        var json = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(stdout);
+        Assert.True(json.GetProperty("chain").GetArrayLength() > 0);
+        Assert.False(string.IsNullOrEmpty(json.GetProperty("target").GetString()));
+    }
+
+    /// <summary>
+    /// Verifies <c>analyze --why</c> with an unknown name errors with a clear message.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_Why_UnknownName_Errors()
+    {
+        Assert.SkipWhen(fixture.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+        Assert.SkipWhen(fixture.NativeAotConsoleDgml is null, "DGML sidecar was not produced");
+
+        var (exitCode, _, stderr) = await RunDotsiderAsync(
+            "analyze", fixture.NativeAotConsoleExe!, "--why", "NoSuchThingAnywhere12345");
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("no compiled type or method matches", stderr);
+    }
+
+    /// <summary>
+    /// Verifies <c>analyze --why</c> on a managed assembly explains the sidecar requirement.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_Why_ManagedAssembly_Errors()
+    {
+        var (exitCode, _, stderr) = await RunDotsiderAsync(
+            "analyze", fixture.RichLibraryDll, "--why", "Program");
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a Native AOT binary", stderr);
+    }
+
     // --- Helpers ---
 
     private static async Task<(int ExitCode, string Stdout, string Stderr)> RunDotsiderAsync(

--- a/tests/Dotsider.Tests/CliTests.cs
+++ b/tests/Dotsider.Tests/CliTests.cs
@@ -479,6 +479,54 @@ public class CliTests(SampleAssemblyFixture fixture)
         Assert.True(anyNonRootSource);
     }
 
+    /// <summary>
+    /// Verifies <c>analyze --size</c> on a Native AOT binary with an mstat sidecar prints the
+    /// per-assembly breakdown and the data categories instead of an empty tree.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_Size_NativeAot_PrintsAssemblyBreakdown()
+    {
+        Assert.SkipWhen(fixture.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.NativeAotConsoleExe!, "--size");
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("System.Private.CoreLib", stdout);
+        Assert.Contains("Blobs", stdout);
+    }
+
+    /// <summary>
+    /// Verifies <c>analyze --size --json</c> on a Native AOT binary carries the new node
+    /// kinds and the dependency-graph node names that make the tree joinable.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_Size_NativeAot_Json_HasAotKindsAndNodeNames()
+    {
+        Assert.SkipWhen(fixture.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.NativeAotConsoleExe!, "--size", "--json");
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"category\"", stdout);
+        Assert.Contains("aotNodeName", stdout);
+    }
+
+    /// <summary>
+    /// Verifies <c>analyze --size --json</c> on a managed assembly is unchanged by the AOT
+    /// additions: no aotNodeName property appears.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_Size_Managed_Json_HasNoAotProperties()
+    {
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.RichLibraryDll, "--size", "--json");
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain("aotNodeName", stdout);
+    }
+
     // --- Helpers ---
 
     private static async Task<(int ExitCode, string Stdout, string Stderr)> RunDotsiderAsync(

--- a/tests/Dotsider.Tests/CliTests.cs
+++ b/tests/Dotsider.Tests/CliTests.cs
@@ -480,6 +480,37 @@ public class CliTests(SampleAssemblyFixture fixture)
     }
 
     /// <summary>
+    /// Verifies <c>analyze --deps --json</c> on a Native AOT binary emits the compiled-in
+    /// assemblies and the native import modules, with only non-default node kinds serialized.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_Deps_NativeAot_Json_EmitsAssembliesAndImports()
+    {
+        Assert.SkipWhen(fixture.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.NativeAotConsoleExe!, "--deps", "--json");
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("System.Private.CoreLib", stdout);
+        Assert.Contains("\"nativeImport\"", stdout);
+    }
+
+    /// <summary>
+    /// Verifies managed <c>analyze --deps --json</c> output is byte-compatible with the
+    /// pre-AOT shape: the default assembly kind is never serialized.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_Deps_Managed_Json_OmitsDefaultKind()
+    {
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.RichLibraryDll, "--deps", "--json");
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain("\"kind\"", stdout);
+    }
+
+    /// <summary>
     /// Verifies <c>analyze --size</c> on a Native AOT binary with an mstat sidecar prints the
     /// per-assembly breakdown and the data categories instead of an empty tree.
     /// </summary>

--- a/tests/Dotsider.Tests/DependencyGraphBuilderTests.cs
+++ b/tests/Dotsider.Tests/DependencyGraphBuilderTests.cs
@@ -362,16 +362,111 @@ public class DependencyGraphBuilderTests(SampleAssemblyFixture samples)
     }
 
     /// <summary>
-    /// An assembly whose PE has no CLR metadata (for example a native binary or unknown format)
-    /// still produces a root-only graph and does not throw.
+    /// A Native AOT binary with mstat and DGML sidecars produces a real graph: the compiled
+    /// assemblies as nodes, DGML links aggregated to assembly-pair edges, and the native
+    /// import modules at depth 1.
     /// </summary>
     [Fact(Timeout = 30_000)]
-    public void NativeOrNoMetadata_ReturnsRootOnlyGraph()
+    public void NativeAot_BuildsAssemblyAndImportGraph()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        using var a = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var root = Assert.Single(graph.Nodes, n => n.IsRoot);
+        Assert.Equal("NativeAotConsole", root.Name);
+        Assert.Contains(graph.Nodes, n =>
+            n.Kind == GraphNodeKind.Assembly && n.Name == "System.Private.CoreLib");
+        Assert.Contains(graph.Nodes, n => n.Kind == GraphNodeKind.NativeImport);
+
+        if (samples.NativeAotConsoleDgml is not null)
+            Assert.Contains(graph.Edges, e => e.SourceId == root.Id && e.TypeRefCount > 0);
+    }
+
+    /// <summary>
+    /// The compiled-in assembly nodes carry full identity — version and public key token —
+    /// and their navigation contexts classify framework assemblies so the hide-framework
+    /// filter works on the AOT graph.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NativeAot_AssemblyNodesCarryIdentityAndFrameworkClassification()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        using var a = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        var corelib = graph.Nodes.First(n => n.Name == "System.Private.CoreLib");
+        Assert.NotNull(corelib.Version);
+        Assert.True(graph.NavigationById[corelib.Id].IsFrameworkAssembly);
+    }
+
+    /// <summary>
+    /// Every AOT node carries a navigation context with a null resolution and the
+    /// compiled-into-native-image provenance, so Enter degrades to a message instead of
+    /// reporting a missing context.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NativeAot_AllNodesHaveDegradedNavigationContexts()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        using var a = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        var graph = DependencyGraphBuilder.Build(a);
+
+        Assert.All(graph.Nodes, n =>
+        {
+            Assert.True(graph.NavigationById.ContainsKey(n.Id), $"{n.Name}: navigation context missing");
+            Assert.Null(graph.NavigationById[n.Id].Resolved);
+        });
+        Assert.All(graph.Nodes.Where(n => !n.IsRoot), n =>
+            Assert.Equal(AssemblyProvenance.CompiledIntoNativeImage, graph.NavigationById[n.Id].Provenance));
+    }
+
+    /// <summary>
+    /// A Native AOT binary with no sidecars falls back to the import star: the root plus its
+    /// native import modules, every edge sourced from the root.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NativeAot_WithoutSidecars_ReturnsRootPlusImportStar()
     {
         Assert.SkipWhen(samples.NativeAotConsoleExe is null || !File.Exists(samples.NativeAotConsoleExe),
             "Native AOT sample is not available on this platform.");
-        using var a = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+
+        var dir = Directory.CreateTempSubdirectory("dotsider-depgraph-");
+        try
+        {
+            var exeCopy = Path.Combine(dir.FullName, Path.GetFileName(samples.NativeAotConsoleExe!));
+            File.Copy(samples.NativeAotConsoleExe!, exeCopy);
+            using var a = new AssemblyAnalyzer(exeCopy);
+
+            var graph = DependencyGraphBuilder.Build(a);
+
+            var root = Assert.Single(graph.Nodes, n => n.IsRoot);
+            Assert.All(graph.Nodes.Where(n => !n.IsRoot), n =>
+                Assert.Equal(GraphNodeKind.NativeImport, n.Kind));
+            Assert.All(graph.Edges, e => Assert.Equal(root.Id, e.SourceId));
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A native binary that is not Native AOT (a plain apphost opened directly) still
+    /// produces a root-only graph and does not throw — the guarantee the AOT branch must not
+    /// disturb.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NativeNonAot_ReturnsRootOnlyGraph()
+    {
+        using var a = new AssemblyAnalyzer(samples.HelloWorldExe);
+        Assert.Equal(BinaryKind.Native, a.BinaryKind);
+
         var graph = DependencyGraphBuilder.Build(a);
+
         Assert.Single(graph.Nodes);
         Assert.True(graph.Nodes[0].IsRoot);
         Assert.Empty(graph.Edges);

--- a/tests/Dotsider.Tests/DgmlReaderTests.cs
+++ b/tests/Dotsider.Tests/DgmlReaderTests.cs
@@ -1,0 +1,257 @@
+using System.Text;
+using Dotsider.Core.Analysis;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="DgmlReader"/> against the real dependency graph published next to the
+/// NativeAOT sample, plus synthetic and malformed documents.
+/// </summary>
+[Collection("SampleAssemblies")]
+public class DgmlReaderTests(SampleAssemblyFixture samples)
+{
+    /// <summary>
+    /// Verifies the fixture's codegen graph parses with consistent nodes and links: every
+    /// indexed link endpoint resolves to a node.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public void Read_FixtureDgml_ParsesNodesAndLinks()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleDgml is null, "DGML sidecar was not produced");
+
+        var graph = DgmlReader.Read(samples.NativeAotConsoleDgml!);
+
+        Assert.NotNull(graph);
+        Assert.NotEmpty(graph.Nodes);
+        Assert.NotEmpty(graph.Links);
+        var ids = graph.Nodes.Select(n => n.Id).ToHashSet();
+        Assert.All(graph.Links, l =>
+        {
+            Assert.Contains(l.SourceId, ids);
+            Assert.Contains(l.TargetId, ids);
+        });
+    }
+
+    /// <summary>
+    /// Verifies a chain from a real method node reaches a root: the walk ends at a node with
+    /// no dependers, starts the returned list with it, and ends the list at the queried node.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public void PathToRoot_KnownMethodLabel_ReachesRoot()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+        Assert.SkipWhen(samples.NativeAotConsoleDgml is null, "DGML sidecar was not produced");
+
+        var graph = DgmlReader.Read(samples.NativeAotConsoleDgml!);
+        var data = MstatReader.Read(samples.NativeAotConsoleMstat!);
+        Assert.NotNull(graph);
+        Assert.NotNull(data);
+
+        // Any compiled method that is present in the graph will do; take the first join hit.
+        var nodeName = data.Methods
+            .Select(m => m.NodeName)
+            .FirstOrDefault(n => n is not null && graph.FindNodeByLabel(n) is not null);
+        Assert.NotNull(nodeName);
+
+        var path = graph.PathToRoot(nodeName!);
+
+        Assert.NotEmpty(path);
+        Assert.Equal(nodeName, path[^1].Label);
+        Assert.Null(path[0].Reason);
+        var rootNode = graph.FindNodeByLabel(path[0].Label);
+        Assert.NotNull(rootNode);
+        Assert.DoesNotContain(graph.Links, l => l.TargetId == rootNode.Id);
+    }
+
+    /// <summary>
+    /// Verifies an unknown label yields an empty chain rather than throwing.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public void PathToRoot_UnknownLabel_ReturnsEmpty()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleDgml is null, "DGML sidecar was not produced");
+
+        var graph = DgmlReader.Read(samples.NativeAotConsoleDgml!);
+
+        Assert.NotNull(graph);
+        Assert.Empty(graph.PathToRoot("no-such-node-anywhere"));
+    }
+
+    /// <summary>
+    /// Verifies querying a root returns the single-step chain: the root explains itself.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void PathToRoot_RootNode_ReturnsSingleStep()
+    {
+        var graph = DgmlReader.Read(ToStream("""
+            <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+              <Nodes>
+                <Node Id="0" Label="root"/>
+                <Node Id="1" Label="leaf"/>
+              </Nodes>
+              <Links>
+                <Link Source="0" Target="1" Reason="kept"/>
+              </Links>
+            </DirectedGraph>
+            """));
+
+        Assert.NotNull(graph);
+        var path = graph.PathToRoot("root");
+        Assert.Single(path);
+        Assert.Equal("root", path[0].Label);
+    }
+
+    /// <summary>
+    /// Verifies a multi-step synthetic chain reconstructs root-first with per-step reasons.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void PathToRoot_SyntheticChain_ReturnsRootFirstWithReasons()
+    {
+        var graph = DgmlReader.Read(ToStream("""
+            <DirectedGraph xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+              <Nodes>
+                <Node Id="10" Label="Main method"/>
+                <Node Id="20" Label="Helper"/>
+                <Node Id="30" Label="Leaf"/>
+              </Nodes>
+              <Links>
+                <Link Source="10" Target="20" Reason="call"/>
+                <Link Source="20" Target="30" Reason="field access"/>
+              </Links>
+            </DirectedGraph>
+            """));
+
+        Assert.NotNull(graph);
+        var path = graph.PathToRoot("Leaf");
+
+        Assert.Equal(3, path.Count);
+        Assert.Equal(("Main method", (string?)null), (path[0].Label, path[0].Reason));
+        Assert.Equal(("Helper", "call"), (path[1].Label, path[1].Reason));
+        Assert.Equal(("Leaf", "field access"), (path[2].Label, path[2].Reason));
+    }
+
+    /// <summary>
+    /// Verifies a cycle with no root reports the queried node alone instead of spinning.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void PathToRoot_PureCycle_ReturnsQueriedNodeAlone()
+    {
+        var graph = DgmlReader.Read(ToStream("""
+            <DirectedGraph>
+              <Nodes>
+                <Node Id="1" Label="a"/>
+                <Node Id="2" Label="b"/>
+              </Nodes>
+              <Links>
+                <Link Source="1" Target="2"/>
+                <Link Source="2" Target="1"/>
+              </Links>
+            </DirectedGraph>
+            """));
+
+        Assert.NotNull(graph);
+        var path = graph.PathToRoot("a");
+        Assert.Single(path);
+        Assert.Equal("a", path[0].Label);
+    }
+
+    /// <summary>
+    /// Verifies a document without the dgml namespace still parses — matching is by local
+    /// element name.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NoNamespace_StillParses()
+    {
+        var graph = DgmlReader.Read(ToStream("""
+            <DirectedGraph>
+              <Nodes><Node Id="1" Label="only"/></Nodes>
+              <Links/>
+            </DirectedGraph>
+            """));
+
+        Assert.NotNull(graph);
+        Assert.Single(graph.Nodes);
+        Assert.Empty(graph.Links);
+    }
+
+    /// <summary>
+    /// Verifies duplicate labels resolve to the first node without throwing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_DuplicateLabels_FirstWins()
+    {
+        var graph = DgmlReader.Read(ToStream("""
+            <DirectedGraph>
+              <Nodes>
+                <Node Id="1" Label="dup"/>
+                <Node Id="2" Label="dup"/>
+              </Nodes>
+            </DirectedGraph>
+            """));
+
+        Assert.NotNull(graph);
+        Assert.Equal(1, graph.FindNodeByLabel("dup")?.Id);
+    }
+
+    /// <summary>
+    /// Verifies malformed nodes and links are skipped while well-formed siblings survive.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_MalformedEntries_AreSkipped()
+    {
+        var graph = DgmlReader.Read(ToStream("""
+            <DirectedGraph>
+              <Nodes>
+                <Node Id="notanint" Label="bad"/>
+                <Node Id="1" Label="good"/>
+              </Nodes>
+              <Links>
+                <Link Source="1" Target="nope"/>
+                <Link Source="1" Target="1"/>
+              </Links>
+            </DirectedGraph>
+            """));
+
+        Assert.NotNull(graph);
+        Assert.Single(graph.Nodes);
+        Assert.Single(graph.Links);
+    }
+
+    /// <summary>
+    /// Verifies a truncated document returns null rather than throwing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_TruncatedXml_ReturnsNull()
+    {
+        Assert.Null(DgmlReader.Read(ToStream("<DirectedGraph><Nodes><Node Id=\"1\"")));
+    }
+
+    /// <summary>
+    /// Verifies a document with the wrong root element returns null.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_WrongRootElement_ReturnsNull()
+    {
+        Assert.Null(DgmlReader.Read(ToStream("<html><body/></html>")));
+    }
+
+    /// <summary>
+    /// Verifies an empty file returns null rather than throwing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_EmptyFile_ReturnsNull()
+    {
+        Assert.Null(DgmlReader.Read(ToStream("")));
+    }
+
+    /// <summary>
+    /// Verifies a missing file returns null rather than throwing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_MissingFile_ReturnsNull()
+    {
+        Assert.Null(DgmlReader.Read(Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.dgml.xml")));
+    }
+
+    private static MemoryStream ToStream(string xml) => new(Encoding.UTF8.GetBytes(xml));
+}

--- a/tests/Dotsider.Tests/DgmlReaderTests.cs
+++ b/tests/Dotsider.Tests/DgmlReaderTests.cs
@@ -14,7 +14,7 @@ public class DgmlReaderTests(SampleAssemblyFixture samples)
     /// Verifies the fixture's codegen graph parses with consistent nodes and links: every
     /// indexed link endpoint resolves to a node.
     /// </summary>
-    [Fact(Timeout = 60_000)]
+    [Fact(Timeout = 30_000)]
     public void Read_FixtureDgml_ParsesNodesAndLinks()
     {
         Assert.SkipWhen(samples.NativeAotConsoleDgml is null, "DGML sidecar was not produced");
@@ -36,7 +36,7 @@ public class DgmlReaderTests(SampleAssemblyFixture samples)
     /// Verifies a chain from a real method node reaches a root: the walk ends at a node with
     /// no dependers, starts the returned list with it, and ends the list at the queried node.
     /// </summary>
-    [Fact(Timeout = 60_000)]
+    [Fact(Timeout = 30_000)]
     public void PathToRoot_KnownMethodLabel_ReachesRoot()
     {
         Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
@@ -66,7 +66,7 @@ public class DgmlReaderTests(SampleAssemblyFixture samples)
     /// <summary>
     /// Verifies an unknown label yields an empty chain rather than throwing.
     /// </summary>
-    [Fact(Timeout = 60_000)]
+    [Fact(Timeout = 30_000)]
     public void PathToRoot_UnknownLabel_ReturnsEmpty()
     {
         Assert.SkipWhen(samples.NativeAotConsoleDgml is null, "DGML sidecar was not produced");

--- a/tests/Dotsider.Tests/MstatReaderTests.cs
+++ b/tests/Dotsider.Tests/MstatReaderTests.cs
@@ -1,0 +1,240 @@
+using Dotsider.Core.Analysis;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="MstatReader"/> against the real size report published next to the
+/// NativeAOT sample, plus malformed-input cases. The fixture publishes with the .NET 10 SDK,
+/// so format assertions pin version 2.2.
+/// </summary>
+[Collection("SampleAssemblies")]
+public class MstatReaderTests(SampleAssemblyFixture samples)
+{
+    /// <summary>
+    /// Verifies the fixture's report parses and carries format version 2.2. The assembly
+    /// version's Build/Revision are unset sentinels and must not leak into the format fields.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_FixtureMstat_ReportsFormat22()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var data = MstatReader.Read(samples.NativeAotConsoleMstat!);
+
+        Assert.NotNull(data);
+        Assert.Equal(2, data.FormatMajorVersion);
+        Assert.Equal(2, data.FormatMinorVersion);
+    }
+
+    /// <summary>
+    /// Verifies methods carry names, non-negative sizes, and assembly attribution spanning
+    /// both the app and the runtime.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_FixtureMstat_MethodsHaveNamesSizesAndAssemblies()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var data = MstatReader.Read(samples.NativeAotConsoleMstat!);
+
+        Assert.NotNull(data);
+        Assert.NotEmpty(data.Methods);
+        Assert.All(data.Methods, m => Assert.True(m.Size >= 0));
+        Assert.Contains(data.Methods, m => m.Size > 0);
+        Assert.All(data.Methods, m => Assert.False(string.IsNullOrEmpty(m.Name)));
+        Assert.Contains(data.Methods, m => m.AssemblyName == "System.Private.CoreLib");
+        Assert.Contains(data.Methods, m => m.AssemblyName == "NativeAotConsole");
+    }
+
+    /// <summary>
+    /// Verifies every method in a 2.x report carries its dependency-graph node name — the
+    /// string that joins the size entry to the DGML graph.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_FixtureMstat_MethodsCarryNodeNames()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var data = MstatReader.Read(samples.NativeAotConsoleMstat!);
+
+        Assert.NotNull(data);
+        Assert.All(data.Methods, m => Assert.False(string.IsNullOrEmpty(m.NodeName)));
+    }
+
+    /// <summary>
+    /// Verifies the sample's own Program type appears among the constructed types.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_FixtureMstat_TypesCoverProgramType()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var data = MstatReader.Read(samples.NativeAotConsoleMstat!);
+
+        Assert.NotNull(data);
+        Assert.NotEmpty(data.Types);
+        Assert.Contains(data.Types, t => t.Name == "Program" && t.AssemblyName == "NativeAotConsole");
+    }
+
+    /// <summary>
+    /// Verifies the well-known global data regions appear among the blobs, including the
+    /// buckets that 2.1+ also breaks down in detail sections.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_FixtureMstat_BlobsIncludeKnownRegions()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var data = MstatReader.Read(samples.NativeAotConsoleMstat!);
+
+        Assert.NotNull(data);
+        Assert.Contains(data.Blobs, b => b.Name == "Metadata" && b.Size > 0);
+        Assert.Contains(data.Blobs, b => b.Name == "ArrayOfFrozenObjects" && b.Size > 0);
+        Assert.Contains(data.Blobs, b => b.Name == "FieldRvaData" && b.Size > 0);
+    }
+
+    /// <summary>
+    /// Verifies the 2.1 detail sections parse: the console sample freezes string literals, so
+    /// frozen objects are non-empty and typed as System.String with no owning type.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_FixtureMstat_FrozenObjectsAreStringLiterals()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var data = MstatReader.Read(samples.NativeAotConsoleMstat!);
+
+        Assert.NotNull(data);
+        Assert.NotEmpty(data.FrozenObjects);
+        Assert.Contains(data.FrozenObjects, f => f.TypeName == "System.String" && f.OwningType is null);
+        Assert.NotEmpty(data.RvaFields);
+    }
+
+    /// <summary>
+    /// Verifies the report lists the referenced assemblies, including the app itself — the
+    /// entry the dependency graph promotes to its root.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_FixtureMstat_AssembliesIncludeAppAndCoreLib()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var data = MstatReader.Read(samples.NativeAotConsoleMstat!);
+
+        Assert.NotNull(data);
+        Assert.Contains(data.Assemblies, a => a.Name == "NativeAotConsole");
+        Assert.Contains(data.Assemblies, a => a.Name == "System.Private.CoreLib");
+    }
+
+    /// <summary>
+    /// Verifies mstat node names appear as DGML labels — the join contract the dependency
+    /// graph and why-chains rely on.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public void Read_FixtureMstat_NodeNamesJoinToDgmlLabels()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+        Assert.SkipWhen(samples.NativeAotConsoleDgml is null, "DGML sidecar was not produced");
+
+        var data = MstatReader.Read(samples.NativeAotConsoleMstat!);
+        Assert.NotNull(data);
+
+        var labels = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var line in File.ReadLines(samples.NativeAotConsoleDgml!))
+        {
+            var start = line.IndexOf("Label=\"", StringComparison.Ordinal);
+            if (start < 0) continue;
+            start += 7;
+            var end = line.IndexOf('"', start);
+            if (end > start) labels.Add(System.Net.WebUtility.HtmlDecode(line[start..end]));
+        }
+
+        var sample = data.Methods.Take(200).ToList();
+        var hits = sample.Count(m => m.NodeName is { } n && labels.Contains(n));
+        Assert.True(hits >= sample.Count * 9 / 10,
+            $"only {hits}/{sample.Count} method node names matched DGML labels");
+    }
+
+    /// <summary>
+    /// Verifies a managed assembly is rejected: RichLibrary's 2.5 assembly version passes the
+    /// version gate, so the recognized-stream gate must reject it.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_ManagedDll_ReturnsNull()
+    {
+        Assert.Null(MstatReader.Read(samples.RichLibraryDll));
+    }
+
+    /// <summary>
+    /// Verifies a non-PE file returns null rather than throwing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NonPeFile_ReturnsNull()
+    {
+        Assert.Null(MstatReader.Read(samples.NonDotNetBinaryPath));
+    }
+
+    /// <summary>
+    /// Verifies the Native AOT executable itself (no CLR metadata) returns null.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NativeAotExeItself_ReturnsNull()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        Assert.Null(MstatReader.Read(samples.NativeAotConsoleExe!));
+    }
+
+    /// <summary>
+    /// Verifies a missing file returns null rather than throwing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_MissingFile_ReturnsNull()
+    {
+        Assert.Null(MstatReader.Read(Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.mstat")));
+    }
+
+    /// <summary>
+    /// Verifies a truncated report never throws: the result is null or carries only the
+    /// entries that parsed completely before the cut.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_TruncatedMstat_ReturnsNullOrParsedPrefix()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var bytes = File.ReadAllBytes(samples.NativeAotConsoleMstat!);
+        using var truncated = new MemoryStream(bytes, 0, bytes.Length * 6 / 10);
+
+        var data = MstatReader.Read(truncated);
+
+        if (data is not null)
+            Assert.All(data.Methods, m => Assert.True(m.Size >= 0));
+    }
+
+    /// <summary>
+    /// Verifies a corrupted IL stream keeps the entries parsed before the damage: flipping an
+    /// opcode mid-stream ends the walk without discarding the prefix or throwing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_CorruptedIlStream_KeepsParsedPrefix()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var intact = MstatReader.Read(samples.NativeAotConsoleMstat!);
+        Assert.NotNull(intact);
+        Assert.True(intact.Methods.Count > 10);
+
+        // Find the Methods IL and flip a byte in its middle to a nop. The IL streams live in
+        // .text, so corrupt a byte at ~25% of the file, well past the headers.
+        var bytes = File.ReadAllBytes(samples.NativeAotConsoleMstat!);
+        bytes[bytes.Length / 4] = 0x00;
+        using var corrupted = new MemoryStream(bytes);
+
+        var data = MstatReader.Read(corrupted);
+
+        // Never throws; either rejected outright or parsed to some prefix.
+        if (data is not null)
+            Assert.True(data.Methods.Count <= intact.Methods.Count);
+    }
+}

--- a/tests/Dotsider.Tests/MstatReaderTests.cs
+++ b/tests/Dotsider.Tests/MstatReaderTests.cs
@@ -130,7 +130,7 @@ public class MstatReaderTests(SampleAssemblyFixture samples)
     /// Verifies mstat node names appear as DGML labels — the join contract the dependency
     /// graph and why-chains rely on.
     /// </summary>
-    [Fact(Timeout = 60_000)]
+    [Fact(Timeout = 30_000)]
     public void Read_FixtureMstat_NodeNamesJoinToDgmlLabels()
     {
         Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");

--- a/tests/Dotsider.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Tests/SampleAssemblyFixture.cs
@@ -133,6 +133,19 @@ public class SampleAssemblyFixture : IAsyncLifetime
     /// </summary>
     public string? NativeAotConsoleExe { get; private set; }
 
+    /// <summary>
+    /// Path to the ILC size report published next to the NativeAOT sample, or null when the
+    /// publish did not produce one. Tests gate on this with <c>Assert.SkipWhen</c>.
+    /// </summary>
+    public string? NativeAotConsoleMstat { get; private set; }
+
+    /// <summary>
+    /// Path to the ILC dependency-graph DGML published next to the NativeAOT sample (the
+    /// codegen graph, falling back to the scan graph), or null when the publish did not
+    /// produce one. Tests gate on this with <c>Assert.SkipWhen</c>.
+    /// </summary>
+    public string? NativeAotConsoleDgml { get; private set; }
+
     // Self-contained single-file sample
     /// <summary>
     /// Path to the published self-contained single-file sample executable.
@@ -239,6 +252,14 @@ public class SampleAssemblyFixture : IAsyncLifetime
         NativeAotConsoleExe = Path.Combine(_repoRoot, "samples", "NativeAotConsole",
             "bin", "Release", tfm, rid, "publish", $"NativeAotConsole{apphostExt}");
 
+        // ILC sidecars copied next to the exe by the sample's publish target. Null when the
+        // toolchain did not produce them, so sidecar tests skip rather than fail.
+        var aotPublishDir = Path.GetDirectoryName(NativeAotConsoleExe)!;
+        NativeAotConsoleMstat = ExistingPathOrNull(Path.Combine(aotPublishDir, "NativeAotConsole.mstat"));
+        NativeAotConsoleDgml =
+            ExistingPathOrNull(Path.Combine(aotPublishDir, "NativeAotConsole.codegen.dgml.xml"))
+            ?? ExistingPathOrNull(Path.Combine(aotPublishDir, "NativeAotConsole.scan.dgml.xml"));
+
         SelfContainedConsoleExe = Path.Combine(_repoRoot, "samples", "SelfContainedConsole",
             "bin", "Release", tfm, rid, "publish", $"SelfContainedConsole{apphostExt}");
 
@@ -330,6 +351,9 @@ public class SampleAssemblyFixture : IAsyncLifetime
 
     private string SamplePath(string project, string config, string tfm, string file)
         => Path.Combine(_repoRoot, "samples", project, "bin", config, tfm, file);
+
+    private static string? ExistingPathOrNull(string path)
+        => File.Exists(path) ? path : null;
 
     private async Task PublishNativeAotProject(string relativePath)
     {

--- a/tests/Dotsider.Tests/SizeAnalyzerTests.cs
+++ b/tests/Dotsider.Tests/SizeAnalyzerTests.cs
@@ -172,4 +172,137 @@ public class SizeAnalyzerTests(SampleAssemblyFixture samples)
             .ToList();
         Assert.Equal(fullPaths.Count, fullPaths.Distinct().Count());
     }
+
+    /// <summary>
+    /// Verifies the AOT tree's root holds assembly subtrees beside category buckets when the
+    /// mstat sidecar is present.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NativeAot_RootHasAssemblyAndCategoryChildren()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        using var a = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        var tree = SizeAnalyzer.BuildSizeTree(a);
+
+        Assert.Equal(SizeNodeKind.Assembly, tree.Kind);
+        Assert.True(tree.Size > 0);
+        Assert.Contains(tree.Children, c => c.Kind == SizeNodeKind.Assembly && c.Name == "System.Private.CoreLib");
+        Assert.Contains(tree.Children, c => c.Kind == SizeNodeKind.Category && c.Name == "Blobs");
+        Assert.Contains(tree.Children, c => c.Kind == SizeNodeKind.Category && c.Name == "Frozen Objects");
+    }
+
+    /// <summary>
+    /// Verifies assembly subtrees nest namespace &gt; type &gt; leaf, and leaves carry the
+    /// dependency-graph node name that powers why-chains.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NativeAot_AssemblySubtreesNestToLeavesWithNodeNames()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        using var a = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        var tree = SizeAnalyzer.BuildSizeTree(a);
+
+        var assembly = tree.Children.First(c => c.Kind == SizeNodeKind.Assembly && c.Name == "System.Private.CoreLib");
+        var ns = assembly.Children[0];
+        Assert.Equal(SizeNodeKind.Namespace, ns.Kind);
+        var type = ns.Children[0];
+        Assert.Equal(SizeNodeKind.Type, type.Kind);
+        var leaves = type.Children;
+        Assert.NotEmpty(leaves);
+        Assert.All(leaves, l => Assert.True(l.Kind is SizeNodeKind.Method or SizeNodeKind.MethodTable));
+        Assert.Contains(leaves, l => l.AotNodeName is not null);
+    }
+
+    /// <summary>
+    /// Verifies sizes sum exactly at every level of an assembly subtree — the MethodTable
+    /// leaf exists precisely so nothing is attributed to a parent without a child to show it.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NativeAot_SizesSumExactlyThroughTheTree()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        using var a = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        var tree = SizeAnalyzer.BuildSizeTree(a);
+
+        Assert.Equal(tree.Children.Sum(c => c.Size), tree.Size);
+        foreach (var assembly in tree.Children.Where(c => c.Kind == SizeNodeKind.Assembly))
+        {
+            Assert.Equal(assembly.Children.Sum(n => n.Size), assembly.Size);
+            foreach (var ns in assembly.Children)
+            {
+                Assert.Equal(ns.Children.Sum(t => t.Size), ns.Size);
+                foreach (var type in ns.Children)
+                    Assert.Equal(type.Children.Sum(m => m.Size), type.Size);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies the double-count guard: the blob buckets that 2.1+ re-reports as detail
+    /// sections are excluded from the Blobs category when those sections have entries.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NativeAot_CategoryBucketsExcludeDoubleCountedBlobs()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        using var a = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        Assert.NotNull(a.Mstat);
+        Assert.NotEmpty(a.Mstat.FrozenObjects);
+
+        var tree = SizeAnalyzer.BuildSizeTree(a);
+        var blobs = tree.Children.First(c => c.Name == "Blobs");
+
+        Assert.DoesNotContain(blobs.Children, b => b.Name == "ArrayOfFrozenObjects");
+        Assert.DoesNotContain(blobs.Children, b => b.Name == "FieldRvaData");
+        Assert.Contains(tree.Children, c => c.Name == "Frozen Objects");
+        Assert.Contains(tree.Children, c => c.Name == "RVA Fields");
+    }
+
+    /// <summary>
+    /// Verifies an AOT binary without an mstat sidecar falls back to the metadata path: an
+    /// empty tree rather than a throw.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NativeAot_WithoutSidecar_FallsBackToEmptyTree()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        var dir = Directory.CreateTempSubdirectory("dotsider-sizemap-");
+        try
+        {
+            var exeCopy = Path.Combine(dir.FullName, Path.GetFileName(samples.NativeAotConsoleExe!));
+            File.Copy(samples.NativeAotConsoleExe!, exeCopy);
+            using var a = new AssemblyAnalyzer(exeCopy);
+
+            var tree = SizeAnalyzer.BuildSizeTree(a);
+
+            Assert.Equal(0, tree.Size);
+            Assert.Empty(tree.Children);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies managed trees are unchanged by the AOT additions: no node carries an AOT
+    /// node name, so serialized output stays identical.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Managed_TreeCarriesNoAotNodeNames()
+    {
+        using var a = new AssemblyAnalyzer(samples.RichLibraryDll);
+        var tree = SizeAnalyzer.BuildSizeTree(a);
+
+        var all = new List<SizeNode>();
+        void Walk(SizeNode n) { all.Add(n); foreach (var c in n.Children) Walk(c); }
+        Walk(tree);
+
+        Assert.All(all, n => Assert.Null(n.AotNodeName));
+    }
 }

--- a/tests/Dotsider.Tests/SizeMapViewTests.cs
+++ b/tests/Dotsider.Tests/SizeMapViewTests.cs
@@ -327,7 +327,7 @@ public class SizeMapViewTests(SampleAssemblyFixture samples) : IDisposable
         _state.TreemapCurrentLevel = frozen;
         _state.TreemapSelectedIndex = 0;
         _state.App.Invalidate();
-        await auto.WaitUntilTextAsync("Frozen Objects");
+        await auto.WaitUntilTextAsync("> Frozen Objects");
 
         await auto.KeyAsync(Hex1bKey.W, ct: cts.Token);
         await auto.WaitUntilAsync(s => s.ContainsText("Why in binary"),
@@ -375,7 +375,7 @@ public class SizeMapViewTests(SampleAssemblyFixture samples) : IDisposable
             _state.TreemapCurrentLevel = frozen;
             _state.TreemapSelectedIndex = 0;
             _state.App.Invalidate();
-            await auto.WaitUntilTextAsync("Frozen Objects");
+            await auto.WaitUntilTextAsync("> Frozen Objects");
 
             await auto.KeyAsync(Hex1bKey.W, ct: cts.Token);
             await auto.WaitUntilAsync(s => s.ContainsText("No DGML dependency graph"),

--- a/tests/Dotsider.Tests/SizeMapViewTests.cs
+++ b/tests/Dotsider.Tests/SizeMapViewTests.cs
@@ -2,6 +2,7 @@ using Dotsider.Core.Analysis.Models;
 using Dotsider.Views;
 using Hex1b;
 using Hex1b.Automation;
+using Hex1b.Input;
 using Hex1b.Widgets;
 
 namespace Dotsider.Tests;
@@ -19,7 +20,7 @@ public class SizeMapViewTests(SampleAssemblyFixture samples) : IDisposable
     private Hex1bApp? _hex1bApp;
     private DotsiderState? _state;
 
-    private (Hex1bTerminal terminal, Hex1bApp app) CreateDotsiderApp()
+    private (Hex1bTerminal terminal, Hex1bApp app) CreateDotsiderApp(string? assemblyPath = null)
     {
         _workload = new Hex1bAppWorkloadAdapter();
         _terminal = Hex1bTerminal.CreateBuilder()
@@ -31,7 +32,7 @@ public class SizeMapViewTests(SampleAssemblyFixture samples) : IDisposable
         _hex1bApp = new Hex1bApp(
             ctx =>
             {
-                _state ??= new DotsiderState(_hex1bApp!, samples.RichLibraryDll)
+                _state ??= new DotsiderState(_hex1bApp!, assemblyPath ?? samples.RichLibraryDll)
                 {
                     CurrentTab = TabId.SizeMap
                 };
@@ -270,6 +271,150 @@ public class SizeMapViewTests(SampleAssemblyFixture samples) : IDisposable
             description: "hovered item resolved for rightmost painted cell");
 
         Assert.NotNull(_state!.TreemapHoveredItem);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Verifies the Size Map on a Native AOT binary with an mstat sidecar renders the
+    /// per-assembly and category breakdown instead of the empty state.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task SizeMap_NativeAot_RendersAssembliesAndBuckets()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var (terminal, app) = CreateDotsiderApp(samples.NativeAotConsoleExe);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
+
+        await auto.WaitUntilAlternateScreenAsync();
+        await auto.WaitUntilTextAsync("Total:");
+        await auto.WaitUntilAsync(s => !s.ContainsText("No code size data available"),
+            description: "AOT size tree to render");
+        await auto.WaitUntilTextAsync("System.Private.CoreLib");
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Verifies w on a node that carries a dependency-graph name opens the why-chain popup,
+    /// and Esc dismisses it.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task SizeMap_NativeAot_WhyKeyOpensAndEscClosesChainPopup()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+        Assert.SkipWhen(samples.NativeAotConsoleDgml is null, "DGML sidecar was not produced");
+
+        var (terminal, app) = CreateDotsiderApp(samples.NativeAotConsoleExe);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
+
+        await auto.WaitUntilAlternateScreenAsync();
+        await auto.WaitUntilTextAsync("Total:");
+        await auto.WaitUntilAsync(_ => _state?.CachedSizeTree is not null,
+            description: "size tree to build");
+
+        // Drive selection to a node-named leaf deterministically: focus the Frozen Objects
+        // category (string literals always join the graph) and select its largest entry.
+        var frozen = _state!.CachedSizeTree!.Children.First(c => c.Name == "Frozen Objects");
+        _state.TreemapBreadcrumb.Push(_state.CachedSizeTree!);
+        _state.TreemapCurrentLevel = frozen;
+        _state.TreemapSelectedIndex = 0;
+        _state.App.Invalidate();
+        await auto.WaitUntilTextAsync("Frozen Objects");
+
+        await auto.KeyAsync(Hex1bKey.W, ct: cts.Token);
+        await auto.WaitUntilAsync(s => s.ContainsText("Why in binary"),
+            description: "why popup to open");
+        await auto.WaitUntilTextAsync("Kept by (root first):");
+
+        await auto.EscapeAsync(ct: cts.Token);
+        await auto.WaitUntilAsync(s => !s.ContainsText("Why in binary"),
+            description: "why popup to close");
+        Assert.Null(_state.SizeMapWhyContent);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Verifies w without a DGML sidecar explains what is missing instead of doing nothing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task SizeMap_NativeAot_WhyKeyWithoutDgml_ExplainsMissingGraph()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var dir = Directory.CreateTempSubdirectory("dotsider-whynodgml-");
+        var name = Path.GetFileName(samples.NativeAotConsoleExe!);
+        var exeCopy = Path.Combine(dir.FullName, name);
+        File.Copy(samples.NativeAotConsoleExe!, exeCopy);
+        var stem = name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ? name[..^4] : name;
+        File.Copy(samples.NativeAotConsoleMstat!, Path.Combine(dir.FullName, stem + ".mstat"));
+
+        var (terminal, app) = CreateDotsiderApp(exeCopy);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        try
+        {
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
+
+            await auto.WaitUntilAlternateScreenAsync();
+            await auto.WaitUntilTextAsync("Total:");
+            await auto.WaitUntilAsync(_ => _state?.CachedSizeTree is not null,
+                description: "size tree to build");
+
+            var frozen = _state!.CachedSizeTree!.Children.First(c => c.Name == "Frozen Objects");
+            _state.TreemapBreadcrumb.Push(_state.CachedSizeTree!);
+            _state.TreemapCurrentLevel = frozen;
+            _state.TreemapSelectedIndex = 0;
+            _state.App.Invalidate();
+            await auto.WaitUntilTextAsync("Frozen Objects");
+
+            await auto.KeyAsync(Hex1bKey.W, ct: cts.Token);
+            await auto.WaitUntilAsync(s => s.ContainsText("No DGML dependency graph"),
+                description: "missing-graph notice to open");
+        }
+        finally
+        {
+            // Stop the app and release the analyzer's handle on the copied exe before the
+            // directory delete, on both the success and failure paths.
+            cts.Cancel();
+            try { await runTask; } catch (OperationCanceledException) { }
+            _state?.Dispose();
+            _state = null;
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies w is inert on a managed assembly's tree, whose nodes carry no dependency
+    /// names.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task SizeMap_Managed_WhyKeyIsNoOp()
+    {
+        var (terminal, app) = CreateDotsiderApp();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
+
+        await auto.WaitUntilAlternateScreenAsync();
+        await auto.WaitUntilTextAsync("Total:");
+
+        await auto.KeyAsync(Hex1bKey.RightArrow, ct: cts.Token);
+        await auto.WaitUntilAsync(_ => _state?.TreemapSelectedIndex >= 0,
+            description: "a treemap node to be selected");
+        await auto.KeyAsync(Hex1bKey.W, ct: cts.Token);
+        await auto.WaitAsync(100, ct: cts.Token);
+
+        Assert.Null(_state!.SizeMapWhyContent);
 
         cts.Cancel();
         await runTask;


### PR DESCRIPTION
Opening a Native AOT binary now fills the Size Map and Dep Graph tabs from the compiler's own records. Publish with IlcGenerateMstatFile and IlcGenerateDgmlFile, keep the sidecars next to the binary, and the treemap shows every compiled assembly down to native method sizes (code plus GC and EH info, with each type's MethodTable as an explicit leaf so sums stay exact) beside categories for blobs, frozen objects, RVA fields, and resources. The graph shows the compiled-in assemblies with edges aggregated from the compiler's dependency graph, plus the native import modules; without sidecars it degrades to the root and its import star.

The join between the two files is the point: mstat format 2.0+ stores each entry's dependency graph node name in a custom .names PE section, and the DGML uses the same string as its node label. That powers the question every AOT user asks — press w on a Size Map node, or run `dotsider analyze app.exe --why Name`, and the chain from a dependency root prints step by step with the compiler's reasons. The issue text said the join was by node id; it is by node name, and the issue body has been corrected.

Both readers are written from the emitters in dotnet/runtime with no new dependencies: an mstat is a valid ECMA-335 assembly whose data lives in IL streams (System.Reflection.Metadata reads it as-is, versions 1.1 through 2.2 handled, including the 2.1 back-compat double-reporting that must not be counted twice), and the DGML streams through XmlReader. Both are public Core API with models, so they double as the library the ecosystem is missing. Malformed input never throws — truncated streams yield the entries parsed before the damage.

The NativeAotConsole sample now publishes the sidecars next to the exe, tests run against the real files on all three platforms, and the mstat↔DGML label join is pinned by a cross-reader contract test. Benchmarks cover both readers and the chain walk, with M4 Pro baselines recorded: the sample's mstat decodes in 765 μs, the codegen DGML parses in 7 ms, and PathToRoot is a 118 ns index walk — chain queries are effectively free once the graph is loaded.

Fixes #176
