### PR TITLE
Native symbol support: Windows PDB, DWARF, and Mach-O

### DIFF
--- a/benchmarks/Dotsider.Benchmarks/NativeSymbolReaderBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/NativeSymbolReaderBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using BenchmarkDotNet.Attributes;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
@@ -9,7 +10,9 @@ namespace Dotsider.Benchmarks;
 /// Benchmarks for <see cref="NativeSymbolReader"/> against the real NativeAotConsole publish:
 /// the full symbol read beside the platform's artifact (native PDB on Windows, <c>.dbg</c> on
 /// Linux, dSYM on macOS), the unwind-data boundary fallback with every sidecar out of reach,
-/// and the cheap PDB identity probe the analyzer constructor runs (Windows artifact only).
+/// and the cheap PDB identity probe the analyzer constructor runs. The probe is plain file
+/// reading, so on legs whose publish makes no PDB it targets a staged minimal MSF — the same
+/// superblock, block-map, directory, and stream-1 reads, just a smaller directory.
 /// </summary>
 [MemoryDiagnoser]
 public class NativeSymbolReaderBenchmarks
@@ -19,12 +22,13 @@ public class NativeSymbolReaderBenchmarks
     private IReadOnlyList<RecoveredType> _recoveredTypes = null!;
     private string _bareExePath = null!;
     private byte[] _bareExeBytes = null!;
-    private string? _pdbPath;
+    private string _pdbPath = null!;
     private string _tempDir = null!;
 
     /// <summary>
     /// Publishes the Native AOT sample (cached across benchmark classes), captures its bytes
-    /// and recovered metadata, and stages a sidecar-free copy for the fallback benchmark.
+    /// and recovered metadata, and stages a sidecar-free copy for the fallback benchmark plus
+    /// a probe target on legs whose publish produces no PDB.
     /// </summary>
     [GlobalSetup]
     public void Setup()
@@ -35,14 +39,16 @@ public class NativeSymbolReaderBenchmarks
         using var analyzer = new AssemblyAnalyzer(_exePath);
         _recoveredTypes = analyzer.RecoveredTypes;
 
-        var pdb = Path.Combine(Path.GetDirectoryName(_exePath)!, "NativeAotConsole.pdb");
-        _pdbPath = File.Exists(pdb) ? pdb : null;
-
         // A copy with no sidecars in reach forces the unwind-data fallback.
         _tempDir = Directory.CreateTempSubdirectory("dotsider-bench-symbols-").FullName;
         _bareExePath = Path.Combine(_tempDir, Path.GetFileName(_exePath));
         File.Copy(_exePath, _bareExePath);
         _bareExeBytes = File.ReadAllBytes(_bareExePath);
+
+        var pdb = Path.Combine(Path.GetDirectoryName(_exePath)!, "NativeAotConsole.pdb");
+        _pdbPath = File.Exists(pdb) ? pdb : StageMinimalPdb();
+        if (!NativePdbReader.TryReadPdbId(_pdbPath, out _, out _))
+            throw new InvalidOperationException($"probe target is not a readable PDB: {_pdbPath}");
     }
 
     /// <summary>Removes the staged sidecar-free copy.</summary>
@@ -62,11 +68,50 @@ public class NativeSymbolReaderBenchmarks
         NativeSymbolReader.Read(_bareExePath, _bareExeBytes, _recoveredTypes);
 
     /// <summary>
-    /// Runs the constructor's cheap PDB identity probe; a fast false on the legs whose
-    /// artifact is not a PDB.
+    /// Runs the constructor's cheap PDB identity probe: the real publish PDB on Windows, the
+    /// staged minimal MSF elsewhere.
     /// </summary>
     /// <returns>Whether the probe read an identity.</returns>
     [Benchmark(Description = "TryReadPdbId probe")]
-    public bool ProbePdbId() =>
-        _pdbPath is not null && NativePdbReader.TryReadPdbId(_pdbPath, out _, out _);
+    public bool ProbePdbId() => NativePdbReader.TryReadPdbId(_pdbPath, out _, out _);
+
+    /// <summary>
+    /// Writes a minimal MSF 7.0 container — superblock, free-block map, a stream-1 block with
+    /// version/signature/age/GUID, the directory, and the block map — so the probe's targeted
+    /// reads run on legs whose publish never produces a PDB.
+    /// </summary>
+    private string StageMinimalPdb()
+    {
+        const int blockSize = 4096;
+        byte[] magic = [.. "Microsoft C/C++ MSF 7.00\r\n"u8, 0x1A, .. "DS"u8, 0, 0, 0];
+
+        // Blocks: 0 superblock, 1 free-block map, 2 stream-1 data, 3 directory, 4 block map.
+        var image = new byte[5 * blockSize];
+        magic.CopyTo(image, 0);
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(32), blockSize);
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(36), 1); // free block map
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(40), 5); // block count
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(44), 16); // directory bytes
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(52), 4); // block map address
+
+        // Stream 1 (PDB info): version, signature, age, GUID.
+        var info = image.AsSpan(2 * blockSize);
+        BinaryPrimitives.WriteInt32LittleEndian(info, 20000404);
+        BinaryPrimitives.WriteInt32LittleEndian(info[4..], 1);
+        BinaryPrimitives.WriteInt32LittleEndian(info[8..], 1);
+        Guid.NewGuid().TryWriteBytes(info.Slice(12, 16));
+
+        // Directory: numStreams = 2, sizes [0, 28], stream 1's block list = [2].
+        var directory = image.AsSpan(3 * blockSize);
+        BinaryPrimitives.WriteInt32LittleEndian(directory, 2);
+        BinaryPrimitives.WriteInt32LittleEndian(directory[8..], 28);
+        BinaryPrimitives.WriteInt32LittleEndian(directory[12..], 2);
+
+        // Block map: the single directory block.
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(4 * blockSize), 3);
+
+        var path = Path.Combine(_tempDir, "probe-target.pdb");
+        File.WriteAllBytes(path, image);
+        return path;
+    }
 }

--- a/benchmarks/Dotsider.Benchmarks/NativeSymbolReaderBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/NativeSymbolReaderBenchmarks.cs
@@ -1,0 +1,72 @@
+using BenchmarkDotNet.Attributes;
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+using Dotsider.Core.Analysis.NativePdb;
+
+namespace Dotsider.Benchmarks;
+
+/// <summary>
+/// Benchmarks for <see cref="NativeSymbolReader"/> against the real NativeAotConsole publish:
+/// the full symbol read beside the platform's artifact (native PDB on Windows, <c>.dbg</c> on
+/// Linux, dSYM on macOS), the unwind-data boundary fallback with every sidecar out of reach,
+/// and the cheap PDB identity probe the analyzer constructor runs (Windows artifact only).
+/// </summary>
+[MemoryDiagnoser]
+public class NativeSymbolReaderBenchmarks
+{
+    private string _exePath = null!;
+    private byte[] _exeBytes = null!;
+    private IReadOnlyList<RecoveredType> _recoveredTypes = null!;
+    private string _bareExePath = null!;
+    private byte[] _bareExeBytes = null!;
+    private string? _pdbPath;
+    private string _tempDir = null!;
+
+    /// <summary>
+    /// Publishes the Native AOT sample (cached across benchmark classes), captures its bytes
+    /// and recovered metadata, and stages a sidecar-free copy for the fallback benchmark.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        BenchmarkHelpers.PublishNativeAotSample("samples/NativeAotConsole");
+        _exePath = BenchmarkHelpers.GetPublishPath("samples/NativeAotConsole", "NativeAotConsole");
+        _exeBytes = File.ReadAllBytes(_exePath);
+        using var analyzer = new AssemblyAnalyzer(_exePath);
+        _recoveredTypes = analyzer.RecoveredTypes;
+
+        var pdb = Path.Combine(Path.GetDirectoryName(_exePath)!, "NativeAotConsole.pdb");
+        _pdbPath = File.Exists(pdb) ? pdb : null;
+
+        // A copy with no sidecars in reach forces the unwind-data fallback.
+        _tempDir = Directory.CreateTempSubdirectory("dotsider-bench-symbols-").FullName;
+        _bareExePath = Path.Combine(_tempDir, Path.GetFileName(_exePath));
+        File.Copy(_exePath, _bareExePath);
+        _bareExeBytes = File.ReadAllBytes(_bareExePath);
+    }
+
+    /// <summary>Removes the staged sidecar-free copy.</summary>
+    [GlobalCleanup]
+    public void Cleanup() => Directory.Delete(_tempDir, recursive: true);
+
+    /// <summary>Reads the full symbol set beside the platform's symbol artifact.</summary>
+    /// <returns>The symbol info, returned so the JIT cannot elide the work.</returns>
+    [Benchmark(Description = "Read symbols (platform artifact)")]
+    public NativeSymbolInfo ReadSymbols() =>
+        NativeSymbolReader.Read(_exePath, _exeBytes, _recoveredTypes);
+
+    /// <summary>Recovers function boundaries with every sidecar out of reach.</summary>
+    /// <returns>The boundary info, returned so the JIT cannot elide the work.</returns>
+    [Benchmark(Description = "Boundary fallback (no sidecars)")]
+    public NativeSymbolInfo ReadBoundaries() =>
+        NativeSymbolReader.Read(_bareExePath, _bareExeBytes, _recoveredTypes);
+
+    /// <summary>
+    /// Runs the constructor's cheap PDB identity probe; a fast false on the legs whose
+    /// artifact is not a PDB.
+    /// </summary>
+    /// <returns>Whether the probe read an identity.</returns>
+    [Benchmark(Description = "TryReadPdbId probe")]
+    public bool ProbePdbId() =>
+        _pdbPath is not null && NativePdbReader.TryReadPdbId(_pdbPath, out _, out _);
+}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -48,6 +48,7 @@ dotnet run --project benchmarks/Dotsider.Benchmarks -c Release -- --list flat
 | `McpToolBenchmarks` | MCP tool call round-trip and session discovery through in-process pipe transport |
 | `MstatReaderBenchmarks` | Full ILC size-report decode: IL stream walk, token resolution with assembly attribution, and .names section reads |
 | `NativeAotDetectorBenchmarks` | ReadyToRun header scan + validation on a real Native AOT exe (positive with false-positive rejection), CoreLib (R2R negative full scan), and an apphost (no candidates) |
+| `NativeSymbolReaderBenchmarks` | Native symbol reading beside the platform's artifact (native PDB / `.dbg` / dSYM), the unwind-data boundary fallback with no sidecars in reach, and the analyzer constructor's cheap PDB identity probe |
 | `NuGetPackageAnalyzerBenchmarks` | NuGet package construction and DLL extraction from standard (2 DLLs) and large (120+ entry) packages |
 | `PeDirectoryReaderBenchmarks` | Native import/export/load-config parsing on a Native AOT binary (PE, ELF, or Mach-O by platform) and CoreLib |
 | `ReadyToRunReaderBenchmarks` | Native AOT ReadyToRun section walk, frozen string recovery, and NativeFormat type/method name recovery |
@@ -219,6 +220,13 @@ One read fully decodes the sample's ILC size report: walks the IL stream for eve
 | Detect NativeAOT exe (positive) | 63.80 μs | 4,752 B |
 | Detect CoreLib (R2R negative) | 470.87 μs | — |
 | Detect apphost (negative) | 3.63 μs | — |
+
+#### NativeSymbolReader
+
+| Benchmark | Mean | Allocated |
+|---|---|---|
+
+On this machine the symbol read follows the dSYM path — the bundle's DWARF and nlist merged — while the Windows leg reads the native PDB and the Linux leg the `.dbg`. The boundary fallback measures the unwind-data walk alone (`LC_FUNCTION_STARTS` here, `.pdata` on Windows, `.eh_frame` on Linux), and the probe is the per-constructor PDB identity check (a fast false where the artifact is not a PDB).
 
 #### NuGetPackageAnalyzer
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -226,7 +226,7 @@ One read fully decodes the sample's ILC size report: walks the IL stream for eve
 | Benchmark | Mean | Allocated |
 |---|---|---|
 
-On this machine the symbol read follows the dSYM path — the bundle's DWARF and nlist merged — while the Windows leg reads the native PDB and the Linux leg the `.dbg`. The boundary fallback measures the unwind-data walk alone (`LC_FUNCTION_STARTS` here, `.pdata` on Windows, `.eh_frame` on Linux), and the probe is the per-constructor PDB identity check (a fast false where the artifact is not a PDB).
+On this machine the symbol read follows the dSYM path — the bundle's DWARF and nlist merged — while the Windows leg reads the native PDB and the Linux leg the `.dbg`. The boundary fallback measures the unwind-data walk alone (`LC_FUNCTION_STARTS` here, `.pdata` on Windows, `.eh_frame` on Linux). The probe is the per-constructor PDB identity check; it is plain file reading, so on legs whose publish makes no PDB it targets a staged minimal MSF — the same superblock, block-map, directory, and stream-1 reads, just a smaller directory than the real artifact's.
 
 #### NuGetPackageAnalyzer
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -225,6 +225,9 @@ One read fully decodes the sample's ILC size report: walks the IL stream for eve
 
 | Benchmark | Mean | Allocated |
 |---|---|---|
+| Read symbols (platform artifact) | 19.16 ms | 64.80 MB |
+| Boundary fallback (no sidecars) | 1.77 ms | 3.41 MB |
+| TryReadPdbId probe | 10.73 μs | 12.4 KB |
 
 On this machine the symbol read follows the dSYM path — the bundle's DWARF and nlist merged — while the Windows leg reads the native PDB and the Linux leg the `.dbg`. The boundary fallback measures the unwind-data walk alone (`LC_FUNCTION_STARTS` here, `.pdata` on Windows, `.eh_frame` on Linux). The probe is the per-constructor PDB identity check; it is plain file reading, so on legs whose publish makes no PDB it targets a staged minimal MSF — the same superblock, block-map, directory, and stream-1 reads, just a smaller directory than the real artifact's.
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
@@ -414,6 +414,29 @@ replacing it.
 public NativeAotInfo? NativeAotInfo { get; }
 ```
 
+### NativeSymbols
+
+The native symbols of this binary — function names, addresses, and sizes read from its
+PDB, DWARF, or dSYM, or function boundaries from unwind data when no symbols exist. Null
+for managed assemblies. Parsed on demand; the value is assigned before the probed flag, so
+a rare concurrent first read costs at most a second parse of immutable data.
+
+**Returns:** [NativeSymbolInfo](/api/dotsider.core.analysis.models.nativesymbolinfo/)
+
+```csharp
+public NativeSymbolInfo? NativeSymbols { get; }
+```
+
+### NativeSymbolsPath
+
+The symbol file the native symbols were read from (PDB, .dbg, or dSYM), or null.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? NativeSymbolsPath { get; }
+```
+
 ### PdbProvenance
 
 Portable PDB provenance for the analyzed assembly.

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeSymbol.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeSymbol.md
@@ -41,7 +41,7 @@ to recompute a mapping.
 **Parameters:**
 
 - `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The raw symbol name (mangled for managed code), or a synthesized `sub_…` for a boundary.
-- `ManagedName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The demangled managed name when the symbol joined a recovered type unambiguously, else null.
+- `ManagedName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The managed name joined from the binary's recovered metadata, or null when no join exists. Overloads share a name, so this alone does not pin a member — [IsExactMatch](/api/dotsider.core.analysis.models.nativesymbol.isexactmatch/) is the precision flag.
 - `VirtualAddress` ([UInt64](https://learn.microsoft.com/dotnet/api/system.uint64)): The symbol's virtual address (image base + RVA on PE; the symbol VA on ELF/Mach-O).
 - `Rva` ([Nullable\<UInt32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The PE relative virtual address, or null for non-PE images.
 - `FileOffset` ([Nullable\<Int64\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The file offset the address maps to, or null when the symbol is not file-backed.
@@ -50,7 +50,7 @@ to recompute a mapping.
 - `Kind` ([NativeSymbolKind](/api/dotsider.core.analysis.models.nativesymbolkind/)): What the symbol represents.
 - `SourceFile` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The declaring source file, when debug line info is present.
 - `Line` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The declaring source line, when debug line info is present.
-- `IsExactMatch` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether [ManagedName](/api/dotsider.core.analysis.models.nativesymbol.managedname/) is an unambiguous demangle rather than a heuristic display.
+- `IsExactMatch` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether [ManagedName](/api/dotsider.core.analysis.models.nativesymbol.managedname/) identifies exactly one recovered member; false when the join is ambiguous (overloads sharing a name, or an overload-suffix join).
 - `Aliases` ([IReadOnlyList\<String\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Alternate names that resolved to the same address and were merged into this symbol.
 
 ```csharp
@@ -81,7 +81,7 @@ public long? FileOffset { get; init; }
 
 ### IsExactMatch
 
-Whether [ManagedName](/api/dotsider.core.analysis.models.nativesymbol.managedname/) is an unambiguous demangle rather than a heuristic display.
+Whether [ManagedName](/api/dotsider.core.analysis.models.nativesymbol.managedname/) identifies exactly one recovered member; false when the join is ambiguous (overloads sharing a name, or an overload-suffix join).
 
 **Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
 
@@ -111,7 +111,7 @@ public int? Line { get; init; }
 
 ### ManagedName
 
-The demangled managed name when the symbol joined a recovered type unambiguously, else null.
+The managed name joined from the binary's recovered metadata, or null when no join exists. Overloads share a name, so this alone does not pin a member — [IsExactMatch](/api/dotsider.core.analysis.models.nativesymbol.isexactmatch/) is the precision flag.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeSymbol.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeSymbol.md
@@ -1,0 +1,181 @@
+---
+title: "NativeSymbol"
+description: "One native symbol recovered from a binary: a function, a compiler-generated data blob, or a nameless boundary. The address is carried in every form a consumer might need — virtual address for display and cross-symbol ordering, PE RVA, file offset when the address is file-backed, and the containing section — so the UI, hex views, and disassembly never have to recompute a mapping."
+slug: api/dotsider.core.analysis.models.nativesymbol
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+One native symbol recovered from a binary: a function, a compiler-generated data blob, or a
+nameless boundary. The address is carried in every form a consumer might need — virtual
+address for display and cross-symbol ordering, PE RVA, file offset when the address is
+file-backed, and the containing section — so the UI, hex views, and disassembly never have
+to recompute a mapping.
+
+```csharp
+public sealed record NativeSymbol : IEquatable<NativeSymbol>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **NativeSymbol**
+
+## Implements
+
+- [IEquatable\<NativeSymbol\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### NativeSymbol(string, string?, ulong, uint?, long?, string?, long, NativeSymbolKind, string?, int?, bool, IReadOnlyList\<string\>)
+
+One native symbol recovered from a binary: a function, a compiler-generated data blob, or a
+nameless boundary. The address is carried in every form a consumer might need — virtual
+address for display and cross-symbol ordering, PE RVA, file offset when the address is
+file-backed, and the containing section — so the UI, hex views, and disassembly never have
+to recompute a mapping.
+
+**Parameters:**
+
+- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The raw symbol name (mangled for managed code), or a synthesized `sub_…` for a boundary.
+- `ManagedName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The demangled managed name when the symbol joined a recovered type unambiguously, else null.
+- `VirtualAddress` ([UInt64](https://learn.microsoft.com/dotnet/api/system.uint64)): The symbol's virtual address (image base + RVA on PE; the symbol VA on ELF/Mach-O).
+- `Rva` ([Nullable\<UInt32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The PE relative virtual address, or null for non-PE images.
+- `FileOffset` ([Nullable\<Int64\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The file offset the address maps to, or null when the symbol is not file-backed.
+- `Section` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The containing section's name, or null when it could not be determined.
+- `Size` ([Int64](https://learn.microsoft.com/dotnet/api/system.int64)): The symbol's size in bytes, derived when the format does not record it directly.
+- `Kind` ([NativeSymbolKind](/api/dotsider.core.analysis.models.nativesymbolkind/)): What the symbol represents.
+- `SourceFile` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The declaring source file, when debug line info is present.
+- `Line` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): The declaring source line, when debug line info is present.
+- `IsExactMatch` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether [ManagedName](/api/dotsider.core.analysis.models.nativesymbol.managedname/) is an unambiguous demangle rather than a heuristic display.
+- `Aliases` ([IReadOnlyList\<String\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Alternate names that resolved to the same address and were merged into this symbol.
+
+```csharp
+public NativeSymbol(string Name, string? ManagedName, ulong VirtualAddress, uint? Rva, long? FileOffset, string? Section, long Size, NativeSymbolKind Kind, string? SourceFile, int? Line, bool IsExactMatch, IReadOnlyList<string> Aliases)
+```
+
+## Properties
+
+### Aliases
+
+Alternate names that resolved to the same address and were merged into this symbol.
+
+**Returns:** [IReadOnlyList\<String\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<string> Aliases { get; init; }
+```
+
+### FileOffset
+
+The file offset the address maps to, or null when the symbol is not file-backed.
+
+**Returns:** [Nullable\<Int64\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)
+
+```csharp
+public long? FileOffset { get; init; }
+```
+
+### IsExactMatch
+
+Whether [ManagedName](/api/dotsider.core.analysis.models.nativesymbol.managedname/) is an unambiguous demangle rather than a heuristic display.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool IsExactMatch { get; init; }
+```
+
+### Kind
+
+What the symbol represents.
+
+**Returns:** [NativeSymbolKind](/api/dotsider.core.analysis.models.nativesymbolkind/)
+
+```csharp
+public NativeSymbolKind Kind { get; init; }
+```
+
+### Line
+
+The declaring source line, when debug line info is present.
+
+**Returns:** [Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)
+
+```csharp
+public int? Line { get; init; }
+```
+
+### ManagedName
+
+The demangled managed name when the symbol joined a recovered type unambiguously, else null.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? ManagedName { get; init; }
+```
+
+### Name
+
+The raw symbol name (mangled for managed code), or a synthesized `sub_…` for a boundary.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string Name { get; init; }
+```
+
+### Rva
+
+The PE relative virtual address, or null for non-PE images.
+
+**Returns:** [Nullable\<UInt32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)
+
+```csharp
+public uint? Rva { get; init; }
+```
+
+### Section
+
+The containing section's name, or null when it could not be determined.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? Section { get; init; }
+```
+
+### Size
+
+The symbol's size in bytes, derived when the format does not record it directly.
+
+**Returns:** [Int64](https://learn.microsoft.com/dotnet/api/system.int64)
+
+```csharp
+public long Size { get; init; }
+```
+
+### SourceFile
+
+The declaring source file, when debug line info is present.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? SourceFile { get; init; }
+```
+
+### VirtualAddress
+
+The symbol's virtual address (image base + RVA on PE; the symbol VA on ELF/Mach-O).
+
+**Returns:** [UInt64](https://learn.microsoft.com/dotnet/api/system.uint64)
+
+```csharp
+public ulong VirtualAddress { get; init; }
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeSymbolInfo.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeSymbolInfo.md
@@ -1,0 +1,123 @@
+---
+title: "NativeSymbolInfo"
+description: "The native symbols recovered from a binary, plus the provenance and status needed to explain the result. Symbols are ordered by VirtualAddress, which NativeSymbol%40) relies on to resolve an address to its containing symbol — the lookup the disassembly and hex views use to name code."
+slug: api/dotsider.core.analysis.models.nativesymbolinfo
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+The native symbols recovered from a binary, plus the provenance and status needed to explain
+the result. Symbols are ordered by [VirtualAddress](/api/dotsider.core.analysis.models.nativesymbol.virtualaddress/), which
+NativeSymbol%40) relies on to resolve an address to its containing symbol —
+the lookup the disassembly and hex views use to name code.
+
+```csharp
+public sealed record NativeSymbolInfo : IEquatable<NativeSymbolInfo>
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **NativeSymbolInfo**
+
+## Implements
+
+- [IEquatable\<NativeSymbolInfo\>](https://learn.microsoft.com/dotnet/api/system.iequatable-1)
+
+## Constructors
+
+### NativeSymbolInfo(IReadOnlyList\<NativeSymbol\>, NativeSymbolSource, NativeSymbolStatus, string?, string?)
+
+The native symbols recovered from a binary, plus the provenance and status needed to explain
+the result. Symbols are ordered by [VirtualAddress](/api/dotsider.core.analysis.models.nativesymbol.virtualaddress/), which
+NativeSymbol%40) relies on to resolve an address to its containing symbol —
+the lookup the disassembly and hex views use to name code.
+
+**Parameters:**
+
+- `Symbols` ([IReadOnlyList\<NativeSymbol\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): The recovered symbols, sorted ascending by virtual address.
+- `Source` ([NativeSymbolSource](/api/dotsider.core.analysis.models.nativesymbolsource/)): Which reader produced the symbols.
+- `Status` ([NativeSymbolStatus](/api/dotsider.core.analysis.models.nativesymbolstatus/)): The probe outcome; explains an empty result.
+- `Path` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The symbol file that was read (PDB, .dbg, or dSYM inner file), or null for self/fallback sources.
+- `Diagnostic` ([String](https://learn.microsoft.com/dotnet/api/system.string)): A human-readable note on the outcome — the mismatch detail, the fallback reason, or null on a clean load.
+
+```csharp
+public NativeSymbolInfo(IReadOnlyList<NativeSymbol> Symbols, NativeSymbolSource Source, NativeSymbolStatus Status, string? Path, string? Diagnostic)
+```
+
+## Properties
+
+### Diagnostic
+
+A human-readable note on the outcome — the mismatch detail, the fallback reason, or null on a clean load.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? Diagnostic { get; init; }
+```
+
+### Path
+
+The symbol file that was read (PDB, .dbg, or dSYM inner file), or null for self/fallback sources.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? Path { get; init; }
+```
+
+### Source
+
+Which reader produced the symbols.
+
+**Returns:** [NativeSymbolSource](/api/dotsider.core.analysis.models.nativesymbolsource/)
+
+```csharp
+public NativeSymbolSource Source { get; init; }
+```
+
+### Status
+
+The probe outcome; explains an empty result.
+
+**Returns:** [NativeSymbolStatus](/api/dotsider.core.analysis.models.nativesymbolstatus/)
+
+```csharp
+public NativeSymbolStatus Status { get; init; }
+```
+
+### Symbols
+
+The recovered symbols, sorted ascending by virtual address.
+
+**Returns:** [IReadOnlyList\<NativeSymbol\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<NativeSymbol> Symbols { get; init; }
+```
+
+## Methods
+
+### TryFindByAddress(ulong, out NativeSymbol)
+
+Finds the symbol whose range contains virtualAddress. Binary-searches
+the address-sorted list for the last symbol starting at or before the address, then
+confirms the address falls within that symbol's size.
+
+**Parameters:**
+
+- `virtualAddress` ([UInt64](https://learn.microsoft.com/dotnet/api/system.uint64)): The virtual address to resolve.
+- `symbol` ([NativeSymbol](/api/dotsider.core.analysis.models.nativesymbol/)): The containing symbol when found.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+True when a symbol contains the address; otherwise false.
+
+```csharp
+public bool TryFindByAddress(ulong virtualAddress, out NativeSymbol symbol)
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeSymbolKind.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeSymbolKind.md
@@ -1,0 +1,102 @@
+---
+title: "NativeSymbolKind"
+description: "What a native symbol represents. Native AOT binaries carry compiler-generated code and data symbols beyond ordinary functions; this classification drives the Size Map's category grouping and the symbol view's presentation."
+slug: api/dotsider.core.analysis.models.nativesymbolkind
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+What a native symbol represents. Native AOT binaries carry compiler-generated code and data
+symbols beyond ordinary functions; this classification drives the Size Map's category
+grouping and the symbol view's presentation.
+
+```csharp
+public enum NativeSymbolKind
+```
+
+## Fields
+
+### Boundary
+
+A nameless function boundary recovered from unwind data when no symbols exist.
+
+**Returns:** [NativeSymbolKind](/api/dotsider.core.analysis.models.nativesymbolkind/)
+
+```csharp
+Boundary = 7
+```
+
+### Data
+
+Other named data (readonly/writable data and the like).
+
+**Returns:** [NativeSymbolKind](/api/dotsider.core.analysis.models.nativesymbolkind/)
+
+```csharp
+Data = 6
+```
+
+### FrozenObject
+
+A frozen (compile-time allocated) object, most often a string literal (`__Str_…`).
+
+**Returns:** [NativeSymbolKind](/api/dotsider.core.analysis.models.nativesymbolkind/)
+
+```csharp
+FrozenObject = 2
+```
+
+### Function
+
+A compiled method body.
+
+**Returns:** [NativeSymbolKind](/api/dotsider.core.analysis.models.nativesymbolkind/)
+
+```csharp
+Function = 0
+```
+
+### GenericDictionary
+
+A generic dictionary blob (`__GenericDict_…`).
+
+**Returns:** [NativeSymbolKind](/api/dotsider.core.analysis.models.nativesymbolkind/)
+
+```csharp
+GenericDictionary = 4
+```
+
+### MethodTable
+
+A type's runtime MethodTable (vtable) — Windows `??_7…@@6B@` / Unix `_ZTV…`.
+
+**Returns:** [NativeSymbolKind](/api/dotsider.core.analysis.models.nativesymbolkind/)
+
+```csharp
+MethodTable = 1
+```
+
+### Statics
+
+Static field storage (GC, non-GC, or thread statics).
+
+**Returns:** [NativeSymbolKind](/api/dotsider.core.analysis.models.nativesymbolkind/)
+
+```csharp
+Statics = 5
+```
+
+### Stub
+
+A generic dictionary or an unboxing/other compiler stub.
+
+**Returns:** [NativeSymbolKind](/api/dotsider.core.analysis.models.nativesymbolkind/)
+
+```csharp
+Stub = 3
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeSymbolSource.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeSymbolSource.md
@@ -1,0 +1,92 @@
+---
+title: "NativeSymbolSource"
+description: "Where a binary's native symbols came from. The three primary sources carry names and (mostly) sizes; the three fallback sources recover only function boundaries from unwind data and are lower fidelity — they can miss leaf and thunk functions."
+slug: api/dotsider.core.analysis.models.nativesymbolsource
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+Where a binary's native symbols came from. The three primary sources carry names and (mostly)
+sizes; the three fallback sources recover only function boundaries from unwind data and are
+lower fidelity — they can miss leaf and thunk functions.
+
+```csharp
+public enum NativeSymbolSource
+```
+
+## Fields
+
+### Dsym
+
+A macOS dSYM bundle (DWARF plus nlist stabs).
+
+**Returns:** [NativeSymbolSource](/api/dotsider.core.analysis.models.nativesymbolsource/)
+
+```csharp
+Dsym = 2
+```
+
+### Dwarf
+
+DWARF debug info in an unstripped ELF binary or a `.dbg` sidecar.
+
+**Returns:** [NativeSymbolSource](/api/dotsider.core.analysis.models.nativesymbolsource/)
+
+```csharp
+Dwarf = 1
+```
+
+### EhFrameFallback
+
+ELF `.eh_frame` unwind info — function boundaries only.
+
+**Returns:** [NativeSymbolSource](/api/dotsider.core.analysis.models.nativesymbolsource/)
+
+```csharp
+EhFrameFallback = 5
+```
+
+### FunctionStartsFallback
+
+Mach-O `LC_FUNCTION_STARTS` — function boundaries only.
+
+**Returns:** [NativeSymbolSource](/api/dotsider.core.analysis.models.nativesymbolsource/)
+
+```csharp
+FunctionStartsFallback = 6
+```
+
+### MachONlist
+
+The Mach-O symbol table (nlist) of the binary itself.
+
+**Returns:** [NativeSymbolSource](/api/dotsider.core.analysis.models.nativesymbolsource/)
+
+```csharp
+MachONlist = 3
+```
+
+### NativePdb
+
+A matched Windows native PDB (MSF container).
+
+**Returns:** [NativeSymbolSource](/api/dotsider.core.analysis.models.nativesymbolsource/)
+
+```csharp
+NativePdb = 0
+```
+
+### PdataFallback
+
+PE `.pdata` exception directory — function boundaries only.
+
+**Returns:** [NativeSymbolSource](/api/dotsider.core.analysis.models.nativesymbolsource/)
+
+```csharp
+PdataFallback = 4
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeSymbolStatus.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NativeSymbolStatus.md
@@ -1,0 +1,92 @@
+---
+title: "NativeSymbolStatus"
+description: "The outcome of probing a binary for native symbols. When no symbols are returned, the status distinguishes the reasons — missing, mismatched, corrupt, ambiguous, or fallback-only — so callers can explain the result instead of showing an empty table with no cause."
+slug: api/dotsider.core.analysis.models.nativesymbolstatus
+sidebar:
+  order: 1
+---
+
+**Namespace:** `Dotsider.Core.Analysis.Models`
+
+**Assembly:** Dotsider.Core.dll
+
+The outcome of probing a binary for native symbols. When no symbols are returned, the status
+distinguishes the reasons — missing, mismatched, corrupt, ambiguous, or fallback-only — so
+callers can explain the result instead of showing an empty table with no cause.
+
+```csharp
+public enum NativeSymbolStatus
+```
+
+## Fields
+
+### AmbiguousImage
+
+A fat/universal binary offered no slice that could be disambiguated.
+
+**Returns:** [NativeSymbolStatus](/api/dotsider.core.analysis.models.nativesymbolstatus/)
+
+```csharp
+AmbiguousImage = 5
+```
+
+### CorruptSymbolFile
+
+A symbol file was found and matched, but could not be parsed.
+
+**Returns:** [NativeSymbolStatus](/api/dotsider.core.analysis.models.nativesymbolstatus/)
+
+```csharp
+CorruptSymbolFile = 3
+```
+
+### FallbackOnly
+
+Only nameless function boundaries were recovered from unwind data.
+
+**Returns:** [NativeSymbolStatus](/api/dotsider.core.analysis.models.nativesymbolstatus/)
+
+```csharp
+FallbackOnly = 4
+```
+
+### IdMismatch
+
+A symbol file was found but its identity did not match the binary.
+
+**Returns:** [NativeSymbolStatus](/api/dotsider.core.analysis.models.nativesymbolstatus/)
+
+```csharp
+IdMismatch = 2
+```
+
+### Loaded
+
+Named symbols loaded from a primary source.
+
+**Returns:** [NativeSymbolStatus](/api/dotsider.core.analysis.models.nativesymbolstatus/)
+
+```csharp
+Loaded = 0
+```
+
+### NoSymbolFile
+
+No symbol file was found beside the binary and no fallback applied.
+
+**Returns:** [NativeSymbolStatus](/api/dotsider.core.analysis.models.nativesymbolstatus/)
+
+```csharp
+NoSymbolFile = 1
+```
+
+### NotApplicable
+
+The binary is managed or otherwise has no native symbols to read.
+
+**Returns:** [NativeSymbolStatus](/api/dotsider.core.analysis.models.nativesymbolstatus/)
+
+```csharp
+NotApplicable = 6
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-PdbProvenanceKind.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-PdbProvenanceKind.md
@@ -25,7 +25,7 @@ The assembly came from a single-file bundle, so sidecar probing was intentionall
 **Returns:** [PdbProvenanceKind](/api/dotsider.core.analysis.models.pdbprovenancekind/)
 
 ```csharp
-BundleSidecarSkipped = 6
+BundleSidecarSkipped = 7
 ```
 
 ### CodeViewSidecarMismatched
@@ -56,6 +56,16 @@ An embedded portable PDB was opened.
 
 ```csharp
 Embedded = 4
+```
+
+### NativePdb
+
+A Windows native PDB was found beside the binary and its GUID and age match the CodeView entry.
+
+**Returns:** [PdbProvenanceKind](/api/dotsider.core.analysis.models.pdbprovenancekind/)
+
+```csharp
+NativePdb = 6
 ```
 
 ### NoDebugDirectory

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-RecoveredType.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-RecoveredType.md
@@ -28,7 +28,7 @@ public sealed record RecoveredType : IEquatable<RecoveredType>
 
 ## Constructors
 
-### RecoveredType(string, IReadOnlyList\<string\>)
+### RecoveredType(string, IReadOnlyList\<string\>, string?)
 
 A type recovered from a Native AOT binary's embedded NativeFormat metadata. ILC strips
 ECMA-335 metadata, but the reflection and stack-trace metadata it keeps still names the
@@ -37,13 +37,26 @@ binary's own types and methods, so a stripped binary can describe itself.
 **Parameters:**
 
 - `FullName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The namespace-qualified type name (nested types use `+`).
-- `MethodNames` ([IReadOnlyList\<String\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): The names of the type's methods.
+- `MethodNames` ([IReadOnlyList\<String\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): The names of the type's methods, in metadata order.
+- `AssemblyName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The simple name of the assembly scope that defined the type, or null when the metadata
+does not record one. Native symbol demangling joins mangled names against this scope.
 
 ```csharp
-public RecoveredType(string FullName, IReadOnlyList<string> MethodNames)
+public RecoveredType(string FullName, IReadOnlyList<string> MethodNames, string? AssemblyName = null)
 ```
 
 ## Properties
+
+### AssemblyName
+
+The simple name of the assembly scope that defined the type, or null when the metadata
+does not record one. Native symbol demangling joins mangled names against this scope.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? AssemblyName { get; init; }
+```
 
 ### FullName
 
@@ -57,11 +70,28 @@ public string FullName { get; init; }
 
 ### MethodNames
 
-The names of the type's methods.
+The names of the type's methods, in metadata order.
 
 **Returns:** [IReadOnlyList\<String\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
 
 ```csharp
 public IReadOnlyList<string> MethodNames { get; init; }
+```
+
+## Methods
+
+### Deconstruct(out string, out IReadOnlyList\<string\>)
+
+Deconstructs into the original two components, preserving call sites written before
+[AssemblyName](/api/dotsider.core.analysis.models.recoveredtype.assemblyname/) existed — a record's generated Deconstruct grows with its
+positional parameters, so the two-value form is kept explicitly.
+
+**Parameters:**
+
+- `fullName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The namespace-qualified type name.
+- `methodNames` ([IReadOnlyList\<String\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): The names of the type's methods, in metadata order.
+
+```csharp
+public void Deconstruct(out string fullName, out IReadOnlyList<string> methodNames)
 ```
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SizeNodeKind.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SizeNodeKind.md
@@ -1,6 +1,6 @@
 ---
 title: "SizeNodeKind"
-description: "The granularity level of a SizeNode in the size breakdown tree. The kinds beyond Method appear only in Native AOT trees built from an mstat report."
+description: "The granularity level of a SizeNode in the size breakdown tree. The kinds beyond Method appear only in Native AOT trees, built from an mstat report or, when none sits beside the binary, from its merged native symbols."
 slug: api/dotsider.core.analysis.models.sizenodekind
 sidebar:
   order: 1
@@ -11,7 +11,8 @@ sidebar:
 **Assembly:** Dotsider.Core.dll
 
 The granularity level of a [SizeNode](/api/dotsider.core.analysis.models.sizenode/) in the size breakdown tree. The kinds
-beyond [Method](/api/dotsider.core.analysis.models.sizenodekind.method/) appear only in Native AOT trees built from an mstat report.
+beyond [Method](/api/dotsider.core.analysis.models.sizenodekind.method/) appear only in Native AOT trees, built from an mstat report or,
+when none sits beside the binary, from its merged native symbols.
 
 ```csharp
 public enum SizeNodeKind
@@ -57,6 +58,17 @@ An object frozen into a Native AOT binary at compile time.
 
 ```csharp
 FrozenObject = 7
+```
+
+### Function
+
+A native function sized from the binary's symbols — unlike [Method](/api/dotsider.core.analysis.models.sizenodekind.method/), there
+is no IL body behind it to drill into.
+
+**Returns:** [SizeNodeKind](/api/dotsider.core.analysis.models.sizenodekind/)
+
+```csharp
+Function = 10
 ```
 
 ### Method

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models.md
@@ -553,6 +553,29 @@ as Native AOT compiled .NET.
 public sealed record NativeAotInfo : IEquatable<NativeAotInfo>
 ```
 
+### [NativeSymbol](/api/dotsider.core.analysis.models.nativesymbol/)
+
+One native symbol recovered from a binary: a function, a compiler-generated data blob, or a
+nameless boundary. The address is carried in every form a consumer might need — virtual
+address for display and cross-symbol ordering, PE RVA, file offset when the address is
+file-backed, and the containing section — so the UI, hex views, and disassembly never have
+to recompute a mapping.
+
+```csharp
+public sealed record NativeSymbol : IEquatable<NativeSymbol>
+```
+
+### [NativeSymbolInfo](/api/dotsider.core.analysis.models.nativesymbolinfo/)
+
+The native symbols recovered from a binary, plus the provenance and status needed to explain
+the result. Symbols are ordered by [VirtualAddress](/api/dotsider.core.analysis.models.nativesymbol.virtualaddress/), which
+NativeSymbol%40) relies on to resolve an address to its containing symbol —
+the lookup the disassembly and hex views use to name code.
+
+```csharp
+public sealed record NativeSymbolInfo : IEquatable<NativeSymbolInfo>
+```
+
 ### [NetFxBindingContext](/api/dotsider.core.analysis.models.netfxbindingcontext/)
 
 Per-root metadata required to drive a CLR-accurate .NET Framework bind. Built once per
@@ -791,6 +814,36 @@ Distinguishes whether a MemberRef entry refers to a method or a field.
 public enum MemberRefKind
 ```
 
+### [NativeSymbolKind](/api/dotsider.core.analysis.models.nativesymbolkind/)
+
+What a native symbol represents. Native AOT binaries carry compiler-generated code and data
+symbols beyond ordinary functions; this classification drives the Size Map's category
+grouping and the symbol view's presentation.
+
+```csharp
+public enum NativeSymbolKind
+```
+
+### [NativeSymbolSource](/api/dotsider.core.analysis.models.nativesymbolsource/)
+
+Where a binary's native symbols came from. The three primary sources carry names and (mostly)
+sizes; the three fallback sources recover only function boundaries from unwind data and are
+lower fidelity — they can miss leaf and thunk functions.
+
+```csharp
+public enum NativeSymbolSource
+```
+
+### [NativeSymbolStatus](/api/dotsider.core.analysis.models.nativesymbolstatus/)
+
+The outcome of probing a binary for native symbols. When no symbols are returned, the status
+distinguishes the reasons — missing, mismatched, corrupt, ambiguous, or fallback-only — so
+callers can explain the result instead of showing an empty table with no cause.
+
+```csharp
+public enum NativeSymbolStatus
+```
+
 ### [NetFxArchitecture](/api/dotsider.core.analysis.models.netfxarchitecture/)
 
 Effective process bitness for a .NET Framework root assembly. Models actual runtime
@@ -837,7 +890,8 @@ public enum PolicyLayer
 ### [SizeNodeKind](/api/dotsider.core.analysis.models.sizenodekind/)
 
 The granularity level of a [SizeNode](/api/dotsider.core.analysis.models.sizenode/) in the size breakdown tree. The kinds
-beyond [Method](/api/dotsider.core.analysis.models.sizenodekind.method/) appear only in Native AOT trees built from an mstat report.
+beyond [Method](/api/dotsider.core.analysis.models.sizenodekind.method/) appear only in Native AOT trees, built from an mstat report or,
+when none sits beside the binary, from its merged native symbols.
 
 ```csharp
 public enum SizeNodeKind

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-NativeSymbolReader.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-NativeSymbolReader.md
@@ -1,0 +1,46 @@
+---
+title: "NativeSymbolReader"
+description: "Reads a native binary's symbols — function names, addresses, and sizes — from its debug information, demangling ILC names back to managed names and merging the overlapping records that different symbol sources produce. Windows native PDBs, Linux DWARF, and macOS dSYM/nlist each feed the same merge and demangle pipeline through String); when no symbols exist, unwind data still yields function boundaries at lower fidelity. The public entry points that dispatch on image format are added as each reader lands."
+slug: api/dotsider.core.analysis.nativesymbolreader
+sidebar:
+  order: 0
+---
+
+**Namespace:** `Dotsider.Core.Analysis`
+
+**Assembly:** Dotsider.Core.dll
+
+Reads a native binary's symbols — function names, addresses, and sizes — from its debug
+information, demangling ILC names back to managed names and merging the overlapping records
+that different symbol sources produce. Windows native PDBs, Linux DWARF, and macOS dSYM/nlist
+each feed the same merge and demangle pipeline through String); when no symbols
+exist, unwind data still yields function boundaries at lower fidelity. The public entry points
+that dispatch on image format are added as each reader lands.
+
+```csharp
+public static class NativeSymbolReader
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **NativeSymbolReader**
+
+## Methods
+
+### Read(string, ReadOnlyMemory\<byte\>, IReadOnlyList\<RecoveredType\>)
+
+Reads the native symbols of a binary, dispatching on image format. Managed and
+unrecognized images return an empty result marked [NotApplicable](/api/dotsider.core.analysis.models.nativesymbolstatus.notapplicable/).
+
+**Parameters:**
+
+- `imagePath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The binary's path, used to probe for sidecar symbol files.
+- `imageBytes` ([ReadOnlyMemory\<Byte\>](https://learn.microsoft.com/dotnet/api/system.readonlymemory-1)): The binary's raw bytes.
+- `recoveredTypes` ([IReadOnlyList\<RecoveredType\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)): Types recovered from the binary's own metadata, for demangling.
+
+**Returns:** [NativeSymbolInfo](/api/dotsider.core.analysis.models.nativesymbolinfo/)
+
+```csharp
+public static NativeSymbolInfo Read(string imagePath, ReadOnlyMemory<byte> imageBytes, IReadOnlyList<RecoveredType> recoveredTypes)
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-SizeAnalyzer.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-SizeAnalyzer.md
@@ -1,6 +1,6 @@
 ---
 title: "SizeAnalyzer"
-description: "Computes IL code size per method and builds a hierarchical size tree for treemap visualization. For a Native AOT binary with an mstat sidecar the tree is built from the compiler's size report instead: native code and MethodTable bytes per assembly, namespace, type, and method, plus the binary's data categories."
+description: "Computes IL code size per method and builds a hierarchical size tree for treemap visualization. For a Native AOT binary with an mstat sidecar the tree is built from the compiler's size report instead: native code and MethodTable bytes per assembly, namespace, type, and method, plus the binary's data categories. Without an mstat, the binary's merged native symbols carry the tree."
 slug: api/dotsider.core.analysis.sizeanalyzer
 sidebar:
   order: 0
@@ -13,7 +13,8 @@ sidebar:
 Computes IL code size per method and builds a hierarchical size tree
 for treemap visualization. For a Native AOT binary with an mstat sidecar the tree is
 built from the compiler's size report instead: native code and MethodTable bytes per
-assembly, namespace, type, and method, plus the binary's data categories.
+assembly, namespace, type, and method, plus the binary's data categories. Without an
+mstat, the binary's merged native symbols carry the tree.
 
 ```csharp
 public static class SizeAnalyzer

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis.md
@@ -149,6 +149,19 @@ toolchain actually emits before it is accepted.
 public static class NativeAotDetector
 ```
 
+### [NativeSymbolReader](/api/dotsider.core.analysis.nativesymbolreader/)
+
+Reads a native binary's symbols — function names, addresses, and sizes — from its debug
+information, demangling ILC names back to managed names and merging the overlapping records
+that different symbol sources produce. Windows native PDBs, Linux DWARF, and macOS dSYM/nlist
+each feed the same merge and demangle pipeline through String); when no symbols
+exist, unwind data still yields function boundaries at lower fidelity. The public entry points
+that dispatch on image format are added as each reader lands.
+
+```csharp
+public static class NativeSymbolReader
+```
+
 ### [NetFxBinder](/api/dotsider.core.analysis.netfxbinder/)
 
 CLR-accurate .NET Framework assembly binder for both CLR generations. Consumes a
@@ -208,7 +221,8 @@ public static class SingleFileBundleReader
 Computes IL code size per method and builds a hierarchical size tree
 for treemap visualization. For a Native AOT binary with an mstat sidecar the tree is
 built from the compiler's size report instead: native code and MethodTable bytes per
-assembly, namespace, type, and method, plus the binary's data categories.
+assembly, namespace, type, and method, plus the binary's data categories. Without an
+mstat, the binary's merged native symbols carry the tree.
 
 ```csharp
 public static class SizeAnalyzer

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -45,13 +45,14 @@ dotsider analyze MyApp.exe                    # apphost .exe → auto-redirects 
 dotsider analyze MyApp                        # single-file bundle → extracts entry assembly
 dotsider analyze MyAotApp.exe                 # Native AOT → binary kind, RTR format, imports
 dotsider analyze MyAotApp.exe --why System.Text.Json.JsonSerializer  # AOT dependency chain
+dotsider analyze MyAotApp.exe --symbols       # native symbols with addresses, sizes, and file:line
 ```
 
 If the file is a native apphost with a companion `.dll`, `analyze` auto-redirects. If it's a self-contained single-file bundle, `analyze` extracts the entry assembly from the bundle. Both cases print a note to stderr.
 
 If the file is a Native AOT executable (a validated ReadyToRun header with no CLR metadata), the default output adds `Kind`, `RTR Format`, `Runtime`, `Imports`, `R2R`, `Recovered`, and `Frozen` lines, and JSON output gains `binaryKind`, `nativeAotInfo`, `readyToRunSections`, `recoveredTypeCount`, and `frozenStringCount`. `--types` falls back to the types recovered from the embedded metadata, `--strings` adds the raw ASCII and UTF-16 scans plus the frozen string literals, since AOT binaries have no metadata string heaps.
 
-With the ILC sidecars next to the binary (publish with `IlcGenerateMstatFile` and `IlcGenerateDgmlFile`, then copy the `.mstat` and `.codegen.dgml.xml` out of `obj/.../native/`), `--size` prints the compiler's own per-assembly breakdown with the binary's data categories, `--deps` shows the compiled-in assemblies and native import modules, and `--why <name>` prints the dependency chain that kept a type or method in the binary — root first, one step per line with the compiler's reason. Names match exactly first, then by unambiguous substring.
+With the ILC sidecars next to the binary (publish with `IlcGenerateMstatFile` and `IlcGenerateDgmlFile`, then copy the `.mstat` and `.codegen.dgml.xml` out of `obj/.../native/`), `--size` prints the compiler's own per-assembly breakdown with the binary's data categories (without an mstat it falls back to the binary's native symbols), `--symbols` lists native symbols with their provenance — the platform's PDB, `.dbg`, or dSYM, or unwind-data boundaries when none exists, `--deps` shows the compiled-in assemblies and native import modules, and `--why <name>` prints the dependency chain that kept a type or method in the binary — root first, one step per line with the compiler's reason. Names match exactly first, then by unambiguous substring.
 
 When portable PDB data is available, default output reports where it came from, and `--il` includes source spans, local names, and Source Link markers. Use `--json` when you need the exact URLs. `--embedded-source` prints source embedded in the PDB.
 
@@ -66,6 +67,7 @@ When portable PDB data is available, default output reports where it came from, 
 | `-n`, `--min-len <n>` | Minimum length for raw string extraction (default: 4) |
 | `--fields` | List field definitions |
 | `--size` | Show size breakdown |
+| `--symbols` | List native symbols with provenance (Native AOT and other native binaries) |
 | `--why <name>` | Explain why a type or method is in a Native AOT binary |
 | `--bundle` | Show single-file bundle manifest |
 | `--json` | Output as JSON |

--- a/docs/src/content/docs/reference/mcp.md
+++ b/docs/src/content/docs/reference/mcp.md
@@ -61,6 +61,7 @@ Add to your MCP client configuration (e.g. `.mcp.json` for Claude Code):
 | Metadata inspection | `get_pe_headers`, `get_clr_header`, `get_sections`, `get_custom_attributes`, `get_resources`, `resolve_token` |
 | Dependencies | `get_assembly_refs`, `get_dependency_graph`, `get_type_refs` |
 | Size analysis | `get_size_breakdown`, `get_largest_methods` |
+| Native symbols | `get_native_symbols` |
 | String extraction | `extract_strings` |
 | Diffing | `diff_assemblies` |
 | NuGet packages | `analyze_nupkg` |

--- a/docs/src/content/docs/usage/general.md
+++ b/docs/src/content/docs/usage/general.md
@@ -24,6 +24,7 @@ Opening a Native AOT executable adds a block below the standard fields. ILC stri
 - **R2R sections** — how many ReadyToRun runtime sections the header describes (the table is in the PE/Metadata tab)
 - **Recovered types** — type and method counts recovered from the embedded metadata (the list is in the PE/Metadata tab)
 - **Frozen strings** — how many frozen string literals were recovered (the list is in the Strings tab)
+- **Native symbols** — the symbol count and its source (native PDB, DWARF, or dSYM), or — when none loaded — the reason: missing, identity mismatch, corrupt, or boundaries-only fallback (the table is in the PE/Metadata tab)
 
 ## Text selection and copy
 

--- a/docs/src/content/docs/usage/pe-metadata.md
+++ b/docs/src/content/docs/usage/pe-metadata.md
@@ -21,10 +21,13 @@ The **PE / Metadata** tab (`2`) exposes the raw structure of the Portable Execut
 - **Load Config** — the load configuration directory: security cookie, SEH handler count, and decoded Control Flow Guard flags
 - **R2R Sections** — the ReadyToRun section table of a Native AOT binary, each region's id, virtual address, size, and file offset
 - **AOT Types** — types recovered from a Native AOT binary's embedded metadata; press Enter to see a type's methods
+- **Symbols** — native symbols with addresses, sizes, and kinds, demangled to managed names where the binary's own metadata allows; press Enter for the mangled name, aliases, section, and source location
 
 Imports and Exports need no CLR header, so they light up for native apphosts and Native AOT executables where the metadata tables are empty. They read whichever native format the binary uses: PE import descriptors on Windows, ELF needed libraries and versioned dynamic symbols on Linux, and Mach-O loaded dylibs and two-level-namespace bindings on macOS. Load Config is a PE-only structure and stays empty on ELF and Mach-O.
 
 R2R Sections and AOT Types apply to Native AOT binaries. ILC strips ECMA-335 metadata, but every AOT image embeds a ReadyToRun header that locates its runtime regions, and the reflection and stack-trace metadata it keeps still names the binary's own types and methods — so a stripped binary describes itself. Both work on every platform where the data is file-backed.
+
+Symbols reads whichever artifact the platform's publish produced — a native PDB on Windows, a `.dbg` ELF sidecar on Linux, or a dSYM bundle on macOS — after validating it against the binary's identity (PDB GUID and age, GNU build id / debuglink CRC, or Mach-O UUID; a mismatching file is rejected, never misread). ILC's mangled names are demangled by joining against the binary's own recovered metadata, so a managed name is marked exact only when the join is unambiguous. Functions carry their declaring source file and line when the symbol file records them. Without a symbol file, unwind data (`.pdata`, `.eh_frame`, or `LC_FUNCTION_STARTS`) still recovers nameless function boundaries — enough for counts and size histograms, though unwind data can miss leaf and thunk functions.
 
 ## Text selection and copy
 

--- a/docs/src/content/docs/usage/size-map.md
+++ b/docs/src/content/docs/usage/size-map.md
@@ -30,3 +30,9 @@ For a Native AOT binary the treemap is built from the compiler's own size report
 With the `.mstat` beside the binary the tree shows every assembly ILC compiled in, drilling through namespaces and types to native method sizes (code plus GC and exception info). Each type carries an explicit `MethodTable` leaf for its runtime type structure, and category regions sit beside the assemblies: `Blobs` for global data like embedded metadata and dispatch maps, `Frozen Objects` for compile-time allocated objects (mostly string literals), `RVA Fields` for data mapped straight into the image, and `Resources` for embedded manifest resources.
 
 With the `.codegen.dgml.xml` beside the binary too, press `w` on any method, type, or frozen object to see why it is in the binary: the chain of dependencies from a root down to the node, each step annotated with the compiler's reason. `Esc` dismisses the chain.
+
+### Without an mstat
+
+When no `.mstat` sits beside a Native AOT binary, the treemap is built from its native symbols instead — the PDB, `.dbg`, or dSYM the publish produced. Functions joined to managed names group under assembly > namespace > type, and the compiler-generated data nodes land in explicit categories (`MethodTables`, `Frozen Objects`, `Stubs`, `Generic Dictionaries`, `Statics`, `Data`), with unjoined names under `Runtime`. The mstat report always wins when present — it is the compiler's own accounting.
+
+With no symbol file either, unwind data still yields nameless function boundaries under an `Unattributed` category — enough for a size histogram, though unwind data can miss leaf and thunk functions, so a boundary-only tree understates slightly.

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -50,6 +50,8 @@ public sealed class AssemblyAnalyzer : IDisposable
     private bool _mstatProbed;
     private DgmlGraph? _dgml;
     private bool _dgmlProbed;
+    private NativeSymbolInfo? _nativeSymbols;
+    private bool _nativeSymbolsProbed;
 
     /// <summary>
     /// Opens and analyzes the specified .NET assembly file.
@@ -362,6 +364,32 @@ public sealed class AssemblyAnalyzer : IDisposable
         BinaryKind == BinaryKind.NativeAot
             ? FindSidecar(".codegen.dgml.xml") ?? FindSidecar(".scan.dgml.xml")
             : null;
+
+    /// <summary>
+    /// The native symbols of this binary — function names, addresses, and sizes read from its
+    /// PDB, DWARF, or dSYM, or function boundaries from unwind data when no symbols exist. Null
+    /// for managed assemblies. Parsed on demand; the value is assigned before the probed flag, so
+    /// a rare concurrent first read costs at most a second parse of immutable data.
+    /// </summary>
+    public NativeSymbolInfo? NativeSymbols
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (!_nativeSymbolsProbed)
+            {
+                _nativeSymbols = BinaryKind != BinaryKind.Managed
+                    ? NativeSymbolReader.Read(FilePath, _rawBytes, RecoveredTypes)
+                    : null;
+                _nativeSymbolsProbed = true;
+            }
+
+            return _nativeSymbols;
+        }
+    }
+
+    /// <summary>The symbol file the native symbols were read from (PDB, .dbg, or dSYM), or null.</summary>
+    public string? NativeSymbolsPath => NativeSymbols?.Path;
 
     /// <summary>
     /// Probes for a sidecar next to the analyzed binary: the binary's extension is replaced

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -1164,6 +1164,17 @@ public sealed class AssemblyAnalyzer : IDisposable
 
         if (!codeViewEntry.IsPortableCodeView)
         {
+            // A native (Windows) PDB. Dotsider can read these; if a matching one sits beside the
+            // binary, mark it so — the full symbol parse stays lazy on the NativeSymbols property.
+            if (!IsBundleBacked && TryMatchNativePdb(codeViewData) is { } nativePath)
+            {
+                PdbProvenance = new PdbProvenance(
+                    PdbProvenanceKind.NativePdb,
+                    nativePath,
+                    $"NativePdb (GUID matched, {nativePath})");
+                return;
+            }
+
             PdbProvenance = new PdbProvenance(
                 PdbProvenanceKind.UnsupportedWindowsPdb,
                 codeViewData.Path,
@@ -1204,6 +1215,36 @@ public sealed class AssemblyAnalyzer : IDisposable
                     foundPath,
                     $"UnsupportedWindowsPdb ({foundPath})");
         }
+    }
+
+    /// <summary>
+    /// Looks for a Windows native PDB beside the binary whose GUID and age match the CodeView
+    /// entry, using the cheap block-level probe. Probes the binary's own directory only — like
+    /// every other sidecar — so the result does not depend on a build-time absolute path that
+    /// happens to still resolve on the current machine. Returns the matching path, or null.
+    /// </summary>
+    private string? TryMatchNativePdb(CodeViewDebugDirectoryData codeViewData)
+    {
+        var directory = Path.GetDirectoryName(FilePath);
+        if (string.IsNullOrEmpty(directory)) return null;
+
+        // The CodeView entry's own file name (its directory is discarded), then <stem>.pdb.
+        var candidates = new List<string>(2);
+        if (!string.IsNullOrEmpty(codeViewData.Path))
+            candidates.Add(Path.Combine(directory, Path.GetFileName(codeViewData.Path)));
+        candidates.Add(Path.Combine(directory, Path.GetFileNameWithoutExtension(FilePath) + ".pdb"));
+
+        foreach (var path in candidates)
+        {
+            if (!File.Exists(path)) continue;
+            if (NativePdb.NativePdbReader.TryReadPdbId(path, out var guid, out var age)
+                && guid == codeViewData.Guid && age == codeViewData.Age)
+            {
+                return path;
+            }
+        }
+
+        return null;
     }
 
     private bool TryOpenAssociatedPortablePdb()

--- a/src/Dotsider.Core/Analysis/Crc32.cs
+++ b/src/Dotsider.Core/Analysis/Crc32.cs
@@ -1,0 +1,34 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// The standard CRC-32 (IEEE 802.3, reflected polynomial 0xEDB88320) — the checksum
+/// <c>.gnu_debuglink</c> stores over the entire sidecar file.
+/// </summary>
+internal static class Crc32
+{
+    private static readonly uint[] Table = BuildTable();
+
+    private static uint[] BuildTable()
+    {
+        var table = new uint[256];
+        for (uint i = 0; i < 256; i++)
+        {
+            var value = i;
+            for (var bit = 0; bit < 8; bit++)
+                value = (value & 1) != 0 ? 0xEDB88320 ^ (value >> 1) : value >> 1;
+            table[i] = value;
+        }
+
+        return table;
+    }
+
+    /// <summary>Computes the CRC-32 of <paramref name="bytes"/>.</summary>
+    /// <param name="bytes">The bytes to checksum.</param>
+    public static uint Compute(ReadOnlySpan<byte> bytes)
+    {
+        var crc = 0xFFFF_FFFF;
+        foreach (var b in bytes)
+            crc = Table[(crc ^ b) & 0xFF] ^ (crc >> 8);
+        return ~crc;
+    }
+}

--- a/src/Dotsider.Core/Analysis/Dwarf/DwarfAbbrevTable.cs
+++ b/src/Dotsider.Core/Analysis/Dwarf/DwarfAbbrevTable.cs
@@ -1,0 +1,78 @@
+namespace Dotsider.Core.Analysis.Dwarf;
+
+/// <summary>
+/// One compilation unit's abbreviation table from <c>.debug_abbrev</c>: each declaration gives a
+/// DIE shape — its tag, whether it has children, and the attribute/form pairs its instances carry
+/// (with the constant value inline for <c>DW_FORM_implicit_const</c>).
+/// </summary>
+internal sealed class DwarfAbbrevTable
+{
+    /// <summary>One attribute slot of an abbreviation declaration.</summary>
+    /// <param name="Attribute">The <c>DW_AT_*</c> code.</param>
+    /// <param name="Form">The <c>DW_FORM_*</c> code.</param>
+    /// <param name="ImplicitConst">The inline constant when the form is <c>implicit_const</c>.</param>
+    internal readonly record struct AttributeSpec(ulong Attribute, ulong Form, long ImplicitConst);
+
+    /// <summary>One abbreviation declaration.</summary>
+    /// <param name="Tag">The <c>DW_TAG_*</c> code.</param>
+    /// <param name="HasChildren">Whether DIEs of this shape own children.</param>
+    /// <param name="Attributes">The attribute slots, in declaration order.</param>
+    internal sealed record Declaration(ulong Tag, bool HasChildren, IReadOnlyList<AttributeSpec> Attributes);
+
+    private readonly Dictionary<ulong, Declaration> _byCode;
+
+    private DwarfAbbrevTable(Dictionary<ulong, Declaration> byCode) => _byCode = byCode;
+
+    /// <summary>Looks up a declaration by its abbreviation code.</summary>
+    /// <param name="code">The code a DIE starts with.</param>
+    /// <param name="declaration">The declaration when known.</param>
+    public bool TryGet(ulong code, out Declaration declaration) =>
+        _byCode.TryGetValue(code, out declaration!);
+
+    /// <summary>
+    /// Parses the abbreviation table at <paramref name="offset"/> in <c>.debug_abbrev</c>. A
+    /// malformed table yields the declarations parsed before the damage.
+    /// </summary>
+    /// <param name="abbrev">The <c>.debug_abbrev</c> bytes.</param>
+    /// <param name="offset">The table's byte offset (the CU header's abbrev offset).</param>
+    public static DwarfAbbrevTable Parse(ReadOnlySpan<byte> abbrev, long offset)
+    {
+        var byCode = new Dictionary<ulong, Declaration>();
+        try
+        {
+            if (offset < 0 || offset >= abbrev.Length) return new DwarfAbbrevTable(byCode);
+            var reader = new DwarfDataReader(abbrev) { Position = (int)offset };
+
+            while (reader.Remaining > 0)
+            {
+                var code = reader.ReadULeb128();
+                if (code == 0) break; // end of this unit's table
+
+                var tag = reader.ReadULeb128();
+                var hasChildren = reader.ReadU8() != 0;
+
+                var attributes = new List<AttributeSpec>();
+                while (true)
+                {
+                    var attribute = reader.ReadULeb128();
+                    var form = reader.ReadULeb128();
+                    if (attribute == 0 && form == 0) break;
+
+                    long implicitConst = 0;
+                    if (form == DwarfForm.ImplicitConst)
+                        implicitConst = reader.ReadSLeb128();
+
+                    attributes.Add(new AttributeSpec(attribute, form, implicitConst));
+                }
+
+                byCode[code] = new Declaration(tag, hasChildren, attributes);
+            }
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            // Keep the declarations parsed so far.
+        }
+
+        return new DwarfAbbrevTable(byCode);
+    }
+}

--- a/src/Dotsider.Core/Analysis/Dwarf/DwarfDataReader.cs
+++ b/src/Dotsider.Core/Analysis/Dwarf/DwarfDataReader.cs
@@ -1,0 +1,141 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Dotsider.Core.Analysis.Dwarf;
+
+/// <summary>
+/// A forward cursor over a DWARF section with the primitive decoders the format is built from:
+/// fixed-width little-endian integers, LEB128 variable-length integers, NUL-terminated strings,
+/// and the initial-length field whose <c>0xFFFFFFFF</c> escape switches a unit to DWARF64
+/// (64-bit lengths and section offsets). Out-of-bounds reads throw
+/// <see cref="ArgumentOutOfRangeException"/>, which the readers catch to end a walk leniently.
+/// </summary>
+internal ref struct DwarfDataReader(ReadOnlySpan<byte> data)
+{
+    private readonly ReadOnlySpan<byte> _data = data;
+
+    /// <summary>The cursor position, in bytes from the start of the section.</summary>
+    public int Position { get; set; }
+
+    /// <summary>The bytes remaining ahead of the cursor.</summary>
+    public readonly int Remaining => _data.Length - Position;
+
+    /// <summary>Reads one byte.</summary>
+    public byte ReadU8() => _data[Position++];
+
+    /// <summary>Reads a little-endian u16.</summary>
+    public ushort ReadU16()
+    {
+        var v = BinaryPrimitives.ReadUInt16LittleEndian(_data[Position..]);
+        Position += 2;
+        return v;
+    }
+
+    /// <summary>Reads a little-endian u32.</summary>
+    public uint ReadU32()
+    {
+        var v = BinaryPrimitives.ReadUInt32LittleEndian(_data[Position..]);
+        Position += 4;
+        return v;
+    }
+
+    /// <summary>Reads a little-endian u64.</summary>
+    public ulong ReadU64()
+    {
+        var v = BinaryPrimitives.ReadUInt64LittleEndian(_data[Position..]);
+        Position += 8;
+        return v;
+    }
+
+    /// <summary>Reads an unsigned LEB128 integer.</summary>
+    public ulong ReadULeb128()
+    {
+        ulong result = 0;
+        var shift = 0;
+        while (true)
+        {
+            var b = _data[Position++];
+            result |= (ulong)(b & 0x7F) << shift;
+            if ((b & 0x80) == 0) return result;
+            shift += 7;
+            if (shift > 63) throw new ArgumentOutOfRangeException(nameof(shift), "LEB128 too long");
+        }
+    }
+
+    /// <summary>Reads a signed LEB128 integer.</summary>
+    public long ReadSLeb128()
+    {
+        long result = 0;
+        var shift = 0;
+        byte b;
+        do
+        {
+            b = _data[Position++];
+            result |= (long)(b & 0x7F) << shift;
+            shift += 7;
+            if (shift > 70) throw new ArgumentOutOfRangeException(nameof(shift), "LEB128 too long");
+        }
+        while ((b & 0x80) != 0);
+
+        if (shift < 64 && (b & 0x40) != 0)
+            result |= -1L << shift;
+        return result;
+    }
+
+    /// <summary>
+    /// Reads a unit's initial length: a u32, or the <c>0xFFFFFFFF</c> escape followed by a u64
+    /// for DWARF64.
+    /// </summary>
+    /// <param name="is64">Set when the unit is DWARF64.</param>
+    public ulong ReadInitialLength(out bool is64)
+    {
+        var first = ReadU32();
+        if (first == 0xFFFF_FFFF)
+        {
+            is64 = true;
+            return ReadU64();
+        }
+
+        is64 = false;
+        return first;
+    }
+
+    /// <summary>Reads a section offset: u32 in DWARF32, u64 in DWARF64.</summary>
+    /// <param name="is64">Whether the containing unit is DWARF64.</param>
+    public ulong ReadSectionOffset(bool is64) => is64 ? ReadU64() : ReadU32();
+
+    /// <summary>Reads an address of the unit's address size (4 or 8 bytes).</summary>
+    /// <param name="addressSize">The unit's address size.</param>
+    public ulong ReadAddress(int addressSize) => addressSize == 8 ? ReadU64() : ReadU32();
+
+    /// <summary>Reads a NUL-terminated UTF-8 string.</summary>
+    public string ReadCString()
+    {
+        var slice = _data[Position..];
+        var end = slice.IndexOf((byte)0);
+        if (end < 0) end = slice.Length;
+        var s = Encoding.UTF8.GetString(slice[..end]);
+        Position += end + 1;
+        return s;
+    }
+
+    /// <summary>Advances the cursor by <paramref name="count"/> bytes.</summary>
+    /// <param name="count">The byte count to skip.</param>
+    public void Skip(int count)
+    {
+        if (count < 0 || Position + count > _data.Length)
+            throw new ArgumentOutOfRangeException(nameof(count));
+        Position += count;
+    }
+
+    /// <summary>Reads a NUL-terminated UTF-8 string at an absolute offset without moving the cursor.</summary>
+    /// <param name="offset">The absolute byte offset.</param>
+    public readonly string? ReadCStringAt(long offset)
+    {
+        if (offset < 0 || offset >= _data.Length) return null;
+        var slice = _data[(int)offset..];
+        var end = slice.IndexOf((byte)0);
+        if (end < 0) end = slice.Length;
+        return Encoding.UTF8.GetString(slice[..end]);
+    }
+}

--- a/src/Dotsider.Core/Analysis/Dwarf/DwarfForm.cs
+++ b/src/Dotsider.Core/Analysis/Dwarf/DwarfForm.cs
@@ -1,0 +1,73 @@
+namespace Dotsider.Core.Analysis.Dwarf;
+
+/// <summary>
+/// The <c>DW_FORM_*</c> codes the reader decodes or skips, plus the <c>DW_TAG_*</c> and
+/// <c>DW_AT_*</c> codes it recognizes — the DWARF 4/5 vocabulary needed to walk subprograms.
+/// </summary>
+internal static class DwarfForm
+{
+    // Forms
+    public const ulong Addr = 0x01;
+    public const ulong Block2 = 0x03;
+    public const ulong Block4 = 0x04;
+    public const ulong Data2 = 0x05;
+    public const ulong Data4 = 0x06;
+    public const ulong Data8 = 0x07;
+    public const ulong String = 0x08;
+    public const ulong Block = 0x09;
+    public const ulong Block1 = 0x0A;
+    public const ulong Data1 = 0x0B;
+    public const ulong Flag = 0x0C;
+    public const ulong Sdata = 0x0D;
+    public const ulong Strp = 0x0E;
+    public const ulong Udata = 0x0F;
+    public const ulong RefAddr = 0x10;
+    public const ulong Ref1 = 0x11;
+    public const ulong Ref2 = 0x12;
+    public const ulong Ref4 = 0x13;
+    public const ulong Ref8 = 0x14;
+    public const ulong RefUdata = 0x15;
+    public const ulong Indirect = 0x16;
+    public const ulong SecOffset = 0x17;
+    public const ulong Exprloc = 0x18;
+    public const ulong FlagPresent = 0x19;
+    public const ulong Strx = 0x1A;
+    public const ulong Addrx = 0x1B;
+    public const ulong RefSup4 = 0x1C;
+    public const ulong StrpSup = 0x1D;
+    public const ulong Data16 = 0x1E;
+    public const ulong LineStrp = 0x1F;
+    public const ulong RefSig8 = 0x20;
+    public const ulong ImplicitConst = 0x21;
+    public const ulong Loclistx = 0x22;
+    public const ulong Rnglistx = 0x23;
+    public const ulong RefSup8 = 0x24;
+    public const ulong Strx1 = 0x25;
+    public const ulong Strx2 = 0x26;
+    public const ulong Strx3 = 0x27;
+    public const ulong Strx4 = 0x28;
+    public const ulong Addrx1 = 0x29;
+    public const ulong Addrx2 = 0x2A;
+    public const ulong Addrx3 = 0x2B;
+    public const ulong Addrx4 = 0x2C;
+
+    // Tags
+    public const ulong TagCompileUnit = 0x11;
+    public const ulong TagSubprogram = 0x2E;
+
+    // Attributes
+    public const ulong AtName = 0x03;
+    public const ulong AtStmtList = 0x10;
+    public const ulong AtLowPc = 0x11;
+    public const ulong AtHighPc = 0x12;
+    public const ulong AtAbstractOrigin = 0x31;
+    public const ulong AtDeclFile = 0x3A;
+    public const ulong AtDeclLine = 0x3B;
+    public const ulong AtSpecification = 0x47;
+    public const ulong AtRanges = 0x55;
+    public const ulong AtLinkageName = 0x6E;
+    public const ulong AtMipsLinkageName = 0x2007;
+    public const ulong AtStrOffsetsBase = 0x72;
+    public const ulong AtAddrBase = 0x73;
+    public const ulong AtRnglistsBase = 0x74;
+}

--- a/src/Dotsider.Core/Analysis/Dwarf/DwarfLineProgram.cs
+++ b/src/Dotsider.Core/Analysis/Dwarf/DwarfLineProgram.cs
@@ -1,0 +1,340 @@
+namespace Dotsider.Core.Analysis.Dwarf;
+
+/// <summary>
+/// One compilation unit's <c>.debug_line</c> program: the file table (v4 directory/file lists or
+/// v5 form-described entry tables, plus <c>DW_LNE_define_file</c> additions) and the decoded
+/// row machine. Source attribution treats <c>DW_AT_decl_file</c>/<c>DW_AT_decl_line</c> as
+/// primary — <see cref="FileName"/> resolves the index with the version's numbering — and the
+/// row covering an address (<see cref="TryFindLine"/>) as the fallback. A malformed program body
+/// keeps the rows decoded before the damage; a malformed header yields no program.
+/// </summary>
+internal sealed class DwarfLineProgram
+{
+    // Standard opcodes (DWARF5 §6.2.5.2).
+    private const byte LnsCopy = 1;
+    private const byte LnsAdvancePc = 2;
+    private const byte LnsAdvanceLine = 3;
+    private const byte LnsSetFile = 4;
+    private const byte LnsSetColumn = 5;
+    private const byte LnsConstAddPc = 8;
+    private const byte LnsFixedAdvancePc = 9;
+    private const byte LnsSetIsa = 12;
+
+    // Extended opcodes (DWARF5 §6.2.5.3).
+    private const byte LneEndSequence = 1;
+    private const byte LneSetAddress = 2;
+    private const byte LneDefineFile = 3;
+
+    // v5 entry-format content types (DWARF5 §6.2.4.1).
+    private const ulong LnctPath = 1;
+    private const ulong LnctDirectoryIndex = 2;
+
+    private const int MaxRows = 1 << 20;
+
+    private readonly record struct Row(ulong Address, int File, int Line, bool EndSequence);
+
+    private readonly string[] _files;
+    private readonly bool _oneBasedFiles;
+    private readonly Row[] _rows; // sorted by address, end-sequence rows first on ties
+
+    private DwarfLineProgram(string[] files, bool oneBasedFiles, Row[] rows)
+    {
+        _files = files;
+        _oneBasedFiles = oneBasedFiles;
+        _rows = rows;
+    }
+
+    /// <summary>
+    /// Resolves a file-table index to its directory-joined name, honoring the version's
+    /// numbering (v4 tables are 1-based, v5 are 0-based), or null when out of range.
+    /// </summary>
+    /// <param name="index">The <c>DW_AT_decl_file</c> or row-machine file value.</param>
+    public string? FileName(int index)
+    {
+        var i = _oneBasedFiles ? index - 1 : index;
+        return i >= 0 && i < _files.Length ? _files[i] : null;
+    }
+
+    /// <summary>Finds the row covering <paramref name="address"/> and returns its file and line.</summary>
+    /// <param name="address">The address to attribute, typically a function's <c>low_pc</c>.</param>
+    /// <param name="file">The covering row's file name, or null when its index is bad.</param>
+    /// <param name="line">The covering row's line.</param>
+    public bool TryFindLine(ulong address, out string? file, out int line)
+    {
+        file = null;
+        line = 0;
+
+        var lo = 0;
+        var hi = _rows.Length - 1;
+        var best = -1;
+        while (lo <= hi)
+        {
+            var mid = lo + ((hi - lo) >> 1);
+            if (_rows[mid].Address <= address)
+            {
+                best = mid;
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+
+        if (best < 0 || _rows[best].EndSequence) return false;
+        file = FileName(_rows[best].File);
+        line = _rows[best].Line;
+        return true;
+    }
+
+    /// <summary>
+    /// Attributes a function to a source file and line: the declaration attributes are primary,
+    /// and the row at <paramref name="address"/> fills whichever of them is absent.
+    /// </summary>
+    /// <param name="declFile">The <c>DW_AT_decl_file</c> index, or -1 when the DIE carried none.</param>
+    /// <param name="declLine">The <c>DW_AT_decl_line</c> value, or 0 when absent.</param>
+    /// <param name="address">The function's start address, for the row fallback.</param>
+    public (string? File, int? Line) ResolveSource(int declFile, int declLine, ulong address)
+    {
+        var file = declFile >= 0 ? FileName(declFile) : null;
+        int? line = declLine > 0 ? declLine : null;
+        if ((file is null || line is null) && TryFindLine(address, out var rowFile, out var rowLine))
+        {
+            file ??= rowFile;
+            line ??= rowLine > 0 ? rowLine : null;
+        }
+
+        return (file, line);
+    }
+
+    /// <summary>
+    /// Parses the line program at <paramref name="offset"/> in <c>.debug_line</c>, or null when
+    /// the header is malformed or the offset is out of range.
+    /// </summary>
+    /// <param name="sections">The DWARF section bytes.</param>
+    /// <param name="offset">The CU's <c>DW_AT_stmt_list</c> offset.</param>
+    public static DwarfLineProgram? Parse(DwarfSections sections, long offset)
+    {
+        if (offset < 0 || offset >= sections.Line.Length) return null;
+        try
+        {
+            return ParseCore(sections, offset);
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            return null;
+        }
+    }
+
+    private static DwarfLineProgram? ParseCore(DwarfSections sections, long offset)
+    {
+        var reader = new DwarfDataReader(sections.Line) { Position = (int)offset };
+        var unitLength = reader.ReadInitialLength(out var is64);
+        var end = reader.Position + (long)unitLength;
+        if (unitLength == 0 || end > sections.Line.Length) return null;
+
+        var version = reader.ReadU16();
+        if (version is < 2 or > 5) return null;
+        if (version >= 5) reader.Skip(2); // address_size, segment_selector_size
+
+        var headerLength = (long)reader.ReadSectionOffset(is64);
+        var programStart = reader.Position + headerLength;
+        if (programStart > end) return null;
+
+        var minimumInstructionLength = reader.ReadU8();
+        if (version >= 4) reader.Skip(1); // maximum_operations_per_instruction
+        reader.Skip(1); // default_is_stmt
+        var lineBase = (sbyte)reader.ReadU8();
+        var lineRange = reader.ReadU8();
+        var opcodeBase = reader.ReadU8();
+        if (lineRange == 0 || opcodeBase == 0) return null;
+        var standardLengths = new byte[opcodeBase];
+        for (var i = 1; i < opcodeBase; i++) standardLengths[i] = reader.ReadU8();
+
+        var directories = new List<string>();
+        var files = new List<string>();
+        bool oneBased;
+        if (version >= 5)
+        {
+            oneBased = false;
+            ReadV5Table(sections, ref reader, is64, directories, isFileTable: false, files);
+            ReadV5Table(sections, ref reader, is64, directories, isFileTable: true, files);
+        }
+        else
+        {
+            oneBased = true;
+            directories.Add(""); // index 0 = the compilation directory, unknown here
+            while (true)
+            {
+                var dir = reader.ReadCString();
+                if (dir.Length == 0) break;
+                directories.Add(dir);
+            }
+
+            while (true)
+            {
+                var name = reader.ReadCString();
+                if (name.Length == 0) break;
+                var dirIndex = (int)reader.ReadULeb128();
+                reader.ReadULeb128(); // mtime
+                reader.ReadULeb128(); // length
+                files.Add(Join(directories, dirIndex, name));
+            }
+        }
+
+        // header_length positions the machine independently of table quirks above.
+        reader.Position = (int)programStart;
+        var rows = RunMachine(ref reader, (int)end, minimumInstructionLength, lineBase, lineRange,
+            opcodeBase, standardLengths, directories, files);
+
+        rows.Sort(static (x, y) => x.Address != y.Address
+            ? x.Address.CompareTo(y.Address)
+            : y.EndSequence.CompareTo(x.EndSequence));
+        return new DwarfLineProgram([.. files], oneBased, [.. rows]);
+    }
+
+    private static List<Row> RunMachine(
+        ref DwarfDataReader reader, int end, byte minimumInstructionLength, sbyte lineBase,
+        byte lineRange, byte opcodeBase, byte[] standardLengths,
+        List<string> directories, List<string> files)
+    {
+        var rows = new List<Row>();
+        ulong address = 0;
+        var file = 1;
+        var line = 1;
+
+        try
+        {
+            while (reader.Position < end && rows.Count < MaxRows)
+            {
+                var opcode = reader.ReadU8();
+                if (opcode >= opcodeBase)
+                {
+                    var adjusted = opcode - opcodeBase;
+                    address += (ulong)(adjusted / lineRange) * minimumInstructionLength;
+                    line += lineBase + adjusted % lineRange;
+                    rows.Add(new Row(address, file, line, EndSequence: false));
+                }
+                else if (opcode == 0)
+                {
+                    var length = (long)reader.ReadULeb128();
+                    var next = reader.Position + length;
+                    var sub = length > 0 ? reader.ReadU8() : (byte)0;
+                    switch (sub)
+                    {
+                        case LneEndSequence:
+                            rows.Add(new Row(address, file, line, EndSequence: true));
+                            address = 0;
+                            file = 1;
+                            line = 1;
+                            break;
+
+                        case LneSetAddress:
+                            address = 0;
+                            for (var i = 0; i < length - 1 && i < 8; i++)
+                                address |= (ulong)reader.ReadU8() << (8 * i);
+                            break;
+
+                        case LneDefineFile:
+                        {
+                            var name = reader.ReadCString();
+                            var dirIndex = (int)reader.ReadULeb128();
+                            files.Add(Join(directories, dirIndex, name));
+                            break;
+                        }
+                    }
+
+                    if (next < reader.Position || next > end) break;
+                    reader.Position = (int)next;
+                }
+                else
+                {
+                    switch (opcode)
+                    {
+                        case LnsCopy: rows.Add(new Row(address, file, line, EndSequence: false)); break;
+                        case LnsAdvancePc: address += reader.ReadULeb128() * minimumInstructionLength; break;
+                        case LnsAdvanceLine: line += (int)reader.ReadSLeb128(); break;
+                        case LnsSetFile: file = (int)reader.ReadULeb128(); break;
+                        case LnsSetColumn: reader.ReadULeb128(); break;
+                        case LnsConstAddPc:
+                            address += (ulong)((255 - opcodeBase) / lineRange) * minimumInstructionLength;
+                            break;
+                        case LnsFixedAdvancePc: address += reader.ReadU16(); break;
+                        case LnsSetIsa: reader.ReadULeb128(); break;
+                        default:
+                            for (var i = 0; i < standardLengths[opcode]; i++) reader.ReadULeb128();
+                            break;
+                    }
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            // Keep the rows decoded before the damage.
+        }
+
+        return rows;
+    }
+
+    private static void ReadV5Table(
+        DwarfSections sections, ref DwarfDataReader reader, bool is64,
+        List<string> directories, bool isFileTable, List<string> files)
+    {
+        var formatCount = reader.ReadU8();
+        var formats = new (ulong Content, ulong Form)[formatCount];
+        for (var i = 0; i < formatCount; i++)
+            formats[i] = (reader.ReadULeb128(), reader.ReadULeb128());
+
+        var count = reader.ReadULeb128();
+        for (ulong i = 0; i < count; i++)
+        {
+            string? path = null;
+            var dirIndex = 0;
+            foreach (var (content, form) in formats)
+            {
+                if (ReadEntryValue(sections, ref reader, form, is64) is not { } value) return;
+                if (content == LnctPath) path = value.S;
+                else if (content == LnctDirectoryIndex) dirIndex = (int)value.U;
+            }
+
+            if (isFileTable) files.Add(Join(directories, dirIndex, path ?? ""));
+            else directories.Add(path ?? "");
+        }
+    }
+
+    private static (ulong U, string? S)? ReadEntryValue(
+        DwarfSections sections, ref DwarfDataReader reader, ulong form, bool is64)
+    {
+        switch (form)
+        {
+            case DwarfForm.String: return (0, reader.ReadCString());
+            case DwarfForm.Strp:
+            {
+                var offset = (long)reader.ReadSectionOffset(is64);
+                return (0, new DwarfDataReader(sections.Str).ReadCStringAt(offset));
+            }
+
+            case DwarfForm.LineStrp:
+            {
+                var offset = (long)reader.ReadSectionOffset(is64);
+                return (0, new DwarfDataReader(sections.LineStr).ReadCStringAt(offset));
+            }
+
+            case DwarfForm.Udata: return (reader.ReadULeb128(), null);
+            case DwarfForm.Data1: return (reader.ReadU8(), null);
+            case DwarfForm.Data2: return (reader.ReadU16(), null);
+            case DwarfForm.Data4: return (reader.ReadU32(), null);
+            case DwarfForm.Data8: return (reader.ReadU64(), null);
+            case DwarfForm.Data16: reader.Skip(16); return (0, null);
+            case DwarfForm.Block: reader.Skip((int)reader.ReadULeb128()); return (0, null);
+            default: return null; // unknown form: entry sizes unknowable from here on
+        }
+    }
+
+    private static string Join(List<string> directories, int dirIndex, string name)
+    {
+        if (name.StartsWith('/') || name.Contains(':')) return name; // already rooted
+        var dir = dirIndex >= 0 && dirIndex < directories.Count ? directories[dirIndex] : "";
+        return dir.Length == 0 ? name : $"{dir}/{name}";
+    }
+}

--- a/src/Dotsider.Core/Analysis/Dwarf/DwarfRangeLists.cs
+++ b/src/Dotsider.Core/Analysis/Dwarf/DwarfRangeLists.cs
@@ -1,0 +1,196 @@
+namespace Dotsider.Core.Analysis.Dwarf;
+
+/// <summary>
+/// Resolves a range-based subprogram's <c>DW_AT_ranges</c> reference into a start address and a
+/// covered byte size: the v4 <c>.debug_ranges</c> begin/end pair walk (with <c>(-1, base)</c>
+/// base-address escape entries), and the v5 <c>.debug_rnglists</c> RLE opcode walk (with
+/// <c>rnglistx</c> index indirection through the CU's offset array and <c>startx</c> forms
+/// through <c>.debug_addr</c>). The start is the lowest range begin; the size is the sum of
+/// covered bytes. Malformed or empty lists yield false.
+/// </summary>
+internal static class DwarfRangeLists
+{
+    // .debug_rnglists entry opcodes (DWARF5 §7.25).
+    private const byte RleEndOfList = 0x00;
+    private const byte RleBaseAddressx = 0x01;
+    private const byte RleStartxEndx = 0x02;
+    private const byte RleStartxLength = 0x03;
+    private const byte RleOffsetPair = 0x04;
+    private const byte RleBaseAddress = 0x05;
+    private const byte RleStartEnd = 0x06;
+    private const byte RleStartLength = 0x07;
+
+    private const int MaxEntries = 65_536;
+
+    /// <summary>
+    /// Resolves the ranges at <paramref name="rangesOffset"/> to the function's start (lowest
+    /// range begin) and size (covered byte sum).
+    /// </summary>
+    /// <param name="sections">The DWARF section bytes.</param>
+    /// <param name="rangesOffset">The <c>DW_AT_ranges</c> value: a section offset, or a <c>rnglistx</c> index.</param>
+    /// <param name="isRnglistx">Whether <paramref name="rangesOffset"/> is a <c>rnglistx</c> index into the CU's offset array.</param>
+    /// <param name="unit">The owning compilation unit's context.</param>
+    /// <param name="start">The lowest range start.</param>
+    /// <param name="size">The covered byte sum.</param>
+    public static bool TryResolve(
+        DwarfSections sections, long rangesOffset, bool isRnglistx,
+        DwarfReader.UnitContext unit, out ulong start, out ulong size)
+    {
+        start = 0;
+        size = 0;
+        try
+        {
+            return unit.Version >= 5
+                ? TryResolveRnglists(sections, rangesOffset, isRnglistx, unit, out start, out size)
+                : TryResolveRanges(sections, rangesOffset, unit, out start, out size);
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryResolveRanges(
+        DwarfSections sections, long offset, DwarfReader.UnitContext unit,
+        out ulong start, out ulong size)
+    {
+        start = 0;
+        size = 0;
+        if (offset < 0 || offset >= sections.Ranges.Length) return false;
+
+        var reader = new DwarfDataReader(sections.Ranges) { Position = (int)offset };
+        var baseAddress = unit.BaseAddress;
+        var escape = unit.AddressSize == 8 ? ulong.MaxValue : uint.MaxValue;
+        var lowest = ulong.MaxValue;
+        ulong sum = 0;
+
+        for (var i = 0; i < MaxEntries; i++)
+        {
+            var begin = reader.ReadAddress(unit.AddressSize);
+            var end = reader.ReadAddress(unit.AddressSize);
+            if (begin == escape)
+            {
+                baseAddress = end;
+                continue;
+            }
+
+            if (begin == 0 && end == 0) break;
+            Accumulate(baseAddress + begin, baseAddress + end, ref lowest, ref sum);
+        }
+
+        return Finish(lowest, sum, ref start, ref size);
+    }
+
+    private static bool TryResolveRnglists(
+        DwarfSections sections, long rangesOffset, bool isRnglistx,
+        DwarfReader.UnitContext unit, out ulong start, out ulong size)
+    {
+        start = 0;
+        size = 0;
+
+        if (isRnglistx)
+        {
+            // The index selects an entry in the CU's offset array; the entry is an offset from
+            // the array's base to the target list.
+            var offsetSize = unit.Is64 ? 8 : 4;
+            var position = unit.RnglistsBase + rangesOffset * offsetSize;
+            if (position < 0 || position + offsetSize > sections.RngLists.Length) return false;
+            var entryReader = new DwarfDataReader(sections.RngLists) { Position = (int)position };
+            rangesOffset = unit.RnglistsBase + (long)entryReader.ReadSectionOffset(unit.Is64);
+        }
+
+        if (rangesOffset < 0 || rangesOffset >= sections.RngLists.Length) return false;
+
+        var reader = new DwarfDataReader(sections.RngLists) { Position = (int)rangesOffset };
+        var baseAddress = unit.BaseAddress;
+        var lowest = ulong.MaxValue;
+        ulong sum = 0;
+
+        for (var i = 0; i < MaxEntries; i++)
+        {
+            var opcode = reader.ReadU8();
+            switch (opcode)
+            {
+                case RleEndOfList:
+                    return Finish(lowest, sum, ref start, ref size);
+
+                case RleBaseAddressx:
+                    if (!TryReadAddr(sections, reader.ReadULeb128(), unit, out baseAddress)) return false;
+                    break;
+
+                case RleStartxEndx:
+                {
+                    if (!TryReadAddr(sections, reader.ReadULeb128(), unit, out var s)) return false;
+                    if (!TryReadAddr(sections, reader.ReadULeb128(), unit, out var e)) return false;
+                    Accumulate(s, e, ref lowest, ref sum);
+                    break;
+                }
+
+                case RleStartxLength:
+                {
+                    if (!TryReadAddr(sections, reader.ReadULeb128(), unit, out var s)) return false;
+                    Accumulate(s, s + reader.ReadULeb128(), ref lowest, ref sum);
+                    break;
+                }
+
+                case RleOffsetPair:
+                {
+                    var s = baseAddress + reader.ReadULeb128();
+                    var e = baseAddress + reader.ReadULeb128();
+                    Accumulate(s, e, ref lowest, ref sum);
+                    break;
+                }
+
+                case RleBaseAddress:
+                    baseAddress = reader.ReadAddress(unit.AddressSize);
+                    break;
+
+                case RleStartEnd:
+                {
+                    var s = reader.ReadAddress(unit.AddressSize);
+                    var e = reader.ReadAddress(unit.AddressSize);
+                    Accumulate(s, e, ref lowest, ref sum);
+                    break;
+                }
+
+                case RleStartLength:
+                {
+                    var s = reader.ReadAddress(unit.AddressSize);
+                    Accumulate(s, s + reader.ReadULeb128(), ref lowest, ref sum);
+                    break;
+                }
+
+                default:
+                    return false; // unknown opcode: operand size unknowable
+            }
+        }
+
+        return false;
+    }
+
+    private static void Accumulate(ulong rangeStart, ulong rangeEnd, ref ulong lowest, ref ulong sum)
+    {
+        if (rangeEnd <= rangeStart) return;
+        sum += rangeEnd - rangeStart;
+        if (rangeStart < lowest) lowest = rangeStart;
+    }
+
+    private static bool Finish(ulong lowest, ulong sum, ref ulong start, ref ulong size)
+    {
+        if (lowest == ulong.MaxValue) return false;
+        start = lowest;
+        size = sum;
+        return true;
+    }
+
+    private static bool TryReadAddr(
+        DwarfSections sections, ulong index, DwarfReader.UnitContext unit, out ulong address)
+    {
+        address = 0;
+        var position = unit.AddrBase + (long)index * unit.AddressSize;
+        if (position < 0 || position + unit.AddressSize > sections.Addr.Length) return false;
+        var reader = new DwarfDataReader(sections.Addr) { Position = (int)position };
+        address = reader.ReadAddress(unit.AddressSize);
+        return true;
+    }
+}

--- a/src/Dotsider.Core/Analysis/Dwarf/DwarfReader.cs
+++ b/src/Dotsider.Core/Analysis/Dwarf/DwarfReader.cs
@@ -1,0 +1,370 @@
+namespace Dotsider.Core.Analysis.Dwarf;
+
+/// <summary>
+/// Walks <c>.debug_info</c> compilation units for <c>DW_TAG_subprogram</c> DIEs — the functions —
+/// resolving names through every string form (inline, <c>strp</c>, <c>line_strp</c>, and the v5
+/// <c>strx</c> indirection), addresses through <c>addr</c>/<c>addrx</c>, and sizes from
+/// <c>high_pc</c> in either its address or offset class. DWARF32 and DWARF64 units both parse;
+/// unit types other than compile/partial units (skeletons, split units) are skipped. A DIE whose
+/// name lives on a referenced declaration resolves one <c>specification</c>/<c>abstract_origin</c>
+/// hop. Malformed units yield the functions parsed before the damage.
+/// </summary>
+internal static class DwarfReader
+{
+    private const int MaxUnits = 4096;
+    private const int MaxDies = 1 << 22;
+
+    /// <summary>One subprogram recovered from the DIE tree.</summary>
+    /// <param name="Name">The best name found: linkage name when present, else the source name.</param>
+    /// <param name="LowPc">The function's start address.</param>
+    /// <param name="Size">The function's byte size, or 0 when the DIE recorded none.</param>
+    /// <param name="DeclFile">The <c>DW_AT_decl_file</c> index into the CU's line-program file table, or 0.</param>
+    /// <param name="DeclLine">The <c>DW_AT_decl_line</c> value, or 0.</param>
+    /// <param name="StmtListOffset">The CU's <c>.debug_line</c> program offset, or -1 when absent.</param>
+    /// <param name="RangesOffset">The <c>DW_AT_ranges</c> offset when the function is range-based, or -1.</param>
+    /// <param name="RangesIsRnglistx">Whether <paramref name="RangesOffset"/> is a <c>rnglistx</c> index rather than a section offset.</param>
+    internal readonly record struct DwarfFunction(
+        string Name, ulong LowPc, ulong Size, int DeclFile, int DeclLine,
+        long StmtListOffset, long RangesOffset, bool RangesIsRnglistx);
+
+    /// <summary>The per-CU context needed to resolve indexed forms and ranges.</summary>
+    /// <param name="Version">The DWARF version.</param>
+    /// <param name="Is64">Whether the unit is DWARF64.</param>
+    /// <param name="AddressSize">The unit's address size.</param>
+    /// <param name="BaseAddress">The CU's base address (its own low_pc), for range lists.</param>
+    /// <param name="StrOffsetsBase">The <c>.debug_str_offsets</c> base for <c>strx</c>.</param>
+    /// <param name="AddrBase">The <c>.debug_addr</c> base for <c>addrx</c>.</param>
+    /// <param name="RnglistsBase">The <c>.debug_rnglists</c> base for <c>rnglistx</c>.</param>
+    /// <param name="StmtListOffset">The CU's line-program offset, or -1.</param>
+    internal readonly record struct UnitContext(
+        ushort Version, bool Is64, int AddressSize, ulong BaseAddress,
+        long StrOffsetsBase, long AddrBase, long RnglistsBase, long StmtListOffset);
+
+    /// <summary>
+    /// Reads every subprogram with an address from the DWARF sections, together with the unit
+    /// context needed to resolve its ranges and file table.
+    /// </summary>
+    /// <param name="sections">The DWARF section bytes.</param>
+    public static List<(DwarfFunction Function, UnitContext Unit)> ReadFunctions(DwarfSections sections)
+    {
+        var result = new List<(DwarfFunction, UnitContext)>();
+        if (!sections.HasInfo) return result;
+
+        try
+        {
+            var reader = new DwarfDataReader(sections.Info);
+            var units = 0;
+            while (reader.Remaining > 12 && units++ < MaxUnits)
+            {
+                var unitStart = reader.Position;
+                var length = reader.ReadInitialLength(out var is64);
+                var nextUnit = reader.Position + (long)length;
+                if (length == 0 || nextUnit > sections.Info.Length) break;
+
+                ReadUnit(sections, ref reader, unitStart, is64, (int)nextUnit, result);
+                reader.Position = (int)nextUnit;
+            }
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            // Keep the functions parsed before the damage.
+        }
+
+        return result;
+    }
+
+    private static void ReadUnit(
+        DwarfSections sections, ref DwarfDataReader reader, int unitStart, bool is64, int unitEnd,
+        List<(DwarfFunction, UnitContext)> result)
+    {
+        var version = reader.ReadU16();
+        if (version is < 2 or > 5) return;
+
+        long abbrevOffset;
+        int addressSize;
+        if (version >= 5)
+        {
+            var unitType = reader.ReadU8();
+            addressSize = reader.ReadU8();
+            abbrevOffset = (long)reader.ReadSectionOffset(is64);
+            if (unitType is not (1 or 3)) return; // DW_UT_compile / DW_UT_partial only
+        }
+        else
+        {
+            abbrevOffset = (long)reader.ReadSectionOffset(is64);
+            addressSize = reader.ReadU8();
+        }
+
+        if (addressSize is not (4 or 8)) return;
+        var abbrevs = DwarfAbbrevTable.Parse(sections.Abbrev, abbrevOffset);
+
+        // Defaults per DWARF5: the base attributes point just past each section's header.
+        var unit = new UnitContext(version, is64, addressSize, BaseAddress: 0,
+            StrOffsetsBase: is64 ? 16 : 8, AddrBase: 8, RnglistsBase: is64 ? 20 : 12, StmtListOffset: -1);
+
+        var dies = 0;
+        var depth = 0;
+        var isRoot = true;
+        while (reader.Position < unitEnd && dies++ < MaxDies)
+        {
+            var code = reader.ReadULeb128();
+            if (code == 0)
+            {
+                if (--depth < 0) break;
+                continue;
+            }
+
+            if (!abbrevs.TryGet(code, out var decl)) break;
+
+            if (isRoot && decl.Tag == DwarfForm.TagCompileUnit)
+            {
+                unit = ReadUnitRoot(sections, ref reader, decl, unit);
+            }
+            else if (decl.Tag == DwarfForm.TagSubprogram)
+            {
+                if (ReadSubprogram(sections, ref reader, unitStart, decl, unit, abbrevs) is { } function)
+                    result.Add((function, unit));
+            }
+            else
+            {
+                SkipAttributes(ref reader, decl, unit);
+            }
+
+            isRoot = false;
+            if (decl.HasChildren) depth++;
+        }
+    }
+
+    private static UnitContext ReadUnitRoot(
+        DwarfSections sections, ref DwarfDataReader reader,
+        DwarfAbbrevTable.Declaration decl, UnitContext unit)
+    {
+        foreach (var spec in decl.Attributes)
+        {
+            var value = ReadValue(sections, ref reader, spec, unit);
+            switch (spec.Attribute)
+            {
+                case DwarfForm.AtLowPc: unit = unit with { BaseAddress = value.U }; break;
+                case DwarfForm.AtStmtList: unit = unit with { StmtListOffset = (long)value.U }; break;
+                case DwarfForm.AtStrOffsetsBase: unit = unit with { StrOffsetsBase = (long)value.U }; break;
+                case DwarfForm.AtAddrBase: unit = unit with { AddrBase = (long)value.U }; break;
+                case DwarfForm.AtRnglistsBase: unit = unit with { RnglistsBase = (long)value.U }; break;
+            }
+        }
+
+        return unit;
+    }
+
+    private static DwarfFunction? ReadSubprogram(
+        DwarfSections sections, ref DwarfDataReader reader, int unitStart,
+        DwarfAbbrevTable.Declaration decl, UnitContext unit, DwarfAbbrevTable abbrevs)
+    {
+        string? name = null;
+        string? linkageName = null;
+        ulong lowPc = 0;
+        var hasLowPc = false;
+        ulong highPc = 0;
+        var highPcIsAddress = false;
+        var hasHighPc = false;
+        long rangesOffset = -1;
+        var rangesIsIndex = false;
+        var declFile = 0;
+        var declLine = 0;
+        long referencedDie = -1;
+
+        foreach (var spec in decl.Attributes)
+        {
+            var value = ReadValue(sections, ref reader, spec, unit);
+            switch (spec.Attribute)
+            {
+                case DwarfForm.AtName: name = value.S; break;
+                case DwarfForm.AtLinkageName:
+                case DwarfForm.AtMipsLinkageName: linkageName = value.S; break;
+                case DwarfForm.AtLowPc: lowPc = value.U; hasLowPc = true; break;
+                case DwarfForm.AtHighPc:
+                    highPc = value.U;
+                    highPcIsAddress = spec.Form is DwarfForm.Addr or DwarfForm.Addrx
+                        or DwarfForm.Addrx1 or DwarfForm.Addrx2 or DwarfForm.Addrx3 or DwarfForm.Addrx4;
+                    hasHighPc = true;
+                    break;
+                case DwarfForm.AtRanges:
+                    rangesOffset = (long)value.U;
+                    rangesIsIndex = spec.Form == DwarfForm.Rnglistx;
+                    break;
+                case DwarfForm.AtDeclFile: declFile = (int)value.U; break;
+                case DwarfForm.AtDeclLine: declLine = (int)value.U; break;
+                case DwarfForm.AtSpecification:
+                case DwarfForm.AtAbstractOrigin:
+                    referencedDie = value.IsSectionRelativeRef ? (long)value.U : unitStart + (long)value.U;
+                    break;
+            }
+        }
+
+        // Names may live on the referenced declaration; resolve one hop.
+        if (name is null && linkageName is null && referencedDie >= 0)
+            (name, linkageName) = ReadReferencedNames(sections, referencedDie, unit, abbrevs);
+
+        var bestName = linkageName ?? name;
+        if (bestName is null) return null;
+        if (!hasLowPc && rangesOffset < 0) return null;
+
+        var size = hasHighPc
+            ? (highPcIsAddress ? (highPc > lowPc ? highPc - lowPc : 0) : highPc)
+            : 0;
+
+        return new DwarfFunction(bestName, lowPc, size, declFile, declLine,
+            unit.StmtListOffset, rangesOffset, rangesIsIndex);
+    }
+
+    private static (string? Name, string? LinkageName) ReadReferencedNames(
+        DwarfSections sections, long dieOffset, UnitContext unit, DwarfAbbrevTable abbrevs)
+    {
+        try
+        {
+            if (dieOffset < 0 || dieOffset >= sections.Info.Length) return (null, null);
+            var reader = new DwarfDataReader(sections.Info) { Position = (int)dieOffset };
+            var code = reader.ReadULeb128();
+            if (code == 0 || !abbrevs.TryGet(code, out var decl)) return (null, null);
+
+            string? name = null;
+            string? linkage = null;
+            foreach (var spec in decl.Attributes)
+            {
+                var value = ReadValue(sections, ref reader, spec, unit);
+                if (spec.Attribute == DwarfForm.AtName) name = value.S;
+                else if (spec.Attribute is DwarfForm.AtLinkageName or DwarfForm.AtMipsLinkageName) linkage = value.S;
+            }
+
+            return (name, linkage);
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            return (null, null);
+        }
+    }
+
+    private static void SkipAttributes(
+        ref DwarfDataReader reader, DwarfAbbrevTable.Declaration decl, UnitContext unit)
+    {
+        foreach (var spec in decl.Attributes)
+            SkipValue(ref reader, spec.Form, unit);
+    }
+
+    /// <summary>A decoded attribute value: an unsigned number, a string, or both empty.</summary>
+    private readonly record struct Value(ulong U, string? S, bool IsSectionRelativeRef);
+
+    private static Value ReadValue(
+        DwarfSections sections, ref DwarfDataReader reader,
+        DwarfAbbrevTable.AttributeSpec spec, UnitContext unit)
+    {
+        var form = spec.Form;
+        while (form == DwarfForm.Indirect)
+            form = reader.ReadULeb128();
+
+        switch (form)
+        {
+            case DwarfForm.Addr: return new Value(reader.ReadAddress(unit.AddressSize), null, false);
+            case DwarfForm.Data1: return new Value(reader.ReadU8(), null, false);
+            case DwarfForm.Data2: return new Value(reader.ReadU16(), null, false);
+            case DwarfForm.Data4: return new Value(reader.ReadU32(), null, false);
+            case DwarfForm.Data8: return new Value(reader.ReadU64(), null, false);
+            case DwarfForm.Data16: reader.Skip(16); return default;
+            case DwarfForm.Udata: return new Value(reader.ReadULeb128(), null, false);
+            case DwarfForm.Sdata: return new Value((ulong)reader.ReadSLeb128(), null, false);
+            case DwarfForm.Flag: return new Value(reader.ReadU8(), null, false);
+            case DwarfForm.FlagPresent: return new Value(1, null, false);
+            case DwarfForm.ImplicitConst: return new Value((ulong)spec.ImplicitConst, null, false);
+            case DwarfForm.SecOffset: return new Value(reader.ReadSectionOffset(unit.Is64), null, false);
+            case DwarfForm.String: return new Value(0, reader.ReadCString(), false);
+
+            case DwarfForm.Strp:
+            {
+                var offset = (long)reader.ReadSectionOffset(unit.Is64);
+                return new Value(0, new DwarfDataReader(sections.Str).ReadCStringAt(offset), false);
+            }
+
+            case DwarfForm.LineStrp:
+            {
+                var offset = (long)reader.ReadSectionOffset(unit.Is64);
+                return new Value(0, new DwarfDataReader(sections.LineStr).ReadCStringAt(offset), false);
+            }
+
+            case DwarfForm.Strx: return ResolveStrx(sections, reader.ReadULeb128(), unit);
+            case DwarfForm.Strx1: return ResolveStrx(sections, reader.ReadU8(), unit);
+            case DwarfForm.Strx2: return ResolveStrx(sections, reader.ReadU16(), unit);
+            case DwarfForm.Strx3: return ResolveStrx(sections, (ulong)(reader.ReadU16() | (reader.ReadU8() << 16)), unit);
+            case DwarfForm.Strx4: return ResolveStrx(sections, reader.ReadU32(), unit);
+
+            case DwarfForm.Addrx: return ResolveAddrx(sections, reader.ReadULeb128(), unit);
+            case DwarfForm.Addrx1: return ResolveAddrx(sections, reader.ReadU8(), unit);
+            case DwarfForm.Addrx2: return ResolveAddrx(sections, reader.ReadU16(), unit);
+            case DwarfForm.Addrx3: return ResolveAddrx(sections, (ulong)(reader.ReadU16() | (reader.ReadU8() << 16)), unit);
+            case DwarfForm.Addrx4: return ResolveAddrx(sections, reader.ReadU32(), unit);
+
+            case DwarfForm.Ref1: return new Value(reader.ReadU8(), null, false);
+            case DwarfForm.Ref2: return new Value(reader.ReadU16(), null, false);
+            case DwarfForm.Ref4: return new Value(reader.ReadU32(), null, false);
+            case DwarfForm.Ref8: return new Value(reader.ReadU64(), null, false);
+            case DwarfForm.RefUdata: return new Value(reader.ReadULeb128(), null, false);
+            case DwarfForm.RefAddr: return new Value(reader.ReadSectionOffset(unit.Is64), null, true);
+            case DwarfForm.RefSig8: reader.Skip(8); return default;
+            case DwarfForm.RefSup4: reader.Skip(4); return default;
+            case DwarfForm.RefSup8: reader.Skip(8); return default;
+            case DwarfForm.StrpSup: reader.Skip(unit.Is64 ? 8 : 4); return default;
+
+            case DwarfForm.Rnglistx:
+            case DwarfForm.Loclistx: return new Value(reader.ReadULeb128(), null, false);
+
+            case DwarfForm.Exprloc:
+            case DwarfForm.Block: reader.Skip((int)reader.ReadULeb128()); return default;
+            case DwarfForm.Block1: reader.Skip(reader.ReadU8()); return default;
+            case DwarfForm.Block2: reader.Skip(reader.ReadU16()); return default;
+            case DwarfForm.Block4: reader.Skip((int)reader.ReadU32()); return default;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(spec), $"unknown DWARF form 0x{form:X}");
+        }
+    }
+
+    private static void SkipValue(ref DwarfDataReader reader, ulong form, UnitContext unit)
+    {
+        // The decode already advances correctly for every form; reuse it with empty sections
+        // since skipped values never dereference other sections' bytes for their side effects.
+        var spec = new DwarfAbbrevTable.AttributeSpec(0, form, 0);
+        ReadValue(EmptySections, ref reader, spec, unit);
+    }
+
+    private static readonly DwarfSections EmptySections = new([], [], [], [], [], [], [], [], []);
+
+    private static Value ResolveStrx(DwarfSections sections, ulong index, UnitContext unit)
+    {
+        try
+        {
+            var offsetSize = unit.Is64 ? 8 : 4;
+            var position = unit.StrOffsetsBase + (long)index * offsetSize;
+            if (position < 0 || position + offsetSize > sections.StrOffsets.Length) return default;
+            var reader = new DwarfDataReader(sections.StrOffsets) { Position = (int)position };
+            var strOffset = (long)reader.ReadSectionOffset(unit.Is64);
+            return new Value(0, new DwarfDataReader(sections.Str).ReadCStringAt(strOffset), false);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return default;
+        }
+    }
+
+    private static Value ResolveAddrx(DwarfSections sections, ulong index, UnitContext unit)
+    {
+        try
+        {
+            var position = unit.AddrBase + (long)index * unit.AddressSize;
+            if (position < 0 || position + unit.AddressSize > sections.Addr.Length) return default;
+            var reader = new DwarfDataReader(sections.Addr) { Position = (int)position };
+            return new Value(reader.ReadAddress(unit.AddressSize), null, false);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return default;
+        }
+    }
+}

--- a/src/Dotsider.Core/Analysis/Dwarf/DwarfReader.cs
+++ b/src/Dotsider.Core/Analysis/Dwarf/DwarfReader.cs
@@ -18,7 +18,7 @@ internal static class DwarfReader
     /// <param name="Name">The best name found: linkage name when present, else the source name.</param>
     /// <param name="LowPc">The function's start address.</param>
     /// <param name="Size">The function's byte size, or 0 when the DIE recorded none.</param>
-    /// <param name="DeclFile">The <c>DW_AT_decl_file</c> index into the CU's line-program file table, or 0.</param>
+    /// <param name="DeclFile">The <c>DW_AT_decl_file</c> index into the CU's line-program file table, or -1 when the DIE recorded none.</param>
     /// <param name="DeclLine">The <c>DW_AT_decl_line</c> value, or 0.</param>
     /// <param name="StmtListOffset">The CU's <c>.debug_line</c> program offset, or -1 when absent.</param>
     /// <param name="RangesOffset">The <c>DW_AT_ranges</c> offset when the function is range-based, or -1.</param>
@@ -168,7 +168,7 @@ internal static class DwarfReader
         var hasHighPc = false;
         long rangesOffset = -1;
         var rangesIsIndex = false;
-        var declFile = 0;
+        var declFile = -1; // v5 file tables are 0-based, so 0 is a real index
         var declLine = 0;
         long referencedDie = -1;
 

--- a/src/Dotsider.Core/Analysis/Dwarf/DwarfSections.cs
+++ b/src/Dotsider.Core/Analysis/Dwarf/DwarfSections.cs
@@ -1,0 +1,47 @@
+namespace Dotsider.Core.Analysis.Dwarf;
+
+/// <summary>
+/// The raw bytes of the DWARF sections a function walk needs. Sections absent from the image are
+/// empty arrays — the form decoders then resolve their indirections to null rather than failing —
+/// so ELF <c>.debug_*</c> sections and Mach-O <c>__DWARF</c> sections feed the same reader.
+/// </summary>
+/// <param name="Info"><c>.debug_info</c> — the DIE tree.</param>
+/// <param name="Abbrev"><c>.debug_abbrev</c> — abbreviation declarations.</param>
+/// <param name="Str"><c>.debug_str</c> — strings referenced by <c>strp</c>.</param>
+/// <param name="LineStr"><c>.debug_line_str</c> — strings referenced by <c>line_strp</c>.</param>
+/// <param name="StrOffsets"><c>.debug_str_offsets</c> — the v5 string-index table behind <c>strx</c>.</param>
+/// <param name="Addr"><c>.debug_addr</c> — the v5 address-index table behind <c>addrx</c>.</param>
+/// <param name="Line"><c>.debug_line</c> — line-number programs.</param>
+/// <param name="Ranges"><c>.debug_ranges</c> — v4 address range lists.</param>
+/// <param name="RngLists"><c>.debug_rnglists</c> — v5 range lists.</param>
+internal sealed record DwarfSections(
+    byte[] Info,
+    byte[] Abbrev,
+    byte[] Str,
+    byte[] LineStr,
+    byte[] StrOffsets,
+    byte[] Addr,
+    byte[] Line,
+    byte[] Ranges,
+    byte[] RngLists)
+{
+    /// <summary>
+    /// Collects the DWARF sections through a name lookup, tolerating absent sections. Names are
+    /// passed without their platform prefix; the lookup applies <c>.debug_*</c> (ELF) or
+    /// <c>__debug_*</c> (Mach-O) itself.
+    /// </summary>
+    /// <param name="lookup">Resolves a DWARF section's bytes by base name (e.g. <c>info</c>), or null.</param>
+    public static DwarfSections Collect(Func<string, byte[]?> lookup) => new(
+        lookup("info") ?? [],
+        lookup("abbrev") ?? [],
+        lookup("str") ?? [],
+        lookup("line_str") ?? [],
+        lookup("str_offsets") ?? [],
+        lookup("addr") ?? [],
+        lookup("line") ?? [],
+        lookup("ranges") ?? [],
+        lookup("rnglists") ?? []);
+
+    /// <summary>Whether the image carries any DIE data at all.</summary>
+    public bool HasInfo => Info.Length > 0 && Abbrev.Length > 0;
+}

--- a/src/Dotsider.Core/Analysis/EhFrameReader.cs
+++ b/src/Dotsider.Core/Analysis/EhFrameReader.cs
@@ -1,0 +1,261 @@
+using System.Buffers.Binary;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Recovers function boundaries from an ELF image's <c>.eh_frame</c> section — the symbol-free
+/// fallback. Each FDE names its function's start (<c>initial_location</c>) and byte length
+/// (<c>address_range</c>), encoded per its CIE's augmentation-declared pointer encoding;
+/// absolute and PC-relative applications of the fixed, LEB128, and signed/unsigned data formats
+/// are decoded, and entries with encodings beyond that (indirect, text/data-relative) are
+/// skipped rather than misread. Malformed data yields the boundaries parsed before the damage.
+/// </summary>
+internal static class EhFrameReader
+{
+    private const int MaxEntries = 262_144;
+
+    // DW_EH_PE_* pointer-encoding format (low nibble) and application (high nibble).
+    private const byte PeOmit = 0xFF;
+    private const byte PeFormatMask = 0x0F;
+    private const byte PeApplicationMask = 0x70;
+    private const byte PeIndirect = 0x80;
+    private const byte PePcrel = 0x10;
+
+    /// <summary>
+    /// Walks <c>.eh_frame</c> into nameless boundary symbols, mapping each to its containing
+    /// section for file offsets.
+    /// </summary>
+    /// <param name="imageBytes">The raw image bytes.</param>
+    public static IReadOnlyList<RawNativeSymbol> ReadBoundaries(ReadOnlySpan<byte> imageBytes)
+    {
+        var result = new List<RawNativeSymbol>();
+        var sections = ElfImageReader.ReadSections(imageBytes);
+        if (!ElfImageReader.TryGetSection(imageBytes, ".eh_frame", out var ehFrame)) return result;
+        if (ehFrame.FileOffset < 0 || ehFrame.FileOffset + ehFrame.Size > imageBytes.Length) return result;
+
+        var data = imageBytes.Slice(ehFrame.FileOffset, ehFrame.Size);
+        var cieEncodings = new Dictionary<long, byte>();
+
+        try
+        {
+            var position = 0;
+            for (var entries = 0; entries < MaxEntries && position + 4 <= data.Length; entries++)
+            {
+                var entryStart = position;
+                long length = BinaryPrimitives.ReadUInt32LittleEndian(data[position..]);
+                position += 4;
+                if (length == 0) break; // terminator
+                if (length == 0xFFFF_FFFF)
+                {
+                    length = (long)BinaryPrimitives.ReadUInt64LittleEndian(data[position..]);
+                    position += 8;
+                }
+
+                var next = position + length;
+                if (length < 4 || next > data.Length) break;
+
+                var idPosition = position;
+                var id = BinaryPrimitives.ReadUInt32LittleEndian(data[position..]);
+                position += 4;
+
+                if (id == 0)
+                {
+                    cieEncodings[entryStart] = ReadCieEncoding(data, position, (int)next);
+                }
+                else if (cieEncodings.TryGetValue(idPosition - id, out var encoding)
+                    && TryReadFdeBoundary(data, position, encoding, ehFrame.Address, out var va, out var size)
+                    && va != 0 && size > 0)
+                {
+                    result.Add(Boundary(va, size, sections));
+                }
+
+                position = (int)next;
+            }
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            // Keep the boundaries parsed before the damage.
+        }
+
+        return result;
+    }
+
+    /// <summary>Parses a CIE far enough to learn its FDE pointer encoding (the 'R' augmentation).</summary>
+    private static byte ReadCieEncoding(ReadOnlySpan<byte> data, int position, int end)
+    {
+        const byte absptr = 0x00;
+        var version = data[position++];
+        if (version is not (1 or 3 or 4)) return absptr;
+
+        var augmentationStart = position;
+        while (position < end && data[position] != 0) position++;
+        var augmentation = data[augmentationStart..position];
+        position++; // NUL
+
+        if (version == 4) position += 2; // address_size, segment_selector_size
+        SkipUleb(data, ref position); // code_alignment_factor
+        SkipUleb(data, ref position); // data_alignment_factor (SLEB shares the wire shape)
+        if (version == 1) position++; // return_address_register
+        else SkipUleb(data, ref position);
+
+        if (augmentation.Length == 0 || augmentation[0] != (byte)'z') return absptr;
+        SkipUleb(data, ref position); // augmentation data length
+
+        foreach (var ch in augmentation[1..])
+        {
+            switch ((char)ch)
+            {
+                case 'L':
+                    position++; // LSDA encoding
+                    break;
+                case 'P':
+                {
+                    var personalityEncoding = data[position++];
+                    DecodePointer(data, ref position, personalityEncoding, fieldVa: 0); // skip the pointer
+                    break;
+                }
+
+                case 'R':
+                    return data[position];
+                case 'S' or 'B' or 'G':
+                    break; // no data
+                default:
+                    return absptr; // unknown augmentation: stop guessing, 'z' covers the skip
+            }
+        }
+
+        return absptr;
+    }
+
+    private static bool TryReadFdeBoundary(
+        ReadOnlySpan<byte> data, int position, byte encoding, ulong sectionAddress,
+        out ulong va, out ulong size)
+    {
+        va = 0;
+        size = 0;
+        if (encoding == PeOmit || (encoding & PeIndirect) != 0) return false;
+        var application = encoding & PeApplicationMask;
+        if (application is not (0 or PePcrel)) return false; // text/data/func-relative: no base here
+
+        var fieldVa = sectionAddress + (ulong)position;
+        var initialLocation = DecodePointer(data, ref position, encoding, fieldVa);
+        if (initialLocation is not { } location) return false;
+
+        // The range is a length: same format, no application.
+        var range = DecodePointer(data, ref position, (byte)(encoding & PeFormatMask), fieldVa: 0);
+        if (range is not { } r) return false;
+
+        va = location;
+        size = r;
+        return true;
+    }
+
+    /// <summary>Decodes one encoded pointer, applying PC-relative adjustment when asked for.</summary>
+    private static ulong? DecodePointer(ReadOnlySpan<byte> data, ref int position, byte encoding, ulong fieldVa)
+    {
+        if (encoding == PeOmit) return null;
+
+        ulong value;
+        switch (encoding & PeFormatMask)
+        {
+            case 0x00: // absptr (64-bit images)
+                value = BinaryPrimitives.ReadUInt64LittleEndian(data[position..]);
+                position += 8;
+                break;
+            case 0x01: // uleb128
+                value = ReadUleb(data, ref position);
+                break;
+            case 0x02: // udata2
+                value = BinaryPrimitives.ReadUInt16LittleEndian(data[position..]);
+                position += 2;
+                break;
+            case 0x03: // udata4
+                value = BinaryPrimitives.ReadUInt32LittleEndian(data[position..]);
+                position += 4;
+                break;
+            case 0x04: // udata8
+                value = BinaryPrimitives.ReadUInt64LittleEndian(data[position..]);
+                position += 8;
+                break;
+            case 0x09: // sleb128
+                value = (ulong)ReadSleb(data, ref position);
+                break;
+            case 0x0A: // sdata2
+                value = (ulong)(long)BinaryPrimitives.ReadInt16LittleEndian(data[position..]);
+                position += 2;
+                break;
+            case 0x0B: // sdata4
+                value = (ulong)(long)BinaryPrimitives.ReadInt32LittleEndian(data[position..]);
+                position += 4;
+                break;
+            case 0x0C: // sdata8
+                value = (ulong)BinaryPrimitives.ReadInt64LittleEndian(data[position..]);
+                position += 8;
+                break;
+            default:
+                return null;
+        }
+
+        return (encoding & PeApplicationMask) == PePcrel ? fieldVa + value : value;
+    }
+
+    private static ulong ReadUleb(ReadOnlySpan<byte> data, ref int position)
+    {
+        ulong result = 0;
+        var shift = 0;
+        while (true)
+        {
+            var b = data[position++];
+            result |= (ulong)(b & 0x7F) << shift;
+            if ((b & 0x80) == 0) return result;
+            shift += 7;
+            if (shift > 63) throw new ArgumentOutOfRangeException(nameof(position), "LEB128 too long");
+        }
+    }
+
+    private static long ReadSleb(ReadOnlySpan<byte> data, ref int position)
+    {
+        long result = 0;
+        var shift = 0;
+        byte b;
+        do
+        {
+            b = data[position++];
+            result |= (long)(b & 0x7F) << shift;
+            shift += 7;
+            if (shift > 70) throw new ArgumentOutOfRangeException(nameof(position), "LEB128 too long");
+        }
+        while ((b & 0x80) != 0);
+
+        if (shift < 64 && (b & 0x40) != 0)
+            result |= -1L << shift;
+        return result;
+    }
+
+    private static void SkipUleb(ReadOnlySpan<byte> data, ref int position)
+    {
+        while ((data[position++] & 0x80) != 0)
+        {
+        }
+    }
+
+    private static RawNativeSymbol Boundary(
+        ulong va, ulong size, IReadOnlyList<ElfImageReader.ElfSection> sections)
+    {
+        var mapped = ElfImageReader.TryMapAddress(sections, va, out var name, out var offset);
+        string? sectionName = mapped ? name : null;
+        long? fileOffset = mapped ? offset : null;
+
+        return new RawNativeSymbol(
+            Name: $"sub_{va:x}",
+            VirtualAddress: va,
+            Rva: null,
+            FileOffset: fileOffset,
+            Section: sectionName,
+            Size: (long)size,
+            IsData: false,
+            IsBoundary: true,
+            SourceFile: null,
+            Line: null);
+    }
+}

--- a/src/Dotsider.Core/Analysis/ElfImageReader.cs
+++ b/src/Dotsider.Core/Analysis/ElfImageReader.cs
@@ -30,6 +30,79 @@ internal static class ElfImageReader
         && bytes[0] == 0x7F && bytes[1] == (byte)'E' && bytes[2] == (byte)'L' && bytes[3] == (byte)'F'
         && bytes[4] == 2; // ELFCLASS64
 
+    /// <summary>One ELF section header's identity and location.</summary>
+    /// <param name="Name">The section name from the section-header string table.</param>
+    /// <param name="Type">The <c>sh_type</c> value.</param>
+    /// <param name="Address">The section's virtual address (<c>sh_addr</c>).</param>
+    /// <param name="FileOffset">The section's file offset (<c>sh_offset</c>).</param>
+    /// <param name="Size">The section's byte size (<c>sh_size</c>).</param>
+    /// <param name="Info">The <c>sh_info</c> value (meaning varies by section type).</param>
+    internal readonly record struct ElfSection(
+        string Name, uint Type, ulong Address, int FileOffset, int Size, uint Info);
+
+    /// <summary>
+    /// Walks the section headers into named sections, or an empty list when the image is not a
+    /// little-endian 64-bit ELF or carries no section headers.
+    /// </summary>
+    /// <param name="bytes">The raw image bytes.</param>
+    internal static IReadOnlyList<ElfSection> ReadSections(ReadOnlySpan<byte> bytes)
+    {
+        try
+        {
+            if (!IsElf(bytes) || bytes[5] != 1) return [];
+
+            var sectionOffset = (long)BinaryPrimitives.ReadUInt64LittleEndian(bytes[40..]);
+            var sectionEntrySize = BinaryPrimitives.ReadUInt16LittleEndian(bytes[58..]);
+            var sectionCount = BinaryPrimitives.ReadUInt16LittleEndian(bytes[60..]);
+            var stringSectionIndex = BinaryPrimitives.ReadUInt16LittleEndian(bytes[62..]);
+            if (sectionOffset <= 0 || sectionEntrySize < SectionHeaderSize || sectionCount == 0)
+                return [];
+
+            var shStrTableOffset = (long)BinaryPrimitives.ReadUInt64LittleEndian(
+                bytes[(int)(sectionOffset + (long)stringSectionIndex * sectionEntrySize + 24)..]);
+
+            var sections = new List<ElfSection>(sectionCount);
+            for (var i = 0; i < sectionCount; i++)
+            {
+                var header = sectionOffset + (long)i * sectionEntrySize;
+                if (header + SectionHeaderSize > bytes.Length) break;
+                var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)header..]);
+                var type = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)(header + 4)..]);
+                var address = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 16)..]);
+                var offset = (int)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 24)..]);
+                var size = (int)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 32)..]);
+                var info = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)(header + 44)..]);
+                var name = ReadString(bytes, shStrTableOffset, nameOffset) ?? "";
+                sections.Add(new ElfSection(name, type, address, offset, size, info));
+            }
+
+            return sections;
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>Finds a section by name.</summary>
+    /// <param name="bytes">The raw image bytes.</param>
+    /// <param name="name">The section name (e.g. <c>.debug_info</c>).</param>
+    /// <param name="section">The section when found.</param>
+    internal static bool TryGetSection(ReadOnlySpan<byte> bytes, string name, out ElfSection section)
+    {
+        foreach (var candidate in ReadSections(bytes))
+        {
+            if (candidate.Name == name)
+            {
+                section = candidate;
+                return true;
+            }
+        }
+
+        section = default;
+        return false;
+    }
+
     /// <summary>
     /// Reads the needed shared libraries and the undefined symbols imported from each.
     /// </summary>

--- a/src/Dotsider.Core/Analysis/ElfImageReader.cs
+++ b/src/Dotsider.Core/Analysis/ElfImageReader.cs
@@ -36,9 +36,10 @@ internal static class ElfImageReader
     /// <param name="Address">The section's virtual address (<c>sh_addr</c>).</param>
     /// <param name="FileOffset">The section's file offset (<c>sh_offset</c>).</param>
     /// <param name="Size">The section's byte size (<c>sh_size</c>).</param>
+    /// <param name="Link">The <c>sh_link</c> value (for a symbol table, its string table's section index).</param>
     /// <param name="Info">The <c>sh_info</c> value (meaning varies by section type).</param>
     internal readonly record struct ElfSection(
-        string Name, uint Type, ulong Address, int FileOffset, int Size, uint Info);
+        string Name, uint Type, ulong Address, int FileOffset, int Size, uint Link, uint Info);
 
     /// <summary>
     /// Walks the section headers into named sections, or an empty list when the image is not a
@@ -71,9 +72,10 @@ internal static class ElfImageReader
                 var address = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 16)..]);
                 var offset = (int)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 24)..]);
                 var size = (int)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 32)..]);
+                var link = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)(header + 40)..]);
                 var info = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)(header + 44)..]);
                 var name = ReadString(bytes, shStrTableOffset, nameOffset) ?? "";
-                sections.Add(new ElfSection(name, type, address, offset, size, info));
+                sections.Add(new ElfSection(name, type, address, offset, size, link, info));
             }
 
             return sections;
@@ -186,6 +188,32 @@ internal static class ElfImageReader
         {
             return [];
         }
+    }
+
+    /// <summary>
+    /// Maps a virtual address to its containing section's name and the corresponding file
+    /// offset, or false when no mapped section covers it.
+    /// </summary>
+    /// <param name="sections">The image's sections.</param>
+    /// <param name="va">The virtual address to map.</param>
+    /// <param name="sectionName">The containing section's name.</param>
+    /// <param name="fileOffset">The file offset the address maps to.</param>
+    internal static bool TryMapAddress(
+        IReadOnlyList<ElfSection> sections, ulong va, out string sectionName, out long fileOffset)
+    {
+        foreach (var section in sections)
+        {
+            if (section.Address != 0 && va >= section.Address && va < section.Address + (ulong)section.Size)
+            {
+                sectionName = section.Name;
+                fileOffset = section.FileOffset + (long)(va - section.Address);
+                return true;
+            }
+        }
+
+        sectionName = "";
+        fileOffset = 0;
+        return false;
     }
 
     /// <summary>

--- a/src/Dotsider.Core/Analysis/ElfImageReader.cs
+++ b/src/Dotsider.Core/Analysis/ElfImageReader.cs
@@ -188,6 +188,68 @@ internal static class ElfImageReader
         }
     }
 
+    /// <summary>
+    /// Reads the GNU build id from the <c>.note.gnu.build-id</c> section — the note whose owner
+    /// is <c>GNU</c> and type is 3 — walking past any other notes sharing the section.
+    /// </summary>
+    /// <param name="bytes">The raw image bytes.</param>
+    /// <param name="buildId">The build id payload when found.</param>
+    internal static bool TryReadBuildId(ReadOnlySpan<byte> bytes, out byte[] buildId)
+    {
+        buildId = [];
+        if (!TryGetSection(bytes, ".note.gnu.build-id", out var section)) return false;
+        if (section.FileOffset < 0 || section.FileOffset + section.Size > bytes.Length) return false;
+
+        var data = bytes.Slice(section.FileOffset, section.Size);
+        var position = 0;
+        while (position + 12 <= data.Length)
+        {
+            var nameSize = BinaryPrimitives.ReadUInt32LittleEndian(data[position..]);
+            var descSize = BinaryPrimitives.ReadUInt32LittleEndian(data[(position + 4)..]);
+            var type = BinaryPrimitives.ReadUInt32LittleEndian(data[(position + 8)..]);
+            var namePosition = position + 12;
+            var descPosition = namePosition + (int)((nameSize + 3) & ~3u);
+            var next = descPosition + (int)((descSize + 3) & ~3u);
+            if (nameSize > (uint)data.Length || descSize > (uint)data.Length || next > data.Length) return false;
+
+            if (type == 3 && nameSize == 4 && data.Slice(namePosition, 4).SequenceEqual("GNU\0"u8))
+            {
+                buildId = data.Slice(descPosition, (int)descSize).ToArray();
+                return buildId.Length > 0;
+            }
+
+            position = next;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Reads the <c>.gnu_debuglink</c> section: the sidecar's file name, then — 4-aligned — the
+    /// CRC-32 of the entire sidecar file.
+    /// </summary>
+    /// <param name="bytes">The raw image bytes.</param>
+    /// <param name="fileName">The named sidecar file.</param>
+    /// <param name="crc">The expected CRC-32 of the sidecar's bytes.</param>
+    internal static bool TryReadDebugLink(ReadOnlySpan<byte> bytes, out string fileName, out uint crc)
+    {
+        fileName = "";
+        crc = 0;
+        if (!TryGetSection(bytes, ".gnu_debuglink", out var section)) return false;
+        if (section.FileOffset < 0 || section.FileOffset + section.Size > bytes.Length) return false;
+
+        var data = bytes.Slice(section.FileOffset, section.Size);
+        var end = data.IndexOf((byte)0);
+        if (end <= 0) return false;
+
+        var crcOffset = (end + 1 + 3) & ~3;
+        if (crcOffset + 4 > data.Length) return false;
+
+        fileName = Encoding.UTF8.GetString(data[..end]);
+        crc = BinaryPrimitives.ReadUInt32LittleEndian(data[crcOffset..]);
+        return true;
+    }
+
     private static string? ReadString(ReadOnlySpan<byte> bytes, long tableOffset, uint offset)
     {
         var start = tableOffset + offset;

--- a/src/Dotsider.Core/Analysis/ElfImageReader.cs
+++ b/src/Dotsider.Core/Analysis/ElfImageReader.cs
@@ -23,6 +23,8 @@ internal static class ElfImageReader
     private const int StbGlobal = 1;
     private const int StbWeak = 2;
     private const ushort ShnUndef = 0;
+    private const ulong ShfCompressed = 0x800;
+    private const uint ElfCompressZlib = 1;
 
     /// <summary>Returns true if the bytes are a 64-bit ELF image.</summary>
     internal static bool IsElf(ReadOnlySpan<byte> bytes) =>
@@ -38,8 +40,9 @@ internal static class ElfImageReader
     /// <param name="Size">The section's byte size (<c>sh_size</c>).</param>
     /// <param name="Link">The <c>sh_link</c> value (for a symbol table, its string table's section index).</param>
     /// <param name="Info">The <c>sh_info</c> value (meaning varies by section type).</param>
+    /// <param name="Flags">The <c>sh_flags</c> value (<c>SHF_COMPRESSED</c> marks a compressed payload).</param>
     internal readonly record struct ElfSection(
-        string Name, uint Type, ulong Address, int FileOffset, int Size, uint Link, uint Info);
+        string Name, uint Type, ulong Address, int FileOffset, int Size, uint Link, uint Info, ulong Flags);
 
     /// <summary>
     /// Walks the section headers into named sections, or an empty list when the image is not a
@@ -69,13 +72,14 @@ internal static class ElfImageReader
                 if (header + SectionHeaderSize > bytes.Length) break;
                 var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)header..]);
                 var type = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)(header + 4)..]);
+                var flags = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 8)..]);
                 var address = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 16)..]);
                 var offset = (int)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 24)..]);
                 var size = (int)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 32)..]);
                 var link = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)(header + 40)..]);
                 var info = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)(header + 44)..]);
                 var name = ReadString(bytes, shStrTableOffset, nameOffset) ?? "";
-                sections.Add(new ElfSection(name, type, address, offset, size, link, info));
+                sections.Add(new ElfSection(name, type, address, offset, size, link, info, flags));
             }
 
             return sections;
@@ -187,6 +191,46 @@ internal static class ElfImageReader
         catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
         {
             return [];
+        }
+    }
+
+    /// <summary>
+    /// Materializes a section's content, transparently inflating <c>SHF_COMPRESSED</c> zlib
+    /// payloads — GNU toolchains compress debug sections by default, prefixing them with an
+    /// <c>Elf64_Chdr</c>. Unsupported compression (zstd) and malformed payloads yield null so
+    /// the section reads as absent rather than as garbage.
+    /// </summary>
+    /// <param name="bytes">The raw image bytes.</param>
+    /// <param name="section">The section to read.</param>
+    internal static byte[]? ReadSectionBytes(ReadOnlySpan<byte> bytes, ElfSection section)
+    {
+        if (section.Size <= 0 || section.FileOffset < 0
+            || section.FileOffset + section.Size > bytes.Length)
+        {
+            return null;
+        }
+
+        var raw = bytes.Slice(section.FileOffset, section.Size);
+        if ((section.Flags & ShfCompressed) == 0) return raw.ToArray();
+
+        // Elf64_Chdr: ch_type u32, ch_reserved u32, ch_size u64, ch_addralign u64.
+        if (raw.Length < 24) return null;
+        var compressionType = BinaryPrimitives.ReadUInt32LittleEndian(raw);
+        var uncompressedSize = BinaryPrimitives.ReadUInt64LittleEndian(raw[8..]);
+        if (compressionType != ElfCompressZlib || uncompressedSize is 0 or > int.MaxValue) return null;
+
+        try
+        {
+            using var compressed = new MemoryStream(raw[24..].ToArray());
+            using var zlib = new System.IO.Compression.ZLibStream(
+                compressed, System.IO.Compression.CompressionMode.Decompress);
+            var inflated = new byte[(int)uncompressedSize];
+            zlib.ReadExactly(inflated);
+            return inflated;
+        }
+        catch (Exception ex) when (ex is InvalidDataException or EndOfStreamException)
+        {
+            return null;
         }
     }
 

--- a/src/Dotsider.Core/Analysis/ElfSidecarIdentity.cs
+++ b/src/Dotsider.Core/Analysis/ElfSidecarIdentity.cs
@@ -1,0 +1,45 @@
+using System.Buffers.Binary;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Decides whether an ELF debug sidecar belongs to a stripped image. The image's identity
+/// signals — the GNU build id and the <c>.gnu_debuglink</c> CRC — are each verified when
+/// present, and all present signals must pass. Only a signal-free image falls back to the loose
+/// checks: same <c>e_machine</c> and a sidecar that actually carries <c>.debug_info</c>.
+/// </summary>
+internal static class ElfSidecarIdentity
+{
+    /// <summary>Checks the sidecar's identity against the image.</summary>
+    /// <param name="image">The stripped image's bytes.</param>
+    /// <param name="sidecar">The candidate sidecar's bytes.</param>
+    public static ElfSidecarMatch Check(ReadOnlySpan<byte> image, ReadOnlySpan<byte> sidecar)
+    {
+        var hasBuildId = ElfImageReader.TryReadBuildId(image, out var imageId);
+        var hasDebugLink = ElfImageReader.TryReadDebugLink(image, out _, out var expectedCrc);
+
+        if (hasBuildId || hasDebugLink)
+        {
+            if (hasBuildId
+                && (!ElfImageReader.TryReadBuildId(sidecar, out var sidecarId)
+                    || !imageId.AsSpan().SequenceEqual(sidecarId)))
+            {
+                return ElfSidecarMatch.Mismatched;
+            }
+
+            if (hasDebugLink && Crc32.Compute(sidecar) != expectedCrc)
+                return ElfSidecarMatch.Mismatched;
+
+            return ElfSidecarMatch.Matched;
+        }
+
+        return SameMachine(image, sidecar) && ElfImageReader.TryGetSection(sidecar, ".debug_info", out _)
+            ? ElfSidecarMatch.LooseMatch
+            : ElfSidecarMatch.Mismatched;
+    }
+
+    private static bool SameMachine(ReadOnlySpan<byte> image, ReadOnlySpan<byte> sidecar) =>
+        ElfImageReader.IsElf(image) && ElfImageReader.IsElf(sidecar)
+        && BinaryPrimitives.ReadUInt16LittleEndian(image[18..])
+            == BinaryPrimitives.ReadUInt16LittleEndian(sidecar[18..]);
+}

--- a/src/Dotsider.Core/Analysis/ElfSidecarMatch.cs
+++ b/src/Dotsider.Core/Analysis/ElfSidecarMatch.cs
@@ -1,0 +1,24 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// How a candidate ELF debug sidecar's identity relates to its stripped image. Every identity
+/// signal present on the image must match — one failing signal rejects the sidecar even when
+/// another matches.
+/// </summary>
+internal enum ElfSidecarMatch
+{
+    /// <summary>At least one identity signal was present and every present signal matched.</summary>
+    Matched,
+
+    /// <summary>
+    /// The image carried no identity signal; the sidecar passed only the loose checks
+    /// (same <c>e_machine</c>, has <c>.debug_info</c>), which a diagnostic should note.
+    /// </summary>
+    LooseMatch,
+
+    /// <summary>
+    /// A present signal disagreed — build id differs or absent from the sidecar, or the
+    /// debuglink CRC failed — or no signal was present and the loose checks failed too.
+    /// </summary>
+    Mismatched,
+}

--- a/src/Dotsider.Core/Analysis/ElfSymtabReader.cs
+++ b/src/Dotsider.Core/Analysis/ElfSymtabReader.cs
@@ -1,0 +1,98 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Reads the named data symbols — <c>STT_OBJECT</c> entries — from an ELF <c>.symtab</c>, with
+/// their exact <c>st_size</c>. This is the data pass beside the DWARF function walk: method
+/// tables, frozen objects, statics, and the other ILC data nodes live here under their mangled
+/// names, which the facade's demangler classifies. Undefined, unnamed, and reserved-section
+/// entries are skipped; a malformed table yields the symbols parsed before the damage.
+/// </summary>
+internal static class ElfSymtabReader
+{
+    private const int SymbolSize = 24;
+    private const uint ShtSymTab = 2;
+    private const ushort ShnLoReserve = 0xFF00;
+    private const byte SttObject = 1;
+    private const int MaxSymbols = 1 << 20;
+
+    /// <summary>
+    /// Reads the data symbols from <paramref name="symbolBytes"/>' symbol table, mapping each
+    /// address through <paramref name="imageSections"/> — the analyzed image's sections — so
+    /// file offsets point into the image even when the symbols come from a sidecar.
+    /// </summary>
+    /// <param name="symbolBytes">The bytes carrying <c>.symtab</c> (the image or its sidecar).</param>
+    /// <param name="imageSections">The analyzed image's sections, for address mapping.</param>
+    public static IReadOnlyList<RawNativeSymbol> ReadDataSymbols(
+        ReadOnlySpan<byte> symbolBytes, IReadOnlyList<ElfImageReader.ElfSection> imageSections)
+    {
+        var result = new List<RawNativeSymbol>();
+        try
+        {
+            var sections = ElfImageReader.ReadSections(symbolBytes);
+            ElfImageReader.ElfSection symtab = default;
+            foreach (var section in sections)
+            {
+                if (section.Type == ShtSymTab)
+                {
+                    symtab = section;
+                    break;
+                }
+            }
+
+            if (symtab.Type != ShtSymTab || symtab.Link >= sections.Count) return result;
+            var strtab = sections[(int)symtab.Link];
+            if (symtab.FileOffset < 0 || symtab.FileOffset + symtab.Size > symbolBytes.Length) return result;
+            if (strtab.FileOffset < 0 || strtab.FileOffset + strtab.Size > symbolBytes.Length) return result;
+
+            var strings = symbolBytes.Slice(strtab.FileOffset, strtab.Size);
+            var count = Math.Min(symtab.Size / SymbolSize, MaxSymbols);
+            for (var i = 1; i < count; i++) // entry 0 is the reserved null symbol
+            {
+                var entry = symbolBytes.Slice(symtab.FileOffset + i * SymbolSize, SymbolSize);
+                if ((entry[4] & 0xF) != SttObject) continue;
+
+                var sectionIndex = BinaryPrimitives.ReadUInt16LittleEndian(entry[6..]);
+                if (sectionIndex == 0 || sectionIndex >= ShnLoReserve) continue;
+
+                var va = BinaryPrimitives.ReadUInt64LittleEndian(entry[8..]);
+                if (va == 0) continue;
+
+                var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(entry);
+                var name = ReadName(strings, nameOffset);
+                if (name.Length == 0) continue;
+
+                var size = (long)BinaryPrimitives.ReadUInt64LittleEndian(entry[16..]);
+                var mapped = ElfImageReader.TryMapAddress(imageSections, va, out var sectionName, out var fileOffset);
+                result.Add(new RawNativeSymbol(
+                    Name: name,
+                    VirtualAddress: va,
+                    Rva: null,
+                    FileOffset: mapped ? fileOffset : null,
+                    Section: mapped ? sectionName : null,
+                    Size: size,
+                    IsData: true,
+                    IsBoundary: false,
+                    SourceFile: null,
+                    Line: null));
+            }
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            // Keep the symbols parsed before the damage.
+        }
+
+        return result;
+    }
+
+    private static string ReadName(ReadOnlySpan<byte> strings, uint offset)
+    {
+        if (offset >= strings.Length) return "";
+        var slice = strings[(int)offset..];
+        var end = slice.IndexOf((byte)0);
+        if (end < 0) end = slice.Length;
+        return Encoding.UTF8.GetString(slice[..end]);
+    }
+}

--- a/src/Dotsider.Core/Analysis/IlcNameDemangler.cs
+++ b/src/Dotsider.Core/Analysis/IlcNameDemangler.cs
@@ -19,9 +19,9 @@ namespace Dotsider.Core.Analysis;
 internal sealed class IlcNameDemangler
 {
     /// <summary>The outcome of demangling a single symbol.</summary>
-    /// <param name="ManagedName">The managed name, or null when no confident name could be produced.</param>
+    /// <param name="ManagedName">The managed name joined from recovered metadata, or null when no join exists — heuristics never populate it. Overloads share a name, so precision lives in <paramref name="IsExactMatch"/>.</param>
     /// <param name="Kind">The classified symbol kind.</param>
-    /// <param name="IsExactMatch">Whether <paramref name="ManagedName"/> is an unambiguous join rather than a heuristic display.</param>
+    /// <param name="IsExactMatch">Whether <paramref name="ManagedName"/> identifies exactly one recovered member.</param>
     internal readonly record struct Result(string? ManagedName, NativeSymbolKind Kind, bool IsExactMatch);
 
     /// <summary>A method-key join: the shared display name and whether the key is ambiguous.</summary>

--- a/src/Dotsider.Core/Analysis/IlcNameDemangler.cs
+++ b/src/Dotsider.Core/Analysis/IlcNameDemangler.cs
@@ -1,0 +1,266 @@
+using System.Text;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Maps ILC-mangled native symbol names back to managed names and classifies compiler-generated
+/// symbols by kind. ILC's name mangler is deterministic (NativeAotNameMangler in dotnet/runtime):
+/// a type mangles to <c>{assembly}_{namespace}_{Outer}_{Inner}</c> with <c>System.Private.*</c>
+/// abbreviated to <c>S.P.*</c>, generic instantiations and constructed forms wrapped in
+/// <c>&lt;…&gt;</c>, and a method appended as <c>{mangledType}__{method}</c>. Because every
+/// non-identifier character (including the <c>.</c>, <c>+</c>, <c>&lt;</c>, <c>&gt;</c>, <c>$</c>
+/// that would mark boundaries) collapses to a single <c>_</c>, the split points are ambiguous —
+/// so rather than guess, the demangler joins a sanitized symbol against the set of names it
+/// recovered from the binary's own metadata (<see cref="RecoveredType"/>) and reports an exact
+/// match only when the join is unambiguous. Node-level prefixes (vtables, statics, frozen
+/// strings, dictionaries, data) are classified from their spelling before any join.
+/// </summary>
+internal sealed class IlcNameDemangler
+{
+    /// <summary>The outcome of demangling a single symbol.</summary>
+    /// <param name="ManagedName">The managed name, or null when no confident name could be produced.</param>
+    /// <param name="Kind">The classified symbol kind.</param>
+    /// <param name="IsExactMatch">Whether <paramref name="ManagedName"/> is an unambiguous join rather than a heuristic display.</param>
+    internal readonly record struct Result(string? ManagedName, NativeSymbolKind Kind, bool IsExactMatch);
+
+    // Sanitized type key -> managed FullName; sanitized "{typeKey}__{method}" -> managed "FullName.method".
+    // Ambiguous keys (sanitization collisions or repeated names) map to null so they can't claim an exact match.
+    private readonly Dictionary<string, string?> _typeByKey = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string?> _methodByKey = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Builds a demangler from the types recovered from a binary's embedded metadata.
+    /// </summary>
+    /// <param name="recoveredTypes">The recovered types, each carrying its assembly scope and method names.</param>
+    internal IlcNameDemangler(IReadOnlyList<RecoveredType> recoveredTypes)
+    {
+        foreach (var type in recoveredTypes)
+        {
+            var typeKey = TypeKey(type);
+            if (typeKey.Length == 0) continue;
+            Add(_typeByKey, typeKey, type.FullName);
+
+            foreach (var method in type.MethodNames)
+                Add(_methodByKey, $"{typeKey}__{Sanitize(method)}", $"{type.FullName}.{method}");
+        }
+    }
+
+    /// <summary>
+    /// Demangles and classifies a raw native symbol name.
+    /// </summary>
+    /// <param name="symbol">The raw symbol name from the PDB/DWARF/nlist reader (Mach-O's leading <c>_</c> already stripped).</param>
+    internal Result Demangle(string symbol)
+    {
+        if (string.IsNullOrEmpty(symbol)) return new Result(null, NativeSymbolKind.Data, false);
+
+        // Node-level classification first — these are data, not functions, and never join as methods.
+        if (TryClassifyNode(symbol, out var nodeResult)) return nodeResult;
+
+        // A function: strip generic/constructed <…> scopes, then join against known methods.
+        var flat = StripScopes(symbol);
+
+        if (_methodByKey.TryGetValue(flat, out var exact) && exact is not null)
+            return new Result(exact, NativeSymbolKind.Function, true);
+
+        // Overload disambiguation suffix (_0, _1, …) that metadata cannot distinguish.
+        var deSuffixed = StripTrailingOverloadSuffix(flat);
+        if (deSuffixed is not null && _methodByKey.TryGetValue(deSuffixed, out var overload) && overload is not null)
+            return new Result(overload, NativeSymbolKind.Function, false);
+
+        // Known type, method absent from the (sparse) metadata: name it by its longest known type prefix.
+        if (TryMatchByTypePrefix(flat, out var byType))
+            return new Result(byType, NativeSymbolKind.Function, false);
+
+        // No join: a heuristic display with the assembly moniker expanded, but no managed name.
+        return new Result(null, NativeSymbolKind.Function, false);
+    }
+
+    /// <summary>Expands ILC assembly monikers for display (e.g. <c>S_P_CoreLib</c> → <c>System.Private.CoreLib</c>).</summary>
+    internal static string PrettifyForDisplay(string symbol)
+    {
+        if (symbol.StartsWith("S_P_", StringComparison.Ordinal))
+            return "System.Private." + symbol[4..];
+        return symbol;
+    }
+
+    private bool TryClassifyNode(string symbol, out Result result)
+    {
+        // Windows vtable: ??_7{type}@@6B@   Unix vtable: _ZTV{decimalLength}{type}
+        if (symbol.StartsWith("??_7", StringComparison.Ordinal) && symbol.EndsWith("@@6B@", StringComparison.Ordinal))
+        {
+            var inner = symbol[4..^5];
+            result = new Result(MethodTableName(inner), NativeSymbolKind.MethodTable, IsExactMatchForType(inner));
+            return true;
+        }
+
+        if (symbol.StartsWith("_ZTV", StringComparison.Ordinal))
+        {
+            var inner = StripItaniumLengthPrefix(symbol[4..]);
+            result = new Result(MethodTableName(inner), NativeSymbolKind.MethodTable, IsExactMatchForType(inner));
+            return true;
+        }
+
+        // Frozen string literals: {compilationUnitPrefix}__Str_…
+        if (symbol.Contains("__Str_", StringComparison.Ordinal))
+        {
+            result = new Result(null, NativeSymbolKind.FrozenObject, false);
+            return true;
+        }
+
+        if (symbol.StartsWith("__GenericDict_", StringComparison.Ordinal))
+        {
+            result = new Result(null, NativeSymbolKind.GenericDictionary, false);
+            return true;
+        }
+
+        // Statics — Windows MSVC form ?__GCSTATICS@… / Unix __GCSTATICS…
+        if (IsStatics(symbol))
+        {
+            result = new Result(null, NativeSymbolKind.Statics, false);
+            return true;
+        }
+
+        if (symbol.StartsWith("__readonlydata_", StringComparison.Ordinal)
+            || symbol.StartsWith("__writableData", StringComparison.Ordinal))
+        {
+            result = new Result(null, NativeSymbolKind.Data, false);
+            return true;
+        }
+
+        if (symbol.StartsWith("__unbox", StringComparison.Ordinal) || symbol.Contains("unwind", StringComparison.Ordinal))
+        {
+            result = new Result(null, NativeSymbolKind.Stub, false);
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
+    private static bool IsStatics(string s) =>
+        s.Contains("__GCSTATICS", StringComparison.Ordinal)
+        || s.Contains("__NONGCSTATICS", StringComparison.Ordinal)
+        || s.Contains("__THREADSTATICS", StringComparison.Ordinal)
+        || s.Contains("__TypeThreadStaticIndex", StringComparison.Ordinal);
+
+    private string MethodTableName(string mangledType)
+    {
+        var flat = StripScopes(mangledType);
+        return _typeByKey.TryGetValue(flat, out var name) && name is not null
+            ? $"{name} (MethodTable)"
+            : $"{PrettifyForDisplay(mangledType)} (MethodTable)";
+    }
+
+    private bool IsExactMatchForType(string mangledType) =>
+        _typeByKey.TryGetValue(StripScopes(mangledType), out var name) && name is not null;
+
+    private bool TryMatchByTypePrefix(string flat, out string managedName)
+    {
+        // Walk the '__' method-separator candidates, longest type prefix first.
+        for (var i = flat.Length - 2; i > 0; i--)
+        {
+            if (flat[i] != '_' || flat[i + 1] != '_') continue;
+            var typeKey = flat[..i];
+            if (_typeByKey.TryGetValue(typeKey, out var typeName) && typeName is not null)
+            {
+                managedName = $"{typeName}.{flat[(i + 2)..]}";
+                return true;
+            }
+        }
+
+        managedName = "";
+        return false;
+    }
+
+    private static string? StripTrailingOverloadSuffix(string flat)
+    {
+        var i = flat.Length - 1;
+        while (i >= 0 && char.IsAsciiDigit(flat[i])) i--;
+        if (i == flat.Length - 1 || i < 1 || flat[i] != '_') return null;
+        return flat[..i];
+    }
+
+    /// <summary>Removes balanced <c>&lt;…&gt;</c> scopes (generic instantiations, constructed forms) at any nesting depth.</summary>
+    private static string StripScopes(string s)
+    {
+        var open = s.IndexOf('<', StringComparison.Ordinal);
+        if (open < 0) return s;
+
+        var sb = new StringBuilder(s.Length);
+        var depth = 0;
+        foreach (var c in s)
+        {
+            if (c == '<') depth++;
+            else if (c == '>') { if (depth > 0) depth--; }
+            else if (depth == 0) sb.Append(c);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>Strips the Itanium <c>_ZTV</c> decimal length prefix, leaving the mangled type name.</summary>
+    private static string StripItaniumLengthPrefix(string s)
+    {
+        var i = 0;
+        while (i < s.Length && char.IsAsciiDigit(s[i])) i++;
+        return i < s.Length ? s[i..] : s;
+    }
+
+    private static string TypeKey(RecoveredType type)
+    {
+        var assembly = type.AssemblyName is { Length: > 0 } asm ? Abbreviate(asm) : "";
+        var sanitizedType = Sanitize(type.FullName);
+        return assembly.Length > 0 ? $"{Sanitize(assembly)}_{sanitizedType}" : sanitizedType;
+    }
+
+    private static string Abbreviate(string assemblyName) =>
+        assemblyName.StartsWith("System.Private.", StringComparison.Ordinal)
+            ? "S.P." + assemblyName["System.Private.".Length..]
+            : assemblyName;
+
+    /// <summary>
+    /// Applies ILC's <c>SanitizeName</c>: ASCII letters and <c>_</c> pass through, digits pass
+    /// (a leading digit is prefixed with <c>_</c>), and every other character — including each
+    /// multibyte codepoint — becomes a single <c>_</c>.
+    /// </summary>
+    internal static string Sanitize(ReadOnlySpan<char> s)
+    {
+        var sb = new StringBuilder(s.Length);
+        for (var i = 0; i < s.Length; i++)
+        {
+            var c = s[i];
+            if (char.IsAsciiLetter(c) || c == '_')
+            {
+                sb.Append(c);
+            }
+            else if (char.IsAsciiDigit(c))
+            {
+                if (i == 0) sb.Append('_');
+                sb.Append(c);
+            }
+            else
+            {
+                sb.Append('_');
+                // A surrogate pair is one codepoint → one underscore.
+                if (char.IsHighSurrogate(c) && i + 1 < s.Length && char.IsLowSurrogate(s[i + 1])) i++;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static void Add(Dictionary<string, string?> map, string key, string value)
+    {
+        // First writer wins the value; a second, different value marks the key ambiguous (null).
+        if (map.TryGetValue(key, out var existing))
+        {
+            if (!string.Equals(existing, value, StringComparison.Ordinal))
+                map[key] = null;
+        }
+        else
+        {
+            map[key] = value;
+        }
+    }
+}

--- a/src/Dotsider.Core/Analysis/IlcNameDemangler.cs
+++ b/src/Dotsider.Core/Analysis/IlcNameDemangler.cs
@@ -24,10 +24,17 @@ internal sealed class IlcNameDemangler
     /// <param name="IsExactMatch">Whether <paramref name="ManagedName"/> is an unambiguous join rather than a heuristic display.</param>
     internal readonly record struct Result(string? ManagedName, NativeSymbolKind Kind, bool IsExactMatch);
 
-    // Sanitized type key -> managed FullName; sanitized "{typeKey}__{method}" -> managed "FullName.method".
-    // Ambiguous keys (sanitization collisions or repeated names) map to null so they can't claim an exact match.
+    /// <summary>A method-key join: the shared display name and whether the key is ambiguous.</summary>
+    /// <param name="Name">The managed display name, or null when a sanitization collision leaves no single name.</param>
+    /// <param name="Ambiguous">Whether more than one recovered method produced this key (overloads share their name).</param>
+    private readonly record struct MethodJoin(string? Name, bool Ambiguous);
+
+    // Sanitized type key -> managed FullName; sanitized "{typeKey}__{method}" -> the method join.
+    // A type key colliding with a different FullName maps to null; a method key hit twice is
+    // ambiguous even when the display name is identical — overloads share a name, and without a
+    // signature the reader cannot tell which one a native symbol is.
     private readonly Dictionary<string, string?> _typeByKey = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, string?> _methodByKey = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, MethodJoin> _methodByKey = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Builds a demangler from the types recovered from a binary's embedded metadata.
@@ -42,7 +49,7 @@ internal sealed class IlcNameDemangler
             Add(_typeByKey, typeKey, type.FullName);
 
             foreach (var method in type.MethodNames)
-                Add(_methodByKey, $"{typeKey}__{Sanitize(method)}", $"{type.FullName}.{method}");
+                AddMethod($"{typeKey}__{Sanitize(method)}", $"{type.FullName}.{method}");
         }
     }
 
@@ -60,19 +67,15 @@ internal sealed class IlcNameDemangler
         // A function: strip generic/constructed <…> scopes, then join against known methods.
         var flat = StripScopes(symbol);
 
-        if (_methodByKey.TryGetValue(flat, out var exact) && exact is not null)
-            return new Result(exact, NativeSymbolKind.Function, true);
+        if (_methodByKey.TryGetValue(flat, out var join) && join.Name is not null)
+            return new Result(join.Name, NativeSymbolKind.Function, !join.Ambiguous);
 
         // Overload disambiguation suffix (_0, _1, …) that metadata cannot distinguish.
         var deSuffixed = StripTrailingOverloadSuffix(flat);
-        if (deSuffixed is not null && _methodByKey.TryGetValue(deSuffixed, out var overload) && overload is not null)
-            return new Result(overload, NativeSymbolKind.Function, false);
+        if (deSuffixed is not null && _methodByKey.TryGetValue(deSuffixed, out var overload) && overload.Name is not null)
+            return new Result(overload.Name, NativeSymbolKind.Function, false);
 
-        // Known type, method absent from the (sparse) metadata: name it by its longest known type prefix.
-        if (TryMatchByTypePrefix(flat, out var byType))
-            return new Result(byType, NativeSymbolKind.Function, false);
-
-        // No join: a heuristic display with the assembly moniker expanded, but no managed name.
+        // No join: heuristics never claim a managed name — the raw name stays the display.
         return new Result(null, NativeSymbolKind.Function, false);
     }
 
@@ -154,24 +157,6 @@ internal sealed class IlcNameDemangler
 
     private bool IsExactMatchForType(string mangledType) =>
         _typeByKey.TryGetValue(StripScopes(mangledType), out var name) && name is not null;
-
-    private bool TryMatchByTypePrefix(string flat, out string managedName)
-    {
-        // Walk the '__' method-separator candidates, longest type prefix first.
-        for (var i = flat.Length - 2; i > 0; i--)
-        {
-            if (flat[i] != '_' || flat[i + 1] != '_') continue;
-            var typeKey = flat[..i];
-            if (_typeByKey.TryGetValue(typeKey, out var typeName) && typeName is not null)
-            {
-                managedName = $"{typeName}.{flat[(i + 2)..]}";
-                return true;
-            }
-        }
-
-        managedName = "";
-        return false;
-    }
 
     private static string? StripTrailingOverloadSuffix(string flat)
     {
@@ -261,6 +246,23 @@ internal sealed class IlcNameDemangler
         else
         {
             map[key] = value;
+        }
+    }
+
+    private void AddMethod(string key, string value)
+    {
+        // Any second writer marks the key ambiguous — even with an identical display name,
+        // duplicates mean overloads, and no signature can say which one a symbol is. The shared
+        // name survives when it is the same, so the symbol can still be named, just not exactly.
+        if (_methodByKey.TryGetValue(key, out var existing))
+        {
+            _methodByKey[key] = new MethodJoin(
+                string.Equals(existing.Name, value, StringComparison.Ordinal) ? existing.Name : null,
+                Ambiguous: true);
+        }
+        else
+        {
+            _methodByKey[key] = new MethodJoin(value, Ambiguous: false);
         }
     }
 }

--- a/src/Dotsider.Core/Analysis/MachOImageReader.cs
+++ b/src/Dotsider.Core/Analysis/MachOImageReader.cs
@@ -25,6 +25,16 @@ internal static class MachOImageReader
     private const uint LcLoadWeakDylib = 0x80000018;
     private const uint LcReexportDylib = 0x8000001F;
     private const uint LcLoadUpwardDylib = 0x80000023;
+    private const uint LcSegment64 = 0x19;
+    private const uint LcUuid = 0x1B;
+    private const uint LcFunctionStarts = 0x26;
+
+    private const uint FatMagic = 0xCAFEBABE;
+    private const uint FatMagic64 = 0xCAFEBABF;
+    private const int MaxFatSlices = 64;
+
+    private const int Segment64HeaderSize = 72;
+    private const int Section64Size = 80;
 
     private const byte NStab = 0xE0;
     private const byte NType = 0x0E;
@@ -36,6 +46,226 @@ internal static class MachOImageReader
     internal static bool IsMachO(ReadOnlySpan<byte> bytes) =>
         bytes.Length >= HeaderSize
         && BinaryPrimitives.ReadUInt32LittleEndian(bytes) == Magic64LittleEndian;
+
+    /// <summary>Returns true if the bytes are a fat/universal Mach-O archive.</summary>
+    internal static bool IsFat(ReadOnlySpan<byte> bytes) =>
+        bytes.Length >= 8
+        && BinaryPrimitives.ReadUInt32BigEndian(bytes) is FatMagic or FatMagic64;
+
+    /// <summary>One architecture slice of a fat/universal archive.</summary>
+    /// <param name="CpuType">The slice's <c>cputype</c>.</param>
+    /// <param name="Offset">The slice's byte offset in the archive.</param>
+    /// <param name="Size">The slice's byte size.</param>
+    internal readonly record struct MachOFatSlice(uint CpuType, long Offset, long Size);
+
+    /// <summary>
+    /// Enumerates the architecture slices of a fat archive (both the 32- and 64-bit header
+    /// forms, which are big-endian), or an empty list for thin images.
+    /// </summary>
+    /// <param name="bytes">The raw archive bytes.</param>
+    internal static IReadOnlyList<MachOFatSlice> ReadFatSlices(ReadOnlySpan<byte> bytes)
+    {
+        var slices = new List<MachOFatSlice>();
+        try
+        {
+            if (!IsFat(bytes)) return slices;
+            var is64 = BinaryPrimitives.ReadUInt32BigEndian(bytes) == FatMagic64;
+            var count = BinaryPrimitives.ReadUInt32BigEndian(bytes[4..]);
+            if (count > MaxFatSlices) return slices;
+
+            var entrySize = is64 ? 32 : 20;
+            for (var i = 0; i < count; i++)
+            {
+                var entry = 8 + i * entrySize;
+                if (entry + entrySize > bytes.Length) break;
+                var cpuType = BinaryPrimitives.ReadUInt32BigEndian(bytes[entry..]);
+                long offset, size;
+                if (is64)
+                {
+                    offset = (long)BinaryPrimitives.ReadUInt64BigEndian(bytes[(entry + 8)..]);
+                    size = (long)BinaryPrimitives.ReadUInt64BigEndian(bytes[(entry + 16)..]);
+                }
+                else
+                {
+                    offset = BinaryPrimitives.ReadUInt32BigEndian(bytes[(entry + 8)..]);
+                    size = BinaryPrimitives.ReadUInt32BigEndian(bytes[(entry + 12)..]);
+                }
+
+                if (offset < 0 || size <= 0 || offset + size > bytes.Length) continue;
+                slices.Add(new MachOFatSlice(cpuType, offset, size));
+            }
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            // Keep the slices parsed so far.
+        }
+
+        return slices;
+    }
+
+    /// <summary>Reads the image's <c>LC_UUID</c> — the identity a dSYM must match.</summary>
+    /// <param name="bytes">The raw image bytes.</param>
+    /// <param name="uuid">The 16-byte UUID payload.</param>
+    internal static bool TryReadUuid(ReadOnlySpan<byte> bytes, out byte[] uuid)
+    {
+        uuid = [];
+        foreach (var (cmd, offset, size) in Commands(bytes))
+        {
+            if (cmd != LcUuid || size < 24) continue;
+            uuid = bytes.Slice(offset + 8, 16).ToArray();
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>One Mach-O section's identity, location, and flags.</summary>
+    /// <param name="Name">The section name (e.g. <c>__text</c>).</param>
+    /// <param name="Segment">The owning segment's name (e.g. <c>__TEXT</c>).</param>
+    /// <param name="Address">The section's virtual address.</param>
+    /// <param name="FileOffset">The section's file offset.</param>
+    /// <param name="Size">The section's byte size.</param>
+    /// <param name="Flags">The section flags (instruction attributes mark executable code).</param>
+    /// <param name="Ordinal">The 1-based ordinal <c>n_sect</c> refers to, across all segments in load order.</param>
+    internal readonly record struct MachOSection(
+        string Name, string Segment, ulong Address, long FileOffset, long Size, uint Flags, int Ordinal)
+    {
+        /// <summary>
+        /// Whether the section holds code: ILC uses <c>__text</c>, <c>__managedcode</c>, and the
+        /// <c>__unbox</c> stubs, so the instruction attributes decide, not the name.
+        /// </summary>
+        public bool IsExecutable => (Flags & 0x8000_0400) != 0; // S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS
+    }
+
+    /// <summary>
+    /// Walks every <c>LC_SEGMENT_64</c> into its sections, in load order, with the running
+    /// 1-based ordinals the symbol table's <c>n_sect</c> field references.
+    /// </summary>
+    /// <param name="bytes">The raw image bytes.</param>
+    internal static IReadOnlyList<MachOSection> ReadSectionList(ReadOnlySpan<byte> bytes)
+    {
+        var sections = new List<MachOSection>();
+        try
+        {
+            var ordinal = 0;
+            foreach (var (cmd, offset, size) in Commands(bytes))
+            {
+                if (cmd != LcSegment64 || size < Segment64HeaderSize) continue;
+                var segmentName = ReadFixedName(bytes, offset + 8);
+                var sectionCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 64)..]);
+
+                for (var i = 0; i < sectionCount; i++)
+                {
+                    var s = offset + Segment64HeaderSize + i * Section64Size;
+                    if (s + Section64Size > offset + size || s + Section64Size > bytes.Length) break;
+                    ordinal++;
+                    sections.Add(new MachOSection(
+                        Name: ReadFixedName(bytes, s),
+                        Segment: segmentName,
+                        Address: BinaryPrimitives.ReadUInt64LittleEndian(bytes[(s + 32)..]),
+                        FileOffset: BinaryPrimitives.ReadUInt32LittleEndian(bytes[(s + 48)..]),
+                        Size: (long)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(s + 40)..]),
+                        Flags: BinaryPrimitives.ReadUInt32LittleEndian(bytes[(s + 64)..]),
+                        Ordinal: ordinal));
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            // Keep the sections parsed so far.
+        }
+
+        return sections;
+    }
+
+    /// <summary>
+    /// Finds the <c>__TEXT</c> segment's <c>vmaddr</c> — the base <c>LC_FUNCTION_STARTS</c>
+    /// deltas are relative to (explicitly that segment, not the first one).
+    /// </summary>
+    /// <param name="bytes">The raw image bytes.</param>
+    /// <param name="vmaddr">The <c>__TEXT</c> segment's virtual address.</param>
+    internal static bool TryGetTextBase(ReadOnlySpan<byte> bytes, out ulong vmaddr)
+    {
+        vmaddr = 0;
+        foreach (var (cmd, offset, size) in Commands(bytes))
+        {
+            if (cmd != LcSegment64 || size < Segment64HeaderSize) continue;
+            if (ReadFixedName(bytes, offset + 8) != "__TEXT") continue;
+            vmaddr = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(offset + 24)..]);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Finds the <c>LC_FUNCTION_STARTS</c> payload — ULEB128 address deltas.</summary>
+    /// <param name="bytes">The raw image bytes.</param>
+    /// <param name="fileOffset">The payload's file offset.</param>
+    /// <param name="size">The payload's byte size.</param>
+    internal static bool TryGetFunctionStarts(ReadOnlySpan<byte> bytes, out int fileOffset, out int size)
+    {
+        fileOffset = 0;
+        size = 0;
+        foreach (var (cmd, offset, cmdSize) in Commands(bytes))
+        {
+            if (cmd != LcFunctionStarts || cmdSize < 16) continue;
+            fileOffset = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 8)..]);
+            size = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 12)..]);
+            return fileOffset >= 0 && size > 0 && fileOffset + size <= bytes.Length;
+        }
+
+        return false;
+    }
+
+    /// <summary>Finds the <c>LC_SYMTAB</c> table locations.</summary>
+    /// <param name="bytes">The raw image bytes.</param>
+    /// <param name="symtab">The nlist array's offset and count, and the string table's offset.</param>
+    internal static bool TryGetSymtab(ReadOnlySpan<byte> bytes, out (int Offset, int Count, int StringOffset) symtab)
+    {
+        symtab = default;
+        foreach (var (cmd, offset, size) in Commands(bytes))
+        {
+            if (cmd != LcSymtab || size < 24) continue;
+            symtab = (
+                (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 8)..]),
+                (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 12)..]),
+                (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 16)..]));
+            return symtab.Count > 0;
+        }
+
+        return false;
+    }
+
+    /// <summary>Enumerates the load commands of a thin image as (cmd, offset, size) triples.</summary>
+    private static List<(uint Cmd, int Offset, int Size)> Commands(ReadOnlySpan<byte> bytes)
+    {
+        var commands = new List<(uint, int, int)>();
+        if (!IsMachO(bytes)) return commands;
+
+        var commandCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes[16..]);
+        if (commandCount > MaxCommands) return commands;
+
+        var command = HeaderSize;
+        for (var i = 0; i < commandCount; i++)
+        {
+            if (command + 8 > bytes.Length) break;
+            var cmd = BinaryPrimitives.ReadUInt32LittleEndian(bytes[command..]);
+            var cmdSize = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 4)..]);
+            if (cmdSize < 8 || command + cmdSize > bytes.Length) break;
+            commands.Add((cmd, command, cmdSize));
+            command += cmdSize;
+        }
+
+        return commands;
+    }
+
+    private static string ReadFixedName(ReadOnlySpan<byte> bytes, int offset)
+    {
+        var slice = bytes.Slice(offset, 16);
+        var end = slice.IndexOf((byte)0);
+        if (end < 0) end = 16;
+        return Encoding.ASCII.GetString(slice[..end]);
+    }
 
     /// <summary>Reads the loaded dylibs and the undefined external symbols bound to each.</summary>
     internal static IReadOnlyList<ImportedModuleInfo> ReadImports(ReadOnlySpan<byte> bytes)

--- a/src/Dotsider.Core/Analysis/MachOSymbolReader.cs
+++ b/src/Dotsider.Core/Analysis/MachOSymbolReader.cs
@@ -1,0 +1,255 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Reads native symbols from a thin 64-bit Mach-O image's <c>nlist</c> table. Functions are the
+/// symbols in executable sections — any section flagged with instruction attributes, which on
+/// ILC output means <c>__managedcode</c> and the <c>__unbox</c> stubs as well as <c>__text</c> —
+/// plus <c>N_FUN</c> stab pairs (dSYMs), whose end entries carry explicit sizes. Data symbols
+/// come from non-executable sections when the demangler recognizes an ILC data node in the name.
+/// nlist records no sizes, so unsized functions take the distance to the next symbol, clamped to
+/// their containing section's end. The Mach-O leading underscore is stripped from every name.
+/// </summary>
+internal static class MachOSymbolReader
+{
+    private const int NListSize = 16;
+    private const int MaxSymbols = 1 << 20;
+
+    private const byte NStab = 0xE0;
+    private const byte NType = 0x0E;
+    private const byte NSect = 0xE;
+    private const byte NFun = 0x24;
+
+    /// <summary>
+    /// Reads the image's named symbols: executable-section functions, <c>N_FUN</c> stab pairs,
+    /// and recognized data nodes, sized and section-attributed.
+    /// </summary>
+    /// <param name="bytes">The raw thin image bytes.</param>
+    /// <param name="demangler">The demangler that recognizes ILC data-node names.</param>
+    public static IReadOnlyList<RawNativeSymbol> ReadSymbols(ReadOnlySpan<byte> bytes, IlcNameDemangler demangler)
+    {
+        var result = new List<RawNativeSymbol>();
+        try
+        {
+            if (!MachOImageReader.TryGetSymtab(bytes, out var symtab)) return result;
+            var sections = MachOImageReader.ReadSectionList(bytes);
+            var functions = new List<(string Name, ulong Va, int Ordinal, long Size)>();
+
+            string? openStabName = null;
+            ulong openStabVa = 0;
+            var openStabOrdinal = 0;
+
+            var count = Math.Min(symtab.Count, MaxSymbols);
+            for (var i = 0; i < count; i++)
+            {
+                var entry = symtab.Offset + i * NListSize;
+                if (entry < 0 || entry + NListSize > bytes.Length) break;
+
+                var type = bytes[entry + 4];
+                var ordinal = bytes[entry + 5];
+                var value = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(entry + 8)..]);
+                var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[entry..]);
+                var name = ReadName(bytes, symtab.StringOffset, nameOffset);
+
+                if ((type & NStab) != 0)
+                {
+                    if (type != NFun) continue;
+                    if (name.Length > 0)
+                    {
+                        // Opening N_FUN: the function's start address.
+                        openStabName = name;
+                        openStabVa = value;
+                        openStabOrdinal = ordinal;
+                    }
+                    else if (openStabName is not null)
+                    {
+                        // Closing N_FUN: n_value is the function's size.
+                        functions.Add((openStabName, openStabVa, openStabOrdinal, (long)value));
+                        openStabName = null;
+                    }
+
+                    continue;
+                }
+
+                if ((type & NType) != NSect || name.Length == 0 || value == 0) continue;
+
+                var section = FindSection(sections, ordinal);
+                if (section is { IsExecutable: true })
+                {
+                    functions.Add((name, value, ordinal, 0));
+                }
+                else if (section is not null
+                    && demangler.Demangle(name).Kind != Models.NativeSymbolKind.Function)
+                {
+                    // Non-executable section: keep only recognized ILC data nodes.
+                    result.Add(Raw(name, value, section.Value, size: 0, isData: true));
+                }
+            }
+
+            AppendSizedFunctions(functions, sections, result);
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            // Keep the symbols parsed before the damage.
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Reads <c>LC_FUNCTION_STARTS</c> into nameless boundaries: ULEB128 deltas relative to the
+    /// <c>__TEXT</c> segment's <c>vmaddr</c>, sized by successive starts with the last clamped
+    /// to the end of its containing executable section.
+    /// </summary>
+    /// <param name="bytes">The raw thin image bytes.</param>
+    public static IReadOnlyList<RawNativeSymbol> ReadFunctionStartBoundaries(ReadOnlySpan<byte> bytes)
+    {
+        var result = new List<RawNativeSymbol>();
+        try
+        {
+            if (!MachOImageReader.TryGetFunctionStarts(bytes, out var offset, out var size)) return result;
+            if (!MachOImageReader.TryGetTextBase(bytes, out var address)) return result;
+            var sections = MachOImageReader.ReadSectionList(bytes);
+
+            var starts = new List<ulong>();
+            var data = bytes.Slice(offset, size);
+            var position = 0;
+            while (position < data.Length && starts.Count < MaxSymbols)
+            {
+                ulong delta = 0;
+                var shift = 0;
+                byte b;
+                do
+                {
+                    if (position >= data.Length || shift > 63) return Finish(starts, sections, result);
+                    b = data[position++];
+                    delta |= (ulong)(b & 0x7F) << shift;
+                    shift += 7;
+                }
+                while ((b & 0x80) != 0);
+
+                if (delta == 0) break; // padding terminates the stream
+                address += delta;
+                starts.Add(address);
+            }
+
+            return Finish(starts, sections, result);
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            return result;
+        }
+    }
+
+    private static List<RawNativeSymbol> Finish(
+        List<ulong> starts, IReadOnlyList<MachOImageReader.MachOSection> sections, List<RawNativeSymbol> result)
+    {
+        for (var i = 0; i < starts.Count; i++)
+        {
+            var va = starts[i];
+            var section = FindSectionByAddress(sections, va);
+            var end = i + 1 < starts.Count
+                ? starts[i + 1]
+                : section is { } s ? s.Address + (ulong)s.Size : va;
+            if (section is { } clamp && end > clamp.Address + (ulong)clamp.Size)
+                end = clamp.Address + (ulong)clamp.Size;
+            if (end <= va) continue;
+
+            long? fileOffset = section is { } fo ? fo.FileOffset + (long)(va - fo.Address) : null;
+            result.Add(new RawNativeSymbol(
+                Name: $"sub_{va:x}",
+                VirtualAddress: va,
+                Rva: null,
+                FileOffset: fileOffset,
+                Section: section?.Name,
+                Size: (long)(end - va),
+                IsData: false,
+                IsBoundary: true,
+                SourceFile: null,
+                Line: null));
+        }
+
+        return result;
+    }
+
+    private static void AppendSizedFunctions(
+        List<(string Name, ulong Va, int Ordinal, long Size)> functions,
+        IReadOnlyList<MachOImageReader.MachOSection> sections, List<RawNativeSymbol> result)
+    {
+        // nlist carries no sizes: sort and size each unsized function by the next start,
+        // clamped to its containing section's end so the last one never bleeds across sections.
+        functions.Sort(static (x, y) => x.Va.CompareTo(y.Va));
+        for (var i = 0; i < functions.Count; i++)
+        {
+            var (name, va, ordinal, size) = functions[i];
+            var section = FindSection(sections, ordinal) ?? FindSectionByAddress(sections, va);
+            if (size == 0)
+            {
+                var j = i + 1;
+                while (j < functions.Count && functions[j].Va <= va) j++;
+                var end = j < functions.Count
+                    ? functions[j].Va
+                    : section is { } s ? s.Address + (ulong)s.Size : va;
+                if (section is { } clamp && end > clamp.Address + (ulong)clamp.Size)
+                    end = clamp.Address + (ulong)clamp.Size;
+                size = end > va ? (long)(end - va) : 0;
+            }
+
+            if (section is { } within)
+                result.Add(Raw(name, va, within, size, isData: false));
+        }
+    }
+
+    private static RawNativeSymbol Raw(
+        string name, ulong va, MachOImageReader.MachOSection section, long size, bool isData) =>
+        new(
+            Name: name,
+            VirtualAddress: va,
+            Rva: null,
+            FileOffset: va >= section.Address && va < section.Address + (ulong)section.Size
+                ? section.FileOffset + (long)(va - section.Address)
+                : null,
+            Section: section.Name,
+            Size: size,
+            IsData: isData,
+            IsBoundary: false,
+            SourceFile: null,
+            Line: null);
+
+    private static MachOImageReader.MachOSection? FindSection(
+        IReadOnlyList<MachOImageReader.MachOSection> sections, int ordinal)
+    {
+        foreach (var section in sections)
+        {
+            if (section.Ordinal == ordinal) return section;
+        }
+
+        return null;
+    }
+
+    private static MachOImageReader.MachOSection? FindSectionByAddress(
+        IReadOnlyList<MachOImageReader.MachOSection> sections, ulong va)
+    {
+        foreach (var section in sections)
+        {
+            if (section.Address != 0 && va >= section.Address && va < section.Address + (ulong)section.Size)
+                return section;
+        }
+
+        return null;
+    }
+
+    /// <summary>Reads a symbol name, stripping the Mach-O leading underscore.</summary>
+    private static string ReadName(ReadOnlySpan<byte> bytes, int stringOffset, uint nameOffset)
+    {
+        var start = (long)stringOffset + nameOffset;
+        if (start < 0 || start >= bytes.Length) return "";
+        var slice = bytes[(int)start..];
+        var end = slice.IndexOf((byte)0);
+        if (end < 0) end = slice.Length;
+        var name = Encoding.UTF8.GetString(slice[..end]);
+        return name.StartsWith('_') ? name[1..] : name;
+    }
+}

--- a/src/Dotsider.Core/Analysis/Models/NativeSymbol.cs
+++ b/src/Dotsider.Core/Analysis/Models/NativeSymbol.cs
@@ -8,7 +8,7 @@ namespace Dotsider.Core.Analysis.Models;
 /// to recompute a mapping.
 /// </summary>
 /// <param name="Name">The raw symbol name (mangled for managed code), or a synthesized <c>sub_…</c> for a boundary.</param>
-/// <param name="ManagedName">The demangled managed name when the symbol joined a recovered type unambiguously, else null.</param>
+/// <param name="ManagedName">The managed name joined from the binary's recovered metadata, or null when no join exists. Overloads share a name, so this alone does not pin a member — <see cref="IsExactMatch"/> is the precision flag.</param>
 /// <param name="VirtualAddress">The symbol's virtual address (image base + RVA on PE; the symbol VA on ELF/Mach-O).</param>
 /// <param name="Rva">The PE relative virtual address, or null for non-PE images.</param>
 /// <param name="FileOffset">The file offset the address maps to, or null when the symbol is not file-backed.</param>
@@ -17,7 +17,7 @@ namespace Dotsider.Core.Analysis.Models;
 /// <param name="Kind">What the symbol represents.</param>
 /// <param name="SourceFile">The declaring source file, when debug line info is present.</param>
 /// <param name="Line">The declaring source line, when debug line info is present.</param>
-/// <param name="IsExactMatch">Whether <see cref="ManagedName"/> is an unambiguous demangle rather than a heuristic display.</param>
+/// <param name="IsExactMatch">Whether <see cref="ManagedName"/> identifies exactly one recovered member; false when the join is ambiguous (overloads sharing a name, or an overload-suffix join).</param>
 /// <param name="Aliases">Alternate names that resolved to the same address and were merged into this symbol.</param>
 public sealed record NativeSymbol(
     string Name,

--- a/src/Dotsider.Core/Analysis/Models/NativeSymbol.cs
+++ b/src/Dotsider.Core/Analysis/Models/NativeSymbol.cs
@@ -1,0 +1,34 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// One native symbol recovered from a binary: a function, a compiler-generated data blob, or a
+/// nameless boundary. The address is carried in every form a consumer might need — virtual
+/// address for display and cross-symbol ordering, PE RVA, file offset when the address is
+/// file-backed, and the containing section — so the UI, hex views, and disassembly never have
+/// to recompute a mapping.
+/// </summary>
+/// <param name="Name">The raw symbol name (mangled for managed code), or a synthesized <c>sub_…</c> for a boundary.</param>
+/// <param name="ManagedName">The demangled managed name when the symbol joined a recovered type unambiguously, else null.</param>
+/// <param name="VirtualAddress">The symbol's virtual address (image base + RVA on PE; the symbol VA on ELF/Mach-O).</param>
+/// <param name="Rva">The PE relative virtual address, or null for non-PE images.</param>
+/// <param name="FileOffset">The file offset the address maps to, or null when the symbol is not file-backed.</param>
+/// <param name="Section">The containing section's name, or null when it could not be determined.</param>
+/// <param name="Size">The symbol's size in bytes, derived when the format does not record it directly.</param>
+/// <param name="Kind">What the symbol represents.</param>
+/// <param name="SourceFile">The declaring source file, when debug line info is present.</param>
+/// <param name="Line">The declaring source line, when debug line info is present.</param>
+/// <param name="IsExactMatch">Whether <see cref="ManagedName"/> is an unambiguous demangle rather than a heuristic display.</param>
+/// <param name="Aliases">Alternate names that resolved to the same address and were merged into this symbol.</param>
+public sealed record NativeSymbol(
+    string Name,
+    string? ManagedName,
+    ulong VirtualAddress,
+    uint? Rva,
+    long? FileOffset,
+    string? Section,
+    long Size,
+    NativeSymbolKind Kind,
+    string? SourceFile,
+    int? Line,
+    bool IsExactMatch,
+    IReadOnlyList<string> Aliases);

--- a/src/Dotsider.Core/Analysis/Models/NativeSymbolInfo.cs
+++ b/src/Dotsider.Core/Analysis/Models/NativeSymbolInfo.cs
@@ -1,0 +1,64 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// The native symbols recovered from a binary, plus the provenance and status needed to explain
+/// the result. Symbols are ordered by <see cref="NativeSymbol.VirtualAddress"/>, which
+/// <see cref="TryFindByAddress"/> relies on to resolve an address to its containing symbol —
+/// the lookup the disassembly and hex views use to name code.
+/// </summary>
+/// <param name="Symbols">The recovered symbols, sorted ascending by virtual address.</param>
+/// <param name="Source">Which reader produced the symbols.</param>
+/// <param name="Status">The probe outcome; explains an empty result.</param>
+/// <param name="Path">The symbol file that was read (PDB, .dbg, or dSYM inner file), or null for self/fallback sources.</param>
+/// <param name="Diagnostic">A human-readable note on the outcome — the mismatch detail, the fallback reason, or null on a clean load.</param>
+public sealed record NativeSymbolInfo(
+    IReadOnlyList<NativeSymbol> Symbols,
+    NativeSymbolSource Source,
+    NativeSymbolStatus Status,
+    string? Path,
+    string? Diagnostic)
+{
+    /// <summary>
+    /// Finds the symbol whose range contains <paramref name="virtualAddress"/>. Binary-searches
+    /// the address-sorted list for the last symbol starting at or before the address, then
+    /// confirms the address falls within that symbol's size.
+    /// </summary>
+    /// <param name="virtualAddress">The virtual address to resolve.</param>
+    /// <param name="symbol">The containing symbol when found.</param>
+    /// <returns>True when a symbol contains the address; otherwise false.</returns>
+    public bool TryFindByAddress(ulong virtualAddress, out NativeSymbol symbol)
+    {
+        var lo = 0;
+        var hi = Symbols.Count - 1;
+        var candidate = -1;
+        while (lo <= hi)
+        {
+            var mid = lo + ((hi - lo) >> 1);
+            if (Symbols[mid].VirtualAddress <= virtualAddress)
+            {
+                candidate = mid;
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+
+        if (candidate >= 0)
+        {
+            var found = Symbols[candidate];
+            // A zero-size symbol (unsized public/data) matches only its exact start; a sized
+            // symbol matches its half-open [start, start+size) range.
+            var end = found.VirtualAddress + (found.Size > 0 ? (ulong)found.Size : 1);
+            if (virtualAddress < end)
+            {
+                symbol = found;
+                return true;
+            }
+        }
+
+        symbol = null!;
+        return false;
+    }
+}

--- a/src/Dotsider.Core/Analysis/Models/NativeSymbolKind.cs
+++ b/src/Dotsider.Core/Analysis/Models/NativeSymbolKind.cs
@@ -1,0 +1,33 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// What a native symbol represents. Native AOT binaries carry compiler-generated code and data
+/// symbols beyond ordinary functions; this classification drives the Size Map's category
+/// grouping and the symbol view's presentation.
+/// </summary>
+public enum NativeSymbolKind
+{
+    /// <summary>A compiled method body.</summary>
+    Function,
+
+    /// <summary>A type's runtime MethodTable (vtable) — Windows <c>??_7…@@6B@</c> / Unix <c>_ZTV…</c>.</summary>
+    MethodTable,
+
+    /// <summary>A frozen (compile-time allocated) object, most often a string literal (<c>__Str_…</c>).</summary>
+    FrozenObject,
+
+    /// <summary>A generic dictionary or an unboxing/other compiler stub.</summary>
+    Stub,
+
+    /// <summary>A generic dictionary blob (<c>__GenericDict_…</c>).</summary>
+    GenericDictionary,
+
+    /// <summary>Static field storage (GC, non-GC, or thread statics).</summary>
+    Statics,
+
+    /// <summary>Other named data (readonly/writable data and the like).</summary>
+    Data,
+
+    /// <summary>A nameless function boundary recovered from unwind data when no symbols exist.</summary>
+    Boundary
+}

--- a/src/Dotsider.Core/Analysis/Models/NativeSymbolSource.cs
+++ b/src/Dotsider.Core/Analysis/Models/NativeSymbolSource.cs
@@ -1,0 +1,30 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// Where a binary's native symbols came from. The three primary sources carry names and (mostly)
+/// sizes; the three fallback sources recover only function boundaries from unwind data and are
+/// lower fidelity — they can miss leaf and thunk functions.
+/// </summary>
+public enum NativeSymbolSource
+{
+    /// <summary>A matched Windows native PDB (MSF container).</summary>
+    NativePdb,
+
+    /// <summary>DWARF debug info in an unstripped ELF binary or a <c>.dbg</c> sidecar.</summary>
+    Dwarf,
+
+    /// <summary>A macOS dSYM bundle (DWARF plus nlist stabs).</summary>
+    Dsym,
+
+    /// <summary>The Mach-O symbol table (nlist) of the binary itself.</summary>
+    MachONlist,
+
+    /// <summary>PE <c>.pdata</c> exception directory — function boundaries only.</summary>
+    PdataFallback,
+
+    /// <summary>ELF <c>.eh_frame</c> unwind info — function boundaries only.</summary>
+    EhFrameFallback,
+
+    /// <summary>Mach-O <c>LC_FUNCTION_STARTS</c> — function boundaries only.</summary>
+    FunctionStartsFallback
+}

--- a/src/Dotsider.Core/Analysis/Models/NativeSymbolStatus.cs
+++ b/src/Dotsider.Core/Analysis/Models/NativeSymbolStatus.cs
@@ -1,0 +1,30 @@
+namespace Dotsider.Core.Analysis.Models;
+
+/// <summary>
+/// The outcome of probing a binary for native symbols. When no symbols are returned, the status
+/// distinguishes the reasons — missing, mismatched, corrupt, ambiguous, or fallback-only — so
+/// callers can explain the result instead of showing an empty table with no cause.
+/// </summary>
+public enum NativeSymbolStatus
+{
+    /// <summary>Named symbols loaded from a primary source.</summary>
+    Loaded,
+
+    /// <summary>No symbol file was found beside the binary and no fallback applied.</summary>
+    NoSymbolFile,
+
+    /// <summary>A symbol file was found but its identity did not match the binary.</summary>
+    IdMismatch,
+
+    /// <summary>A symbol file was found and matched, but could not be parsed.</summary>
+    CorruptSymbolFile,
+
+    /// <summary>Only nameless function boundaries were recovered from unwind data.</summary>
+    FallbackOnly,
+
+    /// <summary>A fat/universal binary offered no slice that could be disambiguated.</summary>
+    AmbiguousImage,
+
+    /// <summary>The binary is managed or otherwise has no native symbols to read.</summary>
+    NotApplicable
+}

--- a/src/Dotsider.Core/Analysis/Models/PdbProvenance.cs
+++ b/src/Dotsider.Core/Analysis/Models/PdbProvenance.cs
@@ -20,6 +20,7 @@ public sealed record PdbProvenance(
         PdbProvenanceKind.CodeViewSidecarMissing => Details ?? "CodeViewSidecarMissing",
         PdbProvenanceKind.CodeViewSidecarMismatched => Details ?? "CodeViewSidecarMismatched",
         PdbProvenanceKind.UnsupportedWindowsPdb => Details ?? "UnsupportedWindowsPdb",
+        PdbProvenanceKind.NativePdb => Details ?? "NativePdb",
         PdbProvenanceKind.BundleSidecarSkipped => Details ?? "BundleSidecarSkipped",
         _ => Kind.ToString()
     };

--- a/src/Dotsider.Core/Analysis/Models/PdbProvenanceKind.cs
+++ b/src/Dotsider.Core/Analysis/Models/PdbProvenanceKind.cs
@@ -23,6 +23,9 @@ public enum PdbProvenanceKind
     /// <summary>A CodeView entry was present, but it identifies a Windows PDB or another non-portable PDB.</summary>
     UnsupportedWindowsPdb,
 
+    /// <summary>A Windows native PDB was found beside the binary and its GUID and age match the CodeView entry.</summary>
+    NativePdb,
+
     /// <summary>The assembly came from a single-file bundle, so sidecar probing was intentionally skipped.</summary>
     BundleSidecarSkipped
 }

--- a/src/Dotsider.Core/Analysis/Models/RecoveredType.cs
+++ b/src/Dotsider.Core/Analysis/Models/RecoveredType.cs
@@ -6,5 +6,26 @@ namespace Dotsider.Core.Analysis.Models;
 /// binary's own types and methods, so a stripped binary can describe itself.
 /// </summary>
 /// <param name="FullName">The namespace-qualified type name (nested types use <c>+</c>).</param>
-/// <param name="MethodNames">The names of the type's methods.</param>
-public sealed record RecoveredType(string FullName, IReadOnlyList<string> MethodNames);
+/// <param name="MethodNames">The names of the type's methods, in metadata order.</param>
+/// <param name="AssemblyName">
+/// The simple name of the assembly scope that defined the type, or null when the metadata
+/// does not record one. Native symbol demangling joins mangled names against this scope.
+/// </param>
+public sealed record RecoveredType(
+    string FullName,
+    IReadOnlyList<string> MethodNames,
+    string? AssemblyName = null)
+{
+    /// <summary>
+    /// Deconstructs into the original two components, preserving call sites written before
+    /// <see cref="AssemblyName"/> existed — a record's generated Deconstruct grows with its
+    /// positional parameters, so the two-value form is kept explicitly.
+    /// </summary>
+    /// <param name="fullName">The namespace-qualified type name.</param>
+    /// <param name="methodNames">The names of the type's methods, in metadata order.</param>
+    public void Deconstruct(out string fullName, out IReadOnlyList<string> methodNames)
+    {
+        fullName = FullName;
+        methodNames = MethodNames;
+    }
+}

--- a/src/Dotsider.Core/Analysis/Models/SizeNodeKind.cs
+++ b/src/Dotsider.Core/Analysis/Models/SizeNodeKind.cs
@@ -2,7 +2,8 @@ namespace Dotsider.Core.Analysis.Models;
 
 /// <summary>
 /// The granularity level of a <see cref="SizeNode"/> in the size breakdown tree. The kinds
-/// beyond <see cref="Method"/> appear only in Native AOT trees built from an mstat report.
+/// beyond <see cref="Method"/> appear only in Native AOT trees, built from an mstat report or,
+/// when none sits beside the binary, from its merged native symbols.
 /// </summary>
 public enum SizeNodeKind
 {
@@ -34,5 +35,11 @@ public enum SizeNodeKind
     RvaField,
 
     /// <summary>A manifest resource embedded in a Native AOT binary.</summary>
-    Resource
+    Resource,
+
+    /// <summary>
+    /// A native function sized from the binary's symbols — unlike <see cref="Method"/>, there
+    /// is no IL body behind it to drill into.
+    /// </summary>
+    Function
 }

--- a/src/Dotsider.Core/Analysis/NativeMetadataReader.cs
+++ b/src/Dotsider.Core/Analysis/NativeMetadataReader.cs
@@ -7,9 +7,10 @@ namespace Dotsider.Core.Analysis;
 /// <summary>
 /// A clean-room reader for the <c>Internal.Metadata.NativeFormat</c> blob that ILC embeds
 /// in a Native AOT binary (ReadyToRun section 313, or the reduced stack-trace metadata in
-/// 326). It recovers namespace-qualified type names and method names — enough to describe a
-/// stripped binary that carries no ECMA-335 metadata. Only the name-bearing records are
-/// decoded; signatures, attributes, and generics are stepped over. Ported clean-room from
+/// 326). It recovers namespace-qualified type names, method names (in metadata order), and the
+/// defining assembly scope name — enough to describe a stripped binary that carries no
+/// ECMA-335 metadata, and enough to demangle native symbols back to it. Only the name-bearing
+/// records are decoded; signatures, attributes, and generics are stepped over. Ported clean-room from
 /// the MIT-licensed reader and writer in dotnet/runtime; the name records are stable across
 /// .NET 8 through 11. Malformed blobs yield the partial result gathered so far.
 /// </summary>
@@ -87,7 +88,7 @@ internal sealed class NativeMetadataReader
         var span = _blob.Span;
         var p = offset;
         DecodeUnsigned(span, ref p);          // Flags
-        DecodeUnsigned(span, ref p);          // Name
+        var nameOffset = (int)DecodeUnsigned(span, ref p);  // Name (the assembly simple name)
         DecodeUnsigned(span, ref p);          // HashAlgorithm
         DecodeUnsigned(span, ref p);          // MajorVersion
         DecodeUnsigned(span, ref p);          // MinorVersion
@@ -97,10 +98,11 @@ internal sealed class NativeMetadataReader
         DecodeUnsigned(span, ref p);          // Culture
         var rootNamespace = (int)DecodeUnsigned(span, ref p);
 
-        ReadNamespace(rootNamespace, parentNamespace: "", depth: 0);
+        var assemblyName = ReadString(nameOffset);
+        ReadNamespace(rootNamespace, parentNamespace: "", assemblyName, depth: 0);
     }
 
-    private void ReadNamespace(int offset, string parentNamespace, int depth)
+    private void ReadNamespace(int offset, string parentNamespace, string? assemblyName, int depth)
     {
         if (depth > MaxDepth || _recordBudget-- <= 0) return;
 
@@ -118,13 +120,13 @@ internal sealed class NativeMetadataReader
             : parentNamespace.Length == 0 ? name : $"{parentNamespace}.{name}";
 
         foreach (var typeOffset in typeDefs)
-            ReadType(typeOffset, fullNamespace, enclosingName: null, depth + 1);
+            ReadType(typeOffset, fullNamespace, enclosingName: null, assemblyName, depth + 1);
 
         foreach (var childOffset in childNamespaces)
-            ReadNamespace(childOffset, fullNamespace, depth + 1);
+            ReadNamespace(childOffset, fullNamespace, assemblyName, depth + 1);
     }
 
-    private void ReadType(int offset, string namespaceName, string? enclosingName, int depth)
+    private void ReadType(int offset, string namespaceName, string? enclosingName, string? assemblyName, int depth)
     {
         if (depth > MaxDepth || _recordBudget-- <= 0) return;
 
@@ -152,10 +154,10 @@ internal sealed class NativeMetadataReader
             if (methodName.Length > 0) methodNames.Add(methodName);
         }
 
-        _types.Add(new RecoveredType(fullName, methodNames));
+        _types.Add(new RecoveredType(fullName, methodNames, assemblyName));
 
         foreach (var nestedOffset in nestedTypes)
-            ReadType(nestedOffset, namespaceName, fullName, depth + 1);
+            ReadType(nestedOffset, namespaceName, fullName, assemblyName, depth + 1);
     }
 
     private string ReadMethodName(int offset)

--- a/src/Dotsider.Core/Analysis/NativePdb/CodeViewSymbolReader.cs
+++ b/src/Dotsider.Core/Analysis/NativePdb/CodeViewSymbolReader.cs
@@ -1,0 +1,181 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Dotsider.Core.Analysis.NativePdb;
+
+/// <summary>
+/// Walks a PDB module's symbol stream for function records (<c>S_GPROC32</c>/<c>S_LPROC32</c>)
+/// and data records (<c>S_GDATA32</c>/<c>S_LDATA32</c>), and joins the C13 line subsections that
+/// follow the symbols to attribute each function to a source file and line. The module stream is
+/// laid out as <c>[u32 CodeView signature][symbol records][C11 lines][C13 lines]</c>; symbol
+/// records span <c>[4, SymByteSize)</c> and the C13 block begins at <c>SymByteSize + C11ByteSize</c>.
+/// </summary>
+internal static class CodeViewSymbolReader
+{
+    private const ushort SLProc32 = 0x110F;
+    private const ushort SGProc32 = 0x1110;
+    private const ushort SLData32 = 0x110C;
+    private const ushort SGData32 = 0x110D;
+    private const uint DebugSLines = 0xF2;
+    private const uint DebugSFileChecksums = 0xF4;
+    private const uint NamesSignature = 0xEFFE_EFFE;
+
+    /// <summary>A function or data symbol recovered from a module, before RVA resolution.</summary>
+    /// <param name="Name">The raw symbol name.</param>
+    /// <param name="Segment">The one-based section index.</param>
+    /// <param name="Offset">The offset within the section.</param>
+    /// <param name="Size">The code/data size, or 0 for data records that carry none.</param>
+    /// <param name="IsData">Whether this is a data record rather than a procedure.</param>
+    /// <param name="SourceFile">The declaring source file, when C13 line data resolved it.</param>
+    /// <param name="Line">The first source line, when C13 line data resolved it.</param>
+    internal readonly record struct ModuleSymbol(
+        string Name, int Segment, uint Offset, uint Size, bool IsData, string? SourceFile, int? Line);
+
+    /// <summary>
+    /// Reads the function and data symbols of one module, attributing source file and line from
+    /// the module's C13 line subsections.
+    /// </summary>
+    /// <param name="moduleStream">The module's full symbol stream.</param>
+    /// <param name="module">The module descriptor giving the symbol and line block sizes.</param>
+    /// <param name="names">The <c>/names</c> string table stream, for resolving file names.</param>
+    public static List<ModuleSymbol> ReadModule(
+        byte[] moduleStream, DbiStream.Module module, byte[] names)
+    {
+        var result = new List<ModuleSymbol>();
+        var span = moduleStream.AsSpan();
+        if (module.SymbolStream < 0 || module.SymByteSize <= 4 || module.SymByteSize > span.Length)
+            return result;
+
+        // Line lookup keyed by (segment, offset): each function has its own DEBUG_S_LINES block.
+        var lines = ParseLineTable(moduleStream, module, names);
+
+        var p = 4; // past the CodeView signature
+        var end = module.SymByteSize;
+        while (p + 4 <= end)
+        {
+            var length = BinaryPrimitives.ReadUInt16LittleEndian(span[p..]);
+            if (length < 2) break;
+            var recordEnd = p + 2 + length;
+            if (recordEnd > end) break;
+
+            var kind = BinaryPrimitives.ReadUInt16LittleEndian(span[(p + 2)..]);
+            var body = span[(p + 4)..recordEnd];
+
+            if (kind is SGProc32 or SLProc32 && body.Length >= 35)
+            {
+                // parent,end,next,codeSize,dbgStart,dbgEnd,typeIndex,offset (8×4), segment(2), flags(1), name
+                var codeSize = BinaryPrimitives.ReadUInt32LittleEndian(body[12..]);
+                var offset = BinaryPrimitives.ReadUInt32LittleEndian(body[28..]);
+                var segment = BinaryPrimitives.ReadUInt16LittleEndian(body[32..]);
+                var name = ReadCString(body[35..]);
+                if (name.Length > 0)
+                {
+                    var (file, line) = lines.GetValueOrDefault((segment, offset));
+                    result.Add(new ModuleSymbol(name, segment, offset, codeSize, false, file, line));
+                }
+            }
+            else if (kind is SGData32 or SLData32 && body.Length >= 10)
+            {
+                // typeIndex(4), offset(4), segment(2), name
+                var offset = BinaryPrimitives.ReadUInt32LittleEndian(body[4..]);
+                var segment = BinaryPrimitives.ReadUInt16LittleEndian(body[8..]);
+                var name = ReadCString(body[10..]);
+                if (name.Length > 0)
+                    result.Add(new ModuleSymbol(name, segment, offset, 0, true, null, null));
+            }
+
+            p = recordEnd;
+        }
+
+        return result;
+    }
+
+    private static Dictionary<(int Segment, uint Offset), (string? File, int? Line)> ParseLineTable(
+        byte[] moduleStream, DbiStream.Module module, byte[] names)
+    {
+        var table = new Dictionary<(int, uint), (string?, int?)>();
+        var c13Start = module.SymByteSize + module.C11ByteSize;
+        if (module.C13ByteSize <= 0 || c13Start + module.C13ByteSize > moduleStream.Length) return table;
+
+        var c13 = moduleStream.AsSpan(c13Start, module.C13ByteSize);
+
+        // First pass: collect the file-checksums subsection (offset-within-it → /names offset).
+        ReadOnlySpan<byte> checksums = default;
+        var p = 0;
+        while (p + 8 <= c13.Length)
+        {
+            var kind = BinaryPrimitives.ReadUInt32LittleEndian(c13[p..]);
+            var length = (int)BinaryPrimitives.ReadUInt32LittleEndian(c13[(p + 4)..]);
+            var contentStart = p + 8;
+            if (length < 0 || contentStart + length > c13.Length) break;
+            if (kind == DebugSFileChecksums) checksums = c13.Slice(contentStart, length);
+            p = contentStart + ((length + 3) & ~3);
+        }
+
+        // Second pass: DEBUG_S_LINES blocks → first line per (segment, offset).
+        p = 0;
+        while (p + 8 <= c13.Length)
+        {
+            var kind = BinaryPrimitives.ReadUInt32LittleEndian(c13[p..]);
+            var length = (int)BinaryPrimitives.ReadUInt32LittleEndian(c13[(p + 4)..]);
+            var contentStart = p + 8;
+            if (length < 0 || contentStart + length > c13.Length) break;
+
+            if (kind == DebugSLines && length >= 12)
+            {
+                var content = c13.Slice(contentStart, length);
+                var contribOffset = BinaryPrimitives.ReadUInt32LittleEndian(content);
+                var contribSegment = BinaryPrimitives.ReadUInt16LittleEndian(content[4..]);
+                var flags = BinaryPrimitives.ReadUInt16LittleEndian(content[6..]);
+                var hasColumns = (flags & 1) != 0;
+
+                var bp = 12;
+                while (bp + 12 <= content.Length)
+                {
+                    var fileChecksumOffset = BinaryPrimitives.ReadUInt32LittleEndian(content[bp..]);
+                    var numLines = BinaryPrimitives.ReadUInt32LittleEndian(content[(bp + 4)..]);
+                    bp += 12; // fileId, numLines, blockSize
+                    if (numLines == 0 || bp + 8 > content.Length) break;
+
+                    var firstLineData = BinaryPrimitives.ReadUInt32LittleEndian(content[(bp + 4)..]);
+                    var line = (int)(firstLineData & 0xFFFFFF);
+                    var file = ResolveFile(checksums, fileChecksumOffset, names);
+                    table.TryAdd((contribSegment, contribOffset), (file, line));
+
+                    // Advance past this block's line (and optional column) entries.
+                    bp += (int)numLines * 8;
+                    if (hasColumns) bp += (int)numLines * 4;
+                }
+            }
+
+            p = contentStart + ((length + 3) & ~3);
+        }
+
+        return table;
+    }
+
+    private static string? ResolveFile(ReadOnlySpan<byte> checksums, uint checksumOffset, byte[] names)
+    {
+        if (checksums.IsEmpty || checksumOffset + 4 > (uint)checksums.Length) return null;
+        var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(checksums[(int)checksumOffset..]);
+        return ResolveName(names, nameOffset);
+    }
+
+    private static string? ResolveName(byte[] names, uint nameOffset)
+    {
+        // /names layout: u32 signature, u32 hashVersion, u32 byteSize, then the string data.
+        var span = names.AsSpan();
+        if (span.Length < 12 || BinaryPrimitives.ReadUInt32LittleEndian(span) != NamesSignature) return null;
+        var byteSize = BinaryPrimitives.ReadUInt32LittleEndian(span[8..]);
+        var dataStart = 12;
+        if (dataStart + byteSize > span.Length || nameOffset >= byteSize) return null;
+        return ReadCString(span.Slice(dataStart + (int)nameOffset));
+    }
+
+    private static string ReadCString(ReadOnlySpan<byte> span)
+    {
+        var end = span.IndexOf((byte)0);
+        if (end < 0) end = span.Length;
+        return Encoding.UTF8.GetString(span[..end]);
+    }
+}

--- a/src/Dotsider.Core/Analysis/NativePdb/DbiStream.cs
+++ b/src/Dotsider.Core/Analysis/NativePdb/DbiStream.cs
@@ -1,0 +1,114 @@
+using System.Buffers.Binary;
+
+namespace Dotsider.Core.Analysis.NativePdb;
+
+/// <summary>
+/// Parses the DBI stream (stream 3) of a PDB: its header, the per-module descriptors that name
+/// each module's symbol stream and byte sizes, and the optional debug header at the tail whose
+/// slots include the section-header dump. The substreams that precede the optional debug header
+/// are skipped by their declared sizes, in order, so the tail is located correctly.
+/// </summary>
+internal sealed class DbiStream
+{
+    /// <summary>One module's symbol-stream location and substream sizes.</summary>
+    /// <param name="SymbolStream">The module's symbol stream index, or -1 when it has none.</param>
+    /// <param name="SymByteSize">The byte length of the CodeView symbol records (including the leading signature).</param>
+    /// <param name="C11ByteSize">The byte length of the C11 line block that follows the symbols.</param>
+    /// <param name="C13ByteSize">The byte length of the C13 line block that follows C11.</param>
+    internal readonly record struct Module(int SymbolStream, int SymByteSize, int C11ByteSize, int C13ByteSize);
+
+    /// <summary>The parsed module descriptors.</summary>
+    public IReadOnlyList<Module> Modules { get; private init; } = [];
+
+    /// <summary>The section-header dump stream index (optional debug header slot 5), or -1 when absent.</summary>
+    public int SectionHeaderStream { get; private init; } = -1;
+
+    /// <summary>The global symbol record stream index.</summary>
+    public int SymbolRecordStream { get; private init; } = -1;
+
+    /// <summary>The publics hash stream index.</summary>
+    public int PublicStream { get; private init; } = -1;
+
+    /// <summary>
+    /// Parses a DBI stream, or returns null when the header is malformed.
+    /// </summary>
+    /// <param name="stream">The raw DBI stream bytes.</param>
+    public static DbiStream? Parse(byte[] stream)
+    {
+        try
+        {
+            var span = stream.AsSpan();
+            if (span.Length < 64) return null;
+            if (BinaryPrimitives.ReadInt32LittleEndian(span) != -1) return null; // VersionSignature
+
+            var publicStream = BinaryPrimitives.ReadUInt16LittleEndian(span[16..]);
+            var symRecordStream = BinaryPrimitives.ReadUInt16LittleEndian(span[20..]);
+            var modInfoSize = BinaryPrimitives.ReadInt32LittleEndian(span[24..]);
+            var sectionContributionSize = BinaryPrimitives.ReadInt32LittleEndian(span[28..]);
+            var sectionMapSize = BinaryPrimitives.ReadInt32LittleEndian(span[32..]);
+            var sourceInfoSize = BinaryPrimitives.ReadInt32LittleEndian(span[36..]);
+            var typeServerMapSize = BinaryPrimitives.ReadInt32LittleEndian(span[40..]);
+            var optionalDbgHeaderSize = BinaryPrimitives.ReadInt32LittleEndian(span[48..]);
+            var ecSubstreamSize = BinaryPrimitives.ReadInt32LittleEndian(span[52..]);
+
+            if (modInfoSize < 0 || (long)64 + modInfoSize > span.Length) return null;
+
+            var modules = ParseModules(span.Slice(64, modInfoSize));
+
+            var sectionHeaderStream = -1;
+            var optionalOffset = 64L + modInfoSize + sectionContributionSize + sectionMapSize
+                + sourceInfoSize + typeServerMapSize + ecSubstreamSize;
+            // Slot 5 of the optional debug header is the section-header dump.
+            if (optionalOffset >= 0 && optionalOffset + 12 <= span.Length && optionalDbgHeaderSize >= 12)
+            {
+                var slot = BinaryPrimitives.ReadUInt16LittleEndian(span[(int)(optionalOffset + 5 * 2)..]);
+                if (slot != 0xFFFF) sectionHeaderStream = slot;
+            }
+
+            return new DbiStream
+            {
+                Modules = modules,
+                SectionHeaderStream = sectionHeaderStream,
+                SymbolRecordStream = symRecordStream == 0xFFFF ? -1 : symRecordStream,
+                PublicStream = publicStream == 0xFFFF ? -1 : publicStream,
+            };
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            return null;
+        }
+    }
+
+    private static List<Module> ParseModules(ReadOnlySpan<byte> modInfo)
+    {
+        var modules = new List<Module>();
+        var p = 0;
+        // Fixed part per record: Unused(4) + SectionContrib(28) + Flags(2) + SymStream(2) +
+        // SymByteSize(4) + C11(4) + C13(4) + SourceFileCount(2) + Pad(2) + Unused2(4) +
+        // SourceFileNameIndex(4) + PdbFilePathNameIndex(4) = 64, then two NUL strings, align 4.
+        while (p + 64 <= modInfo.Length)
+        {
+            var symStream = (short)BinaryPrimitives.ReadUInt16LittleEndian(modInfo[(p + 34)..]);
+            var symByteSize = BinaryPrimitives.ReadInt32LittleEndian(modInfo[(p + 36)..]);
+            var c11 = BinaryPrimitives.ReadInt32LittleEndian(modInfo[(p + 40)..]);
+            var c13 = BinaryPrimitives.ReadInt32LittleEndian(modInfo[(p + 44)..]);
+            modules.Add(new Module(symStream, Math.Max(0, symByteSize), Math.Max(0, c11), Math.Max(0, c13)));
+
+            // Skip the two NUL-terminated names, then 4-byte align.
+            var q = p + 64;
+            q = SkipCString(modInfo, q);
+            q = SkipCString(modInfo, q);
+            q = (q + 3) & ~3;
+            if (q <= p) break; // no progress → malformed
+            p = q;
+        }
+
+        return modules;
+    }
+
+    private static int SkipCString(ReadOnlySpan<byte> span, int p)
+    {
+        while (p < span.Length && span[p] != 0) p++;
+        return p + 1;
+    }
+}

--- a/src/Dotsider.Core/Analysis/NativePdb/MsfFile.cs
+++ b/src/Dotsider.Core/Analysis/NativePdb/MsfFile.cs
@@ -1,0 +1,146 @@
+using System.Buffers.Binary;
+
+namespace Dotsider.Core.Analysis.NativePdb;
+
+/// <summary>
+/// Reads the Multi-Stream Format (MSF 7.0) container that a Windows PDB is stored in. An MSF
+/// file is a block-addressed collection of streams: a superblock points at a block map, the
+/// block map lists the blocks of the stream directory, and the directory lists the size and
+/// blocks of every stream. This class resolves that indirection so callers can pull a stream's
+/// bytes by index. Malformed containers surface as null from <see cref="TryOpen"/> rather than
+/// throwing.
+/// </summary>
+internal sealed class MsfFile
+{
+    // "Microsoft C/C++ MSF 7.00\r\n" + 0x1A + "DS" + three NULs. Built from explicit bytes so
+    // the 0x1A control byte cannot be misread as part of a variable-length \x escape.
+    private static readonly byte[] Magic =
+        [.. "Microsoft C/C++ MSF 7.00\r\n"u8, 0x1A, .. "DS"u8, 0, 0, 0];
+
+    private readonly byte[] _bytes;
+    private readonly int _blockSize;
+    private readonly int[][] _streamBlocks;
+    private readonly int[] _streamSizes;
+
+    private MsfFile(byte[] bytes, int blockSize, int[] streamSizes, int[][] streamBlocks)
+    {
+        _bytes = bytes;
+        _blockSize = blockSize;
+        _streamSizes = streamSizes;
+        _streamBlocks = streamBlocks;
+    }
+
+    /// <summary>The number of streams in the container.</summary>
+    public int StreamCount => _streamSizes.Length;
+
+
+    /// <summary>
+    /// Opens an MSF container from its raw bytes, or returns null when the bytes are not a
+    /// valid MSF 7.0 file or the directory cannot be resolved.
+    /// </summary>
+    /// <param name="bytes">The complete file content.</param>
+    public static MsfFile? TryOpen(byte[] bytes)
+    {
+        try
+        {
+            var span = bytes.AsSpan();
+            if (span.Length < 56 || !span[..Magic.Length].SequenceEqual(Magic)) return null;
+
+            var blockSize = BinaryPrimitives.ReadInt32LittleEndian(span[32..]);
+            if (blockSize is not (512 or 1024 or 2048 or 4096 or 8192)) return null;
+
+            var numBlocks = BinaryPrimitives.ReadInt32LittleEndian(span[40..]);
+            var numDirectoryBytes = BinaryPrimitives.ReadInt32LittleEndian(span[44..]);
+            var blockMapAddr = BinaryPrimitives.ReadInt32LittleEndian(span[52..]);
+            if (numBlocks <= 0 || (long)numBlocks * blockSize > bytes.Length) return null;
+            if (numDirectoryBytes <= 0 || blockMapAddr <= 0 || blockMapAddr >= numBlocks) return null;
+
+            bool InBounds(int block) => block >= 0 && block < numBlocks;
+            Span<byte> Block(int i) => bytes.AsSpan(i * blockSize, blockSize);
+            int BlockCount(int size) => (size + blockSize - 1) / blockSize;
+
+            // The block map lists the directory's own blocks; concatenate them into the directory.
+            var directoryBlockCount = BlockCount(numDirectoryBytes);
+            var mapBlock = Block(blockMapAddr);
+            if (directoryBlockCount * 4 > blockSize) return null; // map must fit one block
+            var directory = new byte[directoryBlockCount * blockSize];
+            for (var i = 0; i < directoryBlockCount; i++)
+            {
+                var block = BinaryPrimitives.ReadInt32LittleEndian(mapBlock[(i * 4)..]);
+                if (!InBounds(block)) return null;
+                Block(block).CopyTo(directory.AsSpan(i * blockSize));
+            }
+
+            // Directory: numStreams, each stream's size, then each stream's block list. Read from
+            // the full block-padded buffer so a final entry landing on the numDirectoryBytes
+            // boundary has slack; the entry counts bound the loops within the real content.
+            var dir = directory.AsSpan();
+            var p = 0;
+            var numStreams = ReadI32(dir, ref p);
+            if (numStreams is < 0 or > 1_000_000) return null;
+
+            var sizes = new int[numStreams];
+            for (var i = 0; i < numStreams; i++)
+            {
+                var size = ReadI32(dir, ref p);
+                sizes[i] = size == unchecked((int)0xFFFFFFFF) ? 0 : size; // 0xFFFFFFFF = nil stream
+                if (sizes[i] < 0) return null;
+            }
+
+            var streamBlocks = new int[numStreams][];
+            for (var i = 0; i < numStreams; i++)
+            {
+                var count = BlockCount(sizes[i]);
+                var blocks = new int[count];
+                for (var j = 0; j < count; j++)
+                {
+                    var block = ReadI32(dir, ref p);
+                    if (!InBounds(block)) return null;
+                    blocks[j] = block;
+                }
+
+                streamBlocks[i] = blocks;
+            }
+
+            return new MsfFile(bytes, blockSize, sizes, streamBlocks);
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>The byte size of the stream at <paramref name="index"/>, or 0 when out of range.</summary>
+    public int StreamSize(int index) =>
+        index >= 0 && index < _streamSizes.Length ? _streamSizes[index] : 0;
+
+    /// <summary>
+    /// Materializes the bytes of the stream at <paramref name="index"/> by concatenating its
+    /// blocks, or an empty array when the index is out of range or nil.
+    /// </summary>
+    /// <param name="index">The stream index.</param>
+    public byte[] GetStream(int index)
+    {
+        if (index < 0 || index >= _streamSizes.Length) return [];
+        var size = _streamSizes[index];
+        if (size == 0) return [];
+
+        var buffer = new byte[size];
+        var offset = 0;
+        foreach (var block in _streamBlocks[index])
+        {
+            var count = Math.Min(_blockSize, size - offset);
+            _bytes.AsSpan(block * _blockSize, count).CopyTo(buffer.AsSpan(offset));
+            offset += count;
+        }
+
+        return buffer;
+    }
+
+    private static int ReadI32(ReadOnlySpan<byte> span, ref int p)
+    {
+        var value = BinaryPrimitives.ReadInt32LittleEndian(span[p..]);
+        p += 4;
+        return value;
+    }
+}

--- a/src/Dotsider.Core/Analysis/NativePdb/NativePdbReader.cs
+++ b/src/Dotsider.Core/Analysis/NativePdb/NativePdbReader.cs
@@ -111,28 +111,46 @@ internal static class NativePdbReader
         var addressSpace = NativeAddressSpace.Create(peImageBytes.Span);
 
         var result = new List<RawNativeSymbol>();
+
+        RawNativeSymbol? Resolve(string name, int segment, uint offset, uint size, bool isData, string? file, int? line)
+        {
+            if (sectionMap.ToRva(segment, offset) is not { } rva) return null;
+            var va = imageBase + rva;
+            long? fileOffset = addressSpace is not null
+                && addressSpace.TryGetFileOffset(va, out var fo, out _) ? fo : null;
+            return new RawNativeSymbol(
+                Name: name, VirtualAddress: va, Rva: rva, FileOffset: fileOffset,
+                Section: sectionMap.SectionName(segment), Size: size,
+                IsData: isData || !sectionMap.IsExecutable(segment), IsBoundary: false,
+                SourceFile: file, Line: line);
+        }
+
+        // Module procedures and data records — the rich source with sizes and line info.
         foreach (var module in dbi.Modules)
         {
             if (module.SymbolStream < 0 || module.SymbolStream >= msf.StreamCount) continue;
             var moduleStream = msf.GetStream(module.SymbolStream);
             foreach (var symbol in CodeViewSymbolReader.ReadModule(moduleStream, module, names))
             {
-                if (sectionMap.ToRva(symbol.Segment, symbol.Offset) is not { } rva) continue;
-                var va = imageBase + rva;
-                long? fileOffset = addressSpace is not null
-                    && addressSpace.TryGetFileOffset(va, out var fo, out _) ? fo : null;
+                if (Resolve(symbol.Name, symbol.Segment, symbol.Offset, symbol.Size, symbol.IsData,
+                    symbol.SourceFile, symbol.Line) is { } raw)
+                {
+                    result.Add(raw);
+                }
+            }
+        }
 
-                result.Add(new RawNativeSymbol(
-                    Name: symbol.Name,
-                    VirtualAddress: va,
-                    Rva: rva,
-                    FileOffset: fileOffset,
-                    Section: sectionMap.SectionName(symbol.Segment),
-                    Size: symbol.Size,
-                    IsData: symbol.IsData || !sectionMap.IsExecutable(symbol.Segment),
-                    IsBoundary: false,
-                    SourceFile: symbol.SourceFile,
-                    Line: symbol.Line));
+        // Publics — named symbols without sizes; the merge pass sizes and dedups them against the
+        // richer module records above.
+        if (dbi.PublicStream >= 0 && dbi.PublicStream < msf.StreamCount
+            && dbi.SymbolRecordStream >= 0 && dbi.SymbolRecordStream < msf.StreamCount)
+        {
+            var publics = PublicsReader.Read(msf.GetStream(dbi.PublicStream), msf.GetStream(dbi.SymbolRecordStream));
+            foreach (var pub in publics)
+            {
+                var isData = !pub.IsFunction && !sectionMap.IsExecutable(pub.Segment);
+                if (Resolve(pub.Name, pub.Segment, pub.Offset, 0, isData, null, null) is { } raw)
+                    result.Add(raw);
             }
         }
 

--- a/src/Dotsider.Core/Analysis/NativePdb/NativePdbReader.cs
+++ b/src/Dotsider.Core/Analysis/NativePdb/NativePdbReader.cs
@@ -1,0 +1,247 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Dotsider.Core.Analysis.NativePdb;
+
+/// <summary>
+/// Reads function and data symbols from a Windows native PDB and joins them to the PE image they
+/// describe. Orchestrates the MSF container, the DBI stream, the per-module CodeView records, and
+/// the section map — resolving each symbol's CodeView <c>(segment, offset)</c> to an RVA, virtual
+/// address, and file offset. Also exposes a cheap identity probe that reads only the blocks needed
+/// to compare a PDB's GUID and age against the image's debug directory.
+/// </summary>
+internal static class NativePdbReader
+{
+    /// <summary>
+    /// Reads a PDB's GUID and age with a handful of targeted block reads, without materializing
+    /// the whole file. Used to confirm a sidecar matches the image before committing to a full
+    /// parse.
+    /// </summary>
+    /// <param name="path">The PDB file path.</param>
+    /// <param name="guid">The PDB info-stream GUID when the read succeeds.</param>
+    /// <param name="age">The PDB info-stream age when the read succeeds.</param>
+    /// <returns>True when the GUID and age were read.</returns>
+    public static bool TryReadPdbId(string path, out Guid guid, out int age)
+    {
+        guid = default;
+        age = 0;
+        try
+        {
+            using var fs = File.OpenRead(path);
+            Span<byte> header = stackalloc byte[56];
+            if (fs.Read(header) != header.Length) return false;
+
+            var magic = Encoding.ASCII.GetString(header[..24]);
+            if (!magic.StartsWith("Microsoft C/C++ MSF 7.00", StringComparison.Ordinal)) return false;
+
+            var blockSize = BinaryPrimitives.ReadInt32LittleEndian(header[32..]);
+            if (blockSize is not (512 or 1024 or 2048 or 4096 or 8192)) return false;
+            var numDirectoryBytes = BinaryPrimitives.ReadInt32LittleEndian(header[44..]);
+            var blockMapAddr = BinaryPrimitives.ReadInt32LittleEndian(header[52..]);
+            if (numDirectoryBytes <= 0 || blockMapAddr <= 0) return false;
+
+            var directoryBlockCount = (numDirectoryBytes + blockSize - 1) / blockSize;
+            var block = new byte[blockSize];
+
+            // Read the block map, then the directory blocks it points at.
+            fs.Position = (long)blockMapAddr * blockSize;
+            if (fs.Read(block, 0, blockSize) != blockSize) return false;
+            var directory = new byte[directoryBlockCount * blockSize];
+            for (var i = 0; i < directoryBlockCount; i++)
+            {
+                var dirBlock = BinaryPrimitives.ReadInt32LittleEndian(block.AsSpan(i * 4));
+                fs.Position = (long)dirBlock * blockSize;
+                if (fs.Read(directory, i * blockSize, blockSize) != blockSize) return false;
+            }
+
+            // Directory: numStreams, sizes[], then block lists. Stream 1's first block holds the
+            // version/signature/age/GUID.
+            var dir = directory.AsSpan(0, numDirectoryBytes);
+            var p = 0;
+            var numStreams = BinaryPrimitives.ReadInt32LittleEndian(dir[p..]);
+            p += 4;
+            if (numStreams < 2) return false;
+            var sizes = new int[numStreams];
+            for (var i = 0; i < numStreams; i++)
+            {
+                var s = BinaryPrimitives.ReadInt32LittleEndian(dir[p..]);
+                p += 4;
+                sizes[i] = s == unchecked((int)0xFFFFFFFF) ? 0 : s;
+            }
+
+            // Skip stream 0's block list to reach stream 1's first block index.
+            var stream0Blocks = (sizes[0] + blockSize - 1) / blockSize;
+            p += stream0Blocks * 4;
+            if (sizes[1] < 28) return false;
+            var stream1FirstBlock = BinaryPrimitives.ReadInt32LittleEndian(dir[p..]);
+
+            fs.Position = (long)stream1FirstBlock * blockSize;
+            if (fs.Read(block, 0, blockSize) != blockSize) return false;
+            age = BinaryPrimitives.ReadInt32LittleEndian(block.AsSpan(8));
+            guid = new Guid(block.AsSpan(12, 16));
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException
+            or IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Reads the module function and data symbols from a PDB, resolved against the PE image.
+    /// Returns an empty list when the container or DBI stream cannot be parsed. Publics from the
+    /// global hash stream are read separately.
+    /// </summary>
+    /// <param name="pdbBytes">The complete PDB file bytes.</param>
+    /// <param name="peImageBytes">The PE image the PDB describes, for RVA→file mapping and section fallback.</param>
+    public static IReadOnlyList<RawNativeSymbol> Read(byte[] pdbBytes, ReadOnlyMemory<byte> peImageBytes)
+    {
+        var msf = MsfFile.TryOpen(pdbBytes);
+        if (msf is null || msf.StreamCount < 4) return [];
+
+        var dbi = DbiStream.Parse(msf.GetStream(3));
+        if (dbi is null) return [];
+
+        var sectionMap = BuildSectionMap(msf, dbi, peImageBytes.Span);
+        if (sectionMap is null) return [];
+
+        var names = ResolveNamesStream(msf);
+        var imageBase = ReadImageBase(peImageBytes.Span);
+        var addressSpace = NativeAddressSpace.Create(peImageBytes.Span);
+
+        var result = new List<RawNativeSymbol>();
+        foreach (var module in dbi.Modules)
+        {
+            if (module.SymbolStream < 0 || module.SymbolStream >= msf.StreamCount) continue;
+            var moduleStream = msf.GetStream(module.SymbolStream);
+            foreach (var symbol in CodeViewSymbolReader.ReadModule(moduleStream, module, names))
+            {
+                if (sectionMap.ToRva(symbol.Segment, symbol.Offset) is not { } rva) continue;
+                var va = imageBase + rva;
+                long? fileOffset = addressSpace is not null
+                    && addressSpace.TryGetFileOffset(va, out var fo, out _) ? fo : null;
+
+                result.Add(new RawNativeSymbol(
+                    Name: symbol.Name,
+                    VirtualAddress: va,
+                    Rva: rva,
+                    FileOffset: fileOffset,
+                    Section: sectionMap.SectionName(symbol.Segment),
+                    Size: symbol.Size,
+                    IsData: symbol.IsData || !sectionMap.IsExecutable(symbol.Segment),
+                    IsBoundary: false,
+                    SourceFile: symbol.SourceFile,
+                    Line: symbol.Line));
+            }
+        }
+
+        return result;
+    }
+
+    private static PdbSectionMap? BuildSectionMap(MsfFile msf, DbiStream dbi, ReadOnlySpan<byte> peImage)
+    {
+        if (dbi.SectionHeaderStream >= 0 && dbi.SectionHeaderStream < msf.StreamCount)
+        {
+            var headers = msf.GetStream(dbi.SectionHeaderStream);
+            if (headers.Length >= 40) return PdbSectionMap.FromSectionHeaders(headers);
+        }
+
+        // Fall back to the PE image's own section headers.
+        var peHeaders = ReadPeSectionHeaders(peImage);
+        return peHeaders.Length >= 40 ? PdbSectionMap.FromSectionHeaders(peHeaders) : null;
+    }
+
+    private static byte[] ResolveNamesStream(MsfFile msf)
+    {
+        // Stream 1's named-stream map: u32 stringBytes, the string blob, then a hash table of
+        // (nameOffset, streamIndex). Find "/names" and return that stream.
+        var info = msf.GetStream(1).AsSpan();
+        if (info.Length < 32) return [];
+
+        var stringBytes = BinaryPrimitives.ReadInt32LittleEndian(info[28..]);
+        var blobStart = 32;
+        if (stringBytes < 0 || blobStart + stringBytes > info.Length) return [];
+        var blob = info.Slice(blobStart, stringBytes);
+
+        var p = blobStart + stringBytes;
+        if (p + 8 > info.Length) return [];
+        var size = BinaryPrimitives.ReadInt32LittleEndian(info[p..]);
+        var capacity = BinaryPrimitives.ReadInt32LittleEndian(info[(p + 4)..]);
+        p += 8;
+        // Present bit vector, then deleted bit vector, then the entries.
+        p = SkipBitVector(info, ref p);
+        p = SkipBitVector(info, ref p);
+        for (var i = 0; i < size && p + 8 <= info.Length; i++)
+        {
+            var nameOffset = BinaryPrimitives.ReadInt32LittleEndian(info[p..]);
+            var streamIndex = BinaryPrimitives.ReadInt32LittleEndian(info[(p + 4)..]);
+            p += 8;
+            if (nameOffset >= 0 && nameOffset < blob.Length)
+            {
+                var name = ReadCString(blob[nameOffset..]);
+                if (name == "/names" && streamIndex >= 0 && streamIndex < msf.StreamCount)
+                    return msf.GetStream(streamIndex);
+            }
+        }
+
+        _ = capacity;
+        return [];
+    }
+
+    private static int SkipBitVector(ReadOnlySpan<byte> span, ref int p)
+    {
+        if (p + 4 > span.Length) return p;
+        var words = BinaryPrimitives.ReadInt32LittleEndian(span[p..]);
+        p += 4 + Math.Max(0, words) * 4;
+        return p;
+    }
+
+    private static ulong ReadImageBase(ReadOnlySpan<byte> pe)
+    {
+        try
+        {
+            if (pe.Length < 0x40 || pe[0] != (byte)'M' || pe[1] != (byte)'Z') return 0;
+            var peHeader = BinaryPrimitives.ReadInt32LittleEndian(pe[0x3C..]);
+            if (peHeader <= 0 || peHeader + 24 > pe.Length) return 0;
+            if (BinaryPrimitives.ReadUInt32LittleEndian(pe[peHeader..]) != 0x0000_4550) return 0;
+            var optional = peHeader + 24;
+            var magic = BinaryPrimitives.ReadUInt16LittleEndian(pe[optional..]);
+            return magic == 0x20B
+                ? BinaryPrimitives.ReadUInt64LittleEndian(pe[(optional + 24)..])
+                : BinaryPrimitives.ReadUInt32LittleEndian(pe[(optional + 28)..]);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return 0;
+        }
+    }
+
+    private static byte[] ReadPeSectionHeaders(ReadOnlySpan<byte> pe)
+    {
+        try
+        {
+            if (pe.Length < 0x40 || pe[0] != (byte)'M' || pe[1] != (byte)'Z') return [];
+            var peHeader = BinaryPrimitives.ReadInt32LittleEndian(pe[0x3C..]);
+            if (peHeader <= 0 || peHeader + 24 > pe.Length) return [];
+            if (BinaryPrimitives.ReadUInt32LittleEndian(pe[peHeader..]) != 0x0000_4550) return [];
+            var sectionCount = BinaryPrimitives.ReadUInt16LittleEndian(pe[(peHeader + 6)..]);
+            var optionalSize = BinaryPrimitives.ReadUInt16LittleEndian(pe[(peHeader + 20)..]);
+            var sectionTable = peHeader + 24 + optionalSize;
+            var byteCount = sectionCount * 40;
+            if (sectionTable < 0 || sectionTable + byteCount > pe.Length) return [];
+            return pe.Slice(sectionTable, byteCount).ToArray();
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return [];
+        }
+    }
+
+    private static string ReadCString(ReadOnlySpan<byte> span)
+    {
+        var end = span.IndexOf((byte)0);
+        if (end < 0) end = span.Length;
+        return Encoding.UTF8.GetString(span[..end]);
+    }
+}

--- a/src/Dotsider.Core/Analysis/NativePdb/PdbSectionMap.cs
+++ b/src/Dotsider.Core/Analysis/NativePdb/PdbSectionMap.cs
@@ -1,0 +1,75 @@
+using System.Buffers.Binary;
+
+namespace Dotsider.Core.Analysis.NativePdb;
+
+/// <summary>
+/// Maps a CodeView <c>(segment, offset)</c> address to a PE relative virtual address and the
+/// containing section's name. The mapping comes from the section-header dump stream the DBI's
+/// optional debug header points at; when that stream is absent it is rebuilt from the PE image's
+/// own section headers, which carry the same virtual addresses.
+/// </summary>
+internal sealed class PdbSectionMap
+{
+    private readonly (uint VirtualAddress, uint VirtualSize, uint Characteristics, string Name)[] _sections;
+
+    private PdbSectionMap((uint, uint, uint, string)[] sections) => _sections = sections;
+
+    /// <summary>
+    /// Builds a section map from a 40-byte-per-entry <c>IMAGE_SECTION_HEADER</c> block — the
+    /// layout of both the PDB section-header dump and the PE section table.
+    /// </summary>
+    /// <param name="headers">The section-header bytes.</param>
+    public static PdbSectionMap FromSectionHeaders(ReadOnlySpan<byte> headers)
+    {
+        const int entrySize = 40;
+        var count = headers.Length / entrySize;
+        var sections = new (uint, uint, uint, string)[count];
+        for (var i = 0; i < count; i++)
+        {
+            var e = headers.Slice(i * entrySize, entrySize);
+            var name = System.Text.Encoding.ASCII.GetString(e[..8]).TrimEnd('\0');
+            var virtualSize = BinaryPrimitives.ReadUInt32LittleEndian(e[8..]);
+            var virtualAddress = BinaryPrimitives.ReadUInt32LittleEndian(e[12..]);
+            var characteristics = BinaryPrimitives.ReadUInt32LittleEndian(e[36..]);
+            sections[i] = (virtualAddress, virtualSize, characteristics, name);
+        }
+
+        return new PdbSectionMap(sections);
+    }
+
+    /// <summary>The number of sections in the map.</summary>
+    public int Count => _sections.Length;
+
+    /// <summary>
+    /// Resolves a one-based CodeView segment and offset to an RVA, or null when the segment is
+    /// out of range.
+    /// </summary>
+    /// <param name="segment">The one-based section index.</param>
+    /// <param name="offset">The offset within the section.</param>
+    public uint? ToRva(int segment, uint offset)
+    {
+        if (segment < 1 || segment > _sections.Length) return null;
+        return _sections[segment - 1].VirtualAddress + offset;
+    }
+
+    /// <summary>The name of a one-based segment, or null when out of range.</summary>
+    /// <param name="segment">The one-based section index.</param>
+    public string? SectionName(int segment) =>
+        segment >= 1 && segment <= _sections.Length ? _sections[segment - 1].Name : null;
+
+    /// <summary>Whether the given one-based segment is executable (IMAGE_SCN_MEM_EXECUTE / CNT_CODE).</summary>
+    /// <param name="segment">The one-based section index.</param>
+    public bool IsExecutable(int segment)
+    {
+        if (segment < 1 || segment > _sections.Length) return false;
+        // IMAGE_SCN_CNT_CODE (0x20) | IMAGE_SCN_MEM_EXECUTE (0x20000000)
+        return (_sections[segment - 1].Characteristics & 0x2000_0020) != 0;
+    }
+
+    /// <summary>The end RVA of a one-based segment (address + virtual size), for sizing by containment.</summary>
+    /// <param name="segment">The one-based section index.</param>
+    public uint SectionEndRva(int segment) =>
+        segment >= 1 && segment <= _sections.Length
+            ? _sections[segment - 1].VirtualAddress + _sections[segment - 1].VirtualSize
+            : 0;
+}

--- a/src/Dotsider.Core/Analysis/NativePdb/PublicsReader.cs
+++ b/src/Dotsider.Core/Analysis/NativePdb/PublicsReader.cs
@@ -1,0 +1,83 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Dotsider.Core.Analysis.NativePdb;
+
+/// <summary>
+/// Reads the <c>S_PUB32</c> public symbols of a PDB. Publics are reached indirectly: the DBI's
+/// publics stream begins with a header whose address map is a sorted list of offsets into the
+/// global symbol-record stream, and each offset points at an <c>S_PUB32</c> record. Native AOT
+/// managed publics in executable sections frequently carry no flags, so a public is treated as a
+/// function when it either has the function flag or lands in an executable section — filtering on
+/// the flag alone would drop most managed method publics.
+/// </summary>
+internal static class PublicsReader
+{
+    private const ushort SPub32 = 0x110E;
+    private const uint PublicSymbolIsFunction = 0x2;
+
+    /// <summary>A public symbol before RVA resolution.</summary>
+    /// <param name="Name">The raw symbol name.</param>
+    /// <param name="Segment">The one-based section index.</param>
+    /// <param name="Offset">The offset within the section.</param>
+    /// <param name="IsFunction">Whether the record carries the function flag.</param>
+    internal readonly record struct PublicSymbol(string Name, int Segment, uint Offset, bool IsFunction);
+
+    /// <summary>
+    /// Reads the public symbols from the publics and symbol-record streams.
+    /// </summary>
+    /// <param name="publicsStream">The DBI publics hash stream.</param>
+    /// <param name="symbolRecordStream">The global symbol-record stream the address map indexes.</param>
+    public static List<PublicSymbol> Read(byte[] publicsStream, byte[] symbolRecordStream)
+    {
+        var result = new List<PublicSymbol>();
+        try
+        {
+            var pub = publicsStream.AsSpan();
+            if (pub.Length < 28) return result;
+
+            // PSGSIHDR: SymHash size, AddrMap size, then thunk fields.
+            var symHashSize = BinaryPrimitives.ReadInt32LittleEndian(pub);
+            var addrMapSize = BinaryPrimitives.ReadInt32LittleEndian(pub[4..]);
+            if (symHashSize < 0 || addrMapSize < 0) return result;
+
+            var addrMapStart = 28 + symHashSize;
+            if (addrMapStart < 0 || (long)addrMapStart + addrMapSize > pub.Length) return result;
+
+            var records = symbolRecordStream.AsSpan();
+            var count = addrMapSize / 4;
+            for (var i = 0; i < count; i++)
+            {
+                var recordOffset = BinaryPrimitives.ReadInt32LittleEndian(pub[(addrMapStart + i * 4)..]);
+                if (recordOffset < 0 || recordOffset + 4 > records.Length) continue;
+
+                var length = BinaryPrimitives.ReadUInt16LittleEndian(records[recordOffset..]);
+                var kind = BinaryPrimitives.ReadUInt16LittleEndian(records[(recordOffset + 2)..]);
+                if (kind != SPub32 || length < 2) continue;
+
+                var body = records[(recordOffset + 4)..Math.Min(records.Length, recordOffset + 2 + length)];
+                if (body.Length < 11) continue; // flags(4), offset(4), segment(2), name
+
+                var flags = BinaryPrimitives.ReadUInt32LittleEndian(body);
+                var offset = BinaryPrimitives.ReadUInt32LittleEndian(body[4..]);
+                var segment = BinaryPrimitives.ReadUInt16LittleEndian(body[8..]);
+                var name = ReadCString(body[10..]);
+                if (name.Length > 0)
+                    result.Add(new PublicSymbol(name, segment, offset, (flags & PublicSymbolIsFunction) != 0));
+            }
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            // Return whatever was read before the stream went out of shape.
+        }
+
+        return result;
+    }
+
+    private static string ReadCString(ReadOnlySpan<byte> span)
+    {
+        var end = span.IndexOf((byte)0);
+        if (end < 0) end = span.Length;
+        return Encoding.UTF8.GetString(span[..end]);
+    }
+}

--- a/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
+++ b/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
@@ -324,8 +324,7 @@ public static class NativeSymbolReader
     {
         var dwarf = DwarfSections.Collect(name =>
             ElfImageReader.TryGetSection(symbolBytes, ".debug_" + name, out var s)
-                && s.Size > 0 && s.FileOffset >= 0 && s.FileOffset + s.Size <= symbolBytes.Length
-                ? symbolBytes.AsSpan(s.FileOffset, s.Size).ToArray()
+                ? ElfImageReader.ReadSectionBytes(symbolBytes, s)
                 : null);
         AppendDwarfFunctions(dwarf, va =>
             ElfImageReader.TryMapAddress(imageSections, va, out var name, out var offset)

--- a/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
+++ b/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
@@ -34,10 +34,191 @@ public static class NativeSymbolReader
         if (ElfImageReader.IsElf(span))
             return ReadElf(imagePath, imageBytes, demangler);
 
-        // Mach-O dispatch lands with its reader.
+        if (MachOImageReader.IsMachO(span) || MachOImageReader.IsFat(span))
+            return ReadMachO(imagePath, imageBytes, demangler);
+
         return new NativeSymbolInfo([], NativeSymbolSource.PdataFallback,
             NativeSymbolStatus.NotApplicable, null, "unrecognized image format");
     }
+
+    private static NativeSymbolInfo ReadMachO(string imagePath, ReadOnlyMemory<byte> imageBytes, IlcNameDemangler demangler)
+    {
+        var span = imageBytes.Span;
+        var dsymPath = FindSidecarDirectory(imagePath);
+        var dsymBytes = dsymPath is not null ? File.ReadAllBytes(dsymPath) : null;
+
+        // Fat archives: pick the slice the dSYM identifies, else the one carrying the Native
+        // AOT signal — never silently the host architecture.
+        long sliceShift = 0;
+        if (MachOImageReader.IsFat(span))
+        {
+            var slices = MachOImageReader.ReadFatSlices(span);
+            var chosen = ChooseFatSlice(span, slices, dsymBytes);
+            if (chosen < 0)
+            {
+                var names = string.Join(", ", slices.Select(s => $"0x{s.CpuType:x}"));
+                return new NativeSymbolInfo([], NativeSymbolSource.MachONlist, NativeSymbolStatus.AmbiguousImage,
+                    null, $"fat archive: no slice disambiguated by dSYM UUID or Native AOT signal (cputypes {names})");
+            }
+
+            sliceShift = slices[chosen].Offset;
+            span = span.Slice((int)slices[chosen].Offset, (int)slices[chosen].Size);
+        }
+
+        var imageSections = MachOImageReader.ReadSectionList(span);
+        var hasImageUuid = MachOImageReader.TryReadUuid(span, out var imageUuid);
+
+        if (dsymBytes is not null)
+        {
+            // The UUID is the identity: when the image has one, the dSYM must carry the same.
+            if (hasImageUuid
+                && (!MachOImageReader.TryReadUuid(dsymBytes, out var dsymUuid)
+                    || !imageUuid.AsSpan().SequenceEqual(dsymUuid)))
+            {
+                return FunctionStartsFallback(span, sliceShift, demangler, NativeSymbolStatus.IdMismatch,
+                    $"dSYM '{Path.GetFileName(dsymPath)}' does not match the image (UUID)");
+            }
+
+            // A dSYM contributes both its DWARF and its nlist — merged, not either/or.
+            var raw = new List<RawNativeSymbol>();
+            AppendMachODwarfFunctions(dsymBytes, imageSections, sliceShift, raw);
+            foreach (var symbol in MachOSymbolReader.ReadSymbols(dsymBytes, demangler))
+                raw.Add(RemapToImage(symbol, imageSections, sliceShift));
+
+            if (raw.Count > 0)
+            {
+                var diagnostic = hasImageUuid ? null : "dSYM matched without UUIDs (none present)";
+                return Build(raw, demangler, NativeSymbolSource.Dsym, NativeSymbolStatus.Loaded, dsymPath, diagnostic);
+            }
+
+            return FunctionStartsFallback(span, sliceShift, demangler, NativeSymbolStatus.CorruptSymbolFile,
+                $"'{Path.GetFileName(dsymPath)}' matched but contains no readable symbols");
+        }
+
+        // No dSYM: the image's own symbol table is still a named primary source.
+        var own = MachOSymbolReader.ReadSymbols(span, demangler);
+        if (own.Count > 0)
+        {
+            var shifted = sliceShift == 0 ? own : [.. own.Select(s => Shift(s, sliceShift))];
+            return Build(shifted, demangler, NativeSymbolSource.MachONlist, NativeSymbolStatus.Loaded,
+                imagePath, "no dSYM bundle; names from the image's symbol table");
+        }
+
+        return FunctionStartsFallback(span, sliceShift, demangler, NativeSymbolStatus.FallbackOnly,
+            "no dSYM bundle and no symbol table");
+    }
+
+    /// <summary>
+    /// Picks a fat slice: a single slice stands alone; otherwise the dSYM's UUID decides, then
+    /// the Native AOT signal; -1 when nothing disambiguates.
+    /// </summary>
+    private static int ChooseFatSlice(
+        ReadOnlySpan<byte> archive, IReadOnlyList<MachOImageReader.MachOFatSlice> slices, byte[]? dsymBytes)
+    {
+        if (slices.Count == 1) return 0;
+
+        if (dsymBytes is not null && MachOImageReader.TryReadUuid(dsymBytes, out var dsymUuid))
+        {
+            for (var i = 0; i < slices.Count; i++)
+            {
+                var slice = archive.Slice((int)slices[i].Offset, (int)slices[i].Size);
+                if (MachOImageReader.TryReadUuid(slice, out var uuid) && uuid.AsSpan().SequenceEqual(dsymUuid))
+                    return i;
+            }
+        }
+
+        for (var i = 0; i < slices.Count; i++)
+        {
+            var slice = archive.Slice((int)slices[i].Offset, (int)slices[i].Size);
+            if (NativeAotDetector.Detect(slice) is not null) return i;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Recovers boundaries from <c>LC_FUNCTION_STARTS</c> under the given failure status; a
+    /// status of <see cref="NativeSymbolStatus.FallbackOnly"/> degrades to
+    /// <see cref="NativeSymbolStatus.NoSymbolFile"/> when there are no boundaries either.
+    /// </summary>
+    private static NativeSymbolInfo FunctionStartsFallback(
+        ReadOnlySpan<byte> imageBytes, long sliceShift, IlcNameDemangler demangler,
+        NativeSymbolStatus status, string baseDiagnostic)
+    {
+        var boundaries = MachOSymbolReader.ReadFunctionStartBoundaries(imageBytes);
+        if (boundaries.Count > 0)
+        {
+            var shifted = sliceShift == 0 ? boundaries : [.. boundaries.Select(b => Shift(b, sliceShift))];
+            return Build(shifted, demangler, NativeSymbolSource.FunctionStartsFallback, status, null,
+                baseDiagnostic + "; recovered function boundaries from LC_FUNCTION_STARTS");
+        }
+
+        var empty = status == NativeSymbolStatus.FallbackOnly ? NativeSymbolStatus.NoSymbolFile : status;
+        return new NativeSymbolInfo([], NativeSymbolSource.FunctionStartsFallback, empty, null,
+            baseDiagnostic + "; no LC_FUNCTION_STARTS data");
+    }
+
+    /// <summary>
+    /// Probes for the dSYM bundle next to the image and returns its inner DWARF file:
+    /// <c>&lt;image&gt;.dSYM/Contents/Resources/DWARF/&lt;name&gt;</c>.
+    /// </summary>
+    private static string? FindSidecarDirectory(string imagePath)
+    {
+        var name = Path.GetFileName(imagePath);
+        if (string.IsNullOrEmpty(name)) return null;
+        var inner = Path.Combine(imagePath + ".dSYM", "Contents", "Resources", "DWARF", name);
+        return File.Exists(inner) ? inner : null;
+    }
+
+    /// <summary>Walks the dSYM's <c>__DWARF</c> sections into function records.</summary>
+    private static void AppendMachODwarfFunctions(
+        byte[] dsymBytes, IReadOnlyList<MachOImageReader.MachOSection> imageSections,
+        long sliceShift, List<RawNativeSymbol> raw)
+    {
+        var sections = MachOImageReader.ReadSectionList(dsymBytes);
+        var dwarf = DwarfSections.Collect(name =>
+        {
+            // Mach-O section names cap at 16 chars: __debug_str_offsets -> __debug_str_offs.
+            var wanted = "__debug_" + name;
+            if (wanted.Length > 16) wanted = wanted[..16];
+            foreach (var s in sections)
+            {
+                if (s.Name == wanted && s.Size > 0 && s.FileOffset >= 0
+                    && s.FileOffset + s.Size <= dsymBytes.Length)
+                {
+                    return dsymBytes.AsSpan((int)s.FileOffset, (int)s.Size).ToArray();
+                }
+            }
+
+            return null;
+        });
+
+        AppendDwarfFunctions(dwarf, va => MapMachOAddress(imageSections, va, sliceShift), raw);
+    }
+
+    /// <summary>Re-anchors a dSYM-derived symbol's section and file offset onto the analyzed image.</summary>
+    private static RawNativeSymbol RemapToImage(
+        RawNativeSymbol symbol, IReadOnlyList<MachOImageReader.MachOSection> imageSections, long sliceShift)
+    {
+        var (section, fileOffset) = MapMachOAddress(imageSections, symbol.VirtualAddress, sliceShift);
+        return symbol with { Section = section ?? symbol.Section, FileOffset = fileOffset };
+    }
+
+    private static (string? Section, long? FileOffset) MapMachOAddress(
+        IReadOnlyList<MachOImageReader.MachOSection> sections, ulong va, long sliceShift)
+    {
+        foreach (var section in sections)
+        {
+            if (section.Address != 0 && va >= section.Address && va < section.Address + (ulong)section.Size)
+                return (section.Name, sliceShift + section.FileOffset + (long)(va - section.Address));
+        }
+
+        return (null, null);
+    }
+
+    /// <summary>Shifts a fat-slice-relative file offset to the whole archive.</summary>
+    private static RawNativeSymbol Shift(RawNativeSymbol symbol, long sliceShift) =>
+        symbol.FileOffset is { } offset ? symbol with { FileOffset = offset + sliceShift } : symbol;
 
     private static NativeSymbolInfo ReadElf(string imagePath, ReadOnlyMemory<byte> imageBytes, IlcNameDemangler demangler)
     {
@@ -135,10 +316,8 @@ public static class NativeSymbolReader
     }
 
     /// <summary>
-    /// Walks the symbol source's DWARF into function records: names from the DIE walk, extents
-    /// from <c>low_pc</c>/<c>high_pc</c> or range lists, and source attribution from the decl
-    /// attributes with the line-program row as fallback. Addresses map to sections and file
-    /// offsets through the analyzed image, not the sidecar.
+    /// Walks the ELF symbol source's DWARF into function records, mapping addresses through the
+    /// analyzed image's sections, not the sidecar's.
     /// </summary>
     private static void ReadDwarfFunctions(
         byte[] symbolBytes, IReadOnlyList<ElfImageReader.ElfSection> imageSections, List<RawNativeSymbol> raw)
@@ -148,6 +327,22 @@ public static class NativeSymbolReader
                 && s.Size > 0 && s.FileOffset >= 0 && s.FileOffset + s.Size <= symbolBytes.Length
                 ? symbolBytes.AsSpan(s.FileOffset, s.Size).ToArray()
                 : null);
+        AppendDwarfFunctions(dwarf, va =>
+            ElfImageReader.TryMapAddress(imageSections, va, out var name, out var offset)
+                ? (name, offset)
+                : (null, null), raw);
+    }
+
+    /// <summary>
+    /// Walks DWARF sections into function records: names from the DIE walk, extents from
+    /// <c>low_pc</c>/<c>high_pc</c> or range lists, and source attribution from the decl
+    /// attributes with the line-program row as fallback. The address map supplies the analyzed
+    /// image's section names and file offsets.
+    /// </summary>
+    private static void AppendDwarfFunctions(
+        DwarfSections dwarf, Func<ulong, (string? Section, long? FileOffset)> mapAddress,
+        List<RawNativeSymbol> raw)
+    {
         if (!dwarf.HasInfo) return;
 
         var lineCache = new Dictionary<long, DwarfLineProgram?>();
@@ -174,13 +369,13 @@ public static class NativeSymbolReader
                 line = lineNumber;
             }
 
-            var mapped = ElfImageReader.TryMapAddress(imageSections, lowPc, out var sectionName, out var fileOffset);
+            var (sectionName, fileOffset) = mapAddress(lowPc);
             raw.Add(new RawNativeSymbol(
                 Name: function.Name,
                 VirtualAddress: lowPc,
                 Rva: null,
-                FileOffset: mapped ? fileOffset : null,
-                Section: mapped ? sectionName : null,
+                FileOffset: fileOffset,
+                Section: sectionName,
                 Size: (long)size,
                 IsData: false,
                 IsBoundary: false,

--- a/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
+++ b/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
@@ -1,3 +1,4 @@
+using Dotsider.Core.Analysis.Dwarf;
 using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
@@ -30,9 +31,175 @@ public static class NativeSymbolReader
         if (span.Length >= 2 && span[0] == (byte)'M' && span[1] == (byte)'Z')
             return ReadPe(imagePath, imageBytes, demangler);
 
-        // ELF and Mach-O dispatch land with their readers.
+        if (ElfImageReader.IsElf(span))
+            return ReadElf(imagePath, imageBytes, demangler);
+
+        // Mach-O dispatch lands with its reader.
         return new NativeSymbolInfo([], NativeSymbolSource.PdataFallback,
             NativeSymbolStatus.NotApplicable, null, "unrecognized image format");
+    }
+
+    private static NativeSymbolInfo ReadElf(string imagePath, ReadOnlyMemory<byte> imageBytes, IlcNameDemangler demangler)
+    {
+        var span = imageBytes.Span;
+        var imageSections = ElfImageReader.ReadSections(span);
+
+        // Choose the symbol source: the image itself when it still carries DWARF, else a
+        // sidecar validated by build id / debuglink CRC.
+        byte[] symbolBytes;
+        string symbolPath;
+        string? diagnostic = null;
+        if (ElfImageReader.TryGetSection(span, ".debug_info", out _))
+        {
+            symbolBytes = imageBytes.ToArray();
+            symbolPath = imagePath;
+        }
+        else if (FindDbgSidecar(imagePath, span) is { } sidecar)
+        {
+            if (sidecar.Match == ElfSidecarMatch.Mismatched)
+            {
+                return BoundaryFallback(span, demangler, NativeSymbolStatus.IdMismatch,
+                    $"debug sidecar '{Path.GetFileName(sidecar.Path)}' does not match the image (build id or debuglink CRC)");
+            }
+
+            symbolBytes = sidecar.Bytes;
+            symbolPath = sidecar.Path;
+            if (sidecar.Match == ElfSidecarMatch.LooseMatch)
+                diagnostic = "sidecar matched by machine and debug info only (no build id or debuglink)";
+        }
+        else
+        {
+            return BoundaryFallback(span, demangler, NativeSymbolStatus.FallbackOnly,
+                "no debug sidecar");
+        }
+
+        var raw = new List<RawNativeSymbol>();
+        ReadDwarfFunctions(symbolBytes, imageSections, raw);
+        raw.AddRange(ElfSymtabReader.ReadDataSymbols(symbolBytes, imageSections));
+
+        return raw.Count > 0
+            ? Build(raw, demangler, NativeSymbolSource.Dwarf, NativeSymbolStatus.Loaded, symbolPath, diagnostic)
+            : BoundaryFallback(span, demangler, NativeSymbolStatus.CorruptSymbolFile,
+                $"'{Path.GetFileName(symbolPath)}' matched but contains no readable symbols");
+    }
+
+    /// <summary>
+    /// Recovers boundaries from <c>.eh_frame</c> under the given failure status; a status of
+    /// <see cref="NativeSymbolStatus.FallbackOnly"/> degrades to
+    /// <see cref="NativeSymbolStatus.NoSymbolFile"/> when there are no boundaries either.
+    /// </summary>
+    private static NativeSymbolInfo BoundaryFallback(
+        ReadOnlySpan<byte> imageBytes, IlcNameDemangler demangler,
+        NativeSymbolStatus status, string baseDiagnostic)
+    {
+        var boundaries = EhFrameReader.ReadBoundaries(imageBytes);
+        if (boundaries.Count > 0)
+        {
+            return Build(boundaries, demangler, NativeSymbolSource.EhFrameFallback, status, null,
+                baseDiagnostic + "; recovered function boundaries from .eh_frame");
+        }
+
+        var empty = status == NativeSymbolStatus.FallbackOnly ? NativeSymbolStatus.NoSymbolFile : status;
+        return new NativeSymbolInfo([], NativeSymbolSource.EhFrameFallback, empty, null,
+            baseDiagnostic + "; no .eh_frame data");
+    }
+
+    /// <summary>
+    /// Probes for a debug sidecar next to the image — the <c>.gnu_debuglink</c>-named file
+    /// first, then <c>&lt;name&gt;.dbg</c> — and validates its identity. The first matching
+    /// candidate wins; when only mismatching candidates exist, the first is reported.
+    /// </summary>
+    private static (string Path, byte[] Bytes, ElfSidecarMatch Match)? FindDbgSidecar(
+        string imagePath, ReadOnlySpan<byte> image)
+    {
+        var directory = Path.GetDirectoryName(imagePath);
+        if (string.IsNullOrEmpty(directory)) return null;
+
+        var candidates = new List<string>(2);
+        if (ElfImageReader.TryReadDebugLink(image, out var linkName, out _) && linkName.Length > 0)
+            candidates.Add(Path.Combine(directory, Path.GetFileName(linkName)));
+        var conventional = Path.Combine(directory, Path.GetFileNameWithoutExtension(imagePath) + ".dbg");
+        if (!candidates.Contains(conventional)) candidates.Add(conventional);
+
+        (string, byte[], ElfSidecarMatch)? mismatch = null;
+        foreach (var candidate in candidates)
+        {
+            if (!File.Exists(candidate)) continue;
+            var bytes = File.ReadAllBytes(candidate);
+            var match = ElfSidecarIdentity.Check(image, bytes);
+            if (match != ElfSidecarMatch.Mismatched) return (candidate, bytes, match);
+            mismatch ??= (candidate, bytes, match);
+        }
+
+        return mismatch;
+    }
+
+    /// <summary>
+    /// Walks the symbol source's DWARF into function records: names from the DIE walk, extents
+    /// from <c>low_pc</c>/<c>high_pc</c> or range lists, and source attribution from the decl
+    /// attributes with the line-program row as fallback. Addresses map to sections and file
+    /// offsets through the analyzed image, not the sidecar.
+    /// </summary>
+    private static void ReadDwarfFunctions(
+        byte[] symbolBytes, IReadOnlyList<ElfImageReader.ElfSection> imageSections, List<RawNativeSymbol> raw)
+    {
+        var dwarf = DwarfSections.Collect(name =>
+            ElfImageReader.TryGetSection(symbolBytes, ".debug_" + name, out var s)
+                && s.Size > 0 && s.FileOffset >= 0 && s.FileOffset + s.Size <= symbolBytes.Length
+                ? symbolBytes.AsSpan(s.FileOffset, s.Size).ToArray()
+                : null);
+        if (!dwarf.HasInfo) return;
+
+        var lineCache = new Dictionary<long, DwarfLineProgram?>();
+        foreach (var (function, unit) in DwarfReader.ReadFunctions(dwarf))
+        {
+            var lowPc = function.LowPc;
+            var size = function.Size;
+            if (function.RangesOffset >= 0
+                && DwarfRangeLists.TryResolve(dwarf, function.RangesOffset, function.RangesIsRnglistx,
+                    unit, out var rangeStart, out var rangeSize))
+            {
+                lowPc = rangeStart;
+                size = rangeSize;
+            }
+
+            if (lowPc == 0) continue;
+
+            string? sourceFile = null;
+            int? line = null;
+            if (GetLineProgram(dwarf, unit.StmtListOffset, lineCache) is { } program)
+            {
+                var (file, lineNumber) = program.ResolveSource(function.DeclFile, function.DeclLine, lowPc);
+                sourceFile = file;
+                line = lineNumber;
+            }
+
+            var mapped = ElfImageReader.TryMapAddress(imageSections, lowPc, out var sectionName, out var fileOffset);
+            raw.Add(new RawNativeSymbol(
+                Name: function.Name,
+                VirtualAddress: lowPc,
+                Rva: null,
+                FileOffset: mapped ? fileOffset : null,
+                Section: mapped ? sectionName : null,
+                Size: (long)size,
+                IsData: false,
+                IsBoundary: false,
+                SourceFile: sourceFile,
+                Line: line));
+        }
+    }
+
+    private static DwarfLineProgram? GetLineProgram(
+        DwarfSections dwarf, long stmtListOffset, Dictionary<long, DwarfLineProgram?> cache)
+    {
+        if (stmtListOffset < 0) return null;
+        if (!cache.TryGetValue(stmtListOffset, out var program))
+        {
+            program = DwarfLineProgram.Parse(dwarf, stmtListOffset);
+            cache[stmtListOffset] = program;
+        }
+
+        return program;
     }
 
     private static NativeSymbolInfo ReadPe(string imagePath, ReadOnlyMemory<byte> imageBytes, IlcNameDemangler demangler)

--- a/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
+++ b/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
@@ -13,6 +13,73 @@ namespace Dotsider.Core.Analysis;
 public static class NativeSymbolReader
 {
     /// <summary>
+    /// Reads the native symbols of a binary, dispatching on image format. Managed and
+    /// unrecognized images return an empty result marked <see cref="NativeSymbolStatus.NotApplicable"/>.
+    /// </summary>
+    /// <param name="imagePath">The binary's path, used to probe for sidecar symbol files.</param>
+    /// <param name="imageBytes">The binary's raw bytes.</param>
+    /// <param name="recoveredTypes">Types recovered from the binary's own metadata, for demangling.</param>
+    public static NativeSymbolInfo Read(
+        string imagePath,
+        ReadOnlyMemory<byte> imageBytes,
+        IReadOnlyList<RecoveredType> recoveredTypes)
+    {
+        var demangler = new IlcNameDemangler(recoveredTypes);
+        var span = imageBytes.Span;
+
+        if (span.Length >= 2 && span[0] == (byte)'M' && span[1] == (byte)'Z')
+            return ReadPe(imagePath, imageBytes, demangler);
+
+        // ELF and Mach-O dispatch land with their readers.
+        return new NativeSymbolInfo([], NativeSymbolSource.PdataFallback,
+            NativeSymbolStatus.NotApplicable, null, "unrecognized image format");
+    }
+
+    private static NativeSymbolInfo ReadPe(string imagePath, ReadOnlyMemory<byte> imageBytes, IlcNameDemangler demangler)
+    {
+        var codeView = PeCodeView.TryRead(imageBytes.Span);
+
+        // A same-directory PDB whose GUID and age match is the rich source.
+        if (codeView is { } id && FindMatchingPdb(imagePath, id) is { } pdbPath)
+        {
+            var raw = NativePdb.NativePdbReader.Read(File.ReadAllBytes(pdbPath), imageBytes);
+            if (raw.Count > 0)
+                return Build(raw, demangler, NativeSymbolSource.NativePdb, NativeSymbolStatus.Loaded, pdbPath, null);
+        }
+
+        // No usable PDB: recover function boundaries from .pdata.
+        var boundaries = PdataReader.ReadBoundaries(imageBytes);
+        return boundaries.Count > 0
+            ? Build(boundaries, demangler, NativeSymbolSource.PdataFallback, NativeSymbolStatus.FallbackOnly,
+                null, "no matching PDB; recovered function boundaries from .pdata")
+            : new NativeSymbolInfo([], NativeSymbolSource.PdataFallback, NativeSymbolStatus.NoSymbolFile,
+                null, "no PDB and no .pdata exception directory");
+    }
+
+    private static string? FindMatchingPdb(string imagePath, PeCodeView.CodeViewId id)
+    {
+        var directory = Path.GetDirectoryName(imagePath);
+        if (string.IsNullOrEmpty(directory)) return null;
+
+        var candidates = new List<string>(2);
+        if (!string.IsNullOrEmpty(id.PdbPath))
+            candidates.Add(Path.Combine(directory, Path.GetFileName(id.PdbPath)));
+        candidates.Add(Path.Combine(directory, Path.GetFileNameWithoutExtension(imagePath) + ".pdb"));
+
+        foreach (var path in candidates)
+        {
+            if (File.Exists(path)
+                && NativePdb.NativePdbReader.TryReadPdbId(path, out var guid, out var age)
+                && guid == id.Guid && age == id.Age)
+            {
+                return path;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Demangles, classifies, sizes, and merges raw reader output into the public symbol model.
     /// Records that share a virtual address collapse to one primary — the richest wins and the
     /// rest become aliases — so no byte is counted twice; unsized symbols take the distance to the

--- a/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
+++ b/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
@@ -1,0 +1,129 @@
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Reads a native binary's symbols — function names, addresses, and sizes — from its debug
+/// information, demangling ILC names back to managed names and merging the overlapping records
+/// that different symbol sources produce. Windows native PDBs, Linux DWARF, and macOS dSYM/nlist
+/// each feed the same merge and demangle pipeline through <see cref="Build"/>; when no symbols
+/// exist, unwind data still yields function boundaries at lower fidelity. The public entry points
+/// that dispatch on image format are added as each reader lands.
+/// </summary>
+public static class NativeSymbolReader
+{
+    /// <summary>
+    /// Demangles, classifies, sizes, and merges raw reader output into the public symbol model.
+    /// Records that share a virtual address collapse to one primary — the richest wins and the
+    /// rest become aliases — so no byte is counted twice; unsized symbols take the distance to the
+    /// next symbol as their size.
+    /// </summary>
+    /// <param name="raw">The symbols a format reader produced.</param>
+    /// <param name="demangler">The demangler seeded from the binary's recovered metadata.</param>
+    /// <param name="source">The source the symbols came from.</param>
+    /// <param name="status">The probe status.</param>
+    /// <param name="path">The symbol file path, or null.</param>
+    /// <param name="diagnostic">A human-readable note on the outcome, or null.</param>
+    internal static NativeSymbolInfo Build(
+        IReadOnlyList<RawNativeSymbol> raw,
+        IlcNameDemangler demangler,
+        NativeSymbolSource source,
+        NativeSymbolStatus status,
+        string? path,
+        string? diagnostic)
+    {
+        if (raw.Count == 0)
+            return new NativeSymbolInfo([], source, status, path, diagnostic);
+
+        // Order by address, then by richness so the primary of each address group comes first.
+        var ordered = raw
+            .OrderBy(r => r.VirtualAddress)
+            .ThenByDescending(Richness)
+            .ToList();
+
+        // Collapse same-address records into a primary plus aliases.
+        var primaries = new List<RawNativeSymbol>();
+        var aliasesByIndex = new List<List<string>>();
+        foreach (var symbol in ordered)
+        {
+            if (primaries.Count > 0 && primaries[^1].VirtualAddress == symbol.VirtualAddress)
+            {
+                if (!string.Equals(primaries[^1].Name, symbol.Name, StringComparison.Ordinal)
+                    && !aliasesByIndex[^1].Contains(symbol.Name))
+                {
+                    aliasesByIndex[^1].Add(symbol.Name);
+                }
+
+                // Keep the richer record's size/line if the primary lacked them.
+                if (primaries[^1].Size == 0 && symbol.Size > 0)
+                    primaries[^1] = primaries[^1] with { Size = symbol.Size };
+                continue;
+            }
+
+            primaries.Add(symbol);
+            aliasesByIndex.Add([]);
+        }
+
+        // Size unsized symbols by the distance to the next symbol's address.
+        for (var i = 0; i < primaries.Count; i++)
+        {
+            if (primaries[i].Size > 0) continue;
+            var next = i + 1 < primaries.Count ? primaries[i + 1].VirtualAddress : primaries[i].VirtualAddress;
+            var gap = (long)(next - primaries[i].VirtualAddress);
+            primaries[i] = primaries[i] with { Size = gap > 0 ? gap : 0 };
+        }
+
+        var symbols = new List<NativeSymbol>(primaries.Count);
+        for (var i = 0; i < primaries.Count; i++)
+        {
+            var p = primaries[i];
+            NativeSymbolKind kind;
+            string? managedName;
+            bool exact;
+
+            if (p.IsBoundary)
+            {
+                kind = NativeSymbolKind.Boundary;
+                managedName = null;
+                exact = false;
+            }
+            else
+            {
+                var demangled = demangler.Demangle(p.Name);
+                kind = demangled.Kind;
+                managedName = demangled.ManagedName;
+                exact = demangled.IsExactMatch;
+                // A symbol the demangler read as a function but that lives in a data section is data.
+                if (kind == NativeSymbolKind.Function && p.IsData)
+                    kind = NativeSymbolKind.Data;
+            }
+
+            symbols.Add(new NativeSymbol(
+                Name: p.Name,
+                ManagedName: managedName,
+                VirtualAddress: p.VirtualAddress,
+                Rva: p.Rva,
+                FileOffset: p.FileOffset,
+                Section: p.Section,
+                Size: p.Size,
+                Kind: kind,
+                SourceFile: p.SourceFile,
+                Line: p.Line,
+                IsExactMatch: exact,
+                Aliases: aliasesByIndex[i]));
+        }
+
+        return new NativeSymbolInfo(symbols, source, status, path, diagnostic);
+    }
+
+    // Rich records (procedures/data with sizes and line info) outrank named-only publics, which
+    // outrank nameless boundaries — so the primary of an address group is the most informative.
+    private static int Richness(RawNativeSymbol s)
+    {
+        if (s.IsBoundary) return 0;
+        var rank = 1;
+        if (s.Size > 0) rank += 2;
+        if (s.SourceFile is not null) rank += 1;
+        return rank;
+    }
+}

--- a/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
+++ b/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
@@ -45,7 +45,9 @@ public static class NativeSymbolReader
     {
         var span = imageBytes.Span;
         var dsymPath = FindSidecarDirectory(imagePath);
-        var dsymBytes = dsymPath is not null ? File.ReadAllBytes(dsymPath) : null;
+        // A dSYM's inner file can itself be a fat archive: work with its thin slices so UUID
+        // validation compares Mach-O identities, not a fat header against an image.
+        var dsymSlices = dsymPath is not null ? ThinSlices(File.ReadAllBytes(dsymPath)) : null;
 
         // Fat archives: pick the slice the dSYM identifies, else the one carrying the Native
         // AOT signal — never silently the host architecture.
@@ -53,7 +55,7 @@ public static class NativeSymbolReader
         if (MachOImageReader.IsFat(span))
         {
             var slices = MachOImageReader.ReadFatSlices(span);
-            var chosen = ChooseFatSlice(span, slices, dsymBytes);
+            var chosen = ChooseFatSlice(span, slices, dsymSlices);
             if (chosen < 0)
             {
                 var names = string.Join(", ", slices.Select(s => $"0x{s.CpuType:x}"));
@@ -68,12 +70,12 @@ public static class NativeSymbolReader
         var imageSections = MachOImageReader.ReadSectionList(span);
         var hasImageUuid = MachOImageReader.TryReadUuid(span, out var imageUuid);
 
-        if (dsymBytes is not null)
+        if (dsymSlices is not null)
         {
-            // The UUID is the identity: when the image has one, the dSYM must carry the same.
-            if (hasImageUuid
-                && (!MachOImageReader.TryReadUuid(dsymBytes, out var dsymUuid)
-                    || !imageUuid.AsSpan().SequenceEqual(dsymUuid)))
+            // The UUID is the identity: when the image has one, some dSYM slice must carry the
+            // same; without one, only an unambiguous single-slice dSYM is safe to trust.
+            var dsymBytes = SelectDsymSlice(dsymSlices, hasImageUuid ? imageUuid : null);
+            if (dsymBytes is null)
             {
                 return FunctionStartsFallback(span, sliceShift, demangler, NativeSymbolStatus.IdMismatch,
                     $"dSYM '{Path.GetFileName(dsymPath)}' does not match the image (UUID)");
@@ -109,21 +111,32 @@ public static class NativeSymbolReader
     }
 
     /// <summary>
-    /// Picks a fat slice: a single slice stands alone; otherwise the dSYM's UUID decides, then
-    /// the Native AOT signal; -1 when nothing disambiguates.
+    /// Picks a fat slice: a single slice stands alone; otherwise a dSYM slice's UUID decides,
+    /// then the Native AOT signal; -1 when nothing disambiguates.
     /// </summary>
     private static int ChooseFatSlice(
-        ReadOnlySpan<byte> archive, IReadOnlyList<MachOImageReader.MachOFatSlice> slices, byte[]? dsymBytes)
+        ReadOnlySpan<byte> archive, IReadOnlyList<MachOImageReader.MachOFatSlice> slices,
+        List<byte[]>? dsymSlices)
     {
         if (slices.Count == 1) return 0;
 
-        if (dsymBytes is not null && MachOImageReader.TryReadUuid(dsymBytes, out var dsymUuid))
+        if (dsymSlices is not null)
         {
+            var dsymUuids = new List<byte[]>();
+            foreach (var dsymSlice in dsymSlices)
+            {
+                if (MachOImageReader.TryReadUuid(dsymSlice, out var uuid))
+                    dsymUuids.Add(uuid);
+            }
+
             for (var i = 0; i < slices.Count; i++)
             {
                 var slice = archive.Slice((int)slices[i].Offset, (int)slices[i].Size);
-                if (MachOImageReader.TryReadUuid(slice, out var uuid) && uuid.AsSpan().SequenceEqual(dsymUuid))
+                if (MachOImageReader.TryReadUuid(slice, out var uuid)
+                    && dsymUuids.Any(d => uuid.AsSpan().SequenceEqual(d)))
+                {
                     return i;
+                }
             }
         }
 
@@ -134,6 +147,40 @@ public static class NativeSymbolReader
         }
 
         return -1;
+    }
+
+    /// <summary>A Mach-O file's thin candidates: itself, or each slice of a fat archive.</summary>
+    private static List<byte[]> ThinSlices(byte[] bytes)
+    {
+        if (!MachOImageReader.IsFat(bytes)) return [bytes];
+
+        var result = new List<byte[]>();
+        foreach (var slice in MachOImageReader.ReadFatSlices(bytes))
+            result.Add(bytes.AsSpan((int)slice.Offset, (int)slice.Size).ToArray());
+        return result.Count > 0 ? result : [bytes];
+    }
+
+    /// <summary>
+    /// Picks the dSYM slice carrying the image's UUID; without an image UUID, only a
+    /// single-slice dSYM is unambiguous enough to trust.
+    /// </summary>
+    private static byte[]? SelectDsymSlice(List<byte[]> slices, byte[]? imageUuid)
+    {
+        if (imageUuid is not null)
+        {
+            foreach (var slice in slices)
+            {
+                if (MachOImageReader.TryReadUuid(slice, out var uuid)
+                    && uuid.AsSpan().SequenceEqual(imageUuid))
+                {
+                    return slice;
+                }
+            }
+
+            return null;
+        }
+
+        return slices.Count == 1 ? slices[0] : null;
     }
 
     /// <summary>
@@ -396,48 +443,104 @@ public static class NativeSymbolReader
         return program;
     }
 
-    private static NativeSymbolInfo ReadPe(string imagePath, ReadOnlyMemory<byte> imageBytes, IlcNameDemangler demangler)
+    /// <summary>The outcome of probing the same-directory PDB candidates.</summary>
+    private enum PdbProbe
     {
-        var codeView = PeCodeView.TryRead(imageBytes.Span);
+        /// <summary>No candidate file exists.</summary>
+        None,
 
-        // A same-directory PDB whose GUID and age match is the rich source.
-        if (codeView is { } id && FindMatchingPdb(imagePath, id) is { } pdbPath)
-        {
-            var raw = NativePdb.NativePdbReader.Read(File.ReadAllBytes(pdbPath), imageBytes);
-            if (raw.Count > 0)
-                return Build(raw, demangler, NativeSymbolSource.NativePdb, NativeSymbolStatus.Loaded, pdbPath, null);
-        }
+        /// <summary>A candidate's GUID and age match the image's RSDS record.</summary>
+        Matched,
 
-        // No usable PDB: recover function boundaries from .pdata.
-        var boundaries = PdataReader.ReadBoundaries(imageBytes);
-        return boundaries.Count > 0
-            ? Build(boundaries, demangler, NativeSymbolSource.PdataFallback, NativeSymbolStatus.FallbackOnly,
-                null, "no matching PDB; recovered function boundaries from .pdata")
-            : new NativeSymbolInfo([], NativeSymbolSource.PdataFallback, NativeSymbolStatus.NoSymbolFile,
-                null, "no PDB and no .pdata exception directory");
+        /// <summary>A candidate exists but its identity differs — a stale build's PDB.</summary>
+        Mismatched,
+
+        /// <summary>A candidate exists but is not a readable MSF container.</summary>
+        Unreadable,
     }
 
-    private static string? FindMatchingPdb(string imagePath, PeCodeView.CodeViewId id)
+    private static NativeSymbolInfo ReadPe(string imagePath, ReadOnlyMemory<byte> imageBytes, IlcNameDemangler demangler)
+    {
+        // A same-directory PDB whose GUID and age match is the rich source; a candidate that
+        // exists but fails identity or parsing is reported, not silently treated as absent.
+        if (PeCodeView.TryRead(imageBytes.Span) is { } id)
+        {
+            var (outcome, pdbPath) = ProbePdb(imagePath, id);
+            switch (outcome)
+            {
+                case PdbProbe.Matched:
+                {
+                    var raw = NativePdb.NativePdbReader.Read(File.ReadAllBytes(pdbPath!), imageBytes);
+                    if (raw.Count > 0)
+                        return Build(raw, demangler, NativeSymbolSource.NativePdb, NativeSymbolStatus.Loaded, pdbPath, null);
+                    return PdataFallback(imageBytes, demangler, NativeSymbolStatus.CorruptSymbolFile,
+                        $"'{Path.GetFileName(pdbPath)}' matched but contains no readable symbols");
+                }
+
+                case PdbProbe.Mismatched:
+                    return PdataFallback(imageBytes, demangler, NativeSymbolStatus.IdMismatch,
+                        $"PDB '{Path.GetFileName(pdbPath)}' does not match the image (GUID or age)");
+                case PdbProbe.Unreadable:
+                    return PdataFallback(imageBytes, demangler, NativeSymbolStatus.CorruptSymbolFile,
+                        $"'{Path.GetFileName(pdbPath)}' is not a readable PDB");
+            }
+        }
+
+        return PdataFallback(imageBytes, demangler, NativeSymbolStatus.FallbackOnly, "no matching PDB");
+    }
+
+    /// <summary>
+    /// Recovers boundaries from <c>.pdata</c> under the given failure status; a status of
+    /// <see cref="NativeSymbolStatus.FallbackOnly"/> degrades to
+    /// <see cref="NativeSymbolStatus.NoSymbolFile"/> when there are no boundaries either.
+    /// </summary>
+    private static NativeSymbolInfo PdataFallback(
+        ReadOnlyMemory<byte> imageBytes, IlcNameDemangler demangler,
+        NativeSymbolStatus status, string baseDiagnostic)
+    {
+        var boundaries = PdataReader.ReadBoundaries(imageBytes);
+        if (boundaries.Count > 0)
+        {
+            return Build(boundaries, demangler, NativeSymbolSource.PdataFallback, status, null,
+                baseDiagnostic + "; recovered function boundaries from .pdata");
+        }
+
+        var empty = status == NativeSymbolStatus.FallbackOnly ? NativeSymbolStatus.NoSymbolFile : status;
+        return new NativeSymbolInfo([], NativeSymbolSource.PdataFallback, empty, null,
+            baseDiagnostic + "; no .pdata exception directory");
+    }
+
+    /// <summary>
+    /// Probes the same-directory PDB candidates: the first matching one wins; when only
+    /// mismatching or unreadable candidates exist, the first is reported so a stale or corrupt
+    /// sidecar is visible to callers.
+    /// </summary>
+    private static (PdbProbe Outcome, string? Path) ProbePdb(string imagePath, PeCodeView.CodeViewId id)
     {
         var directory = Path.GetDirectoryName(imagePath);
-        if (string.IsNullOrEmpty(directory)) return null;
+        if (string.IsNullOrEmpty(directory)) return (PdbProbe.None, null);
 
         var candidates = new List<string>(2);
         if (!string.IsNullOrEmpty(id.PdbPath))
             candidates.Add(Path.Combine(directory, Path.GetFileName(id.PdbPath)));
-        candidates.Add(Path.Combine(directory, Path.GetFileNameWithoutExtension(imagePath) + ".pdb"));
+        var conventional = Path.Combine(directory, Path.GetFileNameWithoutExtension(imagePath) + ".pdb");
+        if (!candidates.Contains(conventional)) candidates.Add(conventional);
 
+        (PdbProbe, string?) firstDefect = (PdbProbe.None, null);
         foreach (var path in candidates)
         {
-            if (File.Exists(path)
-                && NativePdb.NativePdbReader.TryReadPdbId(path, out var guid, out var age)
-                && guid == id.Guid && age == id.Age)
+            if (!File.Exists(path)) continue;
+            if (!NativePdb.NativePdbReader.TryReadPdbId(path, out var guid, out var age))
             {
-                return path;
+                if (firstDefect.Item1 == PdbProbe.None) firstDefect = (PdbProbe.Unreadable, path);
+                continue;
             }
+
+            if (guid == id.Guid && age == id.Age) return (PdbProbe.Matched, path);
+            if (firstDefect.Item1 == PdbProbe.None) firstDefect = (PdbProbe.Mismatched, path);
         }
 
-        return null;
+        return firstDefect;
     }
 
     /// <summary>
@@ -492,19 +595,36 @@ public static class NativeSymbolReader
             aliasesByIndex.Add([]);
         }
 
-        // Size unsized symbols by the distance to the next symbol's address.
-        for (var i = 0; i < primaries.Count; i++)
+        // Size unsized symbols by the distance to the next symbol's start — within the same
+        // section only, so the last symbol of a section never absorbs the gap to the next one.
+        for (var i = 0; i < primaries.Count - 1; i++)
         {
             if (primaries[i].Size > 0) continue;
-            var next = i + 1 < primaries.Count ? primaries[i + 1].VirtualAddress : primaries[i].VirtualAddress;
-            var gap = (long)(next - primaries[i].VirtualAddress);
+            var next = primaries[i + 1];
+            if (primaries[i].Section is not null && next.Section is not null
+                && !string.Equals(primaries[i].Section, next.Section, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var gap = (long)(next.VirtualAddress - primaries[i].VirtualAddress);
             primaries[i] = primaries[i] with { Size = gap > 0 ? gap : 0 };
+        }
+
+        // Clip overlapping extents to the next symbol's start: the Size Map sums this set, so
+        // no byte may be attributed twice.
+        for (var i = 0; i < primaries.Count - 1; i++)
+        {
+            var gap = (long)(primaries[i + 1].VirtualAddress - primaries[i].VirtualAddress);
+            if (primaries[i].Size > gap)
+                primaries[i] = primaries[i] with { Size = gap };
         }
 
         var symbols = new List<NativeSymbol>(primaries.Count);
         for (var i = 0; i < primaries.Count; i++)
         {
             var p = primaries[i];
+            var aliases = aliasesByIndex[i];
             NativeSymbolKind kind;
             string? managedName;
             bool exact;
@@ -521,9 +641,22 @@ public static class NativeSymbolReader
                 kind = demangled.Kind;
                 managedName = demangled.ManagedName;
                 exact = demangled.IsExactMatch;
-                // A symbol the demangler read as a function but that lives in a data section is data.
+
                 if (kind == NativeSymbolKind.Function && p.IsData)
-                    kind = NativeSymbolKind.Data;
+                {
+                    // A data-section record that is neither a recognized ILC node nor a managed
+                    // join is an unrelated global (import thunks, CRT state). Promote a
+                    // recognized alias when the address group has one; otherwise drop the
+                    // record — recognized names only, so the data categories carry no noise.
+                    if (managedName is null && !TryPromoteRecognizedAlias(
+                        demangler, ref p, aliases, out kind, out managedName, out exact))
+                    {
+                        continue;
+                    }
+
+                    if (kind == NativeSymbolKind.Function)
+                        kind = NativeSymbolKind.Data;
+                }
             }
 
             symbols.Add(new NativeSymbol(
@@ -538,10 +671,38 @@ public static class NativeSymbolReader
                 SourceFile: p.SourceFile,
                 Line: p.Line,
                 IsExactMatch: exact,
-                Aliases: aliasesByIndex[i]));
+                Aliases: aliases));
         }
 
         return new NativeSymbolInfo(symbols, source, status, path, diagnostic);
+    }
+
+    /// <summary>
+    /// Re-fronts a merged data record with its first alias the demangler recognizes as an ILC
+    /// node, moving the unrecognized primary name into the aliases.
+    /// </summary>
+    private static bool TryPromoteRecognizedAlias(
+        IlcNameDemangler demangler, ref RawNativeSymbol primary, List<string> aliases,
+        out NativeSymbolKind kind, out string? managedName, out bool exact)
+    {
+        for (var i = 0; i < aliases.Count; i++)
+        {
+            var candidate = demangler.Demangle(aliases[i]);
+            if (candidate.Kind == NativeSymbolKind.Function) continue;
+
+            var promoted = aliases[i];
+            aliases[i] = primary.Name;
+            primary = primary with { Name = promoted };
+            kind = candidate.Kind;
+            managedName = candidate.ManagedName;
+            exact = candidate.IsExactMatch;
+            return true;
+        }
+
+        kind = NativeSymbolKind.Function;
+        managedName = null;
+        exact = false;
+        return false;
     }
 
     // Rich records (procedures/data with sizes and line info) outrank named-only publics, which

--- a/src/Dotsider.Core/Analysis/PdataReader.cs
+++ b/src/Dotsider.Core/Analysis/PdataReader.cs
@@ -1,0 +1,142 @@
+using System.Buffers.Binary;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Recovers function boundaries from a PE's <c>.pdata</c> exception directory when no PDB names
+/// the functions. Each <c>RUNTIME_FUNCTION</c> covers one function's address range; the names are
+/// gone, so these are boundaries, not a symbol table, and — as unwind data — they can miss leaf or
+/// thunk functions. Supports x64 and ARM64 layouts.
+/// </summary>
+internal static class PdataReader
+{
+    private const ushort MachineAmd64 = 0x8664;
+    private const ushort MachineArm64 = 0xAA64;
+    private const int ExceptionDirectoryIndex = 3;
+    private const byte UnwFlagChainInfo = 0x4;
+
+    /// <summary>
+    /// Reads function boundaries from the PE image, or an empty list when it has no usable
+    /// exception directory.
+    /// </summary>
+    /// <param name="peBytes">The raw PE image bytes.</param>
+    public static IReadOnlyList<RawNativeSymbol> ReadBoundaries(ReadOnlyMemory<byte> peBytes)
+    {
+        try
+        {
+            var pe = peBytes.Span;
+            if (pe.Length < 0x40 || pe[0] != (byte)'M' || pe[1] != (byte)'Z') return [];
+            var peHeader = BinaryPrimitives.ReadInt32LittleEndian(pe[0x3C..]);
+            if (peHeader <= 0 || peHeader + 24 > pe.Length) return [];
+            if (BinaryPrimitives.ReadUInt32LittleEndian(pe[peHeader..]) != 0x0000_4550) return [];
+
+            var machine = BinaryPrimitives.ReadUInt16LittleEndian(pe[(peHeader + 4)..]);
+            if (machine is not (MachineAmd64 or MachineArm64)) return [];
+
+            var optional = peHeader + 24;
+            var magic = BinaryPrimitives.ReadUInt16LittleEndian(pe[optional..]);
+            var imageBase = magic == 0x20B
+                ? BinaryPrimitives.ReadUInt64LittleEndian(pe[(optional + 24)..])
+                : BinaryPrimitives.ReadUInt32LittleEndian(pe[(optional + 28)..]);
+            var directoriesStart = optional + (magic == 0x20B ? 112 : 96);
+            var entry = directoriesStart + ExceptionDirectoryIndex * 8;
+            if (entry + 8 > pe.Length) return [];
+
+            var directoryRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[entry..]);
+            var directorySize = BinaryPrimitives.ReadUInt32LittleEndian(pe[(entry + 4)..]);
+            if (directoryRva == 0 || directorySize == 0) return [];
+
+            var addressSpace = NativeAddressSpace.Create(pe);
+            if (addressSpace is null
+                || !addressSpace.TryGetFileOffset(imageBase + directoryRva, out var tableOffset, out _))
+            {
+                return [];
+            }
+
+            return machine == MachineAmd64
+                ? ReadAmd64(pe, tableOffset, (int)directorySize, imageBase, addressSpace)
+                : ReadArm64(pe, tableOffset, (int)directorySize, imageBase, addressSpace);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return [];
+        }
+    }
+
+    private static List<RawNativeSymbol> ReadAmd64(
+        ReadOnlySpan<byte> pe, int tableOffset, int directorySize, ulong imageBase, NativeAddressSpace addressSpace)
+    {
+        var result = new List<RawNativeSymbol>();
+        for (var offset = tableOffset; offset + 12 <= pe.Length && offset < tableOffset + directorySize; offset += 12)
+        {
+            var beginRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[offset..]);
+            var endRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[(offset + 4)..]);
+            var unwindInfoRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[(offset + 8)..]);
+            if (endRva <= beginRva) continue;
+
+            // A chained entry is a fragment of a function whose primary entry appears elsewhere;
+            // folding it in avoids counting one function as several boundaries.
+            if (addressSpace.TryGetFileOffset(imageBase + unwindInfoRva, out var unwindOffset, out var avail)
+                && avail >= 1 && ((pe[unwindOffset] >> 3) & UnwFlagChainInfo) != 0)
+            {
+                continue;
+            }
+
+            result.Add(Boundary(beginRva, endRva - beginRva, imageBase, addressSpace));
+        }
+
+        return result;
+    }
+
+    private static List<RawNativeSymbol> ReadArm64(
+        ReadOnlySpan<byte> pe, int tableOffset, int directorySize, ulong imageBase, NativeAddressSpace addressSpace)
+    {
+        var result = new List<RawNativeSymbol>();
+        for (var offset = tableOffset; offset + 8 <= pe.Length && offset < tableOffset + directorySize; offset += 8)
+        {
+            var beginRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[offset..]);
+            var unwindData = BinaryPrimitives.ReadUInt32LittleEndian(pe[(offset + 4)..]);
+
+            uint functionLength;
+            if ((unwindData & 0x3) != 0)
+            {
+                // Packed unwind: FunctionLength is bits 2..12, in 4-byte words.
+                functionLength = ((unwindData >> 2) & 0x7FF) * 4;
+            }
+            else
+            {
+                // Full .xdata record: the first word's low 18 bits are FunctionLength in words.
+                if (!addressSpace.TryGetFileOffset(imageBase + unwindData, out var xdataOffset, out var avail)
+                    || avail < 4)
+                {
+                    continue;
+                }
+
+                functionLength = (BinaryPrimitives.ReadUInt32LittleEndian(pe[xdataOffset..]) & 0x3_FFFF) * 4;
+            }
+
+            if (functionLength == 0) continue;
+            result.Add(Boundary(beginRva, functionLength, imageBase, addressSpace));
+        }
+
+        return result;
+    }
+
+    private static RawNativeSymbol Boundary(
+        uint rva, uint size, ulong imageBase, NativeAddressSpace addressSpace)
+    {
+        var va = imageBase + rva;
+        long? fileOffset = addressSpace.TryGetFileOffset(va, out var fo, out _) ? fo : null;
+        return new RawNativeSymbol(
+            Name: $"sub_{rva:x}",
+            VirtualAddress: va,
+            Rva: rva,
+            FileOffset: fileOffset,
+            Section: null,
+            Size: size,
+            IsData: false,
+            IsBoundary: true,
+            SourceFile: null,
+            Line: null);
+    }
+}

--- a/src/Dotsider.Core/Analysis/PeCodeView.cs
+++ b/src/Dotsider.Core/Analysis/PeCodeView.cs
@@ -1,0 +1,87 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Extracts the RSDS CodeView debug-directory entry from a PE image's raw bytes — the PDB GUID,
+/// age, and recorded path a Windows native PDB is matched against. Reads the bytes directly so the
+/// native-symbol facade needs no <c>PEReader</c>. Returns null when the image has no RSDS entry.
+/// </summary>
+internal static class PeCodeView
+{
+    /// <summary>The RSDS identity of a PE image.</summary>
+    /// <param name="Guid">The PDB GUID.</param>
+    /// <param name="Age">The PDB age.</param>
+    /// <param name="PdbPath">The recorded PDB path (its file name is used for same-directory probing).</param>
+    internal readonly record struct CodeViewId(Guid Guid, int Age, string PdbPath);
+
+    /// <summary>Reads the RSDS CodeView identity, or null when the image has none.</summary>
+    /// <param name="pe">The raw PE image bytes.</param>
+    public static CodeViewId? TryRead(ReadOnlySpan<byte> pe)
+    {
+        try
+        {
+            if (pe.Length < 0x40 || pe[0] != (byte)'M' || pe[1] != (byte)'Z') return null;
+            var peHeader = BinaryPrimitives.ReadInt32LittleEndian(pe[0x3C..]);
+            if (peHeader <= 0 || peHeader + 24 > pe.Length) return null;
+            if (BinaryPrimitives.ReadUInt32LittleEndian(pe[peHeader..]) != 0x0000_4550) return null;
+
+            var optional = peHeader + 24;
+            var magic = BinaryPrimitives.ReadUInt16LittleEndian(pe[optional..]);
+            var directoriesStart = optional + (magic == 0x20B ? 112 : 96);
+            const int debugDirectoryIndex = 6;
+            var debugEntry = directoriesStart + debugDirectoryIndex * 8;
+            if (debugEntry + 8 > pe.Length) return null;
+
+            var debugRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[debugEntry..]);
+            var debugSize = BinaryPrimitives.ReadUInt32LittleEndian(pe[(debugEntry + 4)..]);
+            if (debugRva == 0 || debugSize == 0) return null;
+
+            var addressSpace = NativeAddressSpace.Create(pe);
+            if (addressSpace is null
+                || !addressSpace.TryGetFileOffset(ReadImageBase(pe) + debugRva, out var tableOffset, out _))
+            {
+                return null;
+            }
+
+            // Walk the 28-byte IMAGE_DEBUG_DIRECTORY entries for a CodeView (type 2) RSDS record.
+            for (var offset = tableOffset; offset + 28 <= pe.Length && offset < tableOffset + (int)debugSize; offset += 28)
+            {
+                var type = BinaryPrimitives.ReadUInt32LittleEndian(pe[(offset + 12)..]);
+                if (type != 2) continue; // IMAGE_DEBUG_TYPE_CODEVIEW
+                var pointerToRawData = (int)BinaryPrimitives.ReadUInt32LittleEndian(pe[(offset + 24)..]);
+                if (pointerToRawData <= 0 || pointerToRawData + 24 > pe.Length) continue;
+
+                if (BinaryPrimitives.ReadUInt32LittleEndian(pe[pointerToRawData..]) != 0x5344_5352) continue; // "RSDS"
+                var guid = new Guid(pe.Slice(pointerToRawData + 4, 16));
+                var age = BinaryPrimitives.ReadInt32LittleEndian(pe[(pointerToRawData + 20)..]);
+                var path = ReadCString(pe[(pointerToRawData + 24)..]);
+                return new CodeViewId(guid, age, path);
+            }
+
+            return null;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return null;
+        }
+    }
+
+    private static ulong ReadImageBase(ReadOnlySpan<byte> pe)
+    {
+        var peHeader = BinaryPrimitives.ReadInt32LittleEndian(pe[0x3C..]);
+        var optional = peHeader + 24;
+        var magic = BinaryPrimitives.ReadUInt16LittleEndian(pe[optional..]);
+        return magic == 0x20B
+            ? BinaryPrimitives.ReadUInt64LittleEndian(pe[(optional + 24)..])
+            : BinaryPrimitives.ReadUInt32LittleEndian(pe[(optional + 28)..]);
+    }
+
+    private static string ReadCString(ReadOnlySpan<byte> span)
+    {
+        var end = span.IndexOf((byte)0);
+        if (end < 0) end = span.Length;
+        return Encoding.UTF8.GetString(span[..end]);
+    }
+}

--- a/src/Dotsider.Core/Analysis/RawNativeSymbol.cs
+++ b/src/Dotsider.Core/Analysis/RawNativeSymbol.cs
@@ -1,0 +1,29 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// A symbol as a format reader (PDB, DWARF, nlist, or a fallback) recovers it, before the facade
+/// demangles its name, classifies its kind, and merges duplicates. Addresses are already resolved
+/// to the forms the reader could compute; the facade fills in the rest and produces the public
+/// <see cref="Models.NativeSymbol"/>.
+/// </summary>
+/// <param name="Name">The raw (mangled) symbol name, or a synthesized boundary name.</param>
+/// <param name="VirtualAddress">The symbol's virtual address.</param>
+/// <param name="Rva">The PE relative virtual address, or null for non-PE images.</param>
+/// <param name="FileOffset">The file offset the address maps to, or null when not file-backed.</param>
+/// <param name="Section">The containing section name, or null when unknown.</param>
+/// <param name="Size">The symbol size in bytes, or 0 when the reader could not determine it.</param>
+/// <param name="IsData">Whether the reader found this in a data (non-executable) context, so it should classify as data even if the name is unrecognized.</param>
+/// <param name="IsBoundary">Whether this is a nameless boundary from a fallback source.</param>
+/// <param name="SourceFile">The declaring source file, when available.</param>
+/// <param name="Line">The declaring source line, when available.</param>
+internal readonly record struct RawNativeSymbol(
+    string Name,
+    ulong VirtualAddress,
+    uint? Rva,
+    long? FileOffset,
+    string? Section,
+    long Size,
+    bool IsData,
+    bool IsBoundary,
+    string? SourceFile,
+    int? Line);

--- a/src/Dotsider.Core/Analysis/SizeAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/SizeAnalyzer.cs
@@ -6,7 +6,8 @@ namespace Dotsider.Core.Analysis;
 /// Computes IL code size per method and builds a hierarchical size tree
 /// for treemap visualization. For a Native AOT binary with an mstat sidecar the tree is
 /// built from the compiler's size report instead: native code and MethodTable bytes per
-/// assembly, namespace, type, and method, plus the binary's data categories.
+/// assembly, namespace, type, and method, plus the binary's data categories. Without an
+/// mstat, the binary's merged native symbols carry the tree.
 /// </summary>
 public static class SizeAnalyzer
 {
@@ -19,6 +20,13 @@ public static class SizeAnalyzer
     {
         if (analyzer.BinaryKind == BinaryKind.NativeAot && analyzer.Mstat is { } mstat)
             return BuildAotSizeTree(analyzer, mstat);
+
+        // No mstat: the merged native symbols carry the tree at symbol fidelity.
+        if (analyzer.BinaryKind == BinaryKind.NativeAot
+            && analyzer.NativeSymbols is { Symbols.Count: > 0 } symbols)
+        {
+            return BuildFromSymbols(analyzer.FileName, analyzer.RecoveredTypes, symbols);
+        }
 
         // Get method sizes
         var methodSizes = new List<(MethodDefInfo Method, long Size)>();
@@ -255,4 +263,150 @@ public static class SizeAnalyzer
         ns.Length > 0 && typeName.StartsWith(ns + ".", StringComparison.Ordinal)
             ? typeName[(ns.Length + 1)..]
             : typeName;
+
+    /// <summary>
+    /// Builds the size tree of a Native AOT binary from its merged native symbols: functions
+    /// joined to managed names land under assembly &gt; namespace &gt; type, and the
+    /// compiler-generated node kinds under explicit categories — unjoined names in
+    /// <c>Runtime</c>, nameless boundaries in <c>Unattributed</c>. Each merged symbol is summed
+    /// exactly once, so no byte is counted twice.
+    /// </summary>
+    /// <param name="fileName">The analyzed binary's file name, for the root node.</param>
+    /// <param name="recoveredTypes">The binary's recovered metadata, for assembly attribution.</param>
+    /// <param name="info">The merged native symbols.</param>
+    internal static SizeNode BuildFromSymbols(
+        string fileName, IReadOnlyList<RecoveredType> recoveredTypes, NativeSymbolInfo info)
+    {
+        // FullName -> assembly scope, for attributing a joined method to its assembly subtree
+        // and for finding the type/method split point inside a joined name.
+        var assemblyByType = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var type in recoveredTypes)
+            assemblyByType.TryAdd(type.FullName, type.AssemblyName ?? "(unknown assembly)");
+
+        // assembly -> namespace -> type FullName -> method leaves
+        var assemblies = new Dictionary<string, Dictionary<string, Dictionary<string, List<SizeNode>>>>(StringComparer.Ordinal);
+        var categories = new Dictionary<string, List<SizeNode>>(StringComparer.Ordinal);
+
+        void Categorize(string category, NativeSymbol symbol, SizeNodeKind kind) =>
+            (categories.TryGetValue(category, out var list) ? list : categories[category] = [])
+                .Add(new SizeNode(
+                    symbol.ManagedName ?? symbol.Name,
+                    $"{category}/{symbol.Name}@0x{symbol.VirtualAddress:x}",
+                    symbol.Size, kind, []));
+
+        foreach (var symbol in info.Symbols)
+        {
+            if (symbol.Size <= 0) continue;
+            switch (symbol.Kind)
+            {
+                case NativeSymbolKind.Function
+                    when symbol.ManagedName is not null
+                        && TrySplitManagedName(symbol.ManagedName, assemblyByType,
+                            out var assembly, out var ns, out var type, out var method):
+                {
+                    var namespaces = assemblies.TryGetValue(assembly, out var a)
+                        ? a
+                        : assemblies[assembly] = new Dictionary<string, Dictionary<string, List<SizeNode>>>(StringComparer.Ordinal);
+                    var types = namespaces.TryGetValue(ns, out var n)
+                        ? n
+                        : namespaces[ns] = new Dictionary<string, List<SizeNode>>(StringComparer.Ordinal);
+                    (types.TryGetValue(type, out var methods) ? methods : types[type] = [])
+                        .Add(new SizeNode(
+                            method, $"{assembly}/{type}::{method}@0x{symbol.VirtualAddress:x}",
+                            symbol.Size, SizeNodeKind.Function, []));
+                    break;
+                }
+
+                case NativeSymbolKind.Function:
+                    Categorize("Runtime", symbol, SizeNodeKind.Function);
+                    break;
+                case NativeSymbolKind.Boundary:
+                    Categorize("Unattributed", symbol, SizeNodeKind.Function);
+                    break;
+                case NativeSymbolKind.MethodTable:
+                    Categorize("MethodTables", symbol, SizeNodeKind.MethodTable);
+                    break;
+                case NativeSymbolKind.FrozenObject:
+                    Categorize("Frozen Objects", symbol, SizeNodeKind.FrozenObject);
+                    break;
+                case NativeSymbolKind.Stub:
+                    Categorize("Stubs", symbol, SizeNodeKind.Function);
+                    break;
+                case NativeSymbolKind.GenericDictionary:
+                    Categorize("Generic Dictionaries", symbol, SizeNodeKind.Blob);
+                    break;
+                case NativeSymbolKind.Statics:
+                    Categorize("Statics", symbol, SizeNodeKind.Blob);
+                    break;
+                default:
+                    Categorize("Data", symbol, SizeNodeKind.Blob);
+                    break;
+            }
+        }
+
+        var roots = new List<SizeNode>();
+        foreach (var (assemblyName, namespaces) in assemblies)
+        {
+            var namespaceNodes = namespaces
+                .Select(kvp => new SizeNode(
+                    kvp.Key, $"{assemblyName}/{kvp.Key}",
+                    kvp.Value.Values.Sum(m => m.Sum(x => x.Size)), SizeNodeKind.Namespace,
+                    [.. kvp.Value
+                        .Select(t => new SizeNode(
+                            StripNamespace(t.Key, kvp.Key == "(global)" ? "" : kvp.Key),
+                            $"{assemblyName}/{t.Key}",
+                            t.Value.Sum(m => m.Size), SizeNodeKind.Type,
+                            [.. t.Value.OrderByDescending(m => m.Size)]))
+                        .OrderByDescending(t => t.Size)]))
+                .OrderByDescending(n => n.Size)
+                .ToList();
+
+            roots.Add(new SizeNode(
+                assemblyName, assemblyName,
+                namespaceNodes.Sum(n => n.Size), SizeNodeKind.Assembly, namespaceNodes));
+        }
+
+        foreach (var (category, entries) in categories)
+        {
+            roots.Add(new SizeNode(
+                category, category, entries.Sum(e => e.Size), SizeNodeKind.Category,
+                [.. entries.OrderByDescending(e => e.Size)]));
+        }
+
+        return new SizeNode(
+            fileName, fileName,
+            roots.Sum(r => r.Size), SizeNodeKind.Assembly,
+            [.. roots.OrderByDescending(r => r.Size)]);
+    }
+
+    /// <summary>
+    /// Splits a joined name (<c>{type.FullName}.{method}</c>) at the recovered type boundary.
+    /// Method names may contain dots (<c>.ctor</c>), so split points are probed right to left
+    /// against the recovered type names rather than guessed.
+    /// </summary>
+    private static bool TrySplitManagedName(
+        string managedName, Dictionary<string, string> assemblyByType,
+        out string assembly, out string ns, out string type, out string method)
+    {
+        for (var i = managedName.LastIndexOf('.'); i > 0; i = managedName.LastIndexOf('.', i - 1))
+        {
+            var candidate = managedName[..i];
+            if (!assemblyByType.TryGetValue(candidate, out var owner)) continue;
+
+            assembly = owner;
+            type = candidate;
+            method = managedName[(i + 1)..];
+
+            // The namespace is the outermost scope's dotted prefix; nested types ('+') keep
+            // their full display under the type node.
+            var plus = candidate.IndexOf('+');
+            var scope = plus >= 0 ? candidate[..plus] : candidate;
+            var dot = scope.LastIndexOf('.');
+            ns = dot > 0 ? scope[..dot] : "(global)";
+            return method.Length > 0;
+        }
+
+        assembly = ns = type = method = "";
+        return false;
+    }
 }

--- a/src/Dotsider.Core/README.md
+++ b/src/Dotsider.Core/README.md
@@ -10,10 +10,11 @@ Core library for .NET assembly analysis. Provides analyzers, models, and the dia
 | `IlDisassembler` | Disassembles method bodies into IL instruction sequences |
 | `IlNavigationResolver` | Resolves metadata tokens from IL instructions to `IlNavigationTarget` records (file path, type/method, member kind) for go-to-definition |
 | `StringExtractor` | Extracts user strings, metadata strings, and raw binary strings from an assembly |
-| `SizeAnalyzer` | Builds a hierarchical size tree (namespace → type → method) by IL byte size; for Native AOT binaries with an mstat sidecar the tree comes from the compiler's size report instead, with per-assembly subtrees and data categories |
+| `SizeAnalyzer` | Builds a hierarchical size tree (namespace → type → method) by IL byte size; for Native AOT binaries the tree comes from the compiler's mstat report when present, else from the binary's merged native symbols, with per-assembly subtrees and data categories |
 | `DependencyGraphBuilder` | Generates a dependency graph (nodes and edges) from assembly references; routes through `NetFxBinder` for .NET Framework roots so nodes are keyed on the *bound* identity (post-redirect). Native AOT binaries graph the compiled-in assemblies (mstat × DGML join) plus native import modules |
 | `MstatReader` | Decodes an ILC size report (`.mstat`) — a valid ECMA-335 assembly whose data lives in IL streams — into per-method, per-type, blob, frozen object, RVA field, and resource sizes with assembly attribution and dependency-graph node names |
 | `DgmlReader` | Streams an ILC dependency-graph DGML file into a `DgmlGraph` whose `PathToRoot` answers "why is this in my binary" — node labels equal mstat node names, joining the two files |
+| `NativeSymbolReader` | Reads a native binary's symbols — names, addresses, sizes, kinds, and source locations — from its native PDB (MSF/DBI/CodeView with C13 lines and publics), DWARF `.dbg` sidecar (DIE walk, range lists, line programs, `.symtab` data pass), or dSYM bundle (DWARF + nlist merged), validating identity first (GUID+age, build id / debuglink CRC, or UUID) and demangling ILC names against the binary's own recovered metadata; falls back to unwind-data boundaries (`.pdata`, `.eh_frame`, `LC_FUNCTION_STARTS`) when no symbol file exists |
 | `AssemblyDiffer` | Compares two assemblies and reports added, removed, and changed types, methods, and references. Method body comparison uses normalized IL instruction walks with semantic token resolution, deep local signature decoding, and exception region analysis |
 | `RuntimeTracer` | Launches a .NET process with EventPipe tracing for JIT, GC, exception, and counter events |
 | `NuGetPackageAnalyzer` | Reads `.nupkg` files for package metadata and DLL listing |
@@ -41,6 +42,8 @@ All models live in `Analysis/Models/` and are plain records or enums suitable fo
 **Size:** `SizeNode`, `SizeNodeKind`
 
 **Native AOT sidecars:** `MstatData`, `MstatMethod`, `MstatType`, `MstatBlob`, `MstatRvaField`, `MstatFrozenObject`, `MstatManifestResource`, `MstatDeduplicatedMethod`, `DgmlGraph`, `DgmlNode`, `DgmlLink`, `DgmlPathStep`
+
+**Native symbols:** `NativeSymbolInfo`, `NativeSymbol`, `NativeSymbolKind`, `NativeSymbolSource`, `NativeSymbolStatus`
 
 **Strings:** `StringEntry`, `StringSource`
 

--- a/src/Dotsider.Core/README.md
+++ b/src/Dotsider.Core/README.md
@@ -93,6 +93,7 @@ The diagnostics protocol enables communication between the dotsider TUI and exte
 | `search-il-opcodes` | Query, MaxResults? | Find methods containing an opcode |
 | `get-size-tree` | — | Hierarchical size tree (AOT-aware: mstat-backed for Native AOT binaries) |
 | `get-largest-methods` | MaxResults? | Top methods by IL size |
+| `get-native-symbols` | — | Native symbols with provenance (PDB/DWARF/dSYM, or unwind-data boundaries) |
 | `get-strings` | Query?, MinLength?, MaxResults? | User, metadata, and binary strings |
 | `get-assembly-refs` | — | Assembly references |
 | `get-dependency-graph` | — | Dependency graph nodes and edges (AOT-aware: compiled-in assemblies and native imports) |

--- a/src/Dotsider.Mcp/Tools/AssemblyTools.cs
+++ b/src/Dotsider.Mcp/Tools/AssemblyTools.cs
@@ -48,7 +48,10 @@ public sealed partial class AssemblyTools(DotsiderSessionManager sessionManager)
                 AssemblyRefCount = analyzer.AssemblyRefs.Count,
                 ReadyToRunSectionCount = analyzer.ReadyToRunSections.Count,
                 RecoveredTypeCount = analyzer.RecoveredTypes.Count,
-                FrozenStringCount = analyzer.FrozenStrings.Count
+                FrozenStringCount = analyzer.FrozenStrings.Count,
+                NativeSymbolCount = analyzer.NativeSymbols?.Symbols.Count ?? 0,
+                NativeSymbolSource = analyzer.NativeSymbols?.Source,
+                NativeSymbolStatus = analyzer.NativeSymbols?.Status
             }, DotsiderJsonOptions.Default);
         }
 

--- a/src/Dotsider.Mcp/Tools/SymbolTools.cs
+++ b/src/Dotsider.Mcp/Tools/SymbolTools.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using Dotsider.Core.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Dotsider.Mcp.Tools;
+
+/// <summary>
+/// MCP tools for native symbols: function names, addresses, and sizes read from a Native AOT
+/// binary's PDB, DWARF, or dSYM — or unwind-data boundaries when no symbol file exists.
+/// </summary>
+[McpServerToolType]
+public sealed partial class SymbolTools(DotsiderSessionManager sessionManager)
+{
+    /// <summary>
+    /// Gets a binary's native symbols with their provenance (source, status, symbol file path).
+    /// </summary>
+    /// <param name="assemblyPath">Path to the binary file.</param>
+    /// <param name="sessionId">PID of a running dotsider instance.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>JSON with the symbol list and its provenance, or an error for managed assemblies.</returns>
+    [McpServerTool(ReadOnly = true, OpenWorld = false)]
+    public async partial Task<string> GetNativeSymbols(
+        string? assemblyPath = null,
+        int? sessionId = null,
+        CancellationToken ct = default)
+    {
+        if (assemblyPath is not null)
+        {
+            ToolHelpers.ValidateAssemblyPath(assemblyPath);
+            using var analyzer = ToolHelpers.OpenAnalyzer(assemblyPath);
+            return analyzer.NativeSymbols is { } info
+                ? JsonSerializer.Serialize(info, DotsiderJsonOptions.Default)
+                : "Error: managed assembly; no native symbols to read.";
+        }
+
+        if (sessionId is not null)
+        {
+            return await sessionManager.GetTarget(sessionId.Value)
+                .SendAndUnwrapAsync(new DotsiderRequest { Method = "get-native-symbols" }, ct);
+        }
+
+        return "Error: Either assemblyPath or sessionId is required.";
+    }
+}

--- a/src/Dotsider/Commands/AnalyzeCommand.cs
+++ b/src/Dotsider/Commands/AnalyzeCommand.cs
@@ -6,7 +6,7 @@ using Dotsider.Infrastructure;
 namespace Dotsider.Commands;
 
 /// <summary>
-/// Headless assembly analysis command: types, methods, IL, deps, strings, size.
+/// Headless assembly analysis command: types, methods, IL, deps, strings, size, symbols.
 /// </summary>
 internal static class AnalyzeCommand
 {
@@ -56,6 +56,11 @@ internal static class AnalyzeCommand
         Description = "Show size breakdown"
     };
 
+    private static readonly Option<bool> s_symbolsOption = new("--symbols")
+    {
+        Description = "List native symbols (Native AOT and other native binaries)"
+    };
+
     private static readonly Option<string?> s_whyOption = new("--why")
     {
         Description = "Explain why a type or method is in a Native AOT binary (requires mstat and DGML sidecars)"
@@ -92,6 +97,7 @@ internal static class AnalyzeCommand
             s_stringsOption,
             s_minLenOption,
             s_sizeOption,
+            s_symbolsOption,
             s_whyOption,
             s_fieldsOption,
             s_bundleOption,
@@ -212,6 +218,9 @@ internal static class AnalyzeCommand
                 if (parseResult.GetValue(s_sizeOption))
                     return Task.FromResult(PrintSize(analyzer, formatter));
 
+                if (parseResult.GetValue(s_symbolsOption))
+                    return Task.FromResult(PrintSymbols(analyzer, formatter));
+
                 if (parseResult.GetValue(s_whyOption) is { } whyTarget)
                     return Task.FromResult(PrintWhy(analyzer, whyTarget, formatter));
 
@@ -247,6 +256,10 @@ internal static class AnalyzeCommand
                 a.ReadyToRunSections,
                 RecoveredTypeCount = a.RecoveredTypes.Count,
                 FrozenStringCount = a.FrozenStrings.Count,
+                NativeSymbolCount = a.NativeSymbols?.Symbols.Count ?? 0,
+                NativeSymbolSource = a.NativeSymbols?.Source,
+                NativeSymbolStatus = a.NativeSymbols?.Status,
+                a.NativeSymbolsPath,
                 Types = a.TypeDefs, Methods = a.MethodDefs, References = a.AssemblyRefs
             });
         }
@@ -269,6 +282,12 @@ internal static class AnalyzeCommand
                 fmt.WriteLine($"Recovered:  {a.RecoveredTypes.Count} types, "
                     + $"{a.RecoveredTypes.Sum(t => t.MethodNames.Count)} methods");
                 fmt.WriteLine($"Frozen:     {a.FrozenStrings.Count} strings");
+                if (a.NativeSymbols is { } symbols)
+                {
+                    fmt.WriteLine(symbols.Symbols.Count > 0
+                        ? $"Symbols:    {symbols.Symbols.Count} from {symbols.Source}"
+                        : $"Symbols:    {symbols.Diagnostic ?? symbols.Status.ToString()}");
+                }
             }
             fmt.WriteLine($"PDB:        {a.PdbProvenance}");
             fmt.WriteLine($"SourceLink: {(a.SourceLink.IsPresent ? $"present, {a.SourceLink.Mappings.Count} mappings" : "not present")}");
@@ -548,6 +567,46 @@ internal static class AnalyzeCommand
             foreach (var s in frozen)
                 fmt.WriteLine($"  [{s.Offset:X6}] {s.Value}");
         }
+
+        return 0;
+    }
+
+    private static int PrintSymbols(AssemblyAnalyzer a, OutputFormatter fmt)
+    {
+        if (a.NativeSymbols is not { } info)
+        {
+            Console.Error.WriteLine("Error: managed assembly; no native symbols to read");
+            return 1;
+        }
+
+        if (fmt.JsonMode)
+        {
+            fmt.WriteJson(new
+            {
+                info.Source, info.Status, info.Path, info.Diagnostic,
+                info.Symbols.Count,
+                info.Symbols
+            });
+            return 0;
+        }
+
+        fmt.WriteLine($"Source:     {info.Source} ({info.Status})");
+        fmt.WriteLine($"Path:       {info.Path ?? "(none)"}");
+        if (info.Diagnostic is not null)
+            fmt.WriteLine($"Note:       {info.Diagnostic}");
+        fmt.WriteLine("");
+
+        fmt.WriteLine($"Symbols ({info.Symbols.Count}):");
+        fmt.WriteTable(
+            ["Address", "Size", "Kind", "Name", "Source"],
+            info.Symbols.Select(s => new[]
+            {
+                $"0x{s.VirtualAddress:X}",
+                s.Size.ToString(),
+                s.Kind.ToString(),
+                s.ManagedName ?? s.Name,
+                s.SourceFile is not null ? $"{s.SourceFile}:{s.Line}" : ""
+            }));
 
         return 0;
     }

--- a/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
+++ b/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
@@ -244,6 +244,9 @@ internal sealed class DotsiderDiagnosticsListener(
                 "get-size-tree" => HandleGetSizeTree(),
                 "get-largest-methods" => HandleGetLargestMethods(request),
 
+                // Symbols
+                "get-native-symbols" => HandleGetNativeSymbols(),
+
                 // Diff
                 "diff" => HandleDiff(request),
 
@@ -333,7 +336,10 @@ internal sealed class DotsiderDiagnosticsListener(
             AssemblyRefCount = a.AssemblyRefs.Count,
             ReadyToRunSectionCount = a.ReadyToRunSections.Count,
             RecoveredTypeCount = a.RecoveredTypes.Count,
-            FrozenStringCount = a.FrozenStrings.Count
+            FrozenStringCount = a.FrozenStrings.Count,
+            NativeSymbolCount = a.NativeSymbols?.Symbols.Count ?? 0,
+            NativeSymbolSource = a.NativeSymbols?.Source,
+            NativeSymbolStatus = a.NativeSymbols?.Status
         });
     }
 
@@ -635,6 +641,16 @@ internal sealed class DotsiderDiagnosticsListener(
             .Take(max);
 
         return DotsiderResponse.Ok(methods);
+    }
+
+    // --- Symbols Handler ---
+
+    private DotsiderResponse HandleGetNativeSymbols()
+    {
+        var a = RequireAnalyzer();
+        return a.NativeSymbols is { } info
+            ? DotsiderResponse.Ok(info)
+            : DotsiderResponse.Fail("Managed assembly; no native symbols to read");
     }
 
     // --- Diff Handler ---

--- a/src/Dotsider/PeSubTabId.cs
+++ b/src/Dotsider/PeSubTabId.cs
@@ -44,6 +44,9 @@ public static class PeSubTabId
     /// <summary>AOT Types sub-tab (types and methods recovered from Native AOT metadata).</summary>
     public const int AotTypes = 12;
 
+    /// <summary>Symbols sub-tab (native symbols from the binary's PDB, DWARF, or dSYM).</summary>
+    public const int Symbols = 13;
+
     /// <summary>Total number of PE/Metadata sub-tabs.</summary>
-    public const int Count = 13;
+    public const int Count = 14;
 }

--- a/src/Dotsider/Views/GeneralView.cs
+++ b/src/Dotsider/Views/GeneralView.cs
@@ -100,6 +100,12 @@ public static class GeneralView
             infoLines.Add($"  Recovered Types:  {recoveredTypes.Count} types, "
                 + $"{recoveredTypes.Sum(t => t.MethodNames.Count)} methods");
             infoLines.Add($"  Frozen Strings:   {analyzer.FrozenStrings.Count}");
+            if (analyzer.NativeSymbols is { } symbols)
+            {
+                infoLines.Add(symbols.Symbols.Count > 0
+                    ? $"  Native Symbols:   {symbols.Symbols.Count} from {symbols.Source}"
+                    : $"  Native Symbols:   {symbols.Diagnostic ?? symbols.Status.ToString()}");
+            }
         }
 
         var infoText = string.Join("\n", infoLines);

--- a/src/Dotsider/Views/PeMetadataView.cs
+++ b/src/Dotsider/Views/PeMetadataView.cs
@@ -79,6 +79,8 @@ public static class PeMetadataView
                         analyzer.ReadyToRunSections[0].SectionId,
                     PeSubTabId.AotTypes when analyzer.RecoveredTypes.Count > 0 =>
                         analyzer.RecoveredTypes[0].FullName,
+                    PeSubTabId.Symbols when GetSymbolRows(analyzer).Count > 0 =>
+                        GetSymbolRows(analyzer)[0].VirtualAddress,
                     _ => null
                 };
         }
@@ -246,7 +248,9 @@ public static class PeMetadataView
                     tp.Tab("R2R Sections", t => [BuildRtrSectionsTable(t, state)])
                         .Selected(state.PeSubTab == PeSubTabId.RtrSections),
                     tp.Tab("AOT Types", t => [BuildAotTypesTable(t, state)])
-                        .Selected(state.PeSubTab == PeSubTabId.AotTypes)
+                        .Selected(state.PeSubTab == PeSubTabId.AotTypes),
+                    tp.Tab("Symbols", t => [BuildSymbolsTable(t, state)])
+                        .Selected(state.PeSubTab == PeSubTabId.Symbols)
                 ])
                 .OnSelectionChanged(e =>
                 {
@@ -829,6 +833,8 @@ public static class PeMetadataView
                 s => $"{s.SectionId} {s.Name}").Select(s => (object)s.SectionId)],
             PeSubTabId.AotTypes => [.. ApplySearch(analyzer.RecoveredTypes, query,
                 t => t.FullName).Select(t => (object)t.FullName)],
+            PeSubTabId.Symbols => [.. ApplySearch(GetSymbolRows(analyzer), query,
+                s => $"{s.Name} {s.ManagedName} {s.Kind} {s.SourceFile}").Select(s => (object)s.VirtualAddress)],
             _ => []
         };
     }
@@ -1025,6 +1031,62 @@ public static class PeMetadataView
             })
             .Compact().Fill();
     }
+
+    private static TableWidget<NativeSymbol> BuildSymbolsTable(
+        WidgetContext<VStackWidget> ctx, DotsiderState state)
+    {
+        var query = state.Search[TabId.PeMetadata].Query;
+        var data = ApplySearch(GetSymbolRows(state.Analyzer), query,
+            s => $"{s.Name} {s.ManagedName} {s.Kind} {s.SourceFile}");
+        state.Search[TabId.PeMetadata].SetMatchCount(data.Count);
+
+        return ctx.Table(data)
+            .RowKey(s => s.VirtualAddress)
+            .Header(h =>
+            [
+                h.Cell("Address").Width(SizeHint.Fixed(14)),
+                h.Cell("RVA").Width(SizeHint.Fixed(12)),
+                h.Cell("Size").Width(SizeHint.Fixed(9)),
+                h.Cell("Kind").Width(SizeHint.Fixed(13)),
+                h.Cell("Name").Width(SizeHint.Fill)
+            ])
+            .Row((r, s, rs) =>
+            [
+                r.Cell(c => FocusStyle(c, HexCell(c, $"0x{s.VirtualAddress:X}"), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, HexCell(c, s.Rva is { } rva ? $"0x{rva:X8}" : ""), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, c.Text(s.Size.ToString()), rs.IsFocused)),
+                r.Cell(c => FocusStyle(c, c.Text(s.Kind.ToString()), rs.IsFocused)),
+                r.Cell(c => FocusHighlightCell(c, s.ManagedName ?? s.Name, query, true, rs.IsFocused))
+            ])
+            .Focus(state.PeDetailContent is not null || state.App.FocusedNode is EditorNode ? null : state.PeFocusedKey)
+            .OnFocusChanged(key => state.PeFocusedKey = key)
+            .OnRowActivated((_, s) =>
+            {
+                var info = state.Analyzer.NativeSymbols!;
+                state.PeDetailContent = string.Join("\n",
+                    "Native Symbol",
+                    $"Name: {s.Name}",
+                    $"Managed: {s.ManagedName ?? "(no managed join)"}{(s.IsExactMatch ? " (exact)" : "")}",
+                    $"Kind: {s.Kind}",
+                    $"Address: 0x{s.VirtualAddress:X}"
+                        + (s.Rva is { } rva ? $"  RVA: 0x{rva:X8}" : "")
+                        + (s.FileOffset is { } fo ? $"  File Offset: 0x{fo:X}" : ""),
+                    $"Section: {s.Section ?? "(unknown)"}",
+                    $"Size: {s.Size} (0x{s.Size:X})",
+                    $"Source: {(s.SourceFile is not null ? $"{s.SourceFile}:{s.Line}" : "(none)")}",
+                    $"Aliases: {(s.Aliases.Count > 0 ? string.Join(", ", s.Aliases) : "(none)")}",
+                    "",
+                    $"Symbols From: {info.Source} ({info.Status})",
+                    $"Path: {info.Path ?? "(none)"}");
+                state.App.RequestFocus(node => node is EditorNode);
+                state.App.Invalidate();
+            })
+            .Compact().Fill();
+    }
+
+    /// <summary>The native symbols to display, or empty when the binary is managed.</summary>
+    private static IReadOnlyList<NativeSymbol> GetSymbolRows(Core.Analysis.AssemblyAnalyzer analyzer) =>
+        analyzer.NativeSymbols?.Symbols ?? [];
 
     /// <summary>Flattens the import table into one row per imported function.</summary>
     private static IReadOnlyList<ImportRow> GetImportRows(Core.Analysis.AssemblyAnalyzer analyzer) =>

--- a/tests/Dotsider.Mcp.Tests/SymbolToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/SymbolToolsTests.cs
@@ -1,0 +1,77 @@
+namespace Dotsider.Mcp.Tests;
+
+/// <summary>
+/// Tests for the native-symbol MCP tool: <c>get_native_symbols</c> against the real Native AOT
+/// fixture and the managed-assembly error path.
+/// </summary>
+[Collection("SampleAssemblies")]
+public class SymbolToolsTests(SampleAssemblyFixture samples) : McpServerTestBase
+{
+    /// <summary>
+    /// get_native_symbols returns the symbol list with its provenance for a Native AOT binary.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task GetNativeSymbols_NativeAot_ReturnsSymbolsWithProvenance()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "get_native_symbols",
+            new Dictionary<string, object?> { ["assemblyPath"] = samples.NativeAotConsoleExe },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        Assert.False(text.StartsWith("Error", StringComparison.Ordinal),
+            "the tool reported an error instead of symbols");
+        Assert.Contains("\"source\"", text);
+        Assert.Contains("\"status\"", text);
+        Assert.Contains("\"symbols\"", text);
+    }
+
+    /// <summary>
+    /// get_native_symbols reports an error for a managed assembly instead of an empty list.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task GetNativeSymbols_Managed_ReturnsError()
+    {
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "get_native_symbols",
+            new Dictionary<string, object?> { ["assemblyPath"] = samples.RichLibraryDll },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        Assert.Contains("Error", text);
+        Assert.Contains("managed", text);
+    }
+
+    /// <summary>
+    /// get_assembly_info carries the native symbol provenance fields.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task GetAssemblyInfo_NativeAot_CarriesSymbolProvenance()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "get_assembly_info",
+            new Dictionary<string, object?> { ["assemblyPath"] = samples.NativeAotConsoleExe },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        Assert.Contains("nativeSymbolCount", text);
+        Assert.Contains("nativeSymbolSource", text);
+        Assert.Contains("nativeSymbolStatus", text);
+    }
+}

--- a/tests/Dotsider.Mcp.Tests/ToolRegistrationTests.cs
+++ b/tests/Dotsider.Mcp.Tests/ToolRegistrationTests.cs
@@ -50,6 +50,9 @@ public class ToolRegistrationTests : McpServerTestBase
         Assert.Contains("get_size_breakdown", names);
         Assert.Contains("get_largest_methods", names);
 
+        // Symbol tools
+        Assert.Contains("get_native_symbols", names);
+
         // Diff tools
         Assert.Contains("diff_assemblies", names);
 

--- a/tests/Dotsider.Tests/AssemblyAnalyzerTests.cs
+++ b/tests/Dotsider.Tests/AssemblyAnalyzerTests.cs
@@ -946,6 +946,114 @@ public class AssemblyAnalyzerTests(SampleAssemblyFixture samples)
         }
     }
 
+    /// <summary>
+    /// Verifies a Native AOT binary with its matching PDB beside it is marked NativePdb, carrying
+    /// the PDB path, rather than the UnsupportedWindowsPdb it used to report.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Provenance_NativeAotExeWithMatchingPdb_IsNativePdb()
+    {
+        Assert.SkipWhen(
+            samples.NativeAotConsoleSymbols is null
+            || !samples.NativeAotConsoleSymbols.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase),
+            "native PDB not present on this platform");
+
+        using var a = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+
+        Assert.Equal(PdbProvenanceKind.NativePdb, a.PdbProvenance.Kind);
+        Assert.Equal(samples.NativeAotConsoleSymbols, a.PdbProvenance.Path);
+    }
+
+    /// <summary>
+    /// Verifies a Native AOT binary copied away from its PDB falls back to UnsupportedWindowsPdb.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Provenance_NativeAotExeWithoutPdb_IsUnsupportedWindowsPdb()
+    {
+        Assert.SkipWhen(
+            samples.NativeAotConsoleSymbols is null
+            || !samples.NativeAotConsoleSymbols.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase),
+            "native PDB not present on this platform");
+
+        var dir = Directory.CreateTempSubdirectory("dotsider-nopdb-");
+        try
+        {
+            var exeCopy = Path.Combine(dir.FullName, Path.GetFileName(samples.NativeAotConsoleExe!));
+            File.Copy(samples.NativeAotConsoleExe!, exeCopy);
+            using var a = new AssemblyAnalyzer(exeCopy);
+
+            Assert.Equal(PdbProvenanceKind.UnsupportedWindowsPdb, a.PdbProvenance.Kind);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a PDB whose GUID does not match the binary is rejected as UnsupportedWindowsPdb,
+    /// not accepted as a native match.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Provenance_NativeAotExeWithWrongPdb_IsUnsupportedWindowsPdb()
+    {
+        Assert.SkipWhen(
+            samples.NativeAotConsoleSymbols is null
+            || !samples.NativeAotConsoleSymbols.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase),
+            "native PDB not present on this platform");
+
+        var dir = Directory.CreateTempSubdirectory("dotsider-wrongpdb-");
+        try
+        {
+            var name = Path.GetFileName(samples.NativeAotConsoleExe!);
+            var exeCopy = Path.Combine(dir.FullName, name);
+            File.Copy(samples.NativeAotConsoleExe!, exeCopy);
+            var stem = name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ? name[..^4] : name;
+
+            // A valid PDB whose GUID no longer matches the binary: flip the info-stream GUID bytes
+            // in a copy of the real PDB, leaving the container otherwise intact.
+            var pdb = File.ReadAllBytes(samples.NativeAotConsoleSymbols!);
+            MutatePdbGuid(pdb);
+            File.WriteAllBytes(Path.Combine(dir.FullName, stem + ".pdb"), pdb);
+
+            using var a = new AssemblyAnalyzer(exeCopy);
+
+            Assert.Equal(PdbProvenanceKind.UnsupportedWindowsPdb, a.PdbProvenance.Kind);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    // Zeroes the PDB info-stream GUID so its id no longer matches the exe, while leaving the MSF
+    // container valid. Walks the superblock → block map → directory to find stream 1's first block.
+    private static void MutatePdbGuid(byte[] pdb)
+    {
+        var s = pdb.AsSpan();
+        var blockSize = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(s[32..]);
+        var numDirBytes = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(s[44..]);
+        var blockMapAddr = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(s[52..]);
+        var dirBlockCount = (numDirBytes + blockSize - 1) / blockSize;
+        var dir = new byte[dirBlockCount * blockSize];
+        for (var i = 0; i < dirBlockCount; i++)
+        {
+            var b = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(s[(blockMapAddr * blockSize + i * 4)..]);
+            s.Slice(b * blockSize, blockSize).CopyTo(dir.AsSpan(i * blockSize));
+        }
+
+        var p = 0;
+        var numStreams = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(dir.AsSpan(p));
+        p += 4;
+        var sizes = new int[numStreams];
+        for (var i = 0; i < numStreams; i++) { sizes[i] = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(dir.AsSpan(p)); p += 4; }
+        var stream0Blocks = (Math.Max(0, sizes[0]) + blockSize - 1) / blockSize;
+        p += stream0Blocks * 4;
+        var stream1FirstBlock = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(dir.AsSpan(p));
+        // GUID is at offset 12 in the info stream's first block.
+        for (var i = 0; i < 16; i++) pdb[stream1FirstBlock * blockSize + 12 + i] ^= 0xFF;
+    }
+
     private static MethodDefInfo FindMethod(AssemblyAnalyzer analyzer, string typeName, string methodName)
     {
         var method = analyzer.MethodDefs.FirstOrDefault(m =>

--- a/tests/Dotsider.Tests/CliTests.cs
+++ b/tests/Dotsider.Tests/CliTests.cs
@@ -559,6 +559,75 @@ public class CliTests(SampleAssemblyFixture fixture)
     }
 
     /// <summary>
+    /// Verifies <c>analyze --symbols</c> on a Native AOT binary prints the provenance header
+    /// and the symbol table.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Analyze_Symbols_NativeAot_PrintsTable()
+    {
+        Assert.SkipWhen(fixture.NativeAotConsoleSymbols is null, "native symbols were not produced");
+
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.NativeAotConsoleExe!, "--symbols");
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Source:", stdout);
+        Assert.Contains("Symbols (", stdout);
+        Assert.Contains("0x", stdout);
+    }
+
+    /// <summary>
+    /// Verifies <c>analyze --symbols --json</c> carries the provenance and the symbol list.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Analyze_Symbols_NativeAot_Json_CarriesProvenance()
+    {
+        Assert.SkipWhen(fixture.NativeAotConsoleSymbols is null, "native symbols were not produced");
+
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.NativeAotConsoleExe!, "--symbols", "--json");
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"source\"", stdout);
+        Assert.Contains("\"status\"", stdout);
+        Assert.Contains("\"symbols\"", stdout);
+        Assert.Contains("virtualAddress", stdout);
+    }
+
+    /// <summary>
+    /// Verifies <c>analyze --symbols</c> on a managed assembly exits 1 — there are no native
+    /// symbols to read.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Analyze_Symbols_Managed_ExitsOne()
+    {
+        var (exitCode, _, stderr) = await RunDotsiderAsync(
+            "analyze", fixture.RichLibraryDll, "--symbols");
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("managed", stderr);
+    }
+
+    /// <summary>
+    /// Verifies the default <c>analyze --json</c> info carries the native symbol provenance
+    /// fields for a Native AOT binary.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Analyze_Info_NativeAot_Json_CarriesSymbolProvenance()
+    {
+        Assert.SkipWhen(fixture.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze", fixture.NativeAotConsoleExe!, "--json");
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("nativeSymbolCount", stdout);
+        Assert.Contains("nativeSymbolSource", stdout);
+        Assert.Contains("nativeSymbolStatus", stdout);
+        Assert.Contains("nativeSymbolsPath", stdout);
+    }
+
+    /// <summary>
     /// Verifies <c>analyze --why</c> prints the root-first dependency chain for a compiled
     /// method when both sidecars are present.
     /// </summary>

--- a/tests/Dotsider.Tests/DwarfBlob.cs
+++ b/tests/Dotsider.Tests/DwarfBlob.cs
@@ -1,0 +1,89 @@
+namespace Dotsider.Tests;
+
+/// <summary>
+/// A little-endian byte composer for hand-building DWARF section blobs in tests: fixed-width
+/// integers, LEB128 variable-length integers, and NUL-terminated strings, with fluent chaining
+/// so a DIE reads as one expression.
+/// </summary>
+internal sealed class DwarfBlob
+{
+    private readonly List<byte> _bytes = [];
+
+    /// <summary>The byte count written so far.</summary>
+    public int Length => _bytes.Count;
+
+    /// <summary>Writes one byte.</summary>
+    public DwarfBlob U8(byte value)
+    {
+        _bytes.Add(value);
+        return this;
+    }
+
+    /// <summary>Writes a little-endian u16.</summary>
+    public DwarfBlob U16(ushort value)
+    {
+        _bytes.Add((byte)value);
+        _bytes.Add((byte)(value >> 8));
+        return this;
+    }
+
+    /// <summary>Writes a little-endian u32.</summary>
+    public DwarfBlob U32(uint value)
+    {
+        for (var i = 0; i < 4; i++) _bytes.Add((byte)(value >> (8 * i)));
+        return this;
+    }
+
+    /// <summary>Writes a little-endian u64.</summary>
+    public DwarfBlob U64(ulong value)
+    {
+        for (var i = 0; i < 8; i++) _bytes.Add((byte)(value >> (8 * i)));
+        return this;
+    }
+
+    /// <summary>Writes an unsigned LEB128 integer.</summary>
+    public DwarfBlob ULeb(ulong value)
+    {
+        do
+        {
+            var b = (byte)(value & 0x7F);
+            value >>= 7;
+            if (value != 0) b |= 0x80;
+            _bytes.Add(b);
+        }
+        while (value != 0);
+        return this;
+    }
+
+    /// <summary>Writes a signed LEB128 integer.</summary>
+    public DwarfBlob SLeb(long value)
+    {
+        while (true)
+        {
+            var b = (byte)(value & 0x7F);
+            value >>= 7;
+            var done = (value == 0 && (b & 0x40) == 0) || (value == -1 && (b & 0x40) != 0);
+            if (!done) b |= 0x80;
+            _bytes.Add(b);
+            if (done) return this;
+        }
+    }
+
+    /// <summary>Writes a NUL-terminated UTF-8 string.</summary>
+    public DwarfBlob CStr(string value)
+    {
+        _bytes.AddRange(System.Text.Encoding.UTF8.GetBytes(value));
+        _bytes.Add(0);
+        return this;
+    }
+
+    /// <summary>Appends raw bytes.</summary>
+    public DwarfBlob Bytes(byte[] data)
+    {
+        _bytes.AddRange(data);
+        return this;
+    }
+
+    /// <summary>Materializes the blob.</summary>
+    public byte[] ToArray() => [.. _bytes];
+}

--- a/tests/Dotsider.Tests/DwarfLineProgramTests.cs
+++ b/tests/Dotsider.Tests/DwarfLineProgramTests.cs
@@ -1,0 +1,262 @@
+using Dotsider.Core.Analysis.Dwarf;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="DwarfLineProgram"/> — header parsing across v2–v5 and DWARF64, the two
+/// file-table shapes, the row state machine (special, standard, and extended opcodes), and the
+/// decl-primary source attribution — driven with hand-built <c>.debug_line</c> blobs.
+/// </summary>
+public class DwarfLineProgramTests
+{
+    private static readonly byte[] StandardLengths = [0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1];
+
+    private static DwarfSections Sections(byte[] line, byte[]? str = null, byte[]? lineStr = null) =>
+        new([], [], str ?? [], lineStr ?? [], [], [], line, [], []);
+
+    /// <summary>Builds a v2–v4 line program with the classic directory and file lists.</summary>
+    private static byte[] Program(
+        ushort version, byte[] ops, string[] dirs, (string Name, int Dir)[] files,
+        sbyte lineBase = -5, byte lineRange = 14, byte opcodeBase = 13,
+        byte[]? standardLengths = null)
+    {
+        var tail = new DwarfBlob()
+            .U8(1); // minimum_instruction_length
+        if (version >= 4) tail.U8(1); // maximum_operations_per_instruction
+        tail.U8(1) // default_is_stmt
+            .U8((byte)lineBase).U8(lineRange).U8(opcodeBase);
+        var lengths = standardLengths ?? StandardLengths;
+        for (var i = 0; i < opcodeBase - 1; i++) tail.U8(lengths[i]);
+
+        foreach (var dir in dirs) tail.CStr(dir);
+        tail.U8(0);
+        foreach (var (name, dir) in files) tail.CStr(name).ULeb((ulong)dir).ULeb(0).ULeb(0);
+        tail.U8(0);
+
+        var body = new DwarfBlob().U16(version).U32((uint)tail.Length).Bytes(tail.ToArray()).Bytes(ops);
+        return new DwarfBlob().U32((uint)body.Length).Bytes(body.ToArray()).ToArray();
+    }
+
+    /// <summary>
+    /// Verifies a v4 program joins directories into file names, decodes copy/advance rows, ends
+    /// coverage at the end-sequence row, and attributes decl-first with row fallback.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Parse_V4_RowsAndDeclPrimaryAttribution()
+    {
+        var ops = new DwarfBlob()
+            .U8(0).ULeb(9).U8(2).U64(0x1000)    // set_address 0x1000
+            .U8(3).SLeb(9)                      // advance_line -> 10
+            .U8(1)                              // copy: row(0x1000, file 1, 10)
+            .U8(2).ULeb(0x20)                   // advance_pc -> 0x1020
+            .U8(3).SLeb(5)                      // -> 15
+            .U8(1)                              // copy: row(0x1020, file 1, 15)
+            .U8(2).ULeb(0x10)                   // -> 0x1030
+            .U8(0).ULeb(1).U8(1)                // end_sequence at 0x1030
+            .ToArray();
+
+        var line = Program(4, ops, ["src"], [("main.cs", 1), ("/abs/other.cs", 1)]);
+        var program = DwarfLineProgram.Parse(Sections(line), 0);
+
+        Assert.NotNull(program);
+        Assert.Equal("src/main.cs", program.FileName(1));
+        Assert.Equal("/abs/other.cs", program.FileName(2)); // rooted names are not joined
+        Assert.Null(program.FileName(0));                   // v4 tables are 1-based
+        Assert.Null(program.FileName(3));
+
+        Assert.True(program.TryFindLine(0x1000, out var file, out var lineNo));
+        Assert.Equal("src/main.cs", file);
+        Assert.Equal(10, lineNo);
+        Assert.True(program.TryFindLine(0x101F, out _, out lineNo));
+        Assert.Equal(10, lineNo);
+        Assert.True(program.TryFindLine(0x102F, out _, out lineNo));
+        Assert.Equal(15, lineNo);
+        Assert.False(program.TryFindLine(0x1030, out _, out _)); // past the sequence
+        Assert.False(program.TryFindLine(0x0FFF, out _, out _)); // before it
+
+        Assert.Equal(("src/main.cs", 42), program.ResolveSource(1, 42, 0x1000));   // decl primary
+        Assert.Equal(("src/main.cs", 15), program.ResolveSource(-1, 0, 0x1024));   // row fallback
+        Assert.Equal(("src/main.cs", 10), program.ResolveSource(1, 0, 0x1000));    // mixed
+    }
+
+    /// <summary>
+    /// Verifies special-opcode address/line arithmetic, <c>const_add_pc</c>,
+    /// <c>fixed_advance_pc</c>, and that an unknown standard opcode is skipped by its declared
+    /// operand count.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Parse_SpecialAndPcOpcodes_AdvanceExactly()
+    {
+        // opcode_base 14: op 13 is an unknown standard opcode declared with 2 operands.
+        byte[] lengths = [0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1, 2];
+        var ops = new DwarfBlob()
+            .U8(0).ULeb(9).U8(2).U64(0x2000)    // set_address 0x2000
+            .U8(14 + 53)                        // special: +8 addr, +2 line -> row(0x2008, 3)
+            .U8(13).ULeb(7).ULeb(9)             // unknown standard opcode: skip 2 LEBs
+            .U8(8)                              // const_add_pc: +(255-14)/6 = +40 -> 0x2030
+            .U8(9).U16(0x10)                    // fixed_advance_pc -> 0x2040
+            .U8(14 + 4)                         // special: +0 addr, +1 line -> row(0x2040, 4)
+            .U8(0).ULeb(1).U8(1)                // end_sequence
+            .ToArray();
+
+        var line = Program(4, ops, [], [("a.c", 0)],
+            lineBase: -3, lineRange: 6, opcodeBase: 14, standardLengths: lengths);
+        var program = DwarfLineProgram.Parse(Sections(line), 0);
+
+        Assert.NotNull(program);
+        Assert.True(program.TryFindLine(0x2008, out var file, out var lineNo));
+        Assert.Equal("a.c", file); // directory index 0 resolves to the bare name
+        Assert.Equal(3, lineNo);
+        Assert.True(program.TryFindLine(0x203F, out _, out lineNo));
+        Assert.Equal(3, lineNo);
+        Assert.True(program.TryFindLine(0x2040, out _, out lineNo));
+        Assert.Equal(4, lineNo);
+    }
+
+    /// <summary>Verifies a v2 header (no maximum-operations field) still parses and decodes rows.</summary>
+    [Fact(Timeout = 30_000)]
+    public void Parse_V2Header_DecodesRows()
+    {
+        var ops = new DwarfBlob()
+            .U8(0).ULeb(9).U8(2).U64(0x100)
+            .U8(1)
+            .U8(0).ULeb(1).U8(1)
+            .ToArray();
+
+        var program = DwarfLineProgram.Parse(Sections(Program(2, ops, [], [("f.c", 0)])), 0);
+
+        Assert.NotNull(program);
+        Assert.True(program.TryFindLine(0x100, out var file, out _));
+        Assert.Equal("f.c", file);
+    }
+
+    /// <summary>
+    /// Verifies the v5 form-described tables: directories via <c>line_strp</c>, files carrying
+    /// path, directory index, and skipped timestamp/MD5 columns, with 0-based numbering.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Parse_V5Tables_ResolveFormsAndZeroBasedFiles()
+    {
+        var lineStr = new DwarfBlob().CStr("proj").CStr("src").ToArray(); // offsets 0 and 5
+
+        var tail = new DwarfBlob()
+            .U8(1).U8(1).U8(1)                          // min_inst, max_ops, default_is_stmt
+            .U8(unchecked((byte)(sbyte)-5)).U8(14).U8(13);
+        foreach (var l in StandardLengths) tail.U8(l);
+
+        tail.U8(1).ULeb(1).ULeb(DwarfForm.LineStrp)     // directory format: path as line_strp
+            .ULeb(2).U32(0).U32(5);                     // 2 directories: "proj", "src"
+        tail.U8(4)                                      // file format: 4 columns
+            .ULeb(1).ULeb(DwarfForm.String)             //   path
+            .ULeb(2).ULeb(DwarfForm.Udata)              //   directory index
+            .ULeb(3).ULeb(DwarfForm.Udata)              //   timestamp (skipped)
+            .ULeb(5).ULeb(DwarfForm.Data16)             //   MD5 (skipped)
+            .ULeb(2)
+            .CStr("app.cs").ULeb(0).ULeb(7).Bytes(new byte[16])
+            .CStr("util.cs").ULeb(1).ULeb(9).Bytes(new byte[16]);
+
+        var ops = new DwarfBlob()
+            .U8(0).ULeb(9).U8(2).U64(0x9000)
+            .U8(4).ULeb(1)                              // set_file 1
+            .U8(1)                                      // copy: row(0x9000, file 1, 1)
+            .U8(2).ULeb(0x10)
+            .U8(0).ULeb(1).U8(1)
+            .ToArray();
+
+        var body = new DwarfBlob().U16(5).U8(8).U8(0)
+            .U32((uint)tail.Length).Bytes(tail.ToArray()).Bytes(ops);
+        var line = new DwarfBlob().U32((uint)body.Length).Bytes(body.ToArray()).ToArray();
+
+        var program = DwarfLineProgram.Parse(Sections(line, lineStr: lineStr), 0);
+
+        Assert.NotNull(program);
+        Assert.Equal("proj/app.cs", program.FileName(0));
+        Assert.Equal("src/util.cs", program.FileName(1));
+        Assert.True(program.TryFindLine(0x9008, out var file, out var lineNo));
+        Assert.Equal("src/util.cs", file);
+        Assert.Equal(1, lineNo);
+    }
+
+    /// <summary>
+    /// Verifies <c>DW_LNE_define_file</c> appends to the v4 file table mid-program and rows can
+    /// attribute to the added file.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Parse_DefineFile_AppendsToTable()
+    {
+        var define = new DwarfBlob().CStr("gen.c").ULeb(1).ULeb(0).ULeb(0).ToArray();
+        var ops = new DwarfBlob()
+            .U8(0).ULeb((ulong)(1 + define.Length)).U8(3).Bytes(define) // define_file "inc/gen.c"
+            .U8(4).ULeb(2)                                              // set_file 2
+            .U8(0).ULeb(9).U8(2).U64(0x100)
+            .U8(1)
+            .U8(0).ULeb(1).U8(1)
+            .ToArray();
+
+        var program = DwarfLineProgram.Parse(Sections(Program(4, ops, ["inc"], [("main.c", 0)])), 0);
+
+        Assert.NotNull(program);
+        Assert.Equal("inc/gen.c", program.FileName(2));
+        Assert.True(program.TryFindLine(0x100, out var file, out _));
+        Assert.Equal("inc/gen.c", file);
+    }
+
+    /// <summary>Verifies a DWARF64 header (escaped length, 8-byte header length) parses.</summary>
+    [Fact(Timeout = 30_000)]
+    public void Parse_Dwarf64Header_DecodesRows()
+    {
+        var tail = new DwarfBlob().U8(1).U8(1).U8(1)
+            .U8(unchecked((byte)(sbyte)-5)).U8(14).U8(13);
+        foreach (var l in StandardLengths) tail.U8(l);
+        tail.U8(0).CStr("f.c").ULeb(0).ULeb(0).ULeb(0).U8(0); // no dirs, one file
+
+        var ops = new DwarfBlob()
+            .U8(0).ULeb(9).U8(2).U64(0x100)
+            .U8(1)
+            .U8(0).ULeb(1).U8(1)
+            .ToArray();
+
+        var body = new DwarfBlob().U16(4).U64((ulong)tail.Length).Bytes(tail.ToArray()).Bytes(ops);
+        var line = new DwarfBlob().U32(0xFFFF_FFFF).U64((ulong)body.Length).Bytes(body.ToArray()).ToArray();
+
+        var program = DwarfLineProgram.Parse(Sections(line), 0);
+
+        Assert.NotNull(program);
+        Assert.True(program.TryFindLine(0x100, out var file, out _));
+        Assert.Equal("f.c", file);
+    }
+
+    /// <summary>
+    /// Verifies malformed inputs: out-of-range offsets and bad headers yield no program, and a
+    /// program whose body breaks mid-opcode keeps the rows decoded before the damage.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Parse_Malformed_FailsClosedOrKeepsPartialRows()
+    {
+        Assert.Null(DwarfLineProgram.Parse(Sections([1, 2, 3]), 0x100));
+
+        var badVersion = Program(4, [], [], []);
+        badVersion[4] = 9; // version u16 low byte
+        Assert.Null(DwarfLineProgram.Parse(Sections(badVersion), 0));
+
+        var zeroRange = Program(4, [], [], []);
+        zeroRange[14] = 0; // line_range: length(4) + version(2) + header_length(4) + 4 machine bytes
+        Assert.Null(DwarfLineProgram.Parse(Sections(zeroRange), 0));
+
+        // A row, then an extended op whose declared length overruns the unit: row survives.
+        var ops = new DwarfBlob()
+            .U8(0).ULeb(9).U8(2).U64(0x500)
+            .U8(1)
+            .U8(0).ULeb(200)
+            .ToArray();
+        var program = DwarfLineProgram.Parse(Sections(Program(4, ops, [], [("k.c", 0)])), 0);
+        Assert.NotNull(program);
+        Assert.True(program.TryFindLine(0x500, out var file, out _));
+        Assert.Equal("k.c", file);
+
+        // An empty program parses but covers nothing.
+        var empty = DwarfLineProgram.Parse(Sections(Program(4, [], [], [("e.c", 0)])), 0);
+        Assert.NotNull(empty);
+        Assert.False(empty.TryFindLine(0, out _, out _));
+    }
+}

--- a/tests/Dotsider.Tests/DwarfRangeListsTests.cs
+++ b/tests/Dotsider.Tests/DwarfRangeListsTests.cs
@@ -1,0 +1,163 @@
+using Dotsider.Core.Analysis.Dwarf;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="DwarfRangeLists"/> — the v4 <c>.debug_ranges</c> pair walk and the v5
+/// <c>.debug_rnglists</c> RLE walk — driven with hand-built section blobs covering every entry
+/// opcode, the base-address escapes, and the <c>rnglistx</c> offset-array indirection.
+/// </summary>
+public class DwarfRangeListsTests
+{
+    private static DwarfReader.UnitContext Unit(
+        ushort version, int addressSize = 8, ulong baseAddress = 0,
+        long addrBase = 8, long rnglistsBase = 12) =>
+        new(version, Is64: false, addressSize, baseAddress,
+            StrOffsetsBase: 8, addrBase, rnglistsBase, StmtListOffset: -1);
+
+    private static DwarfSections Sections(byte[]? ranges = null, byte[]? rngLists = null, byte[]? addr = null) =>
+        new([], [], [], [], [], addr ?? [], [], ranges ?? [], rngLists ?? []);
+
+    /// <summary>Builds a v5 <c>.debug_addr</c> section (8-byte header, u64 entries).</summary>
+    private static byte[] AddrTable(params ulong[] entries)
+    {
+        var blob = new DwarfBlob().U32((uint)(4 + entries.Length * 8)).U16(5).U8(8).U8(0);
+        foreach (var e in entries) blob.U64(e);
+        return blob.ToArray();
+    }
+
+    /// <summary>
+    /// Verifies the v4 walk sums begin/end pairs against the CU base, honors the <c>(-1, base)</c>
+    /// base-address escape, and stops at the <c>(0, 0)</c> terminator.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void TryResolve_V4Pairs_SumsAndRebases()
+    {
+        var ranges = new DwarfBlob()
+            .U64(0x10).U64(0x20)                    // [base+0x10, base+0x20)
+            .U64(ulong.MaxValue).U64(0x2000)        // base := 0x2000
+            .U64(0x0).U64(0x40)                     // [0x2000, 0x2040)
+            .U64(0).U64(0)                          // terminator
+            .ToArray();
+
+        var ok = DwarfRangeLists.TryResolve(Sections(ranges: ranges), 0, isRnglistx: false,
+            Unit(4, baseAddress: 0x1000), out var start, out var size);
+
+        Assert.True(ok);
+        Assert.Equal(0x1010UL, start);
+        Assert.Equal(0x50UL, size);
+    }
+
+    /// <summary>Verifies the v4 walk uses 4-byte entries and the 32-bit escape for 32-bit units.</summary>
+    [Fact(Timeout = 30_000)]
+    public void TryResolve_V4FourByteAddresses_UsesNarrowEscape()
+    {
+        var ranges = new DwarfBlob()
+            .U32(0x10).U32(0x20)
+            .U32(uint.MaxValue).U32(0x9000)
+            .U32(0x0).U32(0x8)
+            .U32(0).U32(0)
+            .ToArray();
+
+        var ok = DwarfRangeLists.TryResolve(Sections(ranges: ranges), 0, isRnglistx: false,
+            Unit(4, addressSize: 4, baseAddress: 0x100), out var start, out var size);
+
+        Assert.True(ok);
+        Assert.Equal(0x110UL, start);
+        Assert.Equal(0x18UL, size);
+    }
+
+    /// <summary>
+    /// Verifies the v5 walk decodes every RLE opcode: base switches (direct and via
+    /// <c>.debug_addr</c>), offset pairs, start/end, start/length, and the <c>startx</c> forms.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void TryResolve_V5AllOpcodes_SumsCoveredBytes()
+    {
+        var list = new DwarfBlob()
+            .U8(0x05).U64(0x5000)                   // base_address 0x5000
+            .U8(0x04).ULeb(0x10).ULeb(0x30)         // offset_pair -> [0x5010, 0x5030) = 0x20
+            .U8(0x07).U64(0x6000).ULeb(0x25)        // start_length = 0x25
+            .U8(0x03).ULeb(0).ULeb(8)               // startx_length: addr[0]=0x7000, 8 bytes
+            .U8(0x02).ULeb(0).ULeb(1)               // startx_endx: [0x7000, 0x8000) = 0x1000
+            .U8(0x01).ULeb(1)                       // base_addressx: base := addr[1] = 0x8000
+            .U8(0x04).ULeb(0).ULeb(4)               // offset_pair -> [0x8000, 0x8004) = 4
+            .U8(0x06).U64(0x9000).U64(0x9010)       // start_end = 0x10
+            .U8(0x00)                               // end_of_list
+            .ToArray();
+
+        var ok = DwarfRangeLists.TryResolve(
+            Sections(rngLists: list, addr: AddrTable(0x7000, 0x8000)),
+            0, isRnglistx: false, Unit(5), out var start, out var size);
+
+        Assert.True(ok);
+        Assert.Equal(0x5010UL, start);
+        Assert.Equal(0x20UL + 0x25 + 8 + 0x1000 + 4 + 0x10, size);
+    }
+
+    /// <summary>
+    /// Verifies a <c>rnglistx</c> index resolves through the CU's offset array — each entry an
+    /// offset from the array base to its list — before walking the list.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void TryResolve_Rnglistx_ResolvesThroughOffsetArray()
+    {
+        var list0 = new DwarfBlob().U8(0x07).U64(0x111).ULeb(1).U8(0x00).ToArray();
+        var list1 = new DwarfBlob().U8(0x07).U64(0x2000).ULeb(0x30).U8(0x00).ToArray();
+        var section = new DwarfBlob()
+            .U32(0).U16(5).U8(8).U8(0).U32(2)       // header: length (unused), version, addr, seg, count
+            .U32(8).U32((uint)(8 + list0.Length))   // offset array, relative to its own base (12)
+            .Bytes(list0).Bytes(list1)
+            .ToArray();
+
+        var ok = DwarfRangeLists.TryResolve(Sections(rngLists: section), 1, isRnglistx: true,
+            Unit(5), out var start, out var size);
+
+        Assert.True(ok);
+        Assert.Equal(0x2000UL, start);
+        Assert.Equal(0x30UL, size);
+
+        Assert.True(DwarfRangeLists.TryResolve(Sections(rngLists: section), 0, isRnglistx: true,
+            Unit(5), out start, out size));
+        Assert.Equal(0x111UL, start);
+        Assert.Equal(1UL, size);
+    }
+
+    /// <summary>
+    /// Verifies malformed inputs fail closed: out-of-range offsets, unknown opcodes, a
+    /// <c>startx</c> without <c>.debug_addr</c>, and lists that cover nothing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void TryResolve_Malformed_ReturnsFalse()
+    {
+        // Offset beyond the section.
+        Assert.False(DwarfRangeLists.TryResolve(Sections(ranges: [1, 2]), 0x100, false,
+            Unit(4), out _, out _));
+
+        // Unknown v5 opcode.
+        Assert.False(DwarfRangeLists.TryResolve(Sections(rngLists: [0xAA]), 0, false,
+            Unit(5), out _, out _));
+
+        // startx with no .debug_addr to resolve against.
+        var startx = new DwarfBlob().U8(0x03).ULeb(0).ULeb(8).U8(0x00).ToArray();
+        Assert.False(DwarfRangeLists.TryResolve(Sections(rngLists: startx), 0, false,
+            Unit(5), out _, out _));
+
+        // Immediate terminator: nothing covered.
+        Assert.False(DwarfRangeLists.TryResolve(Sections(rngLists: [0x00]), 0, false,
+            Unit(5), out _, out _));
+        var emptyV4 = new DwarfBlob().U64(0).U64(0).ToArray();
+        Assert.False(DwarfRangeLists.TryResolve(Sections(ranges: emptyV4), 0, false,
+            Unit(4), out _, out _));
+
+        // rnglistx index beyond the offset array.
+        var tiny = new DwarfBlob().U32(0).U16(5).U8(8).U8(0).U32(0).ToArray();
+        Assert.False(DwarfRangeLists.TryResolve(Sections(rngLists: tiny), 5, true,
+            Unit(5), out _, out _));
+
+        // Truncated v4 list (no terminator) keeps nothing rather than throwing.
+        var truncated = new DwarfBlob().U64(0x10).U64(0x20).ToArray();
+        Assert.False(DwarfRangeLists.TryResolve(Sections(ranges: truncated), 0, false,
+            Unit(4), out _, out _));
+    }
+}

--- a/tests/Dotsider.Tests/DwarfReaderTests.cs
+++ b/tests/Dotsider.Tests/DwarfReaderTests.cs
@@ -1,0 +1,592 @@
+using Dotsider.Core.Analysis.Dwarf;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="DwarfReader"/> — the DIE walk that recovers functions — driven with
+/// hand-built <c>.debug_info</c>/<c>.debug_abbrev</c> blobs so every form the decoder claims
+/// (string indirection, indexed addresses, DWARF64, references, skips) is pinned byte-for-byte.
+/// </summary>
+public class DwarfReaderTests
+{
+    /// <summary>Writes one abbreviation declaration (code, tag, children, attribute/form pairs).</summary>
+    private static DwarfBlob Decl(
+        DwarfBlob blob, ulong code, ulong tag, bool children, params (ulong At, ulong Form)[] attrs)
+    {
+        blob.ULeb(code).ULeb(tag).U8((byte)(children ? 1 : 0));
+        foreach (var (at, form) in attrs) blob.ULeb(at).ULeb(form);
+        return blob.ULeb(0).ULeb(0);
+    }
+
+    /// <summary>Wraps DIE bytes in a compilation-unit header of the given version.</summary>
+    private static byte[] Cu(ushort version, byte[] dies, uint abbrevOffset = 0, bool is64 = false, byte unitType = 1)
+    {
+        var body = new DwarfBlob().U16(version);
+        if (version >= 5)
+        {
+            body.U8(unitType).U8(8);
+            if (is64) body.U64(abbrevOffset);
+            else body.U32(abbrevOffset);
+        }
+        else
+        {
+            if (is64) body.U64(abbrevOffset);
+            else body.U32(abbrevOffset);
+            body.U8(8);
+        }
+
+        body.Bytes(dies);
+        var unit = new DwarfBlob();
+        if (is64) unit.U32(0xFFFF_FFFF).U64((ulong)body.Length);
+        else unit.U32((uint)body.Length);
+        return unit.Bytes(body.ToArray()).ToArray();
+    }
+
+    private static DwarfSections Sections(
+        byte[] info, byte[] abbrev, byte[]? str = null, byte[]? lineStr = null,
+        byte[]? strOffsets = null, byte[]? addr = null) =>
+        new(info, abbrev, str ?? [], lineStr ?? [], strOffsets ?? [], addr ?? [], [], [], []);
+
+    /// <summary>Builds a v5 <c>.debug_str_offsets</c> section (8-byte header, u32 entries).</summary>
+    private static byte[] StrOffsetsTable(params uint[] entries)
+    {
+        var blob = new DwarfBlob().U32((uint)(4 + entries.Length * 4)).U16(5).U16(0);
+        foreach (var e in entries) blob.U32(e);
+        return blob.ToArray();
+    }
+
+    /// <summary>Builds a v5 <c>.debug_addr</c> section (8-byte header, u64 entries).</summary>
+    private static byte[] AddrTable(params ulong[] entries)
+    {
+        var blob = new DwarfBlob().U32((uint)(4 + entries.Length * 8)).U16(5).U8(8).U8(0);
+        foreach (var e in entries) blob.U64(e);
+        return blob.ToArray();
+    }
+
+    /// <summary>
+    /// Verifies a v4 unit yields the subprogram's name, address, size from address-class
+    /// <c>high_pc</c>, and decl file/line, and that the unit context captures the CU's base
+    /// address and line-program offset.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_V4_ReadsNameAddressSizeAndDeclInfo()
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true,
+            (DwarfForm.AtLowPc, DwarfForm.Addr), (DwarfForm.AtStmtList, DwarfForm.SecOffset));
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.String), (DwarfForm.AtDeclFile, DwarfForm.Data1),
+            (DwarfForm.AtDeclLine, DwarfForm.Data2), (DwarfForm.AtLowPc, DwarfForm.Addr),
+            (DwarfForm.AtHighPc, DwarfForm.Addr));
+        abbrev.ULeb(0);
+
+        var dies = new DwarfBlob()
+            .ULeb(1).U64(0x400000).U32(0x77)
+            .ULeb(2).CStr("main").U8(3).U16(42).U64(0x401000).U64(0x401040)
+            .ULeb(0);
+
+        var result = DwarfReader.ReadFunctions(Sections(Cu(4, dies.ToArray()), abbrev.ToArray()));
+
+        var (function, unit) = Assert.Single(result);
+        Assert.Equal("main", function.Name);
+        Assert.Equal(0x401000UL, function.LowPc);
+        Assert.Equal(0x40UL, function.Size);
+        Assert.Equal(3, function.DeclFile);
+        Assert.Equal(42, function.DeclLine);
+        Assert.Equal(0x77, function.StmtListOffset);
+        Assert.Equal(4, unit.Version);
+        Assert.Equal(0x400000UL, unit.BaseAddress);
+        Assert.Equal(0x77, unit.StmtListOffset);
+    }
+
+    /// <summary>
+    /// Verifies a v5 unit honors explicit <c>str_offsets_base</c>/<c>addr_base</c> attributes
+    /// when resolving <c>strx1</c>/<c>addrx1</c>, and takes offset-class <c>high_pc</c> as the
+    /// size directly.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_V5_ExplicitBasesAndOffsetHighPc()
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true,
+            (DwarfForm.AtStrOffsetsBase, DwarfForm.SecOffset), (DwarfForm.AtAddrBase, DwarfForm.SecOffset));
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.Strx1), (DwarfForm.AtLowPc, DwarfForm.Addrx1),
+            (DwarfForm.AtHighPc, DwarfForm.Data4));
+        abbrev.ULeb(0);
+
+        // Bases point past the tables' first entries, so index 0 must land on the second entry.
+        var dies = new DwarfBlob()
+            .ULeb(1).U32(12).U32(16)
+            .ULeb(2).U8(0).U8(0).U32(0x30)
+            .ULeb(0);
+
+        var sections = Sections(Cu(5, dies.ToArray()), abbrev.ToArray(),
+            str: new DwarfBlob().U8(0).CStr("EntryPoint").ToArray(),
+            strOffsets: StrOffsetsTable(999, 1),
+            addr: AddrTable(0xDEAD, 0x2000));
+
+        var (function, unit) = Assert.Single(DwarfReader.ReadFunctions(sections));
+        Assert.Equal("EntryPoint", function.Name);
+        Assert.Equal(0x2000UL, function.LowPc);
+        Assert.Equal(0x30UL, function.Size);
+        Assert.Equal(5, unit.Version);
+    }
+
+    /// <summary>
+    /// Verifies every string form resolves the name: <c>strp</c>, <c>line_strp</c>, and the five
+    /// <c>strx</c> encodings through the default v5 <c>.debug_str_offsets</c> base.
+    /// </summary>
+    [Theory(Timeout = 30_000)]
+    [InlineData(DwarfForm.Strp)]
+    [InlineData(DwarfForm.LineStrp)]
+    [InlineData(DwarfForm.Strx)]
+    [InlineData(DwarfForm.Strx1)]
+    [InlineData(DwarfForm.Strx2)]
+    [InlineData(DwarfForm.Strx3)]
+    [InlineData(DwarfForm.Strx4)]
+    public void ReadFunctions_StringForms_ResolveName(ulong form)
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true);
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, form), (DwarfForm.AtLowPc, DwarfForm.Addr));
+        abbrev.ULeb(0);
+
+        var dies = new DwarfBlob().ULeb(1).ULeb(2);
+        switch (form)
+        {
+            case DwarfForm.Strp or DwarfForm.LineStrp: dies.U32(1); break;
+            case DwarfForm.Strx: dies.ULeb(1); break;
+            case DwarfForm.Strx1: dies.U8(1); break;
+            case DwarfForm.Strx2: dies.U16(1); break;
+            case DwarfForm.Strx3: dies.U16(1).U8(0); break;
+            case DwarfForm.Strx4: dies.U32(1); break;
+        }
+
+        dies.U64(0x1000).ULeb(0);
+
+        var strings = new DwarfBlob().U8(0).CStr("fn").ToArray();
+        var sections = Sections(Cu(5, dies.ToArray()), abbrev.ToArray(),
+            str: strings, lineStr: strings, strOffsets: StrOffsetsTable(0, 1));
+
+        var (function, _) = Assert.Single(DwarfReader.ReadFunctions(sections));
+        Assert.Equal("fn", function.Name);
+        Assert.Equal(0x1000UL, function.LowPc);
+    }
+
+    /// <summary>
+    /// Verifies every indexed address form resolves <c>low_pc</c> through the default v5
+    /// <c>.debug_addr</c> base.
+    /// </summary>
+    [Theory(Timeout = 30_000)]
+    [InlineData(DwarfForm.Addrx)]
+    [InlineData(DwarfForm.Addrx1)]
+    [InlineData(DwarfForm.Addrx2)]
+    [InlineData(DwarfForm.Addrx3)]
+    [InlineData(DwarfForm.Addrx4)]
+    public void ReadFunctions_AddressIndexForms_ResolveLowPc(ulong form)
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true);
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.String), (DwarfForm.AtLowPc, form));
+        abbrev.ULeb(0);
+
+        var dies = new DwarfBlob().ULeb(1).ULeb(2).CStr("f");
+        switch (form)
+        {
+            case DwarfForm.Addrx: dies.ULeb(1); break;
+            case DwarfForm.Addrx1: dies.U8(1); break;
+            case DwarfForm.Addrx2: dies.U16(1); break;
+            case DwarfForm.Addrx3: dies.U16(1).U8(0); break;
+            case DwarfForm.Addrx4: dies.U32(1); break;
+        }
+
+        dies.ULeb(0);
+
+        var sections = Sections(Cu(5, dies.ToArray()), abbrev.ToArray(), addr: AddrTable(0, 0x4000));
+
+        var (function, _) = Assert.Single(DwarfReader.ReadFunctions(sections));
+        Assert.Equal(0x4000UL, function.LowPc);
+    }
+
+    /// <summary>
+    /// Verifies a DWARF64 unit parses: 0xFFFFFFFF-escaped length, 8-byte abbrev offset, and
+    /// 8-byte <c>strp</c> section offsets.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_Dwarf64_ParsesUnitAndWideOffsets()
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true);
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.Strp), (DwarfForm.AtLowPc, DwarfForm.Addr),
+            (DwarfForm.AtHighPc, DwarfForm.Data8));
+        abbrev.ULeb(0);
+
+        var dies = new DwarfBlob()
+            .ULeb(1)
+            .ULeb(2).U64(1).U64(0x1000).U64(0x20)
+            .ULeb(0);
+
+        var sections = Sections(Cu(4, dies.ToArray(), is64: true), abbrev.ToArray(),
+            str: new DwarfBlob().U8(0).CStr("fn").ToArray());
+
+        var (function, unit) = Assert.Single(DwarfReader.ReadFunctions(sections));
+        Assert.True(unit.Is64);
+        Assert.Equal("fn", function.Name);
+        Assert.Equal(0x20UL, function.Size);
+    }
+
+    /// <summary>
+    /// Builds two CUs where the second CU's definition DIE names itself through a reference to a
+    /// declaration DIE (name + linkage name) earlier in that CU — the declaration sits at
+    /// unit-relative offset 12, section-absolute offset 24.
+    /// </summary>
+    private static DwarfSections SpecificationPair(ulong refAttribute, ulong refForm, uint refValue)
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, false);
+        abbrev.ULeb(0);
+        var secondTableOffset = (uint)abbrev.Length;
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true);
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.String), (DwarfForm.AtLinkageName, DwarfForm.String));
+        Decl(abbrev, 3, DwarfForm.TagSubprogram, false,
+            (refAttribute, refForm), (DwarfForm.AtLowPc, DwarfForm.Addr), (DwarfForm.AtHighPc, DwarfForm.Addr));
+        abbrev.ULeb(0);
+
+        var first = Cu(4, new DwarfBlob().ULeb(1).ToArray()); // 12 bytes: root-only unit
+        var dies = new DwarfBlob()
+            .ULeb(1)
+            .ULeb(2).CStr("Widget.Run").CStr("_ZN6Widget3RunEv")
+            .ULeb(3).U32(refValue).U64(0x5000).U64(0x5010)
+            .ULeb(0);
+        var second = Cu(4, dies.ToArray(), abbrevOffset: secondTableOffset);
+        return Sections([.. first, .. second], abbrev.ToArray());
+    }
+
+    /// <summary>
+    /// Verifies a nameless definition resolves its name through a unit-relative
+    /// <c>specification</c> reference, preferring the declaration's linkage name.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_SpecificationRef4_ResolvesUnitRelativeName()
+    {
+        var sections = SpecificationPair(DwarfForm.AtSpecification, DwarfForm.Ref4, refValue: 12);
+
+        var (function, _) = Assert.Single(DwarfReader.ReadFunctions(sections));
+        Assert.Equal("_ZN6Widget3RunEv", function.Name);
+        Assert.Equal(0x5000UL, function.LowPc);
+        Assert.Equal(0x10UL, function.Size);
+    }
+
+    /// <summary>
+    /// Verifies <c>abstract_origin</c> in the <c>ref_addr</c> form resolves as a
+    /// section-absolute offset, not unit-relative.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_AbstractOriginRefAddr_ResolvesSectionAbsoluteName()
+    {
+        var sections = SpecificationPair(DwarfForm.AtAbstractOrigin, DwarfForm.RefAddr, refValue: 24);
+
+        var (function, _) = Assert.Single(DwarfReader.ReadFunctions(sections));
+        Assert.Equal("_ZN6Widget3RunEv", function.Name);
+    }
+
+    /// <summary>
+    /// Verifies a v4 range-based subprogram (no <c>low_pc</c>) is kept with its
+    /// <c>.debug_ranges</c> offset recorded as a section offset.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_V4Ranges_RecordsSectionOffset()
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true, (DwarfForm.AtLowPc, DwarfForm.Addr));
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.String), (DwarfForm.AtRanges, DwarfForm.SecOffset));
+        abbrev.ULeb(0);
+
+        var dies = new DwarfBlob()
+            .ULeb(1).U64(0x400000)
+            .ULeb(2).CStr("ranged").U32(0x40)
+            .ULeb(0);
+
+        var result = DwarfReader.ReadFunctions(Sections(Cu(4, dies.ToArray()), abbrev.ToArray()));
+
+        var (function, unit) = Assert.Single(result);
+        Assert.Equal("ranged", function.Name);
+        Assert.Equal(0x40, function.RangesOffset);
+        Assert.False(function.RangesIsRnglistx);
+        Assert.Equal(0x400000UL, unit.BaseAddress);
+    }
+
+    /// <summary>
+    /// Verifies a v5 <c>rnglistx</c> range reference is recorded as an index and the CU's
+    /// explicit <c>rnglists_base</c> is captured.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_V5Rnglistx_RecordsIndexAndBase()
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true, (DwarfForm.AtRnglistsBase, DwarfForm.SecOffset));
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.String), (DwarfForm.AtRanges, DwarfForm.Rnglistx));
+        abbrev.ULeb(0);
+
+        var dies = new DwarfBlob()
+            .ULeb(1).U32(0x20)
+            .ULeb(2).CStr("r5").ULeb(2)
+            .ULeb(0);
+
+        var result = DwarfReader.ReadFunctions(Sections(Cu(5, dies.ToArray()), abbrev.ToArray()));
+
+        var (function, unit) = Assert.Single(result);
+        Assert.Equal(2, function.RangesOffset);
+        Assert.True(function.RangesIsRnglistx);
+        Assert.Equal(0x20, unit.RnglistsBase);
+    }
+
+    /// <summary>
+    /// Verifies a DIE carrying every skippable form — blocks, exprloc, supplementary refs,
+    /// <c>data16</c>, <c>implicit_const</c>, <c>indirect</c>, and an unresolvable <c>strx2</c> —
+    /// advances the cursor exactly, so the subprogram after it still parses.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_SkipsEveryFormOnUnrelatedDie()
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true);
+
+        abbrev.ULeb(2).ULeb(0x0B).U8(0); // DW_TAG_lexical_block, no children
+        void Attr(ulong form) => abbrev.ULeb(0x60).ULeb(form);
+        Attr(DwarfForm.Exprloc);
+        Attr(DwarfForm.Block1);
+        Attr(DwarfForm.Data16);
+        Attr(DwarfForm.RefSig8);
+        Attr(DwarfForm.FlagPresent);
+        Attr(DwarfForm.Sdata);
+        abbrev.ULeb(0x60).ULeb(DwarfForm.ImplicitConst).SLeb(-5);
+        Attr(DwarfForm.Block2);
+        Attr(DwarfForm.Block4);
+        Attr(DwarfForm.Block);
+        Attr(DwarfForm.RefSup4);
+        Attr(DwarfForm.RefSup8);
+        Attr(DwarfForm.StrpSup);
+        Attr(DwarfForm.Flag);
+        Attr(DwarfForm.Ref1);
+        Attr(DwarfForm.Ref2);
+        Attr(DwarfForm.Ref8);
+        Attr(DwarfForm.RefUdata);
+        Attr(DwarfForm.Udata);
+        Attr(DwarfForm.Loclistx);
+        Attr(DwarfForm.Indirect);
+        Attr(DwarfForm.Data4);
+        Attr(DwarfForm.Strx2);
+        abbrev.ULeb(0).ULeb(0);
+
+        Decl(abbrev, 3, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.String), (DwarfForm.AtLowPc, DwarfForm.Addr));
+        abbrev.ULeb(0);
+
+        var dies = new DwarfBlob()
+            .ULeb(1)
+            .ULeb(2)
+            .ULeb(3).Bytes([7, 8, 9])       // exprloc
+            .U8(2).Bytes([1, 2])            // block1
+            .Bytes(new byte[16])            // data16
+            .U64(0)                         // ref_sig8
+                                            // flag_present: no bytes
+            .SLeb(-100)                     // sdata
+                                            // implicit_const: no bytes
+            .U16(1).U8(0)                   // block2
+            .U32(0)                         // block4 (empty)
+            .ULeb(1).U8(0xAA)               // block
+            .U32(0)                         // ref_sup4
+            .U64(0)                         // ref_sup8
+            .U32(0)                         // strp_sup
+            .U8(1)                          // flag
+            .U8(1)                          // ref1
+            .U16(2)                         // ref2
+            .U64(3)                         // ref8
+            .ULeb(4)                        // ref_udata
+            .ULeb(5)                        // udata
+            .ULeb(6)                        // loclistx
+            .ULeb(DwarfForm.Data1).U8(7)    // indirect -> data1
+            .U32(0xFEED)                    // data4
+            .U16(1)                         // strx2 (no str_offsets section; still advances)
+            .ULeb(3).CStr("after").U64(0x9000)
+            .ULeb(0);
+
+        var result = DwarfReader.ReadFunctions(Sections(Cu(5, dies.ToArray()), abbrev.ToArray()));
+
+        var (function, _) = Assert.Single(result);
+        Assert.Equal("after", function.Name);
+        Assert.Equal(0x9000UL, function.LowPc);
+    }
+
+    /// <summary>
+    /// Verifies the linkage name (plain or MIPS-vendor) is preferred over the source name.
+    /// </summary>
+    [Theory(Timeout = 30_000)]
+    [InlineData(DwarfForm.AtLinkageName)]
+    [InlineData(DwarfForm.AtMipsLinkageName)]
+    public void ReadFunctions_LinkageName_PreferredOverSourceName(ulong linkageAttribute)
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true);
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.String), (linkageAttribute, DwarfForm.String),
+            (DwarfForm.AtLowPc, DwarfForm.Addr));
+        abbrev.ULeb(0);
+
+        var dies = new DwarfBlob()
+            .ULeb(1)
+            .ULeb(2).CStr("plain").CStr("_Zmangled").U64(0x1000)
+            .ULeb(0);
+
+        var (function, _) = Assert.Single(
+            DwarfReader.ReadFunctions(Sections(Cu(4, dies.ToArray()), abbrev.ToArray())));
+        Assert.Equal("_Zmangled", function.Name);
+    }
+
+    /// <summary>
+    /// Verifies an address-class <c>high_pc</c> below <c>low_pc</c> yields size 0 rather than
+    /// wrapping negative.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_HighPcBelowLowPc_SizeZero()
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true);
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.String), (DwarfForm.AtLowPc, DwarfForm.Addr),
+            (DwarfForm.AtHighPc, DwarfForm.Addr));
+        abbrev.ULeb(0);
+
+        var dies = new DwarfBlob()
+            .ULeb(1)
+            .ULeb(2).CStr("f").U64(0x2000).U64(0x1000)
+            .ULeb(0);
+
+        var (function, _) = Assert.Single(
+            DwarfReader.ReadFunctions(Sections(Cu(4, dies.ToArray()), abbrev.ToArray())));
+        Assert.Equal(0UL, function.Size);
+    }
+
+    /// <summary>
+    /// Verifies a second unit whose declared length overruns the section ends the walk, keeping
+    /// the first unit's functions.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_TruncatedSecondUnit_KeepsFirstFunction()
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true);
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.String), (DwarfForm.AtLowPc, DwarfForm.Addr));
+        abbrev.ULeb(0);
+
+        var dies = new DwarfBlob().ULeb(1).ULeb(2).CStr("ok").U64(0x1000).ULeb(0);
+        var truncated = new DwarfBlob().U32(0xFFFF).Bytes(new byte[12]).ToArray();
+        var info = new List<byte>();
+        info.AddRange(Cu(4, dies.ToArray()));
+        info.AddRange(truncated);
+
+        var result = DwarfReader.ReadFunctions(Sections([.. info], abbrev.ToArray()));
+
+        var (function, _) = Assert.Single(result);
+        Assert.Equal("ok", function.Name);
+    }
+
+    /// <summary>
+    /// Verifies an unsupported-version unit is skipped by its declared length and the walk
+    /// continues into the next unit.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_UnsupportedVersionUnit_SkipsToNextUnit()
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true);
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.String), (DwarfForm.AtLowPc, DwarfForm.Addr));
+        abbrev.ULeb(0);
+
+        var dies = new DwarfBlob().ULeb(1).ULeb(2).CStr("ok").U64(0x1000).ULeb(0);
+        var info = new List<byte>();
+        info.AddRange(Cu(9, new byte[] { 1, 2, 3, 4 }));
+        info.AddRange(Cu(4, dies.ToArray()));
+
+        var result = DwarfReader.ReadFunctions(Sections([.. info], abbrev.ToArray()));
+
+        var (function, _) = Assert.Single(result);
+        Assert.Equal("ok", function.Name);
+    }
+
+    /// <summary>
+    /// Verifies a v5 skeleton unit (unit type 4) contributes no functions even though it holds a
+    /// well-formed subprogram.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_SkeletonUnit_Skipped()
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true);
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.String), (DwarfForm.AtLowPc, DwarfForm.Addr));
+        abbrev.ULeb(0);
+
+        var dies = new DwarfBlob().ULeb(1).ULeb(2).CStr("hidden").U64(0x1000).ULeb(0);
+
+        var result = DwarfReader.ReadFunctions(
+            Sections(Cu(5, dies.ToArray(), unitType: 4), abbrev.ToArray()));
+
+        Assert.Empty(result);
+    }
+
+    /// <summary>
+    /// Verifies an abbreviation code missing from the table ends that unit's walk, keeping the
+    /// functions parsed before it.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_UnknownAbbrevCode_KeepsEarlierFunctions()
+    {
+        var abbrev = new DwarfBlob();
+        Decl(abbrev, 1, DwarfForm.TagCompileUnit, true);
+        Decl(abbrev, 2, DwarfForm.TagSubprogram, false,
+            (DwarfForm.AtName, DwarfForm.String), (DwarfForm.AtLowPc, DwarfForm.Addr));
+        abbrev.ULeb(0);
+
+        var dies = new DwarfBlob().ULeb(1).ULeb(2).CStr("first").U64(0x1000).ULeb(99);
+
+        var result = DwarfReader.ReadFunctions(Sections(Cu(4, dies.ToArray()), abbrev.ToArray()));
+
+        var (function, _) = Assert.Single(result);
+        Assert.Equal("first", function.Name);
+    }
+
+    /// <summary>Verifies empty or absent sections yield no functions.</summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctions_EmptyOrZeroLengthInfo_ReturnsEmpty()
+    {
+        Assert.Empty(DwarfReader.ReadFunctions(Sections([], [])));
+
+        var zeroLength = new DwarfBlob().U32(0).Bytes(new byte[16]).ToArray();
+        Assert.Empty(DwarfReader.ReadFunctions(Sections(zeroLength, [1])));
+    }
+
+    /// <summary>
+    /// Verifies <see cref="DwarfSections.Collect"/> maps base names through the lookup and
+    /// tolerates absent sections as empty bytes.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Collect_MapsBaseNamesAndToleratesAbsent()
+    {
+        var sections = DwarfSections.Collect(name => name == "info" ? [0xAB] : null);
+
+        Assert.Equal([0xAB], sections.Info);
+        Assert.Empty(sections.Abbrev);
+        Assert.False(sections.HasInfo); // DIEs without abbreviations are unreadable
+    }
+}

--- a/tests/Dotsider.Tests/EhFrameReaderTests.cs
+++ b/tests/Dotsider.Tests/EhFrameReaderTests.cs
@@ -1,0 +1,184 @@
+using Dotsider.Core.Analysis;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="EhFrameReader"/> — the ELF boundary fallback — driven with hand-built
+/// <c>.eh_frame</c> blobs covering the pointer-encoding matrix (absolute, PC-relative, fixed,
+/// LEB128, signed), CIE augmentation shapes, and the terminator and damage behaviors.
+/// </summary>
+public class EhFrameReaderTests
+{
+    private static byte[] Entry(DwarfBlob content) =>
+        new DwarfBlob().U32((uint)content.Length).Bytes(content.ToArray()).ToArray();
+
+    /// <summary>Builds a CIE whose augmentation declares the FDE pointer encoding.</summary>
+    private static byte[] Cie(byte fdeEncoding, string augmentation = "zR", byte version = 1)
+    {
+        var b = new DwarfBlob()
+            .U32(0)             // CIE id
+            .U8(version)
+            .CStr(augmentation)
+            .ULeb(1)            // code alignment
+            .SLeb(-8);          // data alignment
+        if (version == 1) b.U8(16);
+        else b.ULeb(16);        // return address register
+
+        if (augmentation.StartsWith('z'))
+        {
+            var data = new DwarfBlob();
+            foreach (var ch in augmentation[1..])
+            {
+                switch (ch)
+                {
+                    case 'P': data.U8(0x00).U64(0x12345678); break; // absptr personality
+                    case 'L': data.U8(0x00); break;                 // LSDA encoding
+                    case 'R': data.U8(fdeEncoding); break;
+                }
+            }
+
+            b.ULeb((ulong)data.Length).Bytes(data.ToArray());
+        }
+
+        return Entry(b);
+    }
+
+    private static byte[] Fde(uint ciePointer, DwarfBlob pointers) =>
+        Entry(new DwarfBlob().U32(ciePointer).Bytes(pointers.ToArray()));
+
+    private static byte[] Image(ulong ehFrameAddress, params byte[][] entries)
+    {
+        var section = new List<byte>();
+        foreach (var e in entries) section.AddRange(e);
+        section.AddRange([0, 0, 0, 0]); // terminator
+        return SyntheticImageBuilders.BuildElf(
+            (".text", 0x401000, new byte[0x100]),
+            (".eh_frame", ehFrameAddress, section.ToArray()));
+    }
+
+    /// <summary>
+    /// Verifies absolute 64-bit pointers decode and the boundary maps to its containing section.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadBoundaries_Absptr_DecodesAndMapsSection()
+    {
+        var cie = Cie(0x00);
+        var fde = Fde((uint)(cie.Length + 4), new DwarfBlob().U64(0x401010).U64(0x40));
+
+        var boundaries = EhFrameReader.ReadBoundaries(Image(0x500000, cie, fde));
+
+        var b = Assert.Single(boundaries);
+        Assert.Equal("sub_401010", b.Name);
+        Assert.Equal(0x401010UL, b.VirtualAddress);
+        Assert.Equal(0x40, b.Size);
+        Assert.Equal(".text", b.Section);
+        Assert.True(b.IsBoundary);
+        Assert.NotNull(b.FileOffset);
+    }
+
+    /// <summary>
+    /// Verifies the common <c>pcrel|sdata4</c> encoding: the location is relative to the
+    /// pointer field's own address, and the range is a plain length.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadBoundaries_PcrelSdata4_ResolvesAgainstFieldAddress()
+    {
+        const ulong ehFrameAddress = 0x500000;
+        var cie = Cie(0x1B); // pcrel | sdata4
+
+        // First FDE: id at cie.Length + 4; initial_location field 4 bytes later.
+        var field1 = ehFrameAddress + (ulong)cie.Length + 8;
+        var delta1 = unchecked((uint)(int)(0x401010 - (long)field1));
+        var fde1 = Fde((uint)(cie.Length + 4), new DwarfBlob().U32(delta1).U32(0x40));
+
+        var field2 = ehFrameAddress + (ulong)(cie.Length + fde1.Length) + 8;
+        var delta2 = unchecked((uint)(int)(0x401080 - (long)field2));
+        var fde2 = Fde((uint)(cie.Length + fde1.Length + 4), new DwarfBlob().U32(delta2).U32(0x10));
+
+        var boundaries = EhFrameReader.ReadBoundaries(Image(ehFrameAddress, cie, fde1, fde2));
+
+        Assert.Equal(2, boundaries.Count);
+        Assert.Equal(0x401010UL, boundaries[0].VirtualAddress);
+        Assert.Equal(0x40, boundaries[0].Size);
+        Assert.Equal(0x401080UL, boundaries[1].VirtualAddress);
+        Assert.Equal(0x10, boundaries[1].Size);
+    }
+
+    /// <summary>Verifies the fixed udata4 and variable ULEB128 formats decode absolutely.</summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadBoundaries_Udata4AndUleb_Decode()
+    {
+        var cie4 = Cie(0x03); // udata4 absolute
+        var fde4 = Fde((uint)(cie4.Length + 4), new DwarfBlob().U32(0x401020).U32(0x20));
+        var one = Assert.Single(EhFrameReader.ReadBoundaries(Image(0x500000, cie4, fde4)));
+        Assert.Equal(0x401020UL, one.VirtualAddress);
+        Assert.Equal(0x20, one.Size);
+
+        var cieLeb = Cie(0x01); // uleb128 absolute
+        var fdeLeb = Fde((uint)(cieLeb.Length + 4), new DwarfBlob().ULeb(0x401030).ULeb(0x30));
+        var leb = Assert.Single(EhFrameReader.ReadBoundaries(Image(0x500000, cieLeb, fdeLeb)));
+        Assert.Equal(0x401030UL, leb.VirtualAddress);
+        Assert.Equal(0x30, leb.Size);
+    }
+
+    /// <summary>
+    /// Verifies a <c>zPLR</c> augmentation with a personality pointer parses the encoding behind
+    /// it, on a version-3 CIE whose return register is a ULEB.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadBoundaries_ZplrVersion3_ReadsEncodingBehindPersonality()
+    {
+        var cie = Cie(0x03, augmentation: "zPLR", version: 3);
+        var fde = Fde((uint)(cie.Length + 4), new DwarfBlob().U32(0x401040).U32(0x18));
+
+        var b = Assert.Single(EhFrameReader.ReadBoundaries(Image(0x500000, cie, fde)));
+        Assert.Equal(0x401040UL, b.VirtualAddress);
+        Assert.Equal(0x18, b.Size);
+    }
+
+    /// <summary>
+    /// Verifies the zero-length terminator stops the walk, and entries after it are ignored.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadBoundaries_Terminator_StopsWalk()
+    {
+        var cie = Cie(0x00);
+        var fde = Fde((uint)(cie.Length + 4), new DwarfBlob().U64(0x401010).U64(0x40));
+        var section = new List<byte>();
+        section.AddRange(cie);
+        section.AddRange(fde);
+        section.AddRange([0, 0, 0, 0]); // terminator
+        section.AddRange(fde);          // unreachable duplicate
+
+        var image = SyntheticImageBuilders.BuildElf((".eh_frame", 0x500000, section.ToArray()));
+
+        Assert.Single(EhFrameReader.ReadBoundaries(image));
+    }
+
+    /// <summary>
+    /// Verifies defective entries are skipped, not misread: a zero location, an FDE naming an
+    /// unknown CIE, and a truncated tail after a good FDE.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadBoundaries_DefectiveEntries_SkippedOrKeptPartial()
+    {
+        var cie = Cie(0x00);
+        var zeroLocation = Fde((uint)(cie.Length + 4), new DwarfBlob().U64(0).U64(0x40));
+        var orphan = Fde(2, new DwarfBlob().U64(0x401050).U64(0x40)); // points into no CIE
+        Assert.Empty(EhFrameReader.ReadBoundaries(Image(0x500000, cie, zeroLocation)));
+        Assert.Empty(EhFrameReader.ReadBoundaries(Image(0x500000, orphan)));
+
+        var good = Fde((uint)(cie.Length + 4), new DwarfBlob().U64(0x401010).U64(0x40));
+        var truncated = new DwarfBlob().U32(0xFFF0).U32(0).ToArray(); // claims more than present
+        var section = new List<byte>();
+        section.AddRange(cie);
+        section.AddRange(good);
+        section.AddRange(truncated);
+        var image = SyntheticImageBuilders.BuildElf((".eh_frame", 0x500000, section.ToArray()));
+
+        Assert.Single(EhFrameReader.ReadBoundaries(image));
+
+        Assert.Empty(EhFrameReader.ReadBoundaries(
+            SyntheticImageBuilders.BuildElf((".text", 0x401000, new byte[8]))));
+    }
+}

--- a/tests/Dotsider.Tests/ElfSectionTests.cs
+++ b/tests/Dotsider.Tests/ElfSectionTests.cs
@@ -1,0 +1,56 @@
+using Dotsider.Core.Analysis;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="ElfImageReader.ReadSections"/> and
+/// <see cref="ElfImageReader.TryGetSection"/> — the section-header walk that hands DWARF,
+/// symbol-table, and build-id readers their bytes — driven with synthetic ELF images.
+/// </summary>
+public class ElfSectionTests
+{
+    /// <summary>
+    /// Verifies the walk returns every named section with its address, file offset, and size,
+    /// alongside the null section and <c>.shstrtab</c> the builder always emits.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadSections_ReturnsNamedSectionsWithLocation()
+    {
+        var image = SyntheticImageBuilders.BuildElf(
+            (".text", 0x401000, new byte[] { 1, 2, 3, 4 }),
+            (".debug_info", 0, "\t\t"u8.ToArray()));
+
+        var sections = ElfImageReader.ReadSections(image);
+
+        Assert.Equal(4, sections.Count); // null + .text + .debug_info + .shstrtab
+        var text = Assert.Single(sections, s => s.Name == ".text");
+        Assert.Equal(0x401000UL, text.Address);
+        Assert.Equal(4, text.Size);
+        Assert.Equal(1, image[text.FileOffset]);
+
+        var info = Assert.Single(sections, s => s.Name == ".debug_info");
+        Assert.Equal(2, info.Size);
+        Assert.Equal(9, image[info.FileOffset]);
+    }
+
+    /// <summary>Verifies the name lookup finds a present section and reports an absent one.</summary>
+    [Fact(Timeout = 30_000)]
+    public void TryGetSection_FindsPresentAndReportsAbsent()
+    {
+        var image = SyntheticImageBuilders.BuildElf((".debug_str", 0, new byte[] { 0, (byte)'a', 0 }));
+
+        Assert.True(ElfImageReader.TryGetSection(image, ".debug_str", out var section));
+        Assert.Equal(3, section.Size);
+        Assert.False(ElfImageReader.TryGetSection(image, ".debug_line", out _));
+    }
+
+    /// <summary>Verifies non-ELF bytes and truncated images yield no sections rather than throwing.</summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadSections_RejectsNonElfAndTruncated()
+    {
+        Assert.Empty(ElfImageReader.ReadSections([0x4D, 0x5A, 0, 0]));
+
+        var truncated = SyntheticImageBuilders.BuildElf((".text", 0, new byte[] { 1 }))[..70];
+        Assert.Empty(ElfImageReader.ReadSections(truncated));
+    }
+}

--- a/tests/Dotsider.Tests/ElfSectionTests.cs
+++ b/tests/Dotsider.Tests/ElfSectionTests.cs
@@ -53,4 +53,37 @@ public class ElfSectionTests
         var truncated = SyntheticImageBuilders.BuildElf((".text", 0, new byte[] { 1 }))[..70];
         Assert.Empty(ElfImageReader.ReadSections(truncated));
     }
+
+    /// <summary>
+    /// Verifies section content materializes through <c>SHF_COMPRESSED</c>: a zlib payload
+    /// inflates to the original bytes, plain sections pass through, and unsupported or
+    /// malformed compression reads as absent rather than as garbage.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadSectionBytes_InflatesCompressedSections()
+    {
+        byte[] payload = [.. Enumerable.Range(0, 512).Select(i => (byte)(i * 7))];
+        var image = SyntheticImageBuilders.BuildElf(
+            (".debug_info", 0, SyntheticImageBuilders.CompressDebugSection(payload), 1u, 0u, 0x800UL),
+            (".debug_abbrev", 0, payload, 1u, 0u, 0UL));
+        var sections = ElfImageReader.ReadSections(image);
+
+        var compressed = sections.Single(s => s.Name == ".debug_info");
+        Assert.Equal(payload, ElfImageReader.ReadSectionBytes(image, compressed));
+
+        var plain = sections.Single(s => s.Name == ".debug_abbrev");
+        Assert.Equal(payload, ElfImageReader.ReadSectionBytes(image, plain));
+
+        // Unsupported compression type (zstd = 2): absent, not misread.
+        var zstd = SyntheticImageBuilders.CompressDebugSection(payload);
+        zstd[0] = 2;
+        var zstdImage = SyntheticImageBuilders.BuildElf((".debug_info", 0, zstd, 1u, 0u, 0x800UL));
+        Assert.Null(ElfImageReader.ReadSectionBytes(
+            zstdImage, ElfImageReader.ReadSections(zstdImage).Single(s => s.Name == ".debug_info")));
+
+        // Truncated header: absent.
+        var tiny = SyntheticImageBuilders.BuildElf((".debug_info", 0, new byte[8], 1u, 0u, 0x800UL));
+        Assert.Null(ElfImageReader.ReadSectionBytes(
+            tiny, ElfImageReader.ReadSections(tiny).Single(s => s.Name == ".debug_info")));
+    }
 }

--- a/tests/Dotsider.Tests/ElfSidecarIdentityTests.cs
+++ b/tests/Dotsider.Tests/ElfSidecarIdentityTests.cs
@@ -1,0 +1,139 @@
+using Dotsider.Core.Analysis;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="ElfSidecarIdentity"/> and the note/debuglink readers behind it — the
+/// all-present-signals-must-match rule that decides whether a <c>.dbg</c> sidecar belongs to a
+/// stripped image.
+/// </summary>
+public class ElfSidecarIdentityTests
+{
+    private static readonly byte[] IdA = [0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04];
+    private static readonly byte[] IdB = [0xCA, 0xFE, 0xBA, 0xBE, 0x05, 0x06, 0x07, 0x08];
+
+    private static byte[] ImageWithBuildId(byte[] id) =>
+        SyntheticImageBuilders.BuildElf(
+            (".note.gnu.build-id", 0, SyntheticImageBuilders.GnuBuildIdNote(id)));
+
+    private static byte[] SidecarWithBuildId(byte[] id) =>
+        SyntheticImageBuilders.BuildElf(
+            (".note.gnu.build-id", 0, SyntheticImageBuilders.GnuBuildIdNote(id)),
+            (".debug_info", 0, new byte[] { 1 }));
+
+    /// <summary>Verifies the standard CRC-32 check value.</summary>
+    [Fact(Timeout = 30_000)]
+    public void Crc32_KnownAnswer()
+    {
+        Assert.Equal(0xCBF43926U, Crc32.Compute("123456789"u8));
+        Assert.Equal(0U, Crc32.Compute([]));
+    }
+
+    /// <summary>Verifies the build-id note parses, including walking past a foreign note first.</summary>
+    [Fact(Timeout = 30_000)]
+    public void TryReadBuildId_ParsesGnuNoteBehindForeignNote()
+    {
+        var image = SyntheticImageBuilders.BuildElf(
+            (".note.gnu.build-id", 0, SyntheticImageBuilders.GnuBuildIdNote(IdA, precedeWithForeignNote: true)));
+
+        Assert.True(ElfImageReader.TryReadBuildId(image, out var id));
+        Assert.Equal(IdA, id);
+
+        var plain = SyntheticImageBuilders.BuildElf((".text", 0, new byte[] { 1 }));
+        Assert.False(ElfImageReader.TryReadBuildId(plain, out _));
+
+        var malformed = SyntheticImageBuilders.BuildElf((".note.gnu.build-id", 0, new byte[] { 1, 2, 3 }));
+        Assert.False(ElfImageReader.TryReadBuildId(malformed, out _));
+    }
+
+    /// <summary>Verifies the debuglink reader returns the file name and the 4-aligned CRC.</summary>
+    [Fact(Timeout = 30_000)]
+    public void TryReadDebugLink_ParsesNameAndAlignedCrc()
+    {
+        // "myapp.dbg" + NUL = 10 bytes -> CRC 4-aligned at offset 12.
+        var image = SyntheticImageBuilders.BuildElf(
+            (".gnu_debuglink", 0, SyntheticImageBuilders.GnuDebugLink("myapp.dbg", 0x1234_5678)));
+
+        Assert.True(ElfImageReader.TryReadDebugLink(image, out var name, out var crc));
+        Assert.Equal("myapp.dbg", name);
+        Assert.Equal(0x1234_5678U, crc);
+
+        var absent = SyntheticImageBuilders.BuildElf((".text", 0, new byte[] { 1 }));
+        Assert.False(ElfImageReader.TryReadDebugLink(absent, out _, out _));
+    }
+
+    /// <summary>Verifies matching build ids accept the sidecar.</summary>
+    [Fact(Timeout = 30_000)]
+    public void Check_BuildIdMatch_Accepts()
+    {
+        Assert.Equal(ElfSidecarMatch.Matched,
+            ElfSidecarIdentity.Check(ImageWithBuildId(IdA), SidecarWithBuildId(IdA)));
+    }
+
+    /// <summary>Verifies a differing or absent sidecar build id rejects the sidecar.</summary>
+    [Fact(Timeout = 30_000)]
+    public void Check_BuildIdMismatchOrAbsent_Rejects()
+    {
+        Assert.Equal(ElfSidecarMatch.Mismatched,
+            ElfSidecarIdentity.Check(ImageWithBuildId(IdA), SidecarWithBuildId(IdB)));
+
+        var noIdSidecar = SyntheticImageBuilders.BuildElf((".debug_info", 0, new byte[] { 1 }));
+        Assert.Equal(ElfSidecarMatch.Mismatched,
+            ElfSidecarIdentity.Check(ImageWithBuildId(IdA), noIdSidecar));
+    }
+
+    /// <summary>Verifies the debuglink CRC alone can accept, and a CRC failure rejects.</summary>
+    [Fact(Timeout = 30_000)]
+    public void Check_DebugLinkCrc_AcceptsOnMatchRejectsOnFailure()
+    {
+        var sidecar = SyntheticImageBuilders.BuildElf((".debug_info", 0, new byte[] { 1 }));
+        var crc = Crc32.Compute(sidecar);
+
+        var matching = SyntheticImageBuilders.BuildElf(
+            (".gnu_debuglink", 0, SyntheticImageBuilders.GnuDebugLink("app.dbg", crc)));
+        Assert.Equal(ElfSidecarMatch.Matched, ElfSidecarIdentity.Check(matching, sidecar));
+
+        var failing = SyntheticImageBuilders.BuildElf(
+            (".gnu_debuglink", 0, SyntheticImageBuilders.GnuDebugLink("app.dbg", crc ^ 1)));
+        Assert.Equal(ElfSidecarMatch.Mismatched, ElfSidecarIdentity.Check(failing, sidecar));
+    }
+
+    /// <summary>
+    /// Verifies every present signal must pass: one failing signal rejects even when the other
+    /// matches, in both directions.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Check_BothSignals_OneFailureRejects()
+    {
+        var sidecar = SidecarWithBuildId(IdA);
+        var crc = Crc32.Compute(sidecar);
+
+        byte[] Image(byte[] id, uint expectedCrc) => SyntheticImageBuilders.BuildElf(
+            (".note.gnu.build-id", 0, SyntheticImageBuilders.GnuBuildIdNote(id)),
+            (".gnu_debuglink", 0, SyntheticImageBuilders.GnuDebugLink("app.dbg", expectedCrc)));
+
+        Assert.Equal(ElfSidecarMatch.Matched, ElfSidecarIdentity.Check(Image(IdA, crc), sidecar));
+        Assert.Equal(ElfSidecarMatch.Mismatched, ElfSidecarIdentity.Check(Image(IdA, crc ^ 1), sidecar));
+        Assert.Equal(ElfSidecarMatch.Mismatched, ElfSidecarIdentity.Check(Image(IdB, crc), sidecar));
+    }
+
+    /// <summary>
+    /// Verifies a signal-free image accepts only loosely — same machine and real debug info —
+    /// and rejects when the machine differs or the sidecar lacks <c>.debug_info</c>.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Check_NoSignals_LooseChecksDecide()
+    {
+        var image = SyntheticImageBuilders.BuildElf((".text", 0, new byte[] { 1 }));
+        var sidecar = SyntheticImageBuilders.BuildElf((".debug_info", 0, new byte[] { 1 }));
+
+        Assert.Equal(ElfSidecarMatch.LooseMatch, ElfSidecarIdentity.Check(image, sidecar));
+
+        var foreignMachine = SyntheticImageBuilders.BuildElf((".debug_info", 0, new byte[] { 1 }));
+        foreignMachine[18] = 0x28; // EM_ARM
+        Assert.Equal(ElfSidecarMatch.Mismatched, ElfSidecarIdentity.Check(image, foreignMachine));
+
+        var noDebugInfo = SyntheticImageBuilders.BuildElf((".text", 0, new byte[] { 1 }));
+        Assert.Equal(ElfSidecarMatch.Mismatched, ElfSidecarIdentity.Check(image, noDebugInfo));
+    }
+}

--- a/tests/Dotsider.Tests/ElfSymtabReaderTests.cs
+++ b/tests/Dotsider.Tests/ElfSymtabReaderTests.cs
@@ -1,0 +1,79 @@
+using System.Buffers.Binary;
+using Dotsider.Core.Analysis;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="ElfSymtabReader"/> — the <c>.symtab</c> data pass — verifying that named
+/// <c>STT_OBJECT</c> entries surface with their exact <c>st_size</c> while functions, undefined,
+/// unnamed, and reserved-section entries are skipped.
+/// </summary>
+public class ElfSymtabReaderTests
+{
+    private static byte[] Sym(uint nameOffset, byte type, ushort shndx, ulong value, ulong size)
+    {
+        var b = new byte[24];
+        BinaryPrimitives.WriteUInt32LittleEndian(b, nameOffset);
+        b[4] = type; // bind LOCAL << 4 | type
+        BinaryPrimitives.WriteUInt16LittleEndian(b.AsSpan(6), shndx);
+        BinaryPrimitives.WriteUInt64LittleEndian(b.AsSpan(8), value);
+        BinaryPrimitives.WriteUInt64LittleEndian(b.AsSpan(16), size);
+        return b;
+    }
+
+    private static byte[] Concat(params byte[][] parts)
+    {
+        var all = new List<byte>();
+        foreach (var p in parts) all.AddRange(p);
+        return [.. all];
+    }
+
+    /// <summary>
+    /// Verifies the object pass: an <c>STT_OBJECT</c> keeps its exact size and maps to its
+    /// section, while <c>STT_FUNC</c>, undefined, unnamed, and absolute entries are skipped.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadDataSymbols_KeepsNamedObjectsWithExactSizes()
+    {
+        var strtab = "\0_ZTV6Widget\0main\0"u8.ToArray();
+        var symtab = Concat(
+            Sym(0, 0, 0, 0, 0),                     // null entry
+            Sym(1, 1, 2, 0x2010, 0x18),             // STT_OBJECT in .data -> kept
+            Sym(13, 2, 1, 0x1000, 0x40),            // STT_FUNC -> skipped
+            Sym(1, 1, 0, 0x3000, 8),                // undefined -> skipped
+            Sym(0, 1, 2, 0x2040, 8),                // unnamed -> skipped
+            Sym(1, 1, 0xFFF1, 0x2050, 8));          // SHN_ABS -> skipped
+
+        var image = SyntheticImageBuilders.BuildElf(
+            (".text", 0x1000, new byte[0x100], 1u, 0u),
+            (".data", 0x2000, new byte[0x100], 1u, 0u),
+            (".symtab", 0, symtab, 2u, 4u),
+            (".strtab", 0, strtab, 3u, 0u));
+
+        var symbols = ElfSymtabReader.ReadDataSymbols(image, ElfImageReader.ReadSections(image));
+
+        var s = Assert.Single(symbols);
+        Assert.Equal("_ZTV6Widget", s.Name);
+        Assert.Equal(0x2010UL, s.VirtualAddress);
+        Assert.Equal(0x18, s.Size); // exact st_size, not nearest-next
+        Assert.Equal(".data", s.Section);
+        Assert.True(s.IsData);
+        Assert.NotNull(s.FileOffset);
+    }
+
+    /// <summary>Verifies malformed tables yield nothing rather than throwing.</summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadDataSymbols_Malformed_ReturnsEmpty()
+    {
+        // No symbol table at all.
+        var plain = SyntheticImageBuilders.BuildElf((".text", 0x1000, new byte[8]));
+        Assert.Empty(ElfSymtabReader.ReadDataSymbols(plain, ElfImageReader.ReadSections(plain)));
+
+        // Link points past the section table.
+        var symtab = Concat(Sym(0, 0, 0, 0, 0), Sym(1, 1, 1, 0x1000, 8));
+        var badLink = SyntheticImageBuilders.BuildElf(
+            (".text", 0x1000, new byte[8], 1u, 0u),
+            (".symtab", 0, symtab, 2u, 99u));
+        Assert.Empty(ElfSymtabReader.ReadDataSymbols(badLink, ElfImageReader.ReadSections(badLink)));
+    }
+}

--- a/tests/Dotsider.Tests/IlcNameDemanglerTests.cs
+++ b/tests/Dotsider.Tests/IlcNameDemanglerTests.cs
@@ -1,0 +1,184 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="IlcNameDemangler"/> — the join from ILC-mangled native symbol names back
+/// to managed names, and the classification of compiler-generated symbols. Cases are pinned to
+/// real symbol spellings observed in the NativeAotConsole fixture PDB.
+/// </summary>
+public class IlcNameDemanglerTests
+{
+    private static IlcNameDemangler Build(params RecoveredType[] types) => new(types);
+
+    /// <summary>
+    /// Verifies the top-level-statement entry point joins exactly: type <c>Program</c> in
+    /// assembly <c>NativeAotConsole</c>, method <c>&lt;Main&gt;$</c> → symbol
+    /// <c>NativeAotConsole_Program___Main__</c>.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Demangle_EntryPoint_JoinsExactly()
+    {
+        var d = Build(new RecoveredType("Program", ["<Main>$"], "NativeAotConsole"));
+
+        var result = d.Demangle("NativeAotConsole_Program___Main__");
+
+        Assert.Equal("Program.<Main>$", result.ManagedName);
+        Assert.Equal(NativeSymbolKind.Function, result.Kind);
+        Assert.True(result.IsExactMatch);
+    }
+
+    /// <summary>
+    /// Verifies a framework method with the <c>S.P.</c> assembly abbreviation and a generic
+    /// instantiation scope joins after the scope is stripped:
+    /// <c>S_P_CoreLib_System_ReadOnlySpan_1&lt;Char&gt;__ToString</c>.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Demangle_GenericInstanceMethod_JoinsAfterScopeStrip()
+    {
+        var d = Build(new RecoveredType("System.ReadOnlySpan`1", ["ToString"], "System.Private.CoreLib"));
+
+        var result = d.Demangle("S_P_CoreLib_System_ReadOnlySpan_1<Char>__ToString");
+
+        Assert.Equal("System.ReadOnlySpan`1.ToString", result.ManagedName);
+        Assert.True(result.IsExactMatch);
+    }
+
+    /// <summary>
+    /// Verifies a Windows vtable symbol classifies as a MethodTable and names its type.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Demangle_WindowsVtable_ClassifiesAsMethodTable()
+    {
+        var d = Build(new RecoveredType("System.Collections.Generic.StringEqualityComparer", [], "System.Private.CoreLib"));
+
+        var result = d.Demangle("??_7S_P_CoreLib_System_Collections_Generic_StringEqualityComparer@@6B@");
+
+        Assert.Equal(NativeSymbolKind.MethodTable, result.Kind);
+        Assert.Equal("System.Collections.Generic.StringEqualityComparer (MethodTable)", result.ManagedName);
+        Assert.True(result.IsExactMatch);
+    }
+
+    /// <summary>
+    /// Verifies a Unix vtable symbol strips its Itanium decimal length prefix and classifies as
+    /// a MethodTable.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Demangle_UnixVtable_StripsLengthPrefix()
+    {
+        var d = Build(new RecoveredType("System.Object", [".ctor"], "System.Private.CoreLib"));
+
+        var result = d.Demangle("_ZTV20S_P_CoreLib_System_Object");
+
+        Assert.Equal(NativeSymbolKind.MethodTable, result.Kind);
+        Assert.Equal("System.Object (MethodTable)", result.ManagedName);
+    }
+
+    /// <summary>
+    /// Verifies the node-level data and stub prefixes classify without needing a metadata join.
+    /// </summary>
+    [Theory(Timeout = 30_000)]
+    [InlineData("?__GCSTATICS@S_P_CoreLib_System_Text_EncoderReplacementFallback@@", NativeSymbolKind.Statics)]
+    [InlineData("__NONGCSTATICS_SomeType", NativeSymbolKind.Statics)]
+    [InlineData("__TypeThreadStaticIndex_SomeType", NativeSymbolKind.Statics)]
+    [InlineData("__GenericDict_S_P_CoreLib_System_Array__Resize", NativeSymbolKind.GenericDictionary)]
+    [InlineData("__writableDataString", NativeSymbolKind.Data)]
+    [InlineData("__readonlydata_SomeMethod", NativeSymbolKind.Data)]
+    [InlineData("_MyModule__Str_48656C6C6F", NativeSymbolKind.FrozenObject)]
+    [InlineData("__unbox_SomeType", NativeSymbolKind.Stub)]
+    public void Demangle_NodePrefixes_Classify(string symbol, NativeSymbolKind expected)
+    {
+        var result = Build().Demangle(symbol);
+
+        Assert.Equal(expected, result.Kind);
+    }
+
+    /// <summary>
+    /// Verifies a nested type (compiler <c>&lt;&gt;c</c> display class) is underscore-joined, not
+    /// angle-bracketed: <c>&lt;&gt;c</c> sanitizes to <c>__c</c> and joins as a nested type.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Demangle_NestedDisplayClass_UnderscoreJoined()
+    {
+        var d = Build(new RecoveredType("System.Foo+<>c", ["<Bar>b__0_0"], "System.Private.CoreLib"));
+
+        var result = d.Demangle("S_P_CoreLib_System_Foo___c___Bar_b__0_0");
+
+        Assert.Equal("System.Foo+<>c.<Bar>b__0_0", result.ManagedName);
+        Assert.True(result.IsExactMatch);
+    }
+
+    /// <summary>
+    /// Verifies a known type whose method is absent from sparse metadata still resolves to the
+    /// type by its longest known prefix, marked non-exact.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Demangle_KnownTypeUnknownMethod_ResolvesByPrefixNonExact()
+    {
+        var d = Build(new RecoveredType("System.String", [], "System.Private.CoreLib"));
+
+        var result = d.Demangle("S_P_CoreLib_System_String__SomeMissingMethod");
+
+        Assert.Equal("System.String.SomeMissingMethod", result.ManagedName);
+        Assert.False(result.IsExactMatch);
+    }
+
+    /// <summary>
+    /// Verifies an overload disambiguation suffix (<c>_0</c>) that metadata cannot distinguish
+    /// resolves to the base method name, marked non-exact.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Demangle_OverloadSuffix_ResolvesNonExact()
+    {
+        var d = Build(new RecoveredType("System.Foo", ["Bar"], "System.Private.CoreLib"));
+
+        var result = d.Demangle("S_P_CoreLib_System_Foo__Bar_0");
+
+        Assert.Equal("System.Foo.Bar", result.ManagedName);
+        Assert.False(result.IsExactMatch);
+    }
+
+    /// <summary>
+    /// Verifies a name colliding after sanitization is not claimed as an exact match: two
+    /// distinct methods that sanitize to the same key mark the key ambiguous.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Demangle_SanitizationCollision_NotExact()
+    {
+        // "op.Add" and "op+Add" both sanitize to "op_Add".
+        var d = Build(new RecoveredType("T", ["op.Add", "op+Add"], "App"));
+
+        var result = d.Demangle("App_T__op_Add");
+
+        // Ambiguous key → no confident managed name via the exact path.
+        Assert.False(result.IsExactMatch);
+    }
+
+    /// <summary>
+    /// Verifies an unrecognized symbol yields no managed name but is not misclassified.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Demangle_Unknown_YieldsNoManagedName()
+    {
+        var result = Build().Demangle("Totally_Unknown_Symbol__Xyz");
+
+        Assert.Null(result.ManagedName);
+        Assert.False(result.IsExactMatch);
+    }
+
+    /// <summary>
+    /// Verifies the sanitizer matches ILC's rules: letters/underscore pass, a leading digit is
+    /// prefixed, and every other character (including a multibyte codepoint) becomes one <c>_</c>.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Sanitize_MatchesIlcRules()
+    {
+        Assert.Equal("Foo_Bar", IlcNameDemangler.Sanitize("Foo.Bar"));
+        Assert.Equal("_1Type", IlcNameDemangler.Sanitize("1Type"));
+        Assert.Equal("List_1", IlcNameDemangler.Sanitize("List`1"));
+        Assert.Equal("_Main__", IlcNameDemangler.Sanitize("<Main>$"));
+        Assert.Equal("a_b", IlcNameDemangler.Sanitize("aéb")); // é → one underscore
+        Assert.Equal("x_y", IlcNameDemangler.Sanitize("x\U0001F600y")); // emoji (surrogate pair) → one underscore
+    }
+}

--- a/tests/Dotsider.Tests/IlcNameDemanglerTests.cs
+++ b/tests/Dotsider.Tests/IlcNameDemanglerTests.cs
@@ -110,17 +110,33 @@ public class IlcNameDemanglerTests
     }
 
     /// <summary>
-    /// Verifies a known type whose method is absent from sparse metadata still resolves to the
-    /// type by its longest known prefix, marked non-exact.
+    /// Verifies a known type whose method is absent from sparse metadata claims no managed
+    /// name — heuristics never populate <c>ManagedName</c>; the raw name stays the display.
     /// </summary>
     [Fact(Timeout = 30_000)]
-    public void Demangle_KnownTypeUnknownMethod_ResolvesByPrefixNonExact()
+    public void Demangle_KnownTypeUnknownMethod_ClaimsNoManagedName()
     {
         var d = Build(new RecoveredType("System.String", [], "System.Private.CoreLib"));
 
         var result = d.Demangle("S_P_CoreLib_System_String__SomeMissingMethod");
 
-        Assert.Equal("System.String.SomeMissingMethod", result.ManagedName);
+        Assert.Null(result.ManagedName);
+        Assert.False(result.IsExactMatch);
+    }
+
+    /// <summary>
+    /// Verifies overloads sharing a method name never yield an exact match for the unsuffixed
+    /// symbol: the shared name is kept as the display, but no signature can say which overload
+    /// the symbol is.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Demangle_DuplicateMethodName_SharedNameNeverExact()
+    {
+        var d = Build(new RecoveredType("System.Foo", ["Bar", "Bar"], "System.Private.CoreLib"));
+
+        var result = d.Demangle("S_P_CoreLib_System_Foo__Bar");
+
+        Assert.Equal("System.Foo.Bar", result.ManagedName);
         Assert.False(result.IsExactMatch);
     }
 

--- a/tests/Dotsider.Tests/MachOSymbolReaderTests.cs
+++ b/tests/Dotsider.Tests/MachOSymbolReaderTests.cs
@@ -1,0 +1,209 @@
+using Dotsider.Core.Analysis;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="MachOSymbolReader"/> and the <see cref="MachOImageReader"/> additions
+/// behind it — the executable-section function filter, the recognized-data pass, <c>N_FUN</c>
+/// stab sizes, per-section clamping, <c>LC_FUNCTION_STARTS</c> deltas against the <c>__TEXT</c>
+/// base, UUIDs, and fat archives — driven with synthetic images on every platform.
+/// </summary>
+public class MachOSymbolReaderTests
+{
+    private const uint ExecFlags = 0x8000_0400; // pure + some instructions
+    private const byte SectType = 0x0E;         // N_SECT
+    private const byte FunStab = 0x24;          // N_FUN
+
+    private static readonly IlcNameDemangler EmptyDemangler = new([]);
+
+    private static byte[] Image(
+        (string Name, byte Type, byte Ordinal, ulong Value)[] symbols,
+        byte[]? functionStarts = null) =>
+        SyntheticImageBuilders.BuildMachO(
+            [
+                ("__TEXT", 0x1_0000_0000, new[]
+                {
+                    ("__text", 0x1_0000_1000UL, ExecFlags, new byte[0x100]),
+                    ("__managedcode", 0x1_0000_2000UL, ExecFlags, new byte[0x80]),
+                }),
+                ("__DATA", 0x1_0000_4000, new[]
+                {
+                    ("__const", 0x1_0000_4000UL, 0u, new byte[0x100]),
+                }),
+            ],
+            symbols, functionStarts: functionStarts);
+
+    /// <summary>
+    /// Verifies the section-driven split: symbols in any instruction-flagged section are
+    /// functions (sized by next start, clamped to their section), a recognized data node in a
+    /// data section is kept with the leading underscore stripped, and an unrecognized data-
+    /// section label is dropped.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadSymbols_SplitsFunctionsAndRecognizedData()
+    {
+        var image = Image(
+        [
+            ("_frost_main", SectType, 1, 0x1_0000_1010),
+            ("_helper", SectType, 1, 0x1_0000_1050),
+            ("_managed_fn", SectType, 2, 0x1_0000_2010),
+            ("__ZTV6Widget", SectType, 3, 0x1_0000_4010),
+            ("_randomLabel", SectType, 3, 0x1_0000_4020),
+        ]);
+
+        var symbols = MachOSymbolReader.ReadSymbols(image, EmptyDemangler);
+
+        Assert.Equal(4, symbols.Count); // three functions + one recognized data node
+
+        var main = Assert.Single(symbols, s => s.Name == "frost_main");
+        Assert.Equal(0x40, main.Size); // next start
+        Assert.Equal("__text", main.Section);
+        Assert.False(main.IsData);
+        Assert.NotNull(main.FileOffset);
+
+        var helper = Assert.Single(symbols, s => s.Name == "helper");
+        Assert.Equal(0xB0, helper.Size); // clamped to __text's end, not __managedcode's start
+
+        var managed = Assert.Single(symbols, s => s.Name == "managed_fn");
+        Assert.Equal("__managedcode", managed.Section);
+        Assert.Equal(0x70, managed.Size); // clamped to its own section's end
+
+        var data = Assert.Single(symbols, s => s.Name == "_ZTV6Widget");
+        Assert.True(data.IsData);
+        Assert.Equal("__const", data.Section);
+        Assert.DoesNotContain(symbols, s => s.Name.Contains("randomLabel"));
+    }
+
+    /// <summary>
+    /// Verifies <c>N_FUN</c> stab pairs: the end entry's <c>n_value</c> is the explicit size,
+    /// preferred over nearest-next sizing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadSymbols_NFunPairs_CarryExplicitSizes()
+    {
+        var image = Image(
+        [
+            ("_dsym_fn", FunStab, 1, 0x1_0000_1010),
+            ("", FunStab, 1, 0x18),                      // end entry: size
+            ("_neighbor", SectType, 1, 0x1_0000_1020),   // nearest-next would say 0x10
+        ]);
+
+        var symbols = MachOSymbolReader.ReadSymbols(image, EmptyDemangler);
+
+        var stabbed = Assert.Single(symbols, s => s.Name == "dsym_fn");
+        Assert.Equal(0x18, stabbed.Size);
+    }
+
+    /// <summary>
+    /// Verifies <c>LC_FUNCTION_STARTS</c>: deltas are relative to the <c>__TEXT</c> segment's
+    /// address even when another segment comes first, sizes come from successive starts, the
+    /// last range clamps to its executable section's end, and a zero delta terminates.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFunctionStartBoundaries_RelativeToTextSegment()
+    {
+        var starts = new DwarfBlob().ULeb(0x1010).ULeb(0x40).ULeb(0).ULeb(0x99).ToArray();
+        var image = SyntheticImageBuilders.BuildMachO(
+            [
+                ("__DATA", 0x1_0000_4000, new[] { ("__const", 0x1_0000_4000UL, 0u, new byte[8]) }),
+                ("__TEXT", 0x1_0000_0000, new[] { ("__text", 0x1_0000_1000UL, ExecFlags, new byte[0x100]) }),
+            ],
+            functionStarts: starts);
+
+        var boundaries = MachOSymbolReader.ReadFunctionStartBoundaries(image);
+
+        Assert.Equal(2, boundaries.Count); // the zero delta ends the stream
+        Assert.Equal(0x1_0000_1010UL, boundaries[0].VirtualAddress);
+        Assert.Equal(0x40, boundaries[0].Size);
+        Assert.True(boundaries[0].IsBoundary);
+        Assert.Equal(0x1_0000_1050UL, boundaries[1].VirtualAddress);
+        Assert.Equal(0xB0, boundaries[1].Size); // clamped to __text's end
+        Assert.All(boundaries, b => Assert.StartsWith("sub_", b.Name));
+    }
+
+    /// <summary>Verifies the UUID load command round-trips and its absence reports false.</summary>
+    [Fact(Timeout = 30_000)]
+    public void TryReadUuid_RoundTripsAndReportsAbsence()
+    {
+        byte[] id = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        var image = SyntheticImageBuilders.BuildMachO(
+            [("__TEXT", 0x1_0000_0000, new[] { ("__text", 0x1_0000_1000UL, ExecFlags, new byte[8]) })],
+            uuid: id);
+
+        Assert.True(MachOImageReader.TryReadUuid(image, out var uuid));
+        Assert.Equal(id, uuid);
+
+        var plain = SyntheticImageBuilders.BuildMachO(
+            [("__TEXT", 0x1_0000_0000, new[] { ("__text", 0x1_0000_1000UL, ExecFlags, new byte[8]) })]);
+        Assert.False(MachOImageReader.TryReadUuid(plain, out _));
+    }
+
+    /// <summary>
+    /// Verifies fat archives enumerate their slices — big-endian headers, per-arch offsets and
+    /// sizes — and each slice parses as a thin image.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadFatSlices_EnumeratesAndSlicesParse()
+    {
+        var arm = SyntheticImageBuilders.BuildMachO(
+            [("__TEXT", 0x1_0000_0000, new[] { ("__text", 0x1_0000_1000UL, ExecFlags, new byte[8]) })]);
+        var x64 = SyntheticImageBuilders.BuildMachO(
+            [("__TEXT", 0x1_4000_0000, new[] { ("__text", 0x1_4000_1000UL, ExecFlags, new byte[8]) })],
+            cpuType: 0x0100_0007);
+        var fat = SyntheticImageBuilders.BuildFat(arm, x64);
+
+        Assert.True(MachOImageReader.IsFat(fat));
+        Assert.False(MachOImageReader.IsMachO(fat));
+
+        var slices = MachOImageReader.ReadFatSlices(fat);
+        Assert.Equal(2, slices.Count);
+        Assert.Equal(0x0100000CU, slices[0].CpuType);
+        Assert.Equal(0x01000007U, slices[1].CpuType);
+
+        var slice = fat.AsSpan((int)slices[1].Offset, (int)slices[1].Size);
+        Assert.True(MachOImageReader.IsMachO(slice));
+        var sections = MachOImageReader.ReadSectionList(slice);
+        Assert.Equal("__text", Assert.Single(sections).Name);
+
+        Assert.Empty(MachOImageReader.ReadFatSlices(arm)); // thin image: no slices
+    }
+
+    /// <summary>
+    /// Verifies section ordinals run across segments in load order and executable flags decide
+    /// the code filter, not names.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadSectionList_OrdinalsSpanSegments()
+    {
+        var image = SyntheticImageBuilders.BuildMachO(
+        [
+            ("__TEXT", 0x1_0000_0000, new[]
+            {
+                ("__text", 0x1_0000_1000UL, ExecFlags, new byte[8]),
+                ("__unbox", 0x1_0000_2000UL, ExecFlags, new byte[8]),
+            }),
+            ("__DATA", 0x1_0000_4000, new[] { ("__const", 0x1_0000_4000UL, 0u, new byte[8]) }),
+        ]);
+
+        var sections = MachOImageReader.ReadSectionList(image);
+
+        Assert.Equal(3, sections.Count);
+        Assert.Equal([1, 2, 3], sections.Select(s => s.Ordinal));
+        Assert.True(sections[0].IsExecutable);
+        Assert.True(sections[1].IsExecutable);
+        Assert.False(sections[2].IsExecutable);
+        Assert.Equal("__DATA", sections[2].Segment);
+    }
+
+    /// <summary>Verifies malformed inputs yield empty results rather than throwing.</summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadSymbols_Malformed_ReturnsEmpty()
+    {
+        Assert.Empty(MachOSymbolReader.ReadSymbols([0xDE, 0xAD], EmptyDemangler));
+        Assert.Empty(MachOSymbolReader.ReadFunctionStartBoundaries([0xDE, 0xAD]));
+
+        // A symbol pointing at a nonexistent section ordinal is dropped, not misattributed.
+        var orphan = Image([("_ghost", SectType, 99, 0x1_0000_1010)]);
+        Assert.Empty(MachOSymbolReader.ReadSymbols(orphan, EmptyDemangler));
+    }
+}

--- a/tests/Dotsider.Tests/MsfFileTests.cs
+++ b/tests/Dotsider.Tests/MsfFileTests.cs
@@ -1,0 +1,87 @@
+using Dotsider.Core.Analysis.NativePdb;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="MsfFile"/>, the MSF 7.0 container reader, using synthetic images so the
+/// block and directory math is exercised on every platform.
+/// </summary>
+public class MsfFileTests
+{
+    /// <summary>
+    /// Verifies a stream's bytes round-trip through the block directory, including a stream whose
+    /// content spans more than one block.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void GetStream_MultiBlockStream_RoundTrips()
+    {
+        var payload = new byte[1500];
+        for (var i = 0; i < payload.Length; i++) payload[i] = (byte)(i * 7);
+        var image = SyntheticImageBuilders.BuildMsf(512, payload);
+
+        var msf = MsfFile.TryOpen(image);
+
+        Assert.NotNull(msf);
+        Assert.Equal(payload, msf.GetStream(1));
+    }
+
+    /// <summary>
+    /// Verifies a multi-block stream directory (more directory bytes than one block holds) is
+    /// concatenated and read correctly.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void TryOpen_MultiBlockDirectory_ResolvesAllStreams()
+    {
+        // Many small streams push the directory past one 512-byte block.
+        var streams = new byte[]?[60];
+        for (var i = 0; i < streams.Length; i++) streams[i] = [(byte)i, (byte)(i + 1)];
+        var image = SyntheticImageBuilders.BuildMsf(512, streams);
+
+        var msf = MsfFile.TryOpen(image);
+
+        Assert.NotNull(msf);
+        Assert.Equal(61, msf.StreamCount); // stream 0 + 60
+        Assert.Equal([59, 60], msf.GetStream(60));
+    }
+
+    /// <summary>
+    /// Verifies a nil stream (size 0xFFFFFFFF) reports zero length and yields no bytes.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void GetStream_NilStream_IsEmpty()
+    {
+        var image = SyntheticImageBuilders.BuildMsf(512, [1, 2, 3], null);
+
+        var msf = MsfFile.TryOpen(image);
+
+        Assert.NotNull(msf);
+        Assert.Equal(0, msf.StreamSize(2));
+        Assert.Empty(msf.GetStream(2));
+    }
+
+    /// <summary>
+    /// Verifies non-MSF bytes return null rather than throwing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void TryOpen_NotMsf_ReturnsNull()
+    {
+        Assert.Null(MsfFile.TryOpen([0xDE, 0xAD, 0xBE, 0xEF]));
+        Assert.Null(MsfFile.TryOpen(new byte[512]));
+    }
+
+    /// <summary>
+    /// Verifies an out-of-range block index in the directory is rejected as null.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void TryOpen_CorruptBlockIndex_ReturnsNull()
+    {
+        var image = SyntheticImageBuilders.BuildMsf(512, [1, 2, 3, 4]);
+        // Corrupt the block-map block's first entry to point past the file. The block map sits in
+        // the last block; its first 4 bytes are the directory's block index.
+        var blockMapOffset = image.Length - 512;
+        image[blockMapOffset] = 0xFF;
+        image[blockMapOffset + 1] = 0xFF;
+
+        Assert.Null(MsfFile.TryOpen(image));
+    }
+}

--- a/tests/Dotsider.Tests/NativeMetadataReaderTests.cs
+++ b/tests/Dotsider.Tests/NativeMetadataReaderTests.cs
@@ -65,4 +65,41 @@ public class NativeMetadataReaderTests(SampleAssemblyFixture samples)
 
         Assert.Empty(analyzer.RecoveredTypes);
     }
+
+    /// <summary>
+    /// Verifies recovered types carry their defining assembly scope name — framework types
+    /// resolve to <c>System.Private.CoreLib</c> and the app's own type to the app assembly —
+    /// which native symbol demangling joins against.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void RecoveredTypes_NativeAotExe_CarryAssemblyScopeNames()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        using var analyzer = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+
+        var types = analyzer.RecoveredTypes;
+
+        var systemObject = Assert.Single(types, t => t.FullName == "System.Object");
+        Assert.Equal("System.Private.CoreLib", systemObject.AssemblyName);
+        var program = Assert.Single(types, t => t.FullName == "Program");
+        Assert.Equal("NativeAotConsole", program.AssemblyName);
+    }
+
+    /// <summary>
+    /// Verifies the explicit two-value deconstruction still compiles and yields the type name
+    /// and its methods, unaffected by the added assembly-scope parameter.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void RecoveredType_TwoValueDeconstruction_Preserved()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        using var analyzer = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+
+        var (fullName, methodNames) = analyzer.RecoveredTypes.First(t => t.FullName == "Program");
+
+        Assert.Equal("Program", fullName);
+        Assert.Contains("<Main>$", methodNames);
+    }
 }

--- a/tests/Dotsider.Tests/NativePdbReaderTests.cs
+++ b/tests/Dotsider.Tests/NativePdbReaderTests.cs
@@ -1,0 +1,85 @@
+using Dotsider.Core.Analysis.NativePdb;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="NativePdbReader"/> against the real PDB published beside the NativeAOT
+/// sample on Windows. These run on the Windows CI leg, where the symbol file is a <c>.pdb</c>;
+/// the block-math and container tests in <see cref="MsfFileTests"/> cover the other platforms.
+/// </summary>
+[Collection("SampleAssemblies")]
+public class NativePdbReaderTests(SampleAssemblyFixture samples)
+{
+    private bool HasPdb =>
+        samples.NativeAotConsoleSymbols is not null
+        && samples.NativeAotConsoleSymbols.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Verifies the PDB's GUID reads through the cheap probe and matches the GUID embedded in the
+    /// executable's RSDS debug directory (the bytes appear verbatim in the image).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void TryReadPdbId_MatchesExeRsdsGuid()
+    {
+        Assert.SkipWhen(!HasPdb, "native PDB not present on this platform");
+
+        Assert.True(NativePdbReader.TryReadPdbId(samples.NativeAotConsoleSymbols!, out var guid, out var age));
+        Assert.NotEqual(Guid.Empty, guid);
+        Assert.True(age > 0);
+
+        var exe = File.ReadAllBytes(samples.NativeAotConsoleExe!);
+        Assert.True(IndexOf(exe, guid.ToByteArray()) >= 0, "PDB GUID not found in the exe RSDS entry");
+    }
+
+    /// <summary>
+    /// Verifies the reader recovers function symbols with resolved addresses and names, including
+    /// the app's entry point, and that C13 line data attributes at least one function to a source
+    /// file and line.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_FixturePdb_RecoversFunctionsWithLineData()
+    {
+        Assert.SkipWhen(!HasPdb, "native PDB not present on this platform");
+
+        var pdb = File.ReadAllBytes(samples.NativeAotConsoleSymbols!);
+        var exe = File.ReadAllBytes(samples.NativeAotConsoleExe!);
+
+        var symbols = NativePdbReader.Read(pdb, exe);
+
+        Assert.NotEmpty(symbols);
+        // Addresses resolved: every symbol has a non-zero VA and an RVA.
+        Assert.All(symbols, s =>
+        {
+            Assert.True(s.VirtualAddress > 0);
+            Assert.NotNull(s.Rva);
+        });
+        // The entry point is present in mangled form.
+        Assert.Contains(symbols, s => s.Name.Contains("Program___Main__", StringComparison.Ordinal));
+        // C13 line data attributed at least one function to a source location.
+        Assert.Contains(symbols, s => s.SourceFile is not null && s.Line is > 0);
+    }
+
+    /// <summary>
+    /// Verifies a non-PDB file returns no symbols rather than throwing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NotAPdb_ReturnsEmpty()
+    {
+        Assert.Empty(NativePdbReader.Read([0xDE, 0xAD, 0xBE, 0xEF], new byte[64]));
+    }
+
+
+
+    private static int IndexOf(byte[] haystack, byte[] needle)
+    {
+        for (var i = 0; i + needle.Length <= haystack.Length; i++)
+        {
+            var j = 0;
+            for (; j < needle.Length; j++)
+                if (haystack[i + j] != needle[j]) break;
+            if (j == needle.Length) return i;
+        }
+
+        return -1;
+    }
+}

--- a/tests/Dotsider.Tests/NativePdbReaderTests.cs
+++ b/tests/Dotsider.Tests/NativePdbReaderTests.cs
@@ -68,6 +68,36 @@ public class NativePdbReaderTests(SampleAssemblyFixture samples)
         Assert.Empty(NativePdbReader.Read([0xDE, 0xAD, 0xBE, 0xEF], new byte[64]));
     }
 
+    /// <summary>
+    /// Verifies the full PDB pipeline — module records, publics, and the data pass — merged and
+    /// demangled: addresses are unique (no double count), managed names join, and the compiler's
+    /// data symbols (MethodTables) surface as their own kind.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Build_FixturePdb_MergesDemanglesAndClassifies()
+    {
+        Assert.SkipWhen(!HasPdb, "native PDB not present on this platform");
+
+        using var analyzer = new Dotsider.Core.Analysis.AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        var raw = NativePdbReader.Read(
+            File.ReadAllBytes(samples.NativeAotConsoleSymbols!), analyzer.RawBytes.ToArray());
+        var demangler = new Dotsider.Core.Analysis.IlcNameDemangler(analyzer.RecoveredTypes);
+
+        var info = Dotsider.Core.Analysis.NativeSymbolReader.Build(
+            raw, demangler,
+            Dotsider.Core.Analysis.Models.NativeSymbolSource.NativePdb,
+            Dotsider.Core.Analysis.Models.NativeSymbolStatus.Loaded,
+            samples.NativeAotConsoleSymbols, null);
+
+        Assert.NotEmpty(info.Symbols);
+        // No two symbols share an address after the merge.
+        Assert.Equal(info.Symbols.Count, info.Symbols.Select(s => s.VirtualAddress).Distinct().Count());
+        // Managed names joined for some functions.
+        Assert.Contains(info.Symbols, s => s.IsExactMatch && s.ManagedName is not null);
+        // The compiler's MethodTable data symbols are recovered and classified.
+        Assert.Contains(info.Symbols, s => s.Kind == Dotsider.Core.Analysis.Models.NativeSymbolKind.MethodTable);
+    }
+
 
 
     private static int IndexOf(byte[] haystack, byte[] needle)

--- a/tests/Dotsider.Tests/NativeSymbolMergeTests.cs
+++ b/tests/Dotsider.Tests/NativeSymbolMergeTests.cs
@@ -80,14 +80,88 @@ public class NativeSymbolMergeTests
     }
 
     /// <summary>
-    /// Verifies a function-named symbol found in a data context classifies as data, not a function.
+    /// Verifies an unrecognized data-section record is dropped — unrelated globals and import
+    /// thunks would otherwise inflate the Size Map's data categories — while a recognized ILC
+    /// node at the same footing survives.
     /// </summary>
     [Fact(Timeout = 30_000)]
-    public void Build_FunctionNameInDataSection_ClassifiesAsData()
+    public void Build_UnrecognizedDataSymbol_Dropped()
     {
-        var info = Build(Raw("App_T__Method", 0x2000, 0x10, isData: true));
+        var info = Build(
+            Raw("__imp_GetLastError", 0x2000, 0x08, isData: true),
+            Raw("_ZTV6Widget", 0x2010, 0x18, isData: true));
 
-        Assert.Equal(NativeSymbolKind.Data, Assert.Single(info.Symbols).Kind);
+        var symbol = Assert.Single(info.Symbols);
+        Assert.Equal("_ZTV6Widget", symbol.Name);
+        Assert.Equal(NativeSymbolKind.MethodTable, symbol.Kind);
+    }
+
+    /// <summary>
+    /// Verifies a data record joined to a managed name is kept and classified as data rather
+    /// than dropped with the unrecognized ones.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Build_ManagedJoinedDataSymbol_KeptAsData()
+    {
+        var demangler = new IlcNameDemangler([new RecoveredType("System.Foo", ["Bar"], "System.Private.CoreLib")]);
+        var info = NativeSymbolReader.Build(
+            [Raw("S_P_CoreLib_System_Foo__Bar", 0x2000, 0x10, isData: true)],
+            demangler, NativeSymbolSource.NativePdb, NativeSymbolStatus.Loaded, "x.pdb", null);
+
+        var symbol = Assert.Single(info.Symbols);
+        Assert.Equal(NativeSymbolKind.Data, symbol.Kind);
+        Assert.Equal("System.Foo.Bar", symbol.ManagedName);
+    }
+
+    /// <summary>
+    /// Verifies a merged data group whose primary is unrecognized re-fronts a recognized alias
+    /// instead of dropping the address: the node name leads and the old primary becomes an alias.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Build_UnrecognizedDataPrimary_PromotesRecognizedAlias()
+    {
+        var info = Build(
+            Raw("crt_state", 0x2000, 0x18, isData: true),
+            Raw("_ZTV6Widget", 0x2000, 0, isData: true));
+
+        var symbol = Assert.Single(info.Symbols);
+        Assert.Equal("_ZTV6Widget", symbol.Name);
+        Assert.Equal(NativeSymbolKind.MethodTable, symbol.Kind);
+        Assert.Equal(0x18, symbol.Size);
+        Assert.Contains("crt_state", symbol.Aliases);
+    }
+
+    /// <summary>
+    /// Verifies overlapping extents clip to the next symbol's start so the Size Map never
+    /// counts a byte twice.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Build_OverlappingRanges_ClipToNextStart()
+    {
+        var info = Build(
+            Raw("a", 0x1000, 0x100),
+            Raw("b", 0x1050, 0x20));
+
+        Assert.Equal(0x50, info.Symbols[0].Size);
+        Assert.Equal(0x20, info.Symbols[1].Size);
+    }
+
+    /// <summary>
+    /// Verifies an unsized symbol is not sized across a section boundary: the gap to a symbol
+    /// in a different section says nothing about its extent.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Build_UnsizedSymbol_NotSizedAcrossSections()
+    {
+        var raw = new RawNativeSymbol[]
+        {
+            new("last_in_text", 0x1000, 0x1000, 0x1000, ".text", 0, false, false, null, null),
+            new("_ZTV6Widget", 0x9000, 0x9000, 0x9000, ".data", 0x10, true, false, null, null),
+        };
+        var info = NativeSymbolReader.Build(raw, EmptyDemangler, NativeSymbolSource.NativePdb,
+            NativeSymbolStatus.Loaded, "x.pdb", null);
+
+        Assert.Equal(0, info.Symbols[0].Size);
     }
 
     /// <summary>

--- a/tests/Dotsider.Tests/NativeSymbolMergeTests.cs
+++ b/tests/Dotsider.Tests/NativeSymbolMergeTests.cs
@@ -1,0 +1,125 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for the merge, dedup, sizing, and classification core of <see cref="NativeSymbolReader"/>
+/// (its <c>Build</c> step), driven with synthetic raw symbols so the rules are pinned independently
+/// of any format reader.
+/// </summary>
+public class NativeSymbolMergeTests
+{
+    private static readonly IlcNameDemangler EmptyDemangler = new([]);
+
+    private static RawNativeSymbol Raw(
+        string name, ulong va, long size, bool isData = false, bool isBoundary = false,
+        string? file = null, int? line = null) =>
+        new(name, va, (uint)va, (long)va, ".text", size, isData, isBoundary, file, line);
+
+    private static NativeSymbolInfo Build(params RawNativeSymbol[] raw) =>
+        NativeSymbolReader.Build(raw, EmptyDemangler, NativeSymbolSource.NativePdb,
+            NativeSymbolStatus.Loaded, "x.pdb", null);
+
+    /// <summary>
+    /// Verifies two records at the same address collapse to one symbol, the richer record's size
+    /// wins, and the other name becomes an alias — so the address is never counted twice.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Build_SameAddress_MergesToPrimaryWithAlias()
+    {
+        var info = Build(
+            Raw("proc_with_size", 0x1000, 0x40),
+            Raw("public_no_size", 0x1000, 0));
+
+        var symbol = Assert.Single(info.Symbols);
+        Assert.Equal("proc_with_size", symbol.Name);
+        Assert.Equal(0x40, symbol.Size);
+        Assert.Contains("public_no_size", symbol.Aliases);
+    }
+
+    /// <summary>
+    /// Verifies an unsized symbol is sized by the distance to the next symbol's address.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Build_UnsizedSymbol_SizedByNextAddress()
+    {
+        var info = Build(
+            Raw("a", 0x1000, 0),
+            Raw("b", 0x1050, 0));
+
+        Assert.Equal(0x50, info.Symbols[0].Size);
+    }
+
+    /// <summary>
+    /// Verifies the merged set has no two symbols at the same address — the Size Map sums this set,
+    /// so a duplicate would double-count.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Build_Result_HasUniqueAddresses()
+    {
+        var info = Build(
+            Raw("a", 0x1000, 0x10),
+            Raw("a_alias", 0x1000, 0),
+            Raw("b", 0x1020, 0x10));
+
+        Assert.Equal(info.Symbols.Count, info.Symbols.Select(s => s.VirtualAddress).Distinct().Count());
+    }
+
+    /// <summary>
+    /// Verifies a boundary record classifies as a boundary with no managed name.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Build_Boundary_ClassifiesAsBoundary()
+    {
+        var info = Build(Raw("sub_1000", 0x1000, 0x10, isBoundary: true));
+
+        var symbol = Assert.Single(info.Symbols);
+        Assert.Equal(NativeSymbolKind.Boundary, symbol.Kind);
+        Assert.Null(symbol.ManagedName);
+    }
+
+    /// <summary>
+    /// Verifies a function-named symbol found in a data context classifies as data, not a function.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Build_FunctionNameInDataSection_ClassifiesAsData()
+    {
+        var info = Build(Raw("App_T__Method", 0x2000, 0x10, isData: true));
+
+        Assert.Equal(NativeSymbolKind.Data, Assert.Single(info.Symbols).Kind);
+    }
+
+    /// <summary>
+    /// Verifies the demangler is applied to primaries: a symbol matching a recovered type/method
+    /// gets its managed name, and the interval lookup resolves an address inside it.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Build_AppliesDemanglerAndSupportsIntervalLookup()
+    {
+        var demangler = new IlcNameDemangler([new RecoveredType("System.Foo", ["Bar"], "System.Private.CoreLib")]);
+        var info = NativeSymbolReader.Build(
+            [Raw("S_P_CoreLib_System_Foo__Bar", 0x3000, 0x30)],
+            demangler, NativeSymbolSource.NativePdb, NativeSymbolStatus.Loaded, "x.pdb", null);
+
+        Assert.Equal("System.Foo.Bar", info.Symbols[0].ManagedName);
+        Assert.True(info.Symbols[0].IsExactMatch);
+        Assert.True(info.TryFindByAddress(0x3010, out var hit));
+        Assert.Equal("S_P_CoreLib_System_Foo__Bar", hit.Name);
+        Assert.False(info.TryFindByAddress(0x3040, out _));
+    }
+
+    /// <summary>
+    /// Verifies an empty input carries the status and diagnostic so an empty result is explainable.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Build_Empty_CarriesStatus()
+    {
+        var info = NativeSymbolReader.Build([], EmptyDemangler, NativeSymbolSource.PdataFallback,
+            NativeSymbolStatus.NoSymbolFile, null, "no symbol file beside the binary");
+
+        Assert.Empty(info.Symbols);
+        Assert.Equal(NativeSymbolStatus.NoSymbolFile, info.Status);
+        Assert.Equal("no symbol file beside the binary", info.Diagnostic);
+    }
+}

--- a/tests/Dotsider.Tests/NativeSymbolReaderElfTests.cs
+++ b/tests/Dotsider.Tests/NativeSymbolReaderElfTests.cs
@@ -1,0 +1,342 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for the ELF arm of <see cref="NativeSymbolReader"/>: every probe outcome with synthetic
+/// images on all platforms — unstripped self, matched/loose/mismatched sidecars, corrupt debug
+/// info, and the <c>.eh_frame</c> fallback chain — plus the real NativeAOT fixture on the Linux
+/// leg (where its symbol file is a <c>.dbg</c>).
+/// </summary>
+[Collection("SampleAssemblies")]
+public class NativeSymbolReaderElfTests(SampleAssemblyFixture samples)
+{
+    private static readonly byte[] IdA = [0xDE, 0xAD, 0xBE, 0xEF, 1, 2, 3, 4];
+    private static readonly byte[] IdB = [0xCA, 0xFE, 0xBA, 0xBE, 5, 6, 7, 8];
+
+    private bool HasDbg =>
+        samples.NativeAotConsoleSymbols is not null
+        && samples.NativeAotConsoleSymbols.EndsWith(".dbg", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Builds one-function .debug_info/.debug_abbrev blobs (v4, name + low_pc + size).</summary>
+    private static (byte[] Info, byte[] Abbrev) MinimalDwarf(string name, ulong lowPc, uint size)
+    {
+        var abbrev = new DwarfBlob()
+            .ULeb(1).ULeb(0x11).U8(1).ULeb(0).ULeb(0)                     // compile_unit, children
+            .ULeb(2).ULeb(0x2E).U8(0)                                     // subprogram
+            .ULeb(0x03).ULeb(0x08)                                        //   name: string
+            .ULeb(0x11).ULeb(0x01)                                        //   low_pc: addr
+            .ULeb(0x12).ULeb(0x06)                                        //   high_pc: data4
+            .ULeb(0).ULeb(0)
+            .ULeb(0);
+
+        var dies = new DwarfBlob()
+            .ULeb(1)
+            .ULeb(2).CStr(name).U64(lowPc).U32(size)
+            .ULeb(0);
+        var body = new DwarfBlob().U16(4).U32(0).U8(8).Bytes(dies.ToArray());
+        var info = new DwarfBlob().U32((uint)body.Length).Bytes(body.ToArray()).ToArray();
+        return (info, abbrev.ToArray());
+    }
+
+    private static string Write(string directory, string name, byte[] bytes)
+    {
+        var path = Path.Combine(directory, name);
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    /// <summary>Verifies an unstripped image reads its own DWARF: Loaded, path = the image.</summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_UnstrippedElf_ReadsOwnDwarf()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-elf-");
+        try
+        {
+            var (info, abbrev) = MinimalDwarf("frost_main", 0x1010, 0x40);
+            var exePath = Write(dir.FullName, "app", SyntheticImageBuilders.BuildElf(
+                (".text", 0x1000, new byte[0x100]),
+                (".debug_info", 0, info),
+                (".debug_abbrev", 0, abbrev)));
+
+            var result = NativeSymbolReader.Read(exePath, File.ReadAllBytes(exePath), []);
+
+            Assert.Equal(NativeSymbolSource.Dwarf, result.Source);
+            Assert.Equal(NativeSymbolStatus.Loaded, result.Status);
+            Assert.Equal(exePath, result.Path);
+            var symbol = Assert.Single(result.Symbols);
+            Assert.Equal("frost_main", symbol.Name);
+            Assert.Equal(0x1010UL, symbol.VirtualAddress);
+            Assert.Equal(0x40, symbol.Size);
+            Assert.Equal(".text", symbol.Section);
+            Assert.NotNull(symbol.FileOffset);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a build-id-matched sidecar loads: DWARF functions plus symtab data with exact
+    /// sizes, addresses mapped through the image's sections.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_StrippedWithMatchingSidecar_LoadsDwarfAndSymtabData()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-elf-");
+        try
+        {
+            var exePath = Write(dir.FullName, "app", SyntheticImageBuilders.BuildElf(
+                (".text", 0x1000, new byte[0x100]),
+                (".data", 0x2000, new byte[0x100]),
+                (".note.gnu.build-id", 0, SyntheticImageBuilders.GnuBuildIdNote(IdA))));
+
+            var (info, abbrev) = MinimalDwarf("frost_main", 0x1010, 0x40);
+            var strtab = "\0_ZTV6Widget\0"u8.ToArray();
+            var symtab = new byte[48]; // null entry + one object
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(symtab.AsSpan(24), 1);
+            symtab[28] = 1; // STT_OBJECT
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(symtab.AsSpan(30), 1);
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(symtab.AsSpan(32), 0x2010);
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(symtab.AsSpan(40), 0x18);
+            Write(dir.FullName, "app.dbg", SyntheticImageBuilders.BuildElf(
+                (".note.gnu.build-id", 0, SyntheticImageBuilders.GnuBuildIdNote(IdA), 1u, 0u),
+                (".debug_info", 0, info, 1u, 0u),
+                (".debug_abbrev", 0, abbrev, 1u, 0u),
+                (".symtab", 0, symtab, 2u, 5u),
+                (".strtab", 0, strtab, 3u, 0u)));
+
+            var result = NativeSymbolReader.Read(exePath, File.ReadAllBytes(exePath), []);
+
+            Assert.Equal(NativeSymbolStatus.Loaded, result.Status);
+            Assert.Equal(NativeSymbolSource.Dwarf, result.Source);
+            Assert.EndsWith("app.dbg", result.Path);
+            Assert.Null(result.Diagnostic);
+
+            var function = Assert.Single(result.Symbols, s => s.Kind == NativeSymbolKind.Function);
+            Assert.Equal("frost_main", function.Name);
+            Assert.Equal(".text", function.Section);
+
+            var data = Assert.Single(result.Symbols, s => s.Kind == NativeSymbolKind.MethodTable);
+            Assert.Equal("_ZTV6Widget", data.Name);
+            Assert.Equal(0x18, data.Size); // exact st_size
+            Assert.Equal(".data", data.Section);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>Verifies a <c>.gnu_debuglink</c>-named sidecar is found and CRC-validated.</summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_DebugLinkNamedSidecar_FoundAndCrcValidated()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-elf-");
+        try
+        {
+            var (info, abbrev) = MinimalDwarf("fn", 0x1010, 0x10);
+            var sidecarBytes = SyntheticImageBuilders.BuildElf(
+                (".debug_info", 0, info),
+                (".debug_abbrev", 0, abbrev));
+            Write(dir.FullName, "custom.dbg", sidecarBytes);
+
+            var exePath = Write(dir.FullName, "app", SyntheticImageBuilders.BuildElf(
+                (".text", 0x1000, new byte[0x100]),
+                (".gnu_debuglink", 0, SyntheticImageBuilders.GnuDebugLink(
+                    "custom.dbg", Crc32.Compute(sidecarBytes)))));
+
+            var result = NativeSymbolReader.Read(exePath, File.ReadAllBytes(exePath), []);
+
+            Assert.Equal(NativeSymbolStatus.Loaded, result.Status);
+            Assert.EndsWith("custom.dbg", result.Path);
+            Assert.Null(result.Diagnostic); // CRC is a real signal, not a loose match
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a signal-free image accepts its sidecar loosely, with a diagnostic saying so.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NoSignals_LooseMatchCarriesDiagnostic()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-elf-");
+        try
+        {
+            var exePath = Write(dir.FullName, "app", SyntheticImageBuilders.BuildElf(
+                (".text", 0x1000, new byte[0x100])));
+            var (info, abbrev) = MinimalDwarf("fn", 0x1010, 0x10);
+            Write(dir.FullName, "app.dbg", SyntheticImageBuilders.BuildElf(
+                (".debug_info", 0, info),
+                (".debug_abbrev", 0, abbrev)));
+
+            var result = NativeSymbolReader.Read(exePath, File.ReadAllBytes(exePath), []);
+
+            Assert.Equal(NativeSymbolStatus.Loaded, result.Status);
+            Assert.NotNull(result.Diagnostic);
+            Assert.Contains("machine and debug info only", result.Diagnostic);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a mismatching sidecar is rejected as <see cref="NativeSymbolStatus.IdMismatch"/>,
+    /// naming the sidecar, with boundaries recovered when <c>.eh_frame</c> allows.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_MismatchedSidecar_ReportsIdMismatch()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-elf-");
+        try
+        {
+            var exePath = Write(dir.FullName, "app", SyntheticImageBuilders.BuildElf(
+                (".text", 0x1000, new byte[0x100]),
+                (".note.gnu.build-id", 0, SyntheticImageBuilders.GnuBuildIdNote(IdA)),
+                (".eh_frame", 0x3000, SyntheticImageBuilders.EhFrame((0x1010, 0x40)))));
+            var (info, abbrev) = MinimalDwarf("fn", 0x1010, 0x10);
+            Write(dir.FullName, "app.dbg", SyntheticImageBuilders.BuildElf(
+                (".note.gnu.build-id", 0, SyntheticImageBuilders.GnuBuildIdNote(IdB)),
+                (".debug_info", 0, info),
+                (".debug_abbrev", 0, abbrev)));
+
+            var result = NativeSymbolReader.Read(exePath, File.ReadAllBytes(exePath), []);
+
+            Assert.Equal(NativeSymbolStatus.IdMismatch, result.Status);
+            Assert.Equal(NativeSymbolSource.EhFrameFallback, result.Source);
+            Assert.Contains("app.dbg", result.Diagnostic);
+            var boundary = Assert.Single(result.Symbols);
+            Assert.Equal(NativeSymbolKind.Boundary, boundary.Kind);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the no-sidecar chain: boundaries from <c>.eh_frame</c> as
+    /// <see cref="NativeSymbolStatus.FallbackOnly"/>, and
+    /// <see cref="NativeSymbolStatus.NoSymbolFile"/> when there is no unwind data either.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NoSidecar_FallsBackToEhFrameThenNoSymbolFile()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-elf-");
+        try
+        {
+            var withUnwind = Write(dir.FullName, "app", SyntheticImageBuilders.BuildElf(
+                (".text", 0x1000, new byte[0x100]),
+                (".eh_frame", 0x3000, SyntheticImageBuilders.EhFrame((0x1010, 0x40), (0x1050, 0x20)))));
+            var result = NativeSymbolReader.Read(withUnwind, File.ReadAllBytes(withUnwind), []);
+
+            Assert.Equal(NativeSymbolStatus.FallbackOnly, result.Status);
+            Assert.Equal(NativeSymbolSource.EhFrameFallback, result.Source);
+            Assert.Equal(2, result.Symbols.Count);
+            Assert.All(result.Symbols, s => Assert.Equal(NativeSymbolKind.Boundary, s.Kind));
+
+            var bare = Write(dir.FullName, "bare", SyntheticImageBuilders.BuildElf(
+                (".text", 0x1000, new byte[0x100])));
+            var empty = NativeSymbolReader.Read(bare, File.ReadAllBytes(bare), []);
+
+            Assert.Equal(NativeSymbolStatus.NoSymbolFile, empty.Status);
+            Assert.Empty(empty.Symbols);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a matched sidecar with unreadable debug data reports
+    /// <see cref="NativeSymbolStatus.CorruptSymbolFile"/>.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_MatchedButUnreadableSidecar_ReportsCorrupt()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-elf-");
+        try
+        {
+            var exePath = Write(dir.FullName, "app", SyntheticImageBuilders.BuildElf(
+                (".text", 0x1000, new byte[0x100]),
+                (".note.gnu.build-id", 0, SyntheticImageBuilders.GnuBuildIdNote(IdA))));
+            Write(dir.FullName, "app.dbg", SyntheticImageBuilders.BuildElf(
+                (".note.gnu.build-id", 0, SyntheticImageBuilders.GnuBuildIdNote(IdA)),
+                (".debug_info", 0, new byte[] { 9, 9, 9 }))); // no abbrev, unreadable
+
+            var result = NativeSymbolReader.Read(exePath, File.ReadAllBytes(exePath), []);
+
+            Assert.Equal(NativeSymbolStatus.CorruptSymbolFile, result.Status);
+            Assert.Contains("no readable symbols", result.Diagnostic);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the real Linux fixture: the <c>.dbg</c> loads as the DWARF source, demangles to
+    /// managed names, attributes a user function to a source file and line, and carries data
+    /// categories from the symtab pass.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NativeAotExeWithDbg_UsesDwarfSource()
+    {
+        Assert.SkipWhen(!HasDbg, "native .dbg not present on this platform");
+
+        using var analyzer = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        var info = NativeSymbolReader.Read(
+            samples.NativeAotConsoleExe!, analyzer.RawBytes.ToArray(), analyzer.RecoveredTypes);
+
+        Assert.Equal(NativeSymbolSource.Dwarf, info.Source);
+        Assert.Equal(NativeSymbolStatus.Loaded, info.Status);
+        Assert.True(info.Symbols.Count > 1000,
+            $"expected a real symbol population, got {info.Symbols.Count}");
+        Assert.Contains(info.Symbols, s => s.ManagedName is not null && s.IsExactMatch);
+        Assert.Contains(info.Symbols,
+            s => s.Kind == NativeSymbolKind.Function && s.SourceFile is not null && s.Line > 0);
+        Assert.Contains(info.Symbols, s => s.Kind is NativeSymbolKind.MethodTable
+            or NativeSymbolKind.Statics or NativeSymbolKind.FrozenObject);
+    }
+
+    /// <summary>
+    /// Verifies the real exe copied away from its <c>.dbg</c> falls back to <c>.eh_frame</c>
+    /// boundaries.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NativeAotExeCopiedAway_FallsBackToEhFrame()
+    {
+        Assert.SkipWhen(!HasDbg, "native .dbg not present on this platform");
+
+        var exeBytes = File.ReadAllBytes(samples.NativeAotConsoleExe!);
+        Assert.SkipWhen(ElfImageReader.TryGetSection(exeBytes, ".debug_info", out _),
+            "exe is unstripped; it would read its own DWARF");
+
+        var dir = Directory.CreateTempSubdirectory("dotsider-ehframe-");
+        try
+        {
+            var exeCopy = Path.Combine(dir.FullName, Path.GetFileName(samples.NativeAotConsoleExe!));
+            File.Copy(samples.NativeAotConsoleExe!, exeCopy);
+
+            var info = NativeSymbolReader.Read(exeCopy, File.ReadAllBytes(exeCopy), []);
+
+            Assert.Equal(NativeSymbolSource.EhFrameFallback, info.Source);
+            Assert.NotEmpty(info.Symbols);
+            Assert.All(info.Symbols, s => Assert.Equal(NativeSymbolKind.Boundary, s.Kind));
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+}

--- a/tests/Dotsider.Tests/NativeSymbolReaderElfTests.cs
+++ b/tests/Dotsider.Tests/NativeSymbolReaderElfTests.cs
@@ -257,6 +257,40 @@ public class NativeSymbolReaderElfTests(SampleAssemblyFixture samples)
     }
 
     /// <summary>
+    /// Verifies a sidecar whose debug sections are <c>SHF_COMPRESSED</c> — the GNU toolchain
+    /// default that produces zlib payloads behind an <c>Elf64_Chdr</c> — inflates and loads.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_CompressedDebugSections_InflateAndLoad()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-elf-");
+        try
+        {
+            var exePath = Write(dir.FullName, "app", SyntheticImageBuilders.BuildElf(
+                (".text", 0x1000, new byte[0x100]),
+                (".note.gnu.build-id", 0, SyntheticImageBuilders.GnuBuildIdNote(IdA))));
+
+            var (info, abbrev) = MinimalDwarf("frost_main", 0x1010, 0x40);
+            Write(dir.FullName, "app.dbg", SyntheticImageBuilders.BuildElf(
+                (".note.gnu.build-id", 0, SyntheticImageBuilders.GnuBuildIdNote(IdA), 1u, 0u, 0UL),
+                (".debug_info", 0, SyntheticImageBuilders.CompressDebugSection(info), 1u, 0u, 0x800UL),
+                (".debug_abbrev", 0, SyntheticImageBuilders.CompressDebugSection(abbrev), 1u, 0u, 0x800UL)));
+
+            var result = NativeSymbolReader.Read(exePath, File.ReadAllBytes(exePath), []);
+
+            Assert.Equal(NativeSymbolStatus.Loaded, result.Status);
+            Assert.Equal(NativeSymbolSource.Dwarf, result.Source);
+            var symbol = Assert.Single(result.Symbols);
+            Assert.Equal("frost_main", symbol.Name);
+            Assert.Equal(0x40, symbol.Size);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
     /// Verifies a matched sidecar with unreadable debug data reports
     /// <see cref="NativeSymbolStatus.CorruptSymbolFile"/>.
     /// </summary>

--- a/tests/Dotsider.Tests/NativeSymbolReaderMachOTests.cs
+++ b/tests/Dotsider.Tests/NativeSymbolReaderMachOTests.cs
@@ -1,0 +1,327 @@
+using System.Buffers.Binary;
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for the Mach-O arm of <see cref="NativeSymbolReader"/>: every probe outcome with
+/// synthetic images on all platforms — nlist-only, merged dSYM DWARF+nlist, UUID mismatch, fat
+/// slice selection and ambiguity, and the <c>LC_FUNCTION_STARTS</c> fallback chain — plus the
+/// real NativeAOT fixture on the macOS leg (where its symbol file is a dSYM).
+/// </summary>
+[Collection("SampleAssemblies")]
+public class NativeSymbolReaderMachOTests(SampleAssemblyFixture samples)
+{
+    private const uint ExecFlags = 0x8000_0400;
+    private const byte SectType = 0x0E;
+
+    private static readonly byte[] UuidA = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    private static readonly byte[] UuidB = [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+
+    private static (string, ulong, (string, ulong, uint, byte[])[]) TextSegment() =>
+        ("__TEXT", 0x1_0000_0000, new[] { ("__text", 0x1_0000_1000UL, ExecFlags, new byte[0x100]) });
+
+    /// <summary>Builds one-function .debug_info/.debug_abbrev blobs (v4, name + low_pc + size).</summary>
+    private static (byte[] Info, byte[] Abbrev) MinimalDwarf(string name, ulong lowPc, uint size)
+    {
+        var abbrev = new DwarfBlob()
+            .ULeb(1).ULeb(0x11).U8(1).ULeb(0).ULeb(0)
+            .ULeb(2).ULeb(0x2E).U8(0)
+            .ULeb(0x03).ULeb(0x08).ULeb(0x11).ULeb(0x01).ULeb(0x12).ULeb(0x06)
+            .ULeb(0).ULeb(0)
+            .ULeb(0);
+        var dies = new DwarfBlob()
+            .ULeb(1)
+            .ULeb(2).CStr(name).U64(lowPc).U32(size)
+            .ULeb(0);
+        var body = new DwarfBlob().U16(4).U32(0).U8(8).Bytes(dies.ToArray());
+        return (new DwarfBlob().U32((uint)body.Length).Bytes(body.ToArray()).ToArray(), abbrev.ToArray());
+    }
+
+    private static string WriteDsym(string directory, string imageName, byte[] innerBytes)
+    {
+        var dwarfDir = Path.Combine(directory, imageName + ".dSYM", "Contents", "Resources", "DWARF");
+        Directory.CreateDirectory(dwarfDir);
+        var inner = Path.Combine(dwarfDir, imageName);
+        File.WriteAllBytes(inner, innerBytes);
+        return inner;
+    }
+
+    /// <summary>
+    /// Verifies an image without a dSYM loads its own nlist as a named primary source.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NlistOnly_LoadsFromImage()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-macho-");
+        try
+        {
+            var image = SyntheticImageBuilders.BuildMachO(
+                [TextSegment()],
+                symbols: [("_frost_main", SectType, 1, 0x1_0000_1010)]);
+            var path = Path.Combine(dir.FullName, "app");
+            File.WriteAllBytes(path, image);
+
+            var result = NativeSymbolReader.Read(path, File.ReadAllBytes(path), []);
+
+            Assert.Equal(NativeSymbolSource.MachONlist, result.Source);
+            Assert.Equal(NativeSymbolStatus.Loaded, result.Status);
+            Assert.Equal(path, result.Path);
+            var symbol = Assert.Single(result.Symbols);
+            Assert.Equal("frost_main", symbol.Name);
+            Assert.Equal("__text", symbol.Section);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a UUID-matched dSYM merges its DWARF functions and its nlist data symbols, with
+    /// file offsets re-anchored onto the analyzed image.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_MatchingDsym_MergesDwarfAndNlist()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-macho-");
+        try
+        {
+            var image = SyntheticImageBuilders.BuildMachO(
+                [
+                    TextSegment(),
+                    ("__DATA", 0x1_0000_4000, new[] { ("__const", 0x1_0000_4000UL, 0u, new byte[0x100]) }),
+                ],
+                uuid: UuidA);
+            var path = Path.Combine(dir.FullName, "app");
+            File.WriteAllBytes(path, image);
+
+            var (info, abbrev) = MinimalDwarf("frost_main", 0x1_0000_1010, 0x40);
+            var inner = SyntheticImageBuilders.BuildMachO(
+                [
+                    ("__DWARF", 0x2_0000_0000, new[]
+                    {
+                        ("__debug_info", 0x2_0000_0000UL, 0u, info),
+                        ("__debug_abbrev", 0x2_0000_1000UL, 0u, abbrev),
+                    }),
+                    ("__DATA", 0x1_0000_4000, new[] { ("__const", 0x1_0000_4000UL, 0u, new byte[0x100]) }),
+                ],
+                symbols: [("__ZTV6Widget", SectType, 3, 0x1_0000_4010)],
+                uuid: UuidA);
+            var dsymPath = WriteDsym(dir.FullName, "app", inner);
+
+            var result = NativeSymbolReader.Read(path, File.ReadAllBytes(path), []);
+
+            Assert.Equal(NativeSymbolSource.Dsym, result.Source);
+            Assert.Equal(NativeSymbolStatus.Loaded, result.Status);
+            Assert.Equal(dsymPath, result.Path);
+            Assert.Null(result.Diagnostic);
+
+            var function = Assert.Single(result.Symbols, s => s.Kind == NativeSymbolKind.Function);
+            Assert.Equal("frost_main", function.Name);
+            Assert.Equal(0x40, function.Size);
+            Assert.Equal("__text", function.Section); // mapped through the image, not the dSYM
+            Assert.NotNull(function.FileOffset);
+
+            var data = Assert.Single(result.Symbols, s => s.Kind == NativeSymbolKind.MethodTable);
+            Assert.Equal("_ZTV6Widget", data.Name);
+            Assert.Equal("__const", data.Section); // the dSYM's nlist, re-anchored on the image
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a dSYM whose UUID differs is rejected as
+    /// <see cref="NativeSymbolStatus.IdMismatch"/>, with boundaries recovered from
+    /// <c>LC_FUNCTION_STARTS</c>.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_MismatchedDsym_ReportsIdMismatch()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-macho-");
+        try
+        {
+            var image = SyntheticImageBuilders.BuildMachO(
+                [TextSegment()],
+                uuid: UuidA,
+                functionStarts: new DwarfBlob().ULeb(0x1010).ULeb(0).ToArray());
+            var path = Path.Combine(dir.FullName, "app");
+            File.WriteAllBytes(path, image);
+
+            var (info, abbrev) = MinimalDwarf("fn", 0x1_0000_1010, 0x10);
+            WriteDsym(dir.FullName, "app", SyntheticImageBuilders.BuildMachO(
+                [("__DWARF", 0x2_0000_0000, new[] { ("__debug_info", 0x2_0000_0000UL, 0u, info), ("__debug_abbrev", 0x2_0000_1000UL, 0u, abbrev) })],
+                uuid: UuidB));
+
+            var result = NativeSymbolReader.Read(path, File.ReadAllBytes(path), []);
+
+            Assert.Equal(NativeSymbolStatus.IdMismatch, result.Status);
+            Assert.Equal(NativeSymbolSource.FunctionStartsFallback, result.Source);
+            Assert.Contains("UUID", result.Diagnostic);
+            var boundary = Assert.Single(result.Symbols);
+            Assert.Equal(NativeSymbolKind.Boundary, boundary.Kind);
+            Assert.Equal(0xF0, boundary.Size); // clamped to __text's end
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the symbol-free chain: <c>LC_FUNCTION_STARTS</c> boundaries as
+    /// <see cref="NativeSymbolStatus.FallbackOnly"/>, then
+    /// <see cref="NativeSymbolStatus.NoSymbolFile"/> when nothing at all is present.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NoSymbols_FallsBackToFunctionStartsThenNoSymbolFile()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-macho-");
+        try
+        {
+            var withStarts = Path.Combine(dir.FullName, "app");
+            File.WriteAllBytes(withStarts, SyntheticImageBuilders.BuildMachO(
+                [TextSegment()],
+                functionStarts: new DwarfBlob().ULeb(0x1010).ULeb(0x40).ULeb(0).ToArray()));
+            var result = NativeSymbolReader.Read(withStarts, File.ReadAllBytes(withStarts), []);
+
+            Assert.Equal(NativeSymbolStatus.FallbackOnly, result.Status);
+            Assert.Equal(NativeSymbolSource.FunctionStartsFallback, result.Source);
+            Assert.NotEmpty(result.Symbols);
+
+            var bare = Path.Combine(dir.FullName, "bare");
+            File.WriteAllBytes(bare, SyntheticImageBuilders.BuildMachO([TextSegment()]));
+            var empty = NativeSymbolReader.Read(bare, File.ReadAllBytes(bare), []);
+
+            Assert.Equal(NativeSymbolStatus.NoSymbolFile, empty.Status);
+            Assert.Empty(empty.Symbols);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies fat handling: the dSYM's UUID picks its slice (with file offsets shifted to the
+    /// archive), and an undisambiguated archive reports
+    /// <see cref="NativeSymbolStatus.AmbiguousImage"/> naming the slices found.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_FatArchive_UuidSelectsSliceOrAmbiguous()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-macho-");
+        try
+        {
+            var matching = SyntheticImageBuilders.BuildMachO([TextSegment()], uuid: UuidA);
+            var other = SyntheticImageBuilders.BuildMachO([TextSegment()], uuid: UuidB, cpuType: 0x0100_0007);
+            var fat = SyntheticImageBuilders.BuildFat(other, matching); // match is the second slice
+            var path = Path.Combine(dir.FullName, "app");
+            File.WriteAllBytes(path, fat);
+
+            var (info, abbrev) = MinimalDwarf("sliced_fn", 0x1_0000_1010, 0x20);
+            WriteDsym(dir.FullName, "app", SyntheticImageBuilders.BuildMachO(
+                [("__DWARF", 0x2_0000_0000, new[] { ("__debug_info", 0x2_0000_0000UL, 0u, info), ("__debug_abbrev", 0x2_0000_1000UL, 0u, abbrev) })],
+                uuid: UuidA));
+
+            var result = NativeSymbolReader.Read(path, File.ReadAllBytes(path), []);
+
+            Assert.Equal(NativeSymbolStatus.Loaded, result.Status);
+            var symbol = Assert.Single(result.Symbols, s => s.Name == "sliced_fn");
+            var slices = MachOImageReader.ReadFatSlices(fat);
+            Assert.True(symbol.FileOffset > slices[1].Offset,
+                "the file offset must be shifted into the chosen slice's archive region");
+
+            // No dSYM, no AOT signal: ambiguous, deterministically.
+            var bare = Path.Combine(dir.FullName, "bare");
+            File.WriteAllBytes(bare, fat);
+            var ambiguous = NativeSymbolReader.Read(bare, File.ReadAllBytes(bare), []);
+
+            Assert.Equal(NativeSymbolStatus.AmbiguousImage, ambiguous.Status);
+            Assert.Empty(ambiguous.Symbols);
+            Assert.Contains("0x100000c", ambiguous.Diagnostic);
+            Assert.Contains("0x1000007", ambiguous.Diagnostic);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the real macOS fixture: the dSYM loads as the merged source, demangles to
+    /// managed names, attributes a function to a source file and line, and carries data
+    /// categories.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NativeAotExeWithDsym_UsesDsymSource()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleDsym is null, "dSYM bundle not present on this platform");
+
+        using var analyzer = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        var info = NativeSymbolReader.Read(
+            samples.NativeAotConsoleExe!, analyzer.RawBytes.ToArray(), analyzer.RecoveredTypes);
+
+        Assert.Equal(NativeSymbolSource.Dsym, info.Source);
+        Assert.Equal(NativeSymbolStatus.Loaded, info.Status);
+        Assert.True(info.Symbols.Count > 1000,
+            $"expected a real symbol population, got {info.Symbols.Count}");
+        Assert.Contains(info.Symbols, s => s.ManagedName is not null && s.IsExactMatch);
+        Assert.Contains(info.Symbols,
+            s => s.Kind == NativeSymbolKind.Function && s.SourceFile is not null && s.Line > 0);
+        Assert.Contains(info.Symbols, s => s.Kind is NativeSymbolKind.MethodTable
+            or NativeSymbolKind.Statics or NativeSymbolKind.FrozenObject);
+    }
+
+    /// <summary>
+    /// Verifies the deterministic symbol-free path on the real exe: with the copy's
+    /// <c>LC_SYMTAB</c> count zeroed and no dSYM beside it, <c>LC_FUNCTION_STARTS</c> is forced
+    /// regardless of what <c>strip -x</c> left in the symbol table.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NativeAotExeSymtabZeroed_ForcesFunctionStarts()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+        var bytes = File.ReadAllBytes(samples.NativeAotConsoleExe!);
+        Assert.SkipWhen(!MachOImageReader.IsMachO(bytes), "exe is not a thin Mach-O on this platform");
+
+        // Zero LC_SYMTAB's nsyms in place.
+        var commandCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(16));
+        var command = 32;
+        for (var i = 0; i < commandCount; i++)
+        {
+            var cmd = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(command));
+            var cmdSize = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(command + 4));
+            if (cmd == 0x2)
+            {
+                BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(command + 12), 0);
+                break;
+            }
+
+            command += cmdSize;
+        }
+
+        var dir = Directory.CreateTempSubdirectory("dotsider-fstarts-");
+        try
+        {
+            var copy = Path.Combine(dir.FullName, Path.GetFileName(samples.NativeAotConsoleExe!));
+            File.WriteAllBytes(copy, bytes);
+
+            var info = NativeSymbolReader.Read(copy, File.ReadAllBytes(copy), []);
+
+            Assert.Equal(NativeSymbolSource.FunctionStartsFallback, info.Source);
+            Assert.Equal(NativeSymbolStatus.FallbackOnly, info.Status);
+            Assert.NotEmpty(info.Symbols);
+            Assert.All(info.Symbols, s => Assert.Equal(NativeSymbolKind.Boundary, s.Kind));
+            Assert.All(info.Symbols, s => Assert.True(s.Size > 0));
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+}

--- a/tests/Dotsider.Tests/NativeSymbolReaderMachOTests.cs
+++ b/tests/Dotsider.Tests/NativeSymbolReaderMachOTests.cs
@@ -18,6 +18,7 @@ public class NativeSymbolReaderMachOTests(SampleAssemblyFixture samples)
 
     private static readonly byte[] UuidA = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
     private static readonly byte[] UuidB = [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+    private static readonly byte[] UuidC = [9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9];
 
     private static (string, ulong, (string, ulong, uint, byte[])[]) TextSegment() =>
         ("__TEXT", 0x1_0000_0000, new[] { ("__text", 0x1_0000_1000UL, ExecFlags, new byte[0x100]) });
@@ -245,6 +246,76 @@ public class NativeSymbolReaderMachOTests(SampleAssemblyFixture samples)
             Assert.Empty(ambiguous.Symbols);
             Assert.Contains("0x100000c", ambiguous.Diagnostic);
             Assert.Contains("0x1000007", ambiguous.Diagnostic);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a universal (fat) dSYM is sliced before UUID validation: the slice carrying the
+    /// image's UUID is selected and its DWARF read, instead of the fat header failing the
+    /// identity check.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_FatDsym_SlicesToMatchingUuid()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-fatdsym-");
+        try
+        {
+            var path = Path.Combine(dir.FullName, "app");
+            File.WriteAllBytes(path, SyntheticImageBuilders.BuildMachO([TextSegment()], uuid: UuidA));
+
+            var (info, abbrev) = MinimalDwarf("frost_main", 0x1_0000_1010, 0x40);
+            var matching = SyntheticImageBuilders.BuildMachO(
+                [("__DWARF", 0x2_0000_0000, new[]
+                {
+                    ("__debug_info", 0x2_0000_0000UL, 0u, info),
+                    ("__debug_abbrev", 0x2_0000_1000UL, 0u, abbrev),
+                })],
+                uuid: UuidA);
+            var other = SyntheticImageBuilders.BuildMachO([TextSegment()], uuid: UuidB, cpuType: 0x0100_0007);
+            WriteDsym(dir.FullName, "app", SyntheticImageBuilders.BuildFat(other, matching));
+
+            var result = NativeSymbolReader.Read(path, File.ReadAllBytes(path), []);
+
+            Assert.Equal(NativeSymbolStatus.Loaded, result.Status);
+            Assert.Equal(NativeSymbolSource.Dsym, result.Source);
+            var symbol = Assert.Single(result.Symbols);
+            Assert.Equal("frost_main", symbol.Name);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a fat dSYM with no slice carrying the image's UUID is rejected as
+    /// <see cref="NativeSymbolStatus.IdMismatch"/>, not silently read.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_FatDsym_NoMatchingSlice_ReportsIdMismatch()
+    {
+        var dir = Directory.CreateTempSubdirectory("dotsider-fatdsym-");
+        try
+        {
+            var path = Path.Combine(dir.FullName, "app");
+            File.WriteAllBytes(path, SyntheticImageBuilders.BuildMachO(
+                [TextSegment()],
+                uuid: UuidA,
+                functionStarts: new DwarfBlob().ULeb(0x1010).ULeb(0).ToArray()));
+
+            var sliceB = SyntheticImageBuilders.BuildMachO([TextSegment()], uuid: UuidB);
+            var sliceC = SyntheticImageBuilders.BuildMachO([TextSegment()], uuid: UuidC, cpuType: 0x0100_0007);
+            WriteDsym(dir.FullName, "app", SyntheticImageBuilders.BuildFat(sliceB, sliceC));
+
+            var result = NativeSymbolReader.Read(path, File.ReadAllBytes(path), []);
+
+            Assert.Equal(NativeSymbolStatus.IdMismatch, result.Status);
+            Assert.Equal(NativeSymbolSource.FunctionStartsFallback, result.Source);
+            Assert.Contains("UUID", result.Diagnostic);
         }
         finally
         {

--- a/tests/Dotsider.Tests/NativeSymbolReaderPeTests.cs
+++ b/tests/Dotsider.Tests/NativeSymbolReaderPeTests.cs
@@ -1,0 +1,79 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for the PE arm of <see cref="NativeSymbolReader"/> and the lazy
+/// <see cref="AssemblyAnalyzer.NativeSymbols"/> property, against the real NativeAOT fixture on
+/// the Windows leg (where its symbol file is a PDB).
+/// </summary>
+[Collection("SampleAssemblies")]
+public class NativeSymbolReaderPeTests(SampleAssemblyFixture samples)
+{
+    private bool HasPdb =>
+        samples.NativeAotConsoleSymbols is not null
+        && samples.NativeAotConsoleSymbols.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Verifies the facade reads the matching PDB as the NativePdb source and demangles the entry
+    /// point.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NativeAotExeWithPdb_UsesNativePdbSource()
+    {
+        Assert.SkipWhen(!HasPdb, "native PDB not present on this platform");
+
+        using var analyzer = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        var info = NativeSymbolReader.Read(
+            samples.NativeAotConsoleExe!, analyzer.RawBytes.ToArray(), analyzer.RecoveredTypes);
+
+        Assert.Equal(NativeSymbolSource.NativePdb, info.Source);
+        Assert.Equal(NativeSymbolStatus.Loaded, info.Status);
+        Assert.NotEmpty(info.Symbols);
+        Assert.Contains(info.Symbols, s => s.ManagedName is not null && s.IsExactMatch);
+    }
+
+    /// <summary>
+    /// Verifies a Native AOT binary copied away from its PDB falls back to real .pdata boundaries.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_NativeAotExeWithoutPdb_FallsBackToPdataBoundaries()
+    {
+        Assert.SkipWhen(!HasPdb, "native PDB not present on this platform");
+
+        var dir = Directory.CreateTempSubdirectory("dotsider-pdata-");
+        try
+        {
+            var exeCopy = Path.Combine(dir.FullName, Path.GetFileName(samples.NativeAotConsoleExe!));
+            File.Copy(samples.NativeAotConsoleExe!, exeCopy);
+            var bytes = File.ReadAllBytes(exeCopy);
+
+            var info = NativeSymbolReader.Read(exeCopy, bytes, []);
+
+            Assert.Equal(NativeSymbolSource.PdataFallback, info.Source);
+            Assert.NotEmpty(info.Symbols);
+            Assert.All(info.Symbols, s => Assert.Equal(NativeSymbolKind.Boundary, s.Kind));
+            Assert.All(info.Symbols, s => Assert.True(s.Size > 0));
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the analyzer surfaces native symbols for a Native AOT binary and null for a
+    /// managed assembly.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void NativeSymbols_ManagedIsNull_NativeAotIsPresent()
+    {
+        using var managed = new AssemblyAnalyzer(samples.RichLibraryDll);
+        Assert.Null(managed.NativeSymbols);
+
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+        using var aot = new AssemblyAnalyzer(samples.NativeAotConsoleExe!);
+        Assert.NotNull(aot.NativeSymbols);
+    }
+}

--- a/tests/Dotsider.Tests/NativeSymbolReaderPeTests.cs
+++ b/tests/Dotsider.Tests/NativeSymbolReaderPeTests.cs
@@ -63,6 +63,97 @@ public class NativeSymbolReaderPeTests(SampleAssemblyFixture samples)
     }
 
     /// <summary>
+    /// Verifies a stale PDB — right name, wrong GUID — reports
+    /// <see cref="NativeSymbolStatus.IdMismatch"/> with boundaries, instead of hiding behind
+    /// "no matching PDB".
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Read_StalePdbBesideExe_ReportsIdMismatch()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+        var bytes = File.ReadAllBytes(samples.NativeAotConsoleExe!);
+        Assert.SkipWhen(bytes.Length < 2 || bytes[0] != (byte)'M' || bytes[1] != (byte)'Z',
+            "exe is not a PE on this platform");
+        var id = PeCodeView.TryRead(bytes);
+        Assert.SkipWhen(id is null, "exe carries no RSDS record");
+
+        var dir = Directory.CreateTempSubdirectory("dotsider-stalepdb-");
+        try
+        {
+            var exeCopy = Path.Combine(dir.FullName, Path.GetFileName(samples.NativeAotConsoleExe!));
+            File.Copy(samples.NativeAotConsoleExe!, exeCopy);
+            File.WriteAllBytes(
+                Path.Combine(dir.FullName, Path.GetFileNameWithoutExtension(exeCopy) + ".pdb"),
+                SyntheticImageBuilders.BuildMsf(4096, PdbInfoStream(Guid.NewGuid(), id!.Value.Age)));
+
+            var info = NativeSymbolReader.Read(exeCopy, File.ReadAllBytes(exeCopy), []);
+
+            Assert.Equal(NativeSymbolStatus.IdMismatch, info.Status);
+            Assert.Equal(NativeSymbolSource.PdataFallback, info.Source);
+            Assert.NotEmpty(info.Symbols);
+            Assert.Contains(".pdb", info.Diagnostic);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+
+        await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Verifies an unreadable PDB sidecar reports
+    /// <see cref="NativeSymbolStatus.CorruptSymbolFile"/>, and a matching PDB with no readable
+    /// symbol streams does too — neither masquerades as a missing file.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Read_CorruptOrEmptyPdb_ReportsCorruptSymbolFile()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+        var bytes = File.ReadAllBytes(samples.NativeAotConsoleExe!);
+        Assert.SkipWhen(bytes.Length < 2 || bytes[0] != (byte)'M' || bytes[1] != (byte)'Z',
+            "exe is not a PE on this platform");
+        var id = PeCodeView.TryRead(bytes);
+        Assert.SkipWhen(id is null, "exe carries no RSDS record");
+
+        var dir = Directory.CreateTempSubdirectory("dotsider-badpdb-");
+        try
+        {
+            var exeCopy = Path.Combine(dir.FullName, Path.GetFileName(samples.NativeAotConsoleExe!));
+            File.Copy(samples.NativeAotConsoleExe!, exeCopy);
+            var pdbPath = Path.Combine(dir.FullName, Path.GetFileNameWithoutExtension(exeCopy) + ".pdb");
+
+            // Not an MSF container at all.
+            File.WriteAllBytes(pdbPath, [0xDE, 0xAD, 0xBE, 0xEF]);
+            var unreadable = NativeSymbolReader.Read(exeCopy, File.ReadAllBytes(exeCopy), []);
+            Assert.Equal(NativeSymbolStatus.CorruptSymbolFile, unreadable.Status);
+            Assert.NotEmpty(unreadable.Symbols);
+
+            // Identity matches, but there is no DBI stream to read symbols from.
+            File.WriteAllBytes(pdbPath,
+                SyntheticImageBuilders.BuildMsf(4096, PdbInfoStream(id!.Value.Guid, id.Value.Age)));
+            var empty = NativeSymbolReader.Read(exeCopy, File.ReadAllBytes(exeCopy), []);
+            Assert.Equal(NativeSymbolStatus.CorruptSymbolFile, empty.Status);
+            Assert.Contains("no readable symbols", empty.Diagnostic);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>Builds a PDB info stream: version, signature, age, GUID.</summary>
+    private static byte[] PdbInfoStream(Guid guid, int age)
+    {
+        var stream = new byte[28];
+        System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(stream, 20000404);
+        System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(stream.AsSpan(4), 1);
+        System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(stream.AsSpan(8), age);
+        guid.TryWriteBytes(stream.AsSpan(12));
+        return stream;
+    }
+
+    /// <summary>
     /// Verifies the analyzer surfaces native symbols for a Native AOT binary and null for a
     /// managed assembly.
     /// </summary>

--- a/tests/Dotsider.Tests/PdataReaderTests.cs
+++ b/tests/Dotsider.Tests/PdataReaderTests.cs
@@ -1,0 +1,69 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for <see cref="PdataReader"/>, the PE <c>.pdata</c> function-boundary fallback, using
+/// synthetic PE images so both the x64 and ARM64 layouts are exercised on every platform.
+/// </summary>
+public class PdataReaderTests
+{
+    /// <summary>
+    /// Verifies x64 RUNTIME_FUNCTION entries yield sized boundaries, and a chained fragment is
+    /// folded away rather than counted as its own function.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadBoundaries_Amd64_EmitsFunctionsAndFoldsChained()
+    {
+        var section = new byte[0x200];
+        // Two RUNTIME_FUNCTIONs at RVA 0x1000; unwind info at RVA 0x1100/0x1101.
+        SyntheticImageBuilders.Amd64RuntimeFunction(0x2000, 0x2040, 0x1100).CopyTo(section, 0);
+        SyntheticImageBuilders.Amd64RuntimeFunction(0x2040, 0x2080, 0x1101).CopyTo(section, 12);
+        section[0x100] = 0x01;                       // version 1, flags 0 (standalone)
+        section[0x101] = 0x01 | (0x4 << 3);          // version 1, flags = CHAININFO
+
+        var pe = SyntheticImageBuilders.BuildPe(0x8664, section, exceptionRva: 0x1000, exceptionSize: 24);
+
+        var boundaries = PdataReader.ReadBoundaries(pe);
+
+        var only = Assert.Single(boundaries);
+        Assert.Equal("sub_2000", only.Name);
+        Assert.Equal(0x40, only.Size);
+        Assert.Equal(NativeSymbolKind.Boundary, Build(only).Symbols[0].Kind);
+    }
+
+    /// <summary>
+    /// Verifies an ARM64 packed unwind entry decodes its function length from the packed word.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadBoundaries_Arm64Packed_DecodesFunctionLength()
+    {
+        var section = new byte[0x200];
+        // begin RVA 0x2000; packed unwind: flag bits set, FunctionLength = 0x10 words = 0x40 bytes.
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(section, 0x2000);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(section.AsSpan(4), (0x10u << 2) | 0x1u);
+
+        var pe = SyntheticImageBuilders.BuildPe(0xAA64, section, exceptionRva: 0x1000, exceptionSize: 8);
+
+        var boundaries = PdataReader.ReadBoundaries(pe);
+
+        var only = Assert.Single(boundaries);
+        Assert.Equal(0x40, only.Size);
+    }
+
+    /// <summary>
+    /// Verifies a PE without an exception directory yields no boundaries.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void ReadBoundaries_NoExceptionDirectory_ReturnsEmpty()
+    {
+        var pe = SyntheticImageBuilders.BuildPe(0x8664, new byte[0x200], exceptionRva: 0, exceptionSize: 0);
+
+        Assert.Empty(PdataReader.ReadBoundaries(pe));
+    }
+
+    private static NativeSymbolInfo Build(RawNativeSymbol s) =>
+        NativeSymbolReader.Build([s], new IlcNameDemangler([]),
+            NativeSymbolSource.PdataFallback, NativeSymbolStatus.FallbackOnly, null, null);
+}

--- a/tests/Dotsider.Tests/PeMetadataViewTests.cs
+++ b/tests/Dotsider.Tests/PeMetadataViewTests.cs
@@ -963,6 +963,119 @@ public class PeMetadataViewTests(SampleAssemblyFixture samples) : IDisposable
     }
 
     /// <summary>
+    /// Verifies the Symbols sub-tab lists the Native AOT binary's symbols with the address
+    /// column rendered.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_NativeAot_SymbolsTab_ShowsSymbols()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        var (terminal, app) = CreateDotsiderApp(samples.NativeAotConsoleExe);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        var builder = new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Sections"), TimeSpan.FromSeconds(10));
+        for (var target = 1; target <= PeSubTabId.Symbols; target++)
+        {
+            var expected = target;
+            builder = builder
+                .Key(Hex1bKey.RightArrow)
+                .WaitUntil(_ => _state!.PeSubTab == expected, TimeSpan.FromSeconds(10));
+        }
+
+        await builder
+            .WaitUntil(s => s.ContainsText("Address"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(PeSubTabId.Symbols, _state!.PeSubTab);
+        Assert.NotNull(_state.Analyzer.NativeSymbols);
+        Assert.NotEmpty(_state.Analyzer.NativeSymbols!.Symbols);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Verifies the Symbols detail popup opens on Enter, carrying the mangled name and the
+    /// symbol source line.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_NativeAot_SymbolsDetailPopup_OpensOnEnter()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null,
+            "NativeAOT sample was not built");
+
+        var (terminal, app) = CreateDotsiderApp(samples.NativeAotConsoleExe);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        var builder = new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Sections"), TimeSpan.FromSeconds(10));
+        for (var target = 1; target <= PeSubTabId.Symbols; target++)
+        {
+            var expected = target;
+            builder = builder
+                .Key(Hex1bKey.RightArrow)
+                .WaitUntil(_ => _state!.PeSubTab == expected, TimeSpan.FromSeconds(10));
+        }
+
+        await builder
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(_ => _state!.PeDetailContent is not null, TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Contains("Native Symbol", _state!.PeDetailContent!);
+        Assert.Contains("Symbols From:", _state.PeDetailContent!);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Verifies the Symbols sub-tab renders empty for a managed assembly instead of crashing —
+    /// managed binaries have no native symbols.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task PeMetadata_Managed_SymbolsTab_EmptyNoCrash()
+    {
+        var (terminal, app) = CreateDotsiderApp();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        var builder = new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Sections"), TimeSpan.FromSeconds(10));
+        for (var target = 1; target <= PeSubTabId.Symbols; target++)
+        {
+            var expected = target;
+            builder = builder
+                .Key(Hex1bKey.RightArrow)
+                .WaitUntil(_ => _state!.PeSubTab == expected, TimeSpan.FromSeconds(10));
+        }
+
+        await builder
+            .WaitUntil(s => s.ContainsText("Address"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.Equal(PeSubTabId.Symbols, _state!.PeSubTab);
+        Assert.Null(_state.Analyzer.NativeSymbols);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
     /// Disposes test resources created during the run.
     /// </summary>
     public void Dispose()

--- a/tests/Dotsider.Tests/RuntimeTracerTests.cs
+++ b/tests/Dotsider.Tests/RuntimeTracerTests.cs
@@ -35,6 +35,9 @@ public class RuntimeTracerTests(SampleAssemblyFixture samples) : IDisposable
     /// <summary>
     /// Waits for the tracer to reach Exited or Error. If the process hangs
     /// under EventPipe (known issue on Windows CI), stops it after the timeout.
+    /// The caller's timeout plus the 10-second recovery wait must fit inside
+    /// the test's <c>[Fact(Timeout)]</c>, or xUnit aborts the test before this
+    /// recovery ever runs.
     /// </summary>
     private static async Task WaitForExitAsync(RuntimeTracer tracer, TimeSpan timeout)
     {
@@ -78,7 +81,7 @@ public class RuntimeTracerTests(SampleAssemblyFixture samples) : IDisposable
     {
         var tracer = CreateTracer(samples.HelloWorldDll);
         tracer.Start();
-        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(30));
+        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(15));
         Assert.Equal(TraceProcessState.Exited, tracer.ProcessState);
         // ExitCode is set by the Process.Exited handler which fires asynchronously —
         // wait for it rather than reading immediately after state transition.
@@ -94,7 +97,7 @@ public class RuntimeTracerTests(SampleAssemblyFixture samples) : IDisposable
     {
         var tracer = CreateTracer(samples.HelloWorldDll);
         tracer.Start();
-        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(30));
+        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(15));
         Assert.Equal(TraceProcessState.Exited, tracer.ProcessState);
         var events = tracer.GetEvents();
         Assert.NotEmpty(events);
@@ -126,7 +129,7 @@ public class RuntimeTracerTests(SampleAssemblyFixture samples) : IDisposable
     {
         var tracer = CreateTracer(samples.HelloWorldDll);
         tracer.Start();
-        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(30));
+        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(15));
         Assert.Equal(TraceProcessState.Exited, tracer.ProcessState);
         var output = tracer.GetOutput();
         Assert.NotEmpty(output);
@@ -140,7 +143,7 @@ public class RuntimeTracerTests(SampleAssemblyFixture samples) : IDisposable
     {
         var tracer = CreateTracer(samples.HelloWorldDll);
         tracer.Start();
-        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(30));
+        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(15));
         Assert.Equal(TraceProcessState.Exited, tracer.ProcessState);
         var summary = tracer.GetSummary();
         Assert.True(summary.TotalEvents > 0);
@@ -189,7 +192,7 @@ public class RuntimeTracerTests(SampleAssemblyFixture samples) : IDisposable
     {
         var tracer = CreateTracer(samples.HelloWorldDll);
         tracer.Start();
-        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(30));
+        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(15));
         Assert.Equal(TraceProcessState.Exited, tracer.ProcessState);
         Assert.Null(tracer.ErrorMessage);
     }
@@ -202,7 +205,7 @@ public class RuntimeTracerTests(SampleAssemblyFixture samples) : IDisposable
     {
         var tracer = CreateTracer(samples.HelloWorldDll);
         tracer.Start();
-        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(30));
+        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(15));
         Assert.Equal(TraceProcessState.Exited, tracer.ProcessState);
         var summary = tracer.GetSummary();
         var exceptionEvents = summary.EventsByCategory
@@ -280,7 +283,7 @@ public class RuntimeTracerTests(SampleAssemblyFixture samples) : IDisposable
     {
         var tracer = CreateTracer(samples.HelloWorldDll);
         tracer.Start();
-        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(30));
+        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(15));
         Assert.Equal(TraceProcessState.Exited, tracer.ProcessState);
         var events = tracer.GetEvents();
         var categories = events.Select(e => e.Category).Distinct().ToHashSet();
@@ -298,7 +301,7 @@ public class RuntimeTracerTests(SampleAssemblyFixture samples) : IDisposable
         tracer.Start();
         // Wait for the specific Format JIT events — ProcessState can transition
         // to Exited before all events are flushed from the EventPipe buffer.
-        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(30));
+        await WaitForExitAsync(tracer, TimeSpan.FromSeconds(15));
         Assert.Equal(TraceProcessState.Exited, tracer.ProcessState);
         await TestHelpers.WaitUntilAsync(
             () => tracer.GetEvents().Count(e => e.Category == TraceEventCategory.JIT

--- a/tests/Dotsider.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Tests/SampleAssemblyFixture.cs
@@ -153,6 +153,12 @@ public class SampleAssemblyFixture : IAsyncLifetime
     /// </summary>
     public string? NativeAotConsoleSymbols { get; private set; }
 
+    /// <summary>
+    /// Path to the NativeAOT sample's <c>.dSYM</c> bundle directory (macOS), or null when the
+    /// publish did not produce one. Tests gate on this with <c>Assert.SkipWhen</c>.
+    /// </summary>
+    public string? NativeAotConsoleDsym { get; private set; }
+
     // Self-contained single-file sample
     /// <summary>
     /// Path to the published self-contained single-file sample executable.
@@ -275,6 +281,8 @@ public class SampleAssemblyFixture : IAsyncLifetime
             ?? ExistingPathOrNull(Path.Combine(
                 aotPublishDir, "NativeAotConsole.dSYM", "Contents", "Resources", "DWARF", "NativeAotConsole"));
 
+        NativeAotConsoleDsym = ExistingDirOrNull(Path.Combine(aotPublishDir, "NativeAotConsole.dSYM"));
+
         SelfContainedConsoleExe = Path.Combine(_repoRoot, "samples", "SelfContainedConsole",
             "bin", "Release", tfm, rid, "publish", $"SelfContainedConsole{apphostExt}");
 
@@ -369,6 +377,9 @@ public class SampleAssemblyFixture : IAsyncLifetime
 
     private static string? ExistingPathOrNull(string path)
         => File.Exists(path) ? path : null;
+
+    private static string? ExistingDirOrNull(string path)
+        => Directory.Exists(path) ? path : null;
 
     private async Task PublishNativeAotProject(string relativePath)
     {

--- a/tests/Dotsider.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Tests/SampleAssemblyFixture.cs
@@ -146,6 +146,13 @@ public class SampleAssemblyFixture : IAsyncLifetime
     /// </summary>
     public string? NativeAotConsoleDgml { get; private set; }
 
+    /// <summary>
+    /// Path to the native symbol file beside the NativeAOT sample — the Windows PDB, the Linux
+    /// <c>.dbg</c>, or the macOS dSYM inner DWARF file — for the current platform, or null when
+    /// the publish did not produce one. Tests gate on this with <c>Assert.SkipWhen</c>.
+    /// </summary>
+    public string? NativeAotConsoleSymbols { get; private set; }
+
     // Self-contained single-file sample
     /// <summary>
     /// Path to the published self-contained single-file sample executable.
@@ -259,6 +266,14 @@ public class SampleAssemblyFixture : IAsyncLifetime
         NativeAotConsoleDgml =
             ExistingPathOrNull(Path.Combine(aotPublishDir, "NativeAotConsole.codegen.dgml.xml"))
             ?? ExistingPathOrNull(Path.Combine(aotPublishDir, "NativeAotConsole.scan.dgml.xml"));
+
+        // Native symbols land beside the exe per platform: PDB (Windows), .dbg (Linux), or the
+        // DWARF file inside the dSYM bundle (macOS).
+        NativeAotConsoleSymbols =
+            ExistingPathOrNull(Path.Combine(aotPublishDir, "NativeAotConsole.pdb"))
+            ?? ExistingPathOrNull(Path.Combine(aotPublishDir, "NativeAotConsole.dbg"))
+            ?? ExistingPathOrNull(Path.Combine(
+                aotPublishDir, "NativeAotConsole.dSYM", "Contents", "Resources", "DWARF", "NativeAotConsole"));
 
         SelfContainedConsoleExe = Path.Combine(_repoRoot, "samples", "SelfContainedConsole",
             "bin", "Release", tfm, rid, "publish", $"SelfContainedConsole{apphostExt}");

--- a/tests/Dotsider.Tests/SessionSymbolTests.cs
+++ b/tests/Dotsider.Tests/SessionSymbolTests.cs
@@ -1,0 +1,140 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Dotsider.Core.Protocol;
+using Dotsider.Diagnostics;
+using Dotsider.Infrastructure;
+using Hex1b;
+using Hex1b.Widgets;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// End-to-end protocol tests for the <c>get-native-symbols</c> session method and the symbol
+/// provenance fields on <c>assembly-info</c>, over a real headless TUI and diagnostics socket.
+/// </summary>
+[Collection("SampleAssemblies")]
+public class SessionSymbolTests(SampleAssemblyFixture samples) : IAsyncDisposable
+{
+    private Hex1bAppWorkloadAdapter? _workload;
+    private Hex1bTerminal? _terminal;
+    private Hex1bApp? _app;
+    private DotsiderState? _state;
+    private DotsiderDiagnosticsListener? _listener;
+    private CancellationTokenSource? _appCts;
+
+    /// <summary>
+    /// Starts a headless dotsider TUI with the diagnostics socket listener,
+    /// reproducing the full production stack.
+    /// </summary>
+    private async Task<string> StartTuiWithDiagnosticsAsync(string dllPath, CancellationToken ct)
+    {
+        var pendingMutations = new ConcurrentQueue<Action<DotsiderState>>();
+
+        _workload = new Hex1bAppWorkloadAdapter();
+        _terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(_workload)
+            .WithHeadless()
+            .WithDimensions(120, 30)
+            .Build();
+
+        _app = new Hex1bApp(
+            ctx =>
+            {
+                _state ??= new DotsiderState(_app!, dllPath, pendingMutations);
+
+                var dotsiderApp = new DotsiderApp(_state);
+                return Task.FromResult<Hex1bWidget>(dotsiderApp.Build(ctx));
+            },
+            new Hex1bAppOptions
+            {
+                WorkloadAdapter = _workload,
+                EnableInputCoalescing = false
+            });
+
+        _listener = new DotsiderDiagnosticsListener(() => _state);
+        _listener.StartListening();
+
+        _appCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _ = _app.RunAsync(_appCts.Token);
+        await Task.Delay(100, ct);
+
+        await TestHelpers.WaitUntilAsync(
+            () => _state is not null,
+            TimeSpan.FromSeconds(10));
+
+        return _listener.SocketPath!;
+    }
+
+    /// <summary>
+    /// Verifies <c>get-native-symbols</c> returns the symbol list with provenance for a Native
+    /// AOT binary.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task GetNativeSymbols_NativeAot_ReturnsSymbolsWithProvenance()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        var ct = TestContext.Current.CancellationToken;
+        var socketPath = await StartTuiWithDiagnosticsAsync(samples.NativeAotConsoleExe!, ct);
+
+        var response = await DotsiderClient.SendAsync(socketPath,
+            new DotsiderRequest { Method = "get-native-symbols" }, ct);
+
+        Assert.True(response.Success);
+        var data = (response.Data as JsonElement?)!.Value;
+        Assert.True(data.GetProperty("symbols").GetArrayLength() > 0);
+        Assert.False(string.IsNullOrEmpty(data.GetProperty("source").GetString()));
+        Assert.False(string.IsNullOrEmpty(data.GetProperty("status").GetString()));
+    }
+
+    /// <summary>Verifies <c>get-native-symbols</c> fails cleanly for a managed assembly.</summary>
+    [Fact(Timeout = 30_000)]
+    public async Task GetNativeSymbols_Managed_Fails()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var socketPath = await StartTuiWithDiagnosticsAsync(samples.RichLibraryDll, ct);
+
+        var response = await DotsiderClient.SendAsync(socketPath,
+            new DotsiderRequest { Method = "get-native-symbols" }, ct);
+
+        Assert.False(response.Success);
+        Assert.Contains("no native symbols", response.Error);
+    }
+
+    /// <summary>
+    /// Verifies <c>assembly-info</c> carries the native symbol count, source, and status for a
+    /// Native AOT binary.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task AssemblyInfo_NativeAot_CarriesSymbolProvenance()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        var ct = TestContext.Current.CancellationToken;
+        var socketPath = await StartTuiWithDiagnosticsAsync(samples.NativeAotConsoleExe!, ct);
+
+        var response = await DotsiderClient.SendAsync(socketPath,
+            new DotsiderRequest { Method = "assembly-info" }, ct);
+
+        Assert.True(response.Success);
+        var data = (response.Data as JsonElement?)!.Value;
+        Assert.True(data.GetProperty("nativeSymbolCount").GetInt32() > 0);
+        Assert.False(string.IsNullOrEmpty(data.GetProperty("nativeSymbolSource").GetString()));
+        Assert.False(string.IsNullOrEmpty(data.GetProperty("nativeSymbolStatus").GetString()));
+    }
+
+    /// <summary>
+    /// Disposes the diagnostics listener, state, and terminal.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        _appCts?.Cancel();
+        if (_listener is not null)
+            await _listener.DisposeAsync();
+        _state?.Dispose();
+        if (_terminal is not null)
+            await _terminal.DisposeAsync();
+        _appCts?.Dispose();
+    }
+}

--- a/tests/Dotsider.Tests/SizeAnalyzerSymbolTests.cs
+++ b/tests/Dotsider.Tests/SizeAnalyzerSymbolTests.cs
@@ -1,0 +1,193 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests for the symbol-driven Size Map branch — <see cref="SizeAnalyzer.BuildFromSymbols"/> and
+/// its precedence behind the mstat report — with synthetic merged symbols on every platform and
+/// the real NativeAOT fixture where its symbol file exists.
+/// </summary>
+[Collection("SampleAssemblies")]
+public class SizeAnalyzerSymbolTests(SampleAssemblyFixture samples)
+{
+    private static NativeSymbol Symbol(
+        string name, ulong va, long size, NativeSymbolKind kind,
+        string? managedName = null, bool exact = false) =>
+        new(name, managedName, va, null, null, null, size, kind, null, null, exact, []);
+
+    private static NativeSymbolInfo Info(params NativeSymbol[] symbols) =>
+        new(symbols, NativeSymbolSource.NativePdb, NativeSymbolStatus.Loaded, "x.pdb", null);
+
+    private static SizeNode? Find(SizeNode node, string name) =>
+        node.Name == name ? node : node.Children.Select(c => Find(c, name)).FirstOrDefault(n => n is not null);
+
+    /// <summary>
+    /// Verifies joined functions land under assembly &gt; namespace &gt; type with
+    /// <see cref="SizeNodeKind.Function"/> leaves, including a dotted method name
+    /// (<c>.ctor</c>) split at the recovered type boundary.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void BuildFromSymbols_JoinedFunctions_GroupByAssemblyNamespaceType()
+    {
+        var recovered = new RecoveredType[]
+        {
+            new("System.Foo", ["Bar", ".ctor"], "TestAsm"),
+            new("Ns.Outer+Inner", ["Run"], "OtherAsm"),
+        };
+        var tree = SizeAnalyzer.BuildFromSymbols("app", recovered, Info(
+            Symbol("TestAsm_System_Foo__Bar", 0x1000, 0x40, NativeSymbolKind.Function, "System.Foo.Bar", exact: true),
+            Symbol("TestAsm_System_Foo___ctor", 0x1040, 0x10, NativeSymbolKind.Function, "System.Foo..ctor", exact: true),
+            Symbol("OtherAsm_Ns_Outer_Inner__Run", 0x1050, 0x20, NativeSymbolKind.Function, "Ns.Outer+Inner.Run", exact: true)));
+
+        var assembly = Find(tree, "TestAsm");
+        Assert.NotNull(assembly);
+        Assert.Equal(SizeNodeKind.Assembly, assembly.Kind);
+        Assert.Equal(0x50, assembly.Size);
+
+        var ns = Assert.Single(assembly.Children);
+        Assert.Equal("System", ns.Name);
+        Assert.Equal(SizeNodeKind.Namespace, ns.Kind);
+
+        var type = Assert.Single(ns.Children);
+        Assert.Equal("Foo", type.Name);
+        Assert.Equal(SizeNodeKind.Type, type.Kind);
+        Assert.Equal(2, type.Children.Count);
+        Assert.All(type.Children, m => Assert.Equal(SizeNodeKind.Function, m.Kind));
+        Assert.Contains(type.Children, m => m.Name == ".ctor" && m.Size == 0x10);
+
+        var nested = Find(tree, "Outer+Inner");
+        Assert.NotNull(nested);
+        Assert.Equal("Ns", Find(tree, "OtherAsm")!.Children.Single().Name);
+    }
+
+    /// <summary>
+    /// Verifies the categories: unjoined names in Runtime, boundaries in Unattributed, and each
+    /// data kind under its own category with the matching node kind.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void BuildFromSymbols_Categories_CarryEachKind()
+    {
+        var tree = SizeAnalyzer.BuildFromSymbols("app", [], Info(
+            Symbol("RhpAssignRef", 0x1000, 0x30, NativeSymbolKind.Function),
+            Symbol("sub_2000", 0x2000, 0x20, NativeSymbolKind.Boundary),
+            Symbol("_ZTV6Widget", 0x3000, 0x18, NativeSymbolKind.MethodTable, "Widget (MethodTable)"),
+            Symbol("__Str_abc", 0x3100, 0x10, NativeSymbolKind.FrozenObject),
+            Symbol("__unbox_Widget", 0x3200, 0x08, NativeSymbolKind.Stub),
+            Symbol("__GenericDict_List", 0x3300, 0x28, NativeSymbolKind.GenericDictionary),
+            Symbol("__GCSTATICS_App", 0x3400, 0x38, NativeSymbolKind.Statics),
+            Symbol("__readonlydata_x", 0x3500, 0x48, NativeSymbolKind.Data)));
+
+        void AssertCategory(string name, long size, SizeNodeKind childKind)
+        {
+            var category = Find(tree, name);
+            Assert.NotNull(category);
+            Assert.Equal(SizeNodeKind.Category, category.Kind);
+            Assert.Equal(size, category.Size);
+            Assert.All(category.Children, c => Assert.Equal(childKind, c.Kind));
+        }
+
+        AssertCategory("Runtime", 0x30, SizeNodeKind.Function);
+        AssertCategory("Unattributed", 0x20, SizeNodeKind.Function);
+        AssertCategory("MethodTables", 0x18, SizeNodeKind.MethodTable);
+        AssertCategory("Frozen Objects", 0x10, SizeNodeKind.FrozenObject);
+        AssertCategory("Stubs", 0x08, SizeNodeKind.Function);
+        AssertCategory("Generic Dictionaries", 0x28, SizeNodeKind.Blob);
+        AssertCategory("Statics", 0x38, SizeNodeKind.Blob);
+        AssertCategory("Data", 0x48, SizeNodeKind.Blob);
+
+        Assert.Equal("Widget (MethodTable)", Find(tree, "MethodTables")!.Children.Single().Name);
+    }
+
+    /// <summary>
+    /// Verifies no byte is counted twice: the root sums every sized merged symbol exactly once,
+    /// and zero-size symbols contribute nothing.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void BuildFromSymbols_RootSumsEachSymbolOnce()
+    {
+        var recovered = new RecoveredType[] { new("System.Foo", ["Bar"], "TestAsm") };
+        var symbols = new[]
+        {
+            Symbol("a", 0x1000, 0x40, NativeSymbolKind.Function, "System.Foo.Bar", exact: true),
+            Symbol("b", 0x2000, 0x30, NativeSymbolKind.Function),
+            Symbol("c", 0x3000, 0x20, NativeSymbolKind.MethodTable),
+            Symbol("d", 0x4000, 0, NativeSymbolKind.Function), // unsized: excluded
+        };
+
+        var tree = SizeAnalyzer.BuildFromSymbols("app", recovered, Info(symbols));
+
+        Assert.Equal(0x90, tree.Size);
+        Assert.Equal(tree.Size, tree.Children.Sum(c => c.Size));
+    }
+
+    /// <summary>
+    /// Verifies the real fixture: with the mstat hidden, the Size Map builds from symbols
+    /// (Function leaves, no IL <see cref="SizeNodeKind.Method"/> nodes), and with the mstat
+    /// present it keeps precedence (Method leaves appear).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void BuildSizeTree_MstatPrecedence_SymbolsCarryTheTreeWithoutIt()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat not present");
+        Assert.SkipWhen(samples.NativeAotConsoleSymbols is null, "native symbols not present");
+
+        // mstat beside the exe: the report wins.
+        using (var withMstat = new AssemblyAnalyzer(samples.NativeAotConsoleExe!))
+        {
+            var tree = SizeAnalyzer.BuildSizeTree(withMstat);
+            Assert.Contains(Flatten(tree), n => n.Kind == SizeNodeKind.Method);
+        }
+
+        // Exe and symbols copied away from the mstat: symbols carry the tree.
+        var dir = Directory.CreateTempSubdirectory("dotsider-sizesym-");
+        try
+        {
+            var exeCopy = Path.Combine(dir.FullName, Path.GetFileName(samples.NativeAotConsoleExe!));
+            File.Copy(samples.NativeAotConsoleExe!, exeCopy);
+            CopySymbolsBeside(samples.NativeAotConsoleExe!, samples.NativeAotConsoleSymbols!, dir.FullName);
+
+            using var analyzer = new AssemblyAnalyzer(exeCopy);
+            Assert.Null(analyzer.Mstat);
+            var tree = SizeAnalyzer.BuildSizeTree(analyzer);
+
+            var nodes = Flatten(tree).ToList();
+            Assert.Contains(nodes, n => n.Kind == SizeNodeKind.Function);
+            Assert.DoesNotContain(nodes, n => n.Kind == SizeNodeKind.Method);
+            Assert.True(tree.Size > 0);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    private static IEnumerable<SizeNode> Flatten(SizeNode node)
+    {
+        yield return node;
+        foreach (var child in node.Children)
+        {
+            foreach (var descendant in Flatten(child))
+                yield return descendant;
+        }
+    }
+
+    /// <summary>Copies the platform's symbol artifact beside a relocated exe.</summary>
+    private static void CopySymbolsBeside(string exePath, string symbolsPath, string targetDir)
+    {
+        var exeDir = Path.GetDirectoryName(exePath)!;
+        if (symbolsPath.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase)
+            || symbolsPath.EndsWith(".dbg", StringComparison.OrdinalIgnoreCase))
+        {
+            File.Copy(symbolsPath, Path.Combine(targetDir, Path.GetFileName(symbolsPath)));
+            return;
+        }
+
+        // macOS: recreate the dSYM bundle's DWARF path relative to the exe.
+        var relative = Path.GetRelativePath(exeDir, symbolsPath);
+        var target = Path.Combine(targetDir, relative);
+        Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+        File.Copy(symbolsPath, target);
+    }
+}

--- a/tests/Dotsider.Tests/SizeAnalyzerTests.cs
+++ b/tests/Dotsider.Tests/SizeAnalyzerTests.cs
@@ -263,11 +263,12 @@ public class SizeAnalyzerTests(SampleAssemblyFixture samples)
     }
 
     /// <summary>
-    /// Verifies an AOT binary without an mstat sidecar falls back to the metadata path: an
-    /// empty tree rather than a throw.
+    /// Verifies an AOT binary copied away from every sidecar still carries a Size Map: the
+    /// unwind-data boundaries fill it at symbol fidelity (no IL <see cref="SizeNodeKind.Method"/>
+    /// nodes), instead of the pre-symbol empty tree.
     /// </summary>
     [Fact(Timeout = 30_000)]
-    public void NativeAot_WithoutSidecar_FallsBackToEmptyTree()
+    public void NativeAot_WithoutSidecar_BuildsTreeFromBoundaries()
     {
         Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
 
@@ -280,8 +281,9 @@ public class SizeAnalyzerTests(SampleAssemblyFixture samples)
 
             var tree = SizeAnalyzer.BuildSizeTree(a);
 
-            Assert.Equal(0, tree.Size);
-            Assert.Empty(tree.Children);
+            Assert.True(tree.Size > 0);
+            Assert.NotEmpty(tree.Children);
+            Assert.DoesNotContain(tree.Children, c => c.Kind == SizeNodeKind.Method);
         }
         finally
         {

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -694,6 +694,9 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
             .Key(Hex1bKey.S).Key(Hex1bKey.Y).Key(Hex1bKey.S) // "sys"
             .Key(Hex1bKey.Enter) // Confirm
             .WaitUntil(_ => _state!.Search[TabId.DepGraph].IsConfirmed, TimeSpan.FromSeconds(10))
+            // The match count is recomputed during the render pass, so wait for
+            // the frame that carries it rather than racing the confirm handler.
+            .WaitUntil(_ => _state!.Search[TabId.DepGraph].MatchCount > 0, TimeSpan.FromSeconds(10))
             .Build()
             .ApplyAsync(terminal, cts.Token);
 
@@ -1878,6 +1881,9 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
             .Key(Hex1bKey.R).Key(Hex1bKey.I).Key(Hex1bKey.C).Key(Hex1bKey.H) // "rich"
             .Key(Hex1bKey.Enter) // Confirm
             .WaitUntil(_ => _state!.Search[TabId.SizeMap].IsConfirmed, TimeSpan.FromSeconds(10))
+            // The match count is recomputed during the render pass, so wait for
+            // the frame that carries it rather than racing the confirm handler.
+            .WaitUntil(_ => _state!.Search[TabId.SizeMap].MatchCount > 0, TimeSpan.FromSeconds(10))
             .Build()
             .ApplyAsync(terminal, cts.Token);
 

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -3109,6 +3109,7 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
             .WaitUntil(s => s.ContainsText("Native Imports"), TimeSpan.FromSeconds(10))
             .WaitUntil(s => s.ContainsText("R2R Sections"), TimeSpan.FromSeconds(10))
             .WaitUntil(s => s.ContainsText("Recovered Types"), TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Native Symbols"), TimeSpan.FromSeconds(10))
             .Build()
             .ApplyAsync(terminal, cts.Token);
 
@@ -3116,6 +3117,7 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
         Assert.NotNull(_state.Analyzer.NativeAotInfo);
         Assert.NotEmpty(_state.Analyzer.ReadyToRunSections);
         Assert.NotEmpty(_state.Analyzer.RecoveredTypes);
+        Assert.NotNull(_state.Analyzer.NativeSymbols);
 
         cts.Cancel();
         await runTask;

--- a/tests/Dotsider.Tests/SyntheticImageBuilders.cs
+++ b/tests/Dotsider.Tests/SyntheticImageBuilders.cs
@@ -172,7 +172,16 @@ internal static class SyntheticImageBuilders
     /// indices follow build order: the null section is 0, the given sections are 1..n.
     /// </summary>
     /// <param name="sections">Each section's name, virtual address, content, <c>sh_type</c>, and <c>sh_link</c>.</param>
-    public static byte[] BuildElf(params (string Name, ulong Address, byte[] Content, uint Type, uint Link)[] sections)
+    public static byte[] BuildElf(params (string Name, ulong Address, byte[] Content, uint Type, uint Link)[] sections) =>
+        BuildElf([.. sections.Select(s => (s.Name, s.Address, s.Content, s.Type, s.Link, 0UL))]);
+
+    /// <summary>
+    /// Builds a minimal 64-bit little-endian ELF image with explicit section types, links, and
+    /// flags — <c>SHF_COMPRESSED</c> (0x800) marks content carrying an <c>Elf64_Chdr</c>.
+    /// </summary>
+    /// <param name="sections">Each section's name, address, content, <c>sh_type</c>, <c>sh_link</c>, and <c>sh_flags</c>.</param>
+    public static byte[] BuildElf(
+        params (string Name, ulong Address, byte[] Content, uint Type, uint Link, ulong Flags)[] sections)
     {
         const int headerSize = 64;
         const int sectionHeaderSize = 64;
@@ -223,11 +232,12 @@ internal static class SyntheticImageBuilders
         BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(60), (ushort)sectionCount);
         BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(62), (ushort)(sectionCount - 1)); // e_shstrndx
 
-        void WriteHeader(int index, uint nameOffset, uint type, ulong address, long fileOffset, long size, uint link)
+        void WriteHeader(int index, uint nameOffset, uint type, ulong address, long fileOffset, long size, uint link, ulong flags)
         {
             var h = tableOffset + index * sectionHeaderSize;
             BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(h), nameOffset);
             BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(h + 4), type);
+            BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(h + 8), flags);
             BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(h + 16), address);
             BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(h + 24), (ulong)fileOffset);
             BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(h + 32), (ulong)size);
@@ -238,12 +248,35 @@ internal static class SyntheticImageBuilders
         {
             sections[i].Content.CopyTo(image.AsSpan(contentOffsets[i]));
             WriteHeader(i + 1, nameOffsets[i], sections[i].Type, sections[i].Address,
-                contentOffsets[i], sections[i].Content.Length, sections[i].Link);
+                contentOffsets[i], sections[i].Content.Length, sections[i].Link, sections[i].Flags);
         }
 
         shStrTab.CopyTo(image.AsSpan(shStrTabOffset));
-        WriteHeader(sectionCount - 1, nameOffsets[^1], 3 /* SHT_STRTAB */, 0, shStrTabOffset, shStrTab.Length, 0);
+        WriteHeader(sectionCount - 1, nameOffsets[^1], 3 /* SHT_STRTAB */, 0, shStrTabOffset, shStrTab.Length, 0, 0);
         return image;
+    }
+
+    /// <summary>
+    /// Wraps section content the way GNU toolchains compress debug sections: an
+    /// <c>Elf64_Chdr</c> (zlib type) followed by the zlib-deflated payload. Pair with
+    /// <c>SHF_COMPRESSED</c> (0x800) section flags.
+    /// </summary>
+    /// <param name="content">The uncompressed section content.</param>
+    public static byte[] CompressDebugSection(byte[] content)
+    {
+        using var buffer = new MemoryStream();
+        using (var zlib = new System.IO.Compression.ZLibStream(
+            buffer, System.IO.Compression.CompressionLevel.Fastest, leaveOpen: true))
+        {
+            zlib.Write(content);
+        }
+
+        var section = new byte[24 + buffer.Length];
+        BinaryPrimitives.WriteUInt32LittleEndian(section, 1); // ELFCOMPRESS_ZLIB
+        BinaryPrimitives.WriteUInt64LittleEndian(section.AsSpan(8), (ulong)content.Length);
+        BinaryPrimitives.WriteUInt64LittleEndian(section.AsSpan(16), 1); // ch_addralign
+        buffer.ToArray().CopyTo(section.AsSpan(24));
+        return section;
     }
 
     /// <summary>

--- a/tests/Dotsider.Tests/SyntheticImageBuilders.cs
+++ b/tests/Dotsider.Tests/SyntheticImageBuilders.cs
@@ -234,4 +234,51 @@ internal static class SyntheticImageBuilders
         WriteHeader(sectionCount - 1, nameOffsets[^1], 3 /* SHT_STRTAB */, 0, shStrTabOffset, shStrTab.Length);
         return image;
     }
+
+    /// <summary>
+    /// Builds a GNU build-id note (owner <c>GNU</c>, type 3) for a <c>.note.gnu.build-id</c>
+    /// section, optionally preceded by an unrelated note the reader must walk past.
+    /// </summary>
+    /// <param name="id">The build id payload.</param>
+    /// <param name="precedeWithForeignNote">Whether to prepend a non-GNU note entry.</param>
+    public static byte[] GnuBuildIdNote(byte[] id, bool precedeWithForeignNote = false)
+    {
+        var note = new List<byte>();
+        void U32(uint v) { Span<byte> t = stackalloc byte[4]; BinaryPrimitives.WriteUInt32LittleEndian(t, v); note.AddRange(t); }
+        void Padded(byte[] data)
+        {
+            note.AddRange(data);
+            for (var i = data.Length; (i & 3) != 0; i++) note.Add(0);
+        }
+
+        if (precedeWithForeignNote)
+        {
+            U32(4); U32(2); U32(1); // namesz, descsz, type
+            Padded("XYZ\0"u8.ToArray());
+            Padded([0xAA, 0xBB]);
+        }
+
+        U32(4); U32((uint)id.Length); U32(3);
+        Padded("GNU\0"u8.ToArray());
+        Padded(id);
+        return [.. note];
+    }
+
+    /// <summary>
+    /// Builds <c>.gnu_debuglink</c> content: the sidecar file name, 4-aligned, then the CRC-32
+    /// of the sidecar's bytes.
+    /// </summary>
+    /// <param name="fileName">The sidecar file name.</param>
+    /// <param name="crc">The CRC-32 of the entire sidecar file.</param>
+    public static byte[] GnuDebugLink(string fileName, uint crc)
+    {
+        var content = new List<byte>();
+        content.AddRange(System.Text.Encoding.UTF8.GetBytes(fileName));
+        content.Add(0);
+        while ((content.Count & 3) != 0) content.Add(0);
+        Span<byte> t = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32LittleEndian(t, crc);
+        content.AddRange(t);
+        return [.. content];
+    }
 }

--- a/tests/Dotsider.Tests/SyntheticImageBuilders.cs
+++ b/tests/Dotsider.Tests/SyntheticImageBuilders.cs
@@ -159,10 +159,20 @@ internal static class SyntheticImageBuilders
     /// <summary>
     /// Builds a minimal 64-bit little-endian ELF image whose section header table carries the
     /// given named sections (plus the standard null section and a trailing <c>.shstrtab</c>),
-    /// so section-driven readers — DWARF, symtab, build-id — run on every platform.
+    /// so section-driven readers — DWARF, symtab, build-id — run on every platform. Every
+    /// section is <c>SHT_PROGBITS</c>; use the typed overload for symbol tables.
     /// </summary>
     /// <param name="sections">Each section's name, virtual address, and content bytes.</param>
-    public static byte[] BuildElf(params (string Name, ulong Address, byte[] Content)[] sections)
+    public static byte[] BuildElf(params (string Name, ulong Address, byte[] Content)[] sections) =>
+        BuildElf([.. sections.Select(s => (s.Name, s.Address, s.Content, 1u, 0u))]);
+
+    /// <summary>
+    /// Builds a minimal 64-bit little-endian ELF image with explicit section types and links,
+    /// so <c>.symtab</c> (type 2, link = its string table's index) can be modeled. Section
+    /// indices follow build order: the null section is 0, the given sections are 1..n.
+    /// </summary>
+    /// <param name="sections">Each section's name, virtual address, content, <c>sh_type</c>, and <c>sh_link</c>.</param>
+    public static byte[] BuildElf(params (string Name, ulong Address, byte[] Content, uint Type, uint Link)[] sections)
     {
         const int headerSize = 64;
         const int sectionHeaderSize = 64;
@@ -213,7 +223,7 @@ internal static class SyntheticImageBuilders
         BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(60), (ushort)sectionCount);
         BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(62), (ushort)(sectionCount - 1)); // e_shstrndx
 
-        void WriteHeader(int index, uint nameOffset, uint type, ulong address, long fileOffset, long size)
+        void WriteHeader(int index, uint nameOffset, uint type, ulong address, long fileOffset, long size, uint link)
         {
             var h = tableOffset + index * sectionHeaderSize;
             BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(h), nameOffset);
@@ -221,17 +231,18 @@ internal static class SyntheticImageBuilders
             BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(h + 16), address);
             BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(h + 24), (ulong)fileOffset);
             BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(h + 32), (ulong)size);
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(h + 40), link);
         }
 
         for (var i = 0; i < sections.Length; i++)
         {
             sections[i].Content.CopyTo(image.AsSpan(contentOffsets[i]));
-            WriteHeader(i + 1, nameOffsets[i], 1 /* SHT_PROGBITS */, sections[i].Address,
-                contentOffsets[i], sections[i].Content.Length);
+            WriteHeader(i + 1, nameOffsets[i], sections[i].Type, sections[i].Address,
+                contentOffsets[i], sections[i].Content.Length, sections[i].Link);
         }
 
         shStrTab.CopyTo(image.AsSpan(shStrTabOffset));
-        WriteHeader(sectionCount - 1, nameOffsets[^1], 3 /* SHT_STRTAB */, 0, shStrTabOffset, shStrTab.Length);
+        WriteHeader(sectionCount - 1, nameOffsets[^1], 3 /* SHT_STRTAB */, 0, shStrTabOffset, shStrTab.Length, 0);
         return image;
     }
 
@@ -262,6 +273,37 @@ internal static class SyntheticImageBuilders
         Padded("GNU\0"u8.ToArray());
         Padded(id);
         return [.. note];
+    }
+
+    /// <summary>
+    /// Builds <c>.eh_frame</c> content with one CIE (augmentation <c>zR</c>, absolute-pointer
+    /// encoding) and one FDE per function, terminated — the plain shape the boundary fallback
+    /// walks. Encoding-specific shapes are hand-built in the eh_frame tests.
+    /// </summary>
+    /// <param name="functions">Each function's start address and byte size.</param>
+    public static byte[] EhFrame(params (ulong Va, ulong Size)[] functions)
+    {
+        var section = new List<byte>();
+        void U32(uint v) { for (var i = 0; i < 4; i++) section.Add((byte)(v >> (8 * i))); }
+        void U64(ulong v) { for (var i = 0; i < 8; i++) section.Add((byte)(v >> (8 * i))); }
+
+        // CIE: id 0, version 1, "zR", code align 1, data align 0x78 (SLEB -8), return reg 16,
+        // aug length 1, FDE encoding 0x00 (absptr).
+        byte[] cie = [0, 0, 0, 0, 1, (byte)'z', (byte)'R', 0, 1, 0x78, 16, 1, 0x00];
+        U32((uint)cie.Length);
+        section.AddRange(cie);
+
+        foreach (var (va, size) in functions)
+        {
+            U32(20); // FDE length: cie_pointer + two 8-byte pointers
+            // cie_pointer: distance from this FDE's id field back to the CIE at offset 0.
+            U32((uint)section.Count);
+            U64(va);
+            U64(size);
+        }
+
+        U32(0); // terminator
+        return [.. section];
     }
 
     /// <summary>

--- a/tests/Dotsider.Tests/SyntheticImageBuilders.cs
+++ b/tests/Dotsider.Tests/SyntheticImageBuilders.cs
@@ -307,6 +307,175 @@ internal static class SyntheticImageBuilders
     }
 
     /// <summary>
+    /// Builds a minimal thin 64-bit little-endian Mach-O image: the given segments with their
+    /// sections (ordinals follow declaration order across segments), an optional symbol table,
+    /// an optional <c>LC_UUID</c>, and an optional <c>LC_FUNCTION_STARTS</c> payload. Symbol
+    /// names are written verbatim — give them their on-disk leading underscore.
+    /// </summary>
+    /// <param name="segments">Each segment's name, base address, and sections (name, address, flags, content).</param>
+    /// <param name="symbols">nlist entries: name, <c>n_type</c>, <c>n_sect</c> ordinal, and <c>n_value</c>.</param>
+    /// <param name="uuid">The 16-byte <c>LC_UUID</c> payload, or null for none.</param>
+    /// <param name="functionStarts">The raw <c>LC_FUNCTION_STARTS</c> ULEB payload, or null for none.</param>
+    /// <param name="cpuType">The header <c>cputype</c> (ARM64 by default).</param>
+    public static byte[] BuildMachO(
+        (string Segment, ulong VmAddr, (string Name, ulong Address, uint Flags, byte[] Content)[] Sections)[] segments,
+        (string Name, byte Type, byte Ordinal, ulong Value)[]? symbols = null,
+        byte[]? uuid = null,
+        byte[]? functionStarts = null,
+        uint cpuType = 0x0100000C)
+    {
+        const int headerSize = 32;
+        const int segmentHeaderSize = 72;
+        const int sectionSize = 80;
+        const int nlistSize = 16;
+
+        var commandsSize = segments.Sum(s => segmentHeaderSize + sectionSize * s.Sections.Length)
+            + (uuid is null ? 0 : 24)
+            + (symbols is null ? 0 : 24)
+            + (functionStarts is null ? 0 : 16);
+        var ncmds = segments.Length + (uuid is null ? 0 : 1) + (symbols is null ? 0 : 1)
+            + (functionStarts is null ? 0 : 1);
+
+        // Content layout: section contents, string table, nlist array, function-starts payload.
+        var offset = headerSize + commandsSize;
+        var contentOffsets = segments.Select(s => s.Sections.Select(sec =>
+        {
+            var at = offset;
+            offset += sec.Content.Length;
+            return at;
+        }).ToArray()).ToArray();
+
+        var strings = new List<byte> { 0 };
+        var nameOffsets = new uint[symbols?.Length ?? 0];
+        for (var i = 0; i < (symbols?.Length ?? 0); i++)
+        {
+            if (symbols![i].Name.Length == 0)
+            {
+                nameOffsets[i] = 0;
+                continue;
+            }
+
+            nameOffsets[i] = (uint)strings.Count;
+            strings.AddRange(System.Text.Encoding.UTF8.GetBytes(symbols[i].Name));
+            strings.Add(0);
+        }
+
+        var stringOffset = offset;
+        offset += strings.Count;
+        var nlistOffset = offset;
+        offset += (symbols?.Length ?? 0) * nlistSize;
+        var startsOffset = offset;
+        offset += functionStarts?.Length ?? 0;
+
+        var image = new byte[offset];
+        BinaryPrimitives.WriteUInt32LittleEndian(image, 0xFEEDFACF);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(4), cpuType);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(12), 2); // MH_EXECUTE
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(16), (uint)ncmds);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(20), (uint)commandsSize);
+
+        var command = headerSize;
+        for (var si = 0; si < segments.Length; si++)
+        {
+            var (segment, vmAddr, sections) = segments[si];
+            var cmdSize = segmentHeaderSize + sectionSize * sections.Length;
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command), 0x19);
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command + 4), (uint)cmdSize);
+            System.Text.Encoding.ASCII.GetBytes(segment).CopyTo(image.AsSpan(command + 8));
+            BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(command + 24), vmAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(command + 32), 0x4000); // vmsize
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command + 64), (uint)sections.Length);
+
+            for (var i = 0; i < sections.Length; i++)
+            {
+                var s = command + segmentHeaderSize + i * sectionSize;
+                System.Text.Encoding.ASCII.GetBytes(sections[i].Name).CopyTo(image.AsSpan(s));
+                System.Text.Encoding.ASCII.GetBytes(segment).CopyTo(image.AsSpan(s + 16));
+                BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(s + 32), sections[i].Address);
+                BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(s + 40), (ulong)sections[i].Content.Length);
+                BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(s + 48), (uint)contentOffsets[si][i]);
+                BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(s + 64), sections[i].Flags);
+                sections[i].Content.CopyTo(image.AsSpan(contentOffsets[si][i]));
+            }
+
+            command += cmdSize;
+        }
+
+        if (uuid is not null)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command), 0x1B);
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command + 4), 24);
+            uuid.CopyTo(image.AsSpan(command + 8));
+            command += 24;
+        }
+
+        if (symbols is not null)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command), 0x2);
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command + 4), 24);
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command + 8), (uint)nlistOffset);
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command + 12), (uint)symbols.Length);
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command + 16), (uint)stringOffset);
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command + 20), (uint)strings.Count);
+            command += 24;
+
+            for (var i = 0; i < symbols.Length; i++)
+            {
+                var entry = nlistOffset + i * nlistSize;
+                BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(entry), nameOffsets[i]);
+                image[entry + 4] = symbols[i].Type;
+                image[entry + 5] = symbols[i].Ordinal;
+                BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(entry + 8), symbols[i].Value);
+            }
+
+            strings.ToArray().CopyTo(image.AsSpan(stringOffset));
+        }
+
+        if (functionStarts is not null)
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command), 0x26);
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command + 4), 16);
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command + 8), (uint)startsOffset);
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(command + 12), (uint)functionStarts.Length);
+            functionStarts.CopyTo(image.AsSpan(startsOffset));
+        }
+
+        return image;
+    }
+
+    /// <summary>
+    /// Wraps thin Mach-O slices in a fat/universal archive (32-bit big-endian header), reading
+    /// each slice's <c>cputype</c> from its own header.
+    /// </summary>
+    /// <param name="slices">The thin images to wrap.</param>
+    public static byte[] BuildFat(params byte[][] slices)
+    {
+        var headerSize = 8 + slices.Length * 20;
+        var offsets = new int[slices.Length];
+        var offset = (headerSize + 7) & ~7;
+        for (var i = 0; i < slices.Length; i++)
+        {
+            offsets[i] = offset;
+            offset += (slices[i].Length + 7) & ~7;
+        }
+
+        var image = new byte[offset];
+        BinaryPrimitives.WriteUInt32BigEndian(image, 0xCAFEBABE);
+        BinaryPrimitives.WriteUInt32BigEndian(image.AsSpan(4), (uint)slices.Length);
+        for (var i = 0; i < slices.Length; i++)
+        {
+            var entry = 8 + i * 20;
+            var cpuType = BinaryPrimitives.ReadUInt32LittleEndian(slices[i].AsSpan(4));
+            BinaryPrimitives.WriteUInt32BigEndian(image.AsSpan(entry), cpuType);
+            BinaryPrimitives.WriteUInt32BigEndian(image.AsSpan(entry + 8), (uint)offsets[i]);
+            BinaryPrimitives.WriteUInt32BigEndian(image.AsSpan(entry + 12), (uint)slices[i].Length);
+            slices[i].CopyTo(image.AsSpan(offsets[i]));
+        }
+
+        return image;
+    }
+
+    /// <summary>
     /// Builds <c>.gnu_debuglink</c> content: the sidecar file name, 4-aligned, then the CRC-32
     /// of the sidecar's bytes.
     /// </summary>

--- a/tests/Dotsider.Tests/SyntheticImageBuilders.cs
+++ b/tests/Dotsider.Tests/SyntheticImageBuilders.cs
@@ -155,4 +155,83 @@ internal static class SyntheticImageBuilders
 
         return image;
     }
+
+    /// <summary>
+    /// Builds a minimal 64-bit little-endian ELF image whose section header table carries the
+    /// given named sections (plus the standard null section and a trailing <c>.shstrtab</c>),
+    /// so section-driven readers — DWARF, symtab, build-id — run on every platform.
+    /// </summary>
+    /// <param name="sections">Each section's name, virtual address, and content bytes.</param>
+    public static byte[] BuildElf(params (string Name, ulong Address, byte[] Content)[] sections)
+    {
+        const int headerSize = 64;
+        const int sectionHeaderSize = 64;
+
+        // Section-name string table: NUL, then each name, then ".shstrtab".
+        var names = new List<byte> { 0 };
+        var nameOffsets = new uint[sections.Length + 1];
+        for (var i = 0; i < sections.Length; i++)
+        {
+            nameOffsets[i] = (uint)names.Count;
+            names.AddRange(System.Text.Encoding.UTF8.GetBytes(sections[i].Name));
+            names.Add(0);
+        }
+
+        nameOffsets[^1] = (uint)names.Count;
+        names.AddRange(".shstrtab"u8.ToArray());
+        names.Add(0);
+        var shStrTab = names.ToArray();
+
+        // Layout: header | section contents | .shstrtab | section header table.
+        var contentOffsets = new int[sections.Length];
+        var offset = headerSize;
+        for (var i = 0; i < sections.Length; i++)
+        {
+            contentOffsets[i] = offset;
+            offset += sections[i].Content.Length;
+        }
+
+        var shStrTabOffset = offset;
+        offset += shStrTab.Length;
+        var tableOffset = offset;
+        var sectionCount = sections.Length + 2; // null section + user sections + .shstrtab
+        var image = new byte[tableOffset + sectionCount * sectionHeaderSize];
+
+        image[0] = 0x7F;
+        image[1] = (byte)'E';
+        image[2] = (byte)'L';
+        image[3] = (byte)'F';
+        image[4] = 2; // ELFCLASS64
+        image[5] = 1; // little-endian
+        image[6] = 1; // EV_CURRENT
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(16), 2); // ET_EXEC
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(18), 0x3E); // EM_X86_64
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(20), 1);
+        BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(40), (ulong)tableOffset); // e_shoff
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(52), headerSize); // e_ehsize
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(58), sectionHeaderSize); // e_shentsize
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(60), (ushort)sectionCount);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(62), (ushort)(sectionCount - 1)); // e_shstrndx
+
+        void WriteHeader(int index, uint nameOffset, uint type, ulong address, long fileOffset, long size)
+        {
+            var h = tableOffset + index * sectionHeaderSize;
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(h), nameOffset);
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(h + 4), type);
+            BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(h + 16), address);
+            BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(h + 24), (ulong)fileOffset);
+            BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(h + 32), (ulong)size);
+        }
+
+        for (var i = 0; i < sections.Length; i++)
+        {
+            sections[i].Content.CopyTo(image.AsSpan(contentOffsets[i]));
+            WriteHeader(i + 1, nameOffsets[i], 1 /* SHT_PROGBITS */, sections[i].Address,
+                contentOffsets[i], sections[i].Content.Length);
+        }
+
+        shStrTab.CopyTo(image.AsSpan(shStrTabOffset));
+        WriteHeader(sectionCount - 1, nameOffsets[^1], 3 /* SHT_STRTAB */, 0, shStrTabOffset, shStrTab.Length);
+        return image;
+    }
 }

--- a/tests/Dotsider.Tests/SyntheticImageBuilders.cs
+++ b/tests/Dotsider.Tests/SyntheticImageBuilders.cs
@@ -1,0 +1,96 @@
+using System.Buffers.Binary;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Builds minimal synthetic binary images in memory so the native-symbol readers can be
+/// exercised on every platform, not only the CI leg whose real format matches. Each builder
+/// produces the smallest well-formed structure that drives the code path under test.
+/// </summary>
+internal static class SyntheticImageBuilders
+{
+    private static readonly byte[] MsfMagic =
+        [.. "Microsoft C/C++ MSF 7.00\r\n"u8, 0x1A, .. "DS"u8, 0, 0, 0];
+
+    /// <summary>
+    /// Builds a minimal MSF 7.0 container with a multi-block stream directory and the given
+    /// stream contents. Stream 0 is empty; the supplied streams follow as streams 1..n. A nil
+    /// stream is represented by a null entry in <paramref name="streams"/>.
+    /// </summary>
+    /// <param name="blockSize">The MSF block size (must be a valid MSF block size).</param>
+    /// <param name="streams">The content of streams 1..n; a null entry produces a nil stream.</param>
+    /// <returns>The complete MSF file bytes.</returns>
+    public static byte[] BuildMsf(int blockSize, params byte[]?[] streams)
+    {
+        var allStreams = new List<byte[]?> { Array.Empty<byte>() }; // stream 0 is always present and empty
+        allStreams.AddRange(streams);
+
+        int BlockCount(int size) => (size + blockSize - 1) / blockSize;
+
+        // Lay out data blocks for each stream starting after a reserved header region:
+        // block 0 = superblock, block 1 = FPM, blocks 2.. = stream data, then directory, then map.
+        var nextBlock = 2;
+        var streamBlockLists = new List<int[]>();
+        foreach (var s in allStreams)
+        {
+            if (s is null) { streamBlockLists.Add([]); continue; }
+            var count = BlockCount(s.Length);
+            var list = new int[count];
+            for (var i = 0; i < count; i++) list[i] = nextBlock++;
+            streamBlockLists.Add(list);
+        }
+
+        // Directory bytes: numStreams, sizes, then per-stream block lists.
+        var dir = new List<byte>();
+        void PutI32(List<byte> b, int v) { Span<byte> t = stackalloc byte[4]; BinaryPrimitives.WriteInt32LittleEndian(t, v); b.AddRange(t); }
+        PutI32(dir, allStreams.Count);
+        for (var i = 0; i < allStreams.Count; i++)
+            PutI32(dir, allStreams[i] is null ? unchecked((int)0xFFFFFFFF) : allStreams[i]!.Length);
+        for (var i = 0; i < allStreams.Count; i++)
+            foreach (var block in streamBlockLists[i]) PutI32(dir, block);
+
+        var directoryBytes = dir.ToArray();
+        var directoryBlockCount = BlockCount(directoryBytes.Length);
+        var directoryFirstBlock = nextBlock;
+        nextBlock += directoryBlockCount;
+        var blockMapBlock = nextBlock++;
+
+        var totalBlocks = nextBlock;
+        var image = new byte[totalBlocks * blockSize];
+
+        // Superblock.
+        MsfMagic.CopyTo(image, 0);
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(32), blockSize);
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(36), 1); // free block map
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(40), totalBlocks);
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(44), directoryBytes.Length);
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(52), blockMapBlock);
+
+        // Stream data.
+        for (var i = 0; i < allStreams.Count; i++)
+        {
+            var s = allStreams[i];
+            if (s is null) continue;
+            for (var j = 0; j < streamBlockLists[i].Length; j++)
+            {
+                var off = j * blockSize;
+                var n = Math.Min(blockSize, s.Length - off);
+                s.AsSpan(off, n).CopyTo(image.AsSpan(streamBlockLists[i][j] * blockSize));
+            }
+        }
+
+        // Directory blocks.
+        for (var i = 0; i < directoryBlockCount; i++)
+        {
+            var off = i * blockSize;
+            var n = Math.Min(blockSize, directoryBytes.Length - off);
+            directoryBytes.AsSpan(off, n).CopyTo(image.AsSpan((directoryFirstBlock + i) * blockSize));
+        }
+
+        // Block map: the list of directory block indices.
+        for (var i = 0; i < directoryBlockCount; i++)
+            BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(blockMapBlock * blockSize + i * 4), directoryFirstBlock + i);
+
+        return image;
+    }
+}

--- a/tests/Dotsider.Tests/SyntheticImageBuilders.cs
+++ b/tests/Dotsider.Tests/SyntheticImageBuilders.cs
@@ -13,6 +13,68 @@ internal static class SyntheticImageBuilders
         [.. "Microsoft C/C++ MSF 7.00\r\n"u8, 0x1A, .. "DS"u8, 0, 0, 0];
 
     /// <summary>
+    /// Builds a minimal 64-bit PE image (one section) with an optional exception directory, so the
+    /// <c>.pdata</c> reader can be exercised for x64 and ARM64 on any platform. The section holds
+    /// <paramref name="sectionData"/> at RVA 0x1000 mapped to a matching file offset; the exception
+    /// directory points at <paramref name="exceptionRva"/> for <paramref name="exceptionSize"/> bytes.
+    /// </summary>
+    /// <param name="machine">The COFF machine (0x8664 for x64, 0xAA64 for ARM64).</param>
+    /// <param name="sectionData">The bytes of the single section, placed at RVA 0x1000.</param>
+    /// <param name="exceptionRva">The exception directory RVA (within the section), or 0 for none.</param>
+    /// <param name="exceptionSize">The exception directory size in bytes.</param>
+    /// <param name="imageBase">The image base.</param>
+    public static byte[] BuildPe(
+        ushort machine, byte[] sectionData, uint exceptionRva, uint exceptionSize, ulong imageBase = 0x140000000)
+    {
+        const int sectionRva = 0x1000;
+        const int sectionFileOffset = 0x400;
+        var peHeaderOffset = 0x80;
+
+        var image = new byte[sectionFileOffset + Math.Max(0x200, sectionData.Length + 0x200)];
+        image[0] = (byte)'M';
+        image[1] = (byte)'Z';
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(0x3C), peHeaderOffset);
+
+        var p = peHeaderOffset;
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(p), 0x0000_4550); // "PE\0\0"
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(p + 4), machine);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(p + 6), 1); // NumberOfSections
+        const int optionalSize = 240; // PE32+ optional header with 16 data directories
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(p + 20), optionalSize);
+
+        var optional = p + 24;
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(optional), 0x20B); // PE32+
+        BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(optional + 24), imageBase);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(optional + 108), 16); // NumberOfRvaAndSizes
+        // Data directory index 3 = Exception.
+        var directories = optional + 112;
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(directories + 3 * 8), exceptionRva);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(directories + 3 * 8 + 4), exceptionSize);
+
+        // One section covering the data, with VA 0x1000 mapped to file offset 0x400.
+        var sectionTable = optional + optionalSize;
+        System.Text.Encoding.ASCII.GetBytes(".text").CopyTo(image.AsSpan(sectionTable));
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(sectionTable + 8), (uint)Math.Max(sectionData.Length, 0x200)); // VirtualSize
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(sectionTable + 12), sectionRva);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(sectionTable + 16), (uint)Math.Max(sectionData.Length, 0x200)); // SizeOfRawData
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(sectionTable + 20), sectionFileOffset);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(sectionTable + 36), 0x6000_0020); // code | execute | read
+
+        sectionData.CopyTo(image.AsSpan(sectionFileOffset));
+        return image;
+    }
+
+    /// <summary>Packs an x64 RUNTIME_FUNCTION (begin, end, unwind-info RVAs).</summary>
+    public static byte[] Amd64RuntimeFunction(uint beginRva, uint endRva, uint unwindInfoRva)
+    {
+        var b = new byte[12];
+        BinaryPrimitives.WriteUInt32LittleEndian(b, beginRva);
+        BinaryPrimitives.WriteUInt32LittleEndian(b.AsSpan(4), endRva);
+        BinaryPrimitives.WriteUInt32LittleEndian(b.AsSpan(8), unwindInfoRva);
+        return b;
+    }
+
+    /// <summary>
     /// Builds a minimal MSF 7.0 container with a multi-block stream directory and the given
     /// stream contents. Stream 0 is empty; the supplied streams follow as streams 1..n. A nil
     /// stream is represented by a null entry in <paramref name="streams"/>.


### PR DESCRIPTION
Opening a Native AOT binary now shows its native symbols on every platform, read from whichever artifact the publish produced: the native PDB on Windows, the `.dbg` DWARF sidecar on Linux, the dSYM bundle on macOS. Every reader is written from scratch against the format specs and the emitters in dotnet/runtime — MSF/DBI/CodeView with C13 line data and the publics stream, DWARF 2–5 with DWARF64, range lists, and line programs, Mach-O nlist with N_FUN stab sizes and fat-archive slices — with no new dependencies.

A symbol file is validated before it is believed: PDB GUID and age against the RSDS record, GNU build id and debuglink CRC-32 where every signal that is present must match, Mach-O UUID between exe and dSYM. A fat archive picks its slice by dSYM UUID or the ReadyToRun signal and reports AmbiguousImage rather than silently taking the host architecture. Mangled names demangle by joining against the metadata the binary itself still carries; ILC collapses every non-identifier character to a single underscore, so split points are ambiguous, and a managed name is claimed exact only when the join is unambiguous — everything else stays a display heuristic. The model never presents a guess as a fact.

The symbols carry the rest of the tool. The Size Map keeps mstat precedence and fills from symbols when the report is absent, assemblies down to per-function native sizes beside MethodTable, frozen object, statics, and dictionary categories. PE/Metadata gains a Symbols sub-tab with a detail popup (mangled name, aliases, section, file:line, provenance), the General tab a summary line, the CLI `analyze --symbols` with provenance in the default info output, and the session protocol `get-native-symbols` with the matching MCP tool `get_native_symbols`.

When symbols are stripped too, unwind data still recovers function boundaries: `.pdata` on Windows (x64 and ARM64 packed and chained forms), `.eh_frame` on Linux, `LC_FUNCTION_STARTS` on macOS. That is enough for counts and size histograms, with the caveat — stated in the docs, not just here — that unwind data can miss leaf and thunk functions, so a boundary-only tree understates slightly.

Every format is pinned by synthetic images that run on all platforms (hand-built MSF containers, DWARF blobs exercising the form matrix byte for byte, ELF and Mach-O builders), and each CI leg tests its real artifact end to end: source and status, managed joins, file:line on a user function, data categories. The macOS leg zeroes LC_SYMTAB on a copy so the FUNCTION_STARTS path runs deterministically regardless of what strip -x left. On scale, scout's 5.7 MB win-x64 exe yields 11,109 `.pdata` boundaries in well under a second and the sample's 6.9 MB PDB parses in about 36 ms; benchmarks cover the read, the fallback, and the constructor's PDB probe, with M4 Pro baselines recorded as before.

Fixes #177
