### PR TITLE
Window the IL tree so fully expanded native trees scroll to the bottom

### DIFF
--- a/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
+++ b/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
@@ -784,8 +784,11 @@ internal sealed class DotsiderDiagnosticsListener(
             s.Tracer.Start();
         });
 
-        // Trigger a render frame so the mutation queue gets drained
+        // Trigger a render frame so the mutation queue gets drained. The socket-thread
+        // invalidate can race an in-flight frame and be drained by the Hex1b main loop;
+        // the nudger guarantees a build actually runs.
         state.App.Invalidate();
+        state.RequestExtraFrame();
 
         return DotsiderResponse.Ok(new { Message = "Trace start queued" });
     }
@@ -847,8 +850,11 @@ internal sealed class DotsiderDiagnosticsListener(
             s.NavigateToTab(tabIndex);
         });
 
-        // Trigger a render frame so the mutation queue gets drained
+        // Trigger a render frame so the mutation queue gets drained. The socket-thread
+        // invalidate can race an in-flight frame and be drained by the Hex1b main loop;
+        // the nudger guarantees a build actually runs.
         state.App.Invalidate();
+        state.RequestExtraFrame();
 
         return DotsiderResponse.Ok(new { Message = $"Navigation to tab {tabId} queued" });
     }
@@ -870,8 +876,11 @@ internal sealed class DotsiderDiagnosticsListener(
             search.Confirm();
         });
 
-        // Trigger a render frame so the mutation queue gets drained
+        // Trigger a render frame so the mutation queue gets drained. The socket-thread
+        // invalidate can race an in-flight frame and be drained by the Hex1b main loop;
+        // the nudger guarantees a build actually runs.
         state.App.Invalidate();
+        state.RequestExtraFrame();
 
         return DotsiderResponse.Ok(new { Message = $"Search for '{request.Query}' queued on tab {tabId}" });
     }
@@ -962,6 +971,7 @@ internal sealed class DotsiderDiagnosticsListener(
             s.App.Invalidate();
         });
         state.App.Invalidate();
+        state.RequestExtraFrame();
         return DotsiderResponse.Ok(new { Status = "queued" });
     }
 
@@ -999,6 +1009,7 @@ internal sealed class DotsiderDiagnosticsListener(
             }
         });
         state.App.Invalidate();
+        state.RequestExtraFrame();
         return DotsiderResponse.Ok(new { Status = "queued" });
     }
 
@@ -1053,6 +1064,7 @@ internal sealed class DotsiderDiagnosticsListener(
         }
 
         state.App.Invalidate();
+        state.RequestExtraFrame();
         return DotsiderResponse.Ok(new { Status = "queued" });
     }
 

--- a/src/Dotsider/Dotsider.csproj
+++ b/src/Dotsider/Dotsider.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hex1b" Version="0.149.0" />
+    <PackageReference Include="Hex1b" Version="0.165.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.7" />
   </ItemGroup>
 

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -30,6 +30,11 @@ public sealed class DotsiderApp(DotsiderState state)
     /// <returns>The root widget of the application.</returns>
     public Hex1bWidget Build(RootContext ctx)
     {
+        // A new build is running: advance the generation so any in-flight extra-frame
+        // nudger stops, and allow this build's views to arm a fresh one if needed.
+        unchecked { _state.BuildGeneration++; }
+        _state.ExtraFrameArmed = false;
+
         // Drain pending mutations from the diagnostics socket listener
         while (_state.PendingMutations.TryDequeue(out var mutation))
             mutation(_state);
@@ -834,6 +839,8 @@ public sealed class DotsiderApp(DotsiderState state)
         state.IlEditorField = null;
         state.IlScrollPanelNode = null;
         state.IlScrollSelectionIntoViewPending = false;
+        state.IlTreeScrollOffset = 0;
+        state.IlTreeWindowViewport = 0;
         state.IlEditorKeyCache.Clear();
         state.IlCachedEditors.Clear();
         state.IlInstructions = null;

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -271,8 +271,46 @@ public sealed class DotsiderState : IDisposable
     internal FieldDefInfo? IlEditorField { get; set; }
 
     /// <summary>Cached scroll-panel node hosting the IL tree. Captured each render via
-    /// the <see cref="Hex1bApp.Focusables"/> scan in <see cref="Views.IlInspectorView"/>.</summary>
+    /// the <see cref="Hex1bApp.Focusables"/> scan in <see cref="Views.IlInspectorView"/>.
+    /// The panel's child is a viewport-sized window of rows, so the node itself never
+    /// scrolls; it serves as the focusable input host and the viewport-height source.</summary>
     internal ScrollPanelNode? IlScrollPanelNode { get; set; }
+
+    /// <summary>
+    /// First visible row index of the IL tree — the tree's scroll offset, owned by state
+    /// rather than the <see cref="ScrollPanelNode"/>. Hex1b clamps a scroll child's render
+    /// surface to 10,000 rows, so trees past that (fully expanded native trees) go blank
+    /// when the panel itself translates; instead the view renders only the visible window
+    /// of rows and this offset selects it. Clamped to the row count during each build.
+    /// </summary>
+    internal int IlTreeScrollOffset { get; set; }
+
+    /// <summary>
+    /// Monotonic count of widget builds, advanced at the top of
+    /// <see cref="DotsiderApp.Build"/>. The deferred nudger behind
+    /// <see cref="RequestExtraFrame"/> watches it to know a new build has run and stop.
+    /// </summary>
+    internal int BuildGeneration { get; set; }
+
+    /// <summary>
+    /// Whether a deferred extra-frame nudger is in flight. Cleared at the top of each
+    /// build; prevents one build's multiple requests from stacking duplicate nudgers.
+    /// </summary>
+    internal bool ExtraFrameArmed { get; set; }
+
+    /// <summary>
+    /// The viewport height the current tree window was built against, recorded by
+    /// <see cref="Views.IlTreeList.Build"/>. The verifier behind
+    /// <see cref="RequestIlTreeViewportCheck"/> compares it to the panel's arranged
+    /// <see cref="ScrollPanelNode.ViewportSize"/> after the frame.
+    /// </summary>
+    internal int IlTreeWindowViewport { get; set; }
+
+    /// <summary>
+    /// Whether a tree viewport verifier is in flight. At most one runs at a time; it
+    /// disarms itself on exit.
+    /// </summary>
+    internal bool IlTreeViewportCheckArmed { get; set; }
 
     /// <summary>One-shot flag set by <see cref="SetIlFocusedTreeKey"/> so the next IL
     /// Inspector render scrolls the focused row into view. Cleared by the consumer in
@@ -1111,6 +1149,75 @@ public sealed class DotsiderState : IDisposable
         IlFocusedTreeKey = key;
         IlScrollSelectionIntoViewPending = true;
         App.Invalidate();
+        // The immediate invalidate can race an in-flight frame and be drained by the
+        // Hex1b main loop without producing a build; the nudger guarantees one runs.
+        RequestExtraFrame();
+    }
+
+    /// <summary>
+    /// Guarantees a follow-up widget build. An <see cref="Hex1bApp.Invalidate"/> that
+    /// lands while a frame is still rendering is drained by the Hex1b main loop's
+    /// frame-rate guard without producing another frame — and the frame in flight can
+    /// be arbitrarily slow (a first IL render disassembles the selected method). The
+    /// nudger keeps invalidating on a short period until it observes
+    /// <see cref="BuildGeneration"/> advance (a new build ran) or its attempt budget
+    /// runs out. At most one nudger is in flight; each build re-arms eligibility.
+    /// </summary>
+    internal void RequestExtraFrame()
+    {
+        if (ExtraFrameArmed) return;
+        ExtraFrameArmed = true;
+
+        var generation = BuildGeneration;
+        _ = Task.Run(async () =>
+        {
+            for (var attempt = 0; attempt < 50; attempt++)
+            {
+                await Task.Delay(16).ConfigureAwait(false);
+                // The first nudge is unconditional: a caller racing the top of a root
+                // build can capture that build's generation, and a build already in
+                // flight when the request was made cannot have honored it. One extra
+                // frame at worst; later ticks stop as soon as a new build runs.
+                if (attempt > 0 && BuildGeneration != generation) return;
+                App.Invalidate();
+            }
+        });
+    }
+
+    /// <summary>
+    /// Verifies, after the frame, that the tree window was built against the viewport
+    /// height the panel actually arranged to. The window is sized from the previous
+    /// frame's layout, so a render that changes the pane height (search bar toggle,
+    /// terminal resize) leaves the tree underfilled or over-scrolled with nothing else
+    /// scheduling a rebuild. The verifier polls the live panel and nudges builds until
+    /// <see cref="IlTreeWindowViewport"/> matches the arranged
+    /// <see cref="ScrollPanelNode.ViewportSize"/> or its budget runs out. At most one
+    /// is in flight; it disarms on exit so the next build can re-arm.
+    /// </summary>
+    internal void RequestIlTreeViewportCheck()
+    {
+        if (CurrentTab != TabId.IlInspector) return;
+        if (IlTreeViewportCheckArmed) return;
+        IlTreeViewportCheckArmed = true;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                for (var attempt = 0; attempt < 50; attempt++)
+                {
+                    await Task.Delay(16).ConfigureAwait(false);
+                    var live = IlScrollPanelNode?.ViewportSize ?? 0;
+                    if (live <= 0) continue;
+                    if (live == IlTreeWindowViewport) return;
+                    App.Invalidate();
+                }
+            }
+            finally
+            {
+                IlTreeViewportCheckArmed = false;
+            }
+        });
     }
 
     /// <summary>
@@ -1594,6 +1701,8 @@ public sealed class DotsiderState : IDisposable
         IlEditorField = null;
         IlScrollPanelNode = null;
         IlScrollSelectionIntoViewPending = false;
+        IlTreeScrollOffset = 0;
+        IlTreeWindowViewport = 0;
         IlEditorKeyCache.Clear();
         IlNativeEditorKeyCache.Clear();
         IlCachedEditors.Clear();

--- a/src/Dotsider/NuGetApp.cs
+++ b/src/Dotsider/NuGetApp.cs
@@ -31,9 +31,12 @@ public sealed class NuGetApp(NuGetState state)
         if (_state.SelectedDllState is { PerformEditorYank: null } dllSetup)
             dllSetup.PerformEditorYank = PerformEditorYank;
 
-        // Drain pending mutations from the diagnostics socket listener
+        // Drain pending mutations from the diagnostics socket listener. Advancing the
+        // build generation stops any in-flight extra-frame nudger armed by the listener.
         if (_state.SelectedDllState is { } dllState)
         {
+            unchecked { dllState.BuildGeneration++; }
+            dllState.ExtraFrameArmed = false;
             while (dllState.PendingMutations.TryDequeue(out var mutation))
                 mutation(dllState);
         }

--- a/src/Dotsider/Views/DependencyGraphView.cs
+++ b/src/Dotsider/Views/DependencyGraphView.cs
@@ -582,12 +582,15 @@ public static class DependencyGraphView
         // against the pre-rebuild snapshot. Compare the new geometry against what the
         // scrollbar saw and schedule one extra frame on change so the next render reflects
         // the new ContentHeight/viewport. The snapshot guard prevents an invalidation loop:
-        // we invalidate only when the geometry actually moved.
+        // we invalidate only when the geometry actually moved. This runs mid-render, where
+        // a bare Invalidate is drained by the Hex1b main loop's frame-rate guard — the
+        // nudger guarantees the extra build actually happens.
         var newSnapshot = (key.Width, key.Height, built.ContentHeight);
         if (state.DepGraphScrollbarSnapshot != newSnapshot)
         {
             state.DepGraphScrollbarSnapshot = newSnapshot;
             state.App.Invalidate();
+            state.RequestExtraFrame();
         }
 
         return built;

--- a/src/Dotsider/Views/IlInspectorView.cs
+++ b/src/Dotsider/Views/IlInspectorView.cs
@@ -135,65 +135,7 @@ public static class IlInspectorView
         var treeRows = isNative ? BuildNativeTreeRows(state) : BuildTreeRows(state);
         var formattedRows = treeRows.Select(r => FormatTreeRow(r, state)).ToList();
 
-        // Capture the ScrollPanelNode that hosts the tree from App.Focusables.
-        // ScrollPanelNode enters the focus ring after the focus-ring rebuild, which
-        // happens on frame 2 after a tab switch. The bootstrap invalidate below kicks
-        // a second frame so first-arrival rendering and pending-scroll consumption
-        // do not have to wait for user input.
-        if (state.IlScrollPanelNode is null || !state.App.Focusables.Contains(state.IlScrollPanelNode))
-        {
-            state.IlScrollPanelNode = null;
-            foreach (var node in state.App.Focusables)
-            {
-                if (node is ScrollPanelNode sp)
-                {
-                    state.IlScrollPanelNode = sp;
-                    break;
-                }
-            }
-        }
-
-        // Pending-scroll consumer. The flag is armed by SetIlFocusedTreeKey at every
-        // non-user-driven mutation site (cross-view jumps, search match navigation,
-        // back navigation). It is cleared only when the consumer can make a final,
-        // well-clamped decision: panel captured AND ContentSize matches the freshly
-        // built rows. Until both are true, request another frame and try again — this
-        // is how external first-arrival jumps land in the viewport even though the
-        // panel is null on frame 1, and how same-frame tree expansions still scroll
-        // correctly after the next layout grows the content.
-        if (state.IlScrollSelectionIntoViewPending)
-        {
-            if (state.IlFocusedTreeKey is not string pendingKey)
-            {
-                state.IlScrollSelectionIntoViewPending = false;
-            }
-            else if (IlTreeList.FindRowIndex(treeRows, pendingKey) is var pendingIdx && pendingIdx < 0)
-            {
-                state.IlScrollSelectionIntoViewPending = false;
-            }
-            else if (state.IlScrollPanelNode is not { } pendingSp
-                     || pendingSp.ViewportSize <= 0
-                     || pendingSp.ContentSize != treeRows.Count)
-            {
-                state.App.Invalidate();
-            }
-            else
-            {
-                EnsureSelectionVisible(pendingSp, pendingIdx);
-                state.IlScrollSelectionIntoViewPending = false;
-            }
-        }
-
-        // First-arrival bootstrap: the ScrollPanelNode is reconciled but does not enter
-        // App.Focusables until the next focus-ring rebuild. Without an extra frame,
-        // the scrollbar would stay invisible until the user pressed a key. The
-        // invalidate self-terminates the moment the panel is captured.
-        if (state.CurrentTab == TabId.IlInspector
-            && state.IlScrollPanelNode is null
-            && treeRows.Count > 0)
-        {
-            state.App.Invalidate();
-        }
+        SyncTreeScroll(state, treeRows);
 
         return ctx.VStack(outer =>
         {
@@ -204,7 +146,8 @@ public static class IlInspectorView
 
             // Main content: HSplitter with tree list on left, disassembly editor on right
             widgets.Add(outer.HSplitter(
-                // Left pane: scroll-panel-hosted tree list (provides its own scrollbar)
+                // Left pane: windowed tree list (panel hosts the visible rows; a
+                // standalone scrollbar gutter appears when content overflows)
                 left =>
                 [
                     IlTreeList.Build(
@@ -461,7 +404,9 @@ public static class IlInspectorView
             : "  ";
         var marker = row.Kind switch
         {
-            IlTreeRowKind.Method when row.Method?.Token == state.IlSelectedMethod?.Token => "● ",
+            // row.Method must be non-null: native leaves carry a null Method, and with
+            // no managed selection `null == null` would mark every native row.
+            IlTreeRowKind.Method when row.Method is { } m && m.Token == state.IlSelectedMethod?.Token => "● ",
             IlTreeRowKind.Method when row.Symbol is { } nsym
                 && nsym.VirtualAddress == state.IlSelectedNativeSymbol?.VirtualAddress => "● ",
             IlTreeRowKind.Type when row.Method is null
@@ -786,33 +731,102 @@ public static class IlInspectorView
     }
 
     /// <summary>
-    /// Sets <paramref name="sp"/>'s <see cref="ScrollPanelNode.Offset"/> so the row at
-    /// <paramref name="rowIndex"/> sits inside the viewport. No-op when the row is
-    /// already visible. The setter clamps to <c>[0, MaxOffset]</c> internally.
+    /// Per-render scroll bookkeeping for the tree, called by <see cref="Build"/> with the
+    /// freshly built rows: captures the panel node from <see cref="Hex1bApp.Focusables"/>,
+    /// consumes the pending scroll-into-view request once the panel is arranged, and keeps
+    /// invalidating until first arrival completes. Internal so the virtualization tests
+    /// drive the same capture/pending logic the view runs.
     /// </summary>
-    /// <param name="sp">The IL tree's scroll panel.</param>
-    /// <param name="rowIndex">The target row index in the flattened tree.</param>
-    internal static void EnsureSelectionVisible(ScrollPanelNode sp, int rowIndex)
+    /// <param name="state">The shared application state.</param>
+    /// <param name="treeRows">The rows built for this render.</param>
+    internal static void SyncTreeScroll(DotsiderState state, IReadOnlyList<IlTreeRow> treeRows)
     {
-        if (rowIndex < sp.Offset)
-            sp.Offset = rowIndex;
-        else if (rowIndex >= sp.Offset + sp.ViewportSize)
-            sp.Offset = rowIndex - sp.ViewportSize + 1;
+        // Only the root build advances BuildGeneration (DotsiderApp.Build; the tests'
+        // harness builder mirrors it). Advancing it here — mid-frame — would make a
+        // nudger armed concurrently from a socket thread believe a later build already
+        // ran and exit without nudging, dropping the very invalidation it protects.
+
+        // Capture the ScrollPanelNode that hosts the tree from App.Focusables.
+        // ScrollPanelNode enters the focus ring after the focus-ring rebuild, which
+        // happens on frame 2 after a tab switch. The bootstrap invalidate below kicks
+        // a second frame so first-arrival rendering and pending-scroll consumption
+        // do not have to wait for user input.
+        if (state.IlScrollPanelNode is null || !state.App.Focusables.Contains(state.IlScrollPanelNode))
+        {
+            state.IlScrollPanelNode = null;
+            foreach (var node in state.App.Focusables)
+            {
+                if (node is ScrollPanelNode sp)
+                {
+                    state.IlScrollPanelNode = sp;
+                    break;
+                }
+            }
+        }
+
+        // Pending-scroll consumer. The flag is armed by SetIlFocusedTreeKey at every
+        // non-user-driven mutation site (cross-view jumps, search match navigation,
+        // back navigation). It is cleared only when the consumer can make a final,
+        // well-clamped decision: the panel is captured and arranged, so its viewport
+        // height and the freshly built rows fully determine the offset. Until then,
+        // request another frame and try again — this is how external first-arrival
+        // jumps land in the viewport even though the panel is null on frame 1.
+        if (state.IlScrollSelectionIntoViewPending)
+        {
+            if (state.IlFocusedTreeKey is not string pendingKey)
+            {
+                state.IlScrollSelectionIntoViewPending = false;
+            }
+            else if (IlTreeList.FindRowIndex(treeRows, pendingKey) is var pendingIdx && pendingIdx < 0)
+            {
+                state.IlScrollSelectionIntoViewPending = false;
+            }
+            else if (state.IlScrollPanelNode is not { } pendingSp || pendingSp.ViewportSize <= 0)
+            {
+                state.RequestExtraFrame();
+            }
+            else
+            {
+                EnsureSelectionVisible(state, pendingSp, pendingIdx, treeRows.Count);
+                state.IlScrollSelectionIntoViewPending = false;
+            }
+        }
+
+        // First-arrival bootstrap: the ScrollPanelNode is reconciled but does not enter
+        // App.Focusables until the next focus-ring rebuild. Without an extra frame,
+        // the tree renders at its fallback window and the scrollbar stays invisible
+        // until the user presses a key. The retry self-terminates the moment the panel
+        // is captured.
+        if (state.CurrentTab == TabId.IlInspector
+            && state.IlScrollPanelNode is null
+            && treeRows.Count > 0)
+        {
+            state.RequestExtraFrame();
+        }
     }
 
     /// <summary>
-    /// Convenience overload that resolves the panel from
-    /// <see cref="DotsiderState.IlScrollPanelNode"/>. No-op when the panel is not yet
-    /// captured — callers wanting first-arrival scroll should also arm
-    /// <see cref="DotsiderState.IlScrollSelectionIntoViewPending"/> via
-    /// <see cref="DotsiderState.SetIlFocusedTreeKey"/>.
+    /// Adjusts <see cref="DotsiderState.IlTreeScrollOffset"/> so the row at
+    /// <paramref name="rowIndex"/> sits inside the viewport. No-op when the row is
+    /// already visible or the panel has not been arranged yet. The result is clamped
+    /// to <c>[0, rowCount - viewport]</c>; the next build renders the new window.
     /// </summary>
-    /// <param name="state">The shared application state.</param>
+    /// <param name="state">The shared application state owning the scroll offset.</param>
+    /// <param name="sp">The IL tree's scroll panel (the viewport-height source).</param>
     /// <param name="rowIndex">The target row index in the flattened tree.</param>
-    internal static void EnsureSelectionVisible(DotsiderState state, int rowIndex)
+    /// <param name="rowCount">The current flattened row count, for clamping.</param>
+    internal static void EnsureSelectionVisible(DotsiderState state, ScrollPanelNode sp, int rowIndex, int rowCount)
     {
-        if (state.IlScrollPanelNode is { } sp)
-            EnsureSelectionVisible(sp, rowIndex);
+        var viewport = sp.ViewportSize;
+        if (viewport <= 0) return;
+
+        var offset = state.IlTreeScrollOffset;
+        if (rowIndex < offset)
+            offset = rowIndex;
+        else if (rowIndex >= offset + viewport)
+            offset = rowIndex - viewport + 1;
+
+        state.IlTreeScrollOffset = Math.Clamp(offset, 0, Math.Max(0, rowCount - viewport));
     }
 
     internal static bool GetExpansionState(DotsiderState state, string key, bool defaultExpanded) =>

--- a/src/Dotsider/Views/IlTreeList.cs
+++ b/src/Dotsider/Views/IlTreeList.cs
@@ -7,16 +7,28 @@ using Hex1b.Widgets;
 namespace Dotsider.Views;
 
 /// <summary>
-/// Builds the IL Inspector's namespace/type/method tree as a non-focusable VStack
-/// of <see cref="TextBlockWidget"/> rows wrapped in a <see cref="ScrollPanelWidget"/>.
-/// The panel owns viewport scrolling, the scrollbar gutter, mouse wheel, thumb drag,
-/// and track-click pagination — independent of the selected row, so wheel scrolls
-/// can push the selection offscreen and stay there. Selection lives in
-/// <see cref="DotsiderState.IlFocusedTreeKey"/>; keyboard handlers move the key and
-/// pull the viewport along via <see cref="IlInspectorView.EnsureSelectionVisible(ScrollPanelNode, int)"/>.
+/// Builds the IL Inspector's namespace/type/method tree as a windowed row list: a
+/// <see cref="ScrollPanelWidget"/> hosting only the visible rows plus the
+/// <see cref="IlTreeScrollbar"/> gutter column. The panel never scrolls itself — Hex1b
+/// clamps a scroll child's render surface to 10,000 rows, which blanks fully expanded
+/// native trees — so the scroll offset lives in <see cref="DotsiderState.IlTreeScrollOffset"/>
+/// and each render materializes rows <c>[offset, offset + viewport)</c>. The panel is the
+/// tree's only focusable and owns all input: keys, wheel, row clicks, and gutter presses
+/// (thumb drag, track-click pagination). Scrolling stays independent of the selection, so
+/// wheel scrolls can push the selection offscreen and stay there. Selection lives in
+/// <see cref="DotsiderState.IlFocusedTreeKey"/>; keyboard handlers move the key and pull
+/// the viewport along via <see cref="IlInspectorView.EnsureSelectionVisible(DotsiderState, ScrollPanelNode, int, int)"/>.
 /// </summary>
 internal static class IlTreeList
 {
+    /// <summary>
+    /// Rows rendered on the first frame, before the panel has been captured and its
+    /// viewport height is known. Generous enough to fill any plausible terminal; the
+    /// bootstrap invalidate in <see cref="IlInspectorView"/> re-renders with the exact
+    /// height one frame later.
+    /// </summary>
+    private const int FallbackViewportRows = 256;
+
     /// <summary>
     /// Builds the tree-list widget tree.
     /// </summary>
@@ -35,7 +47,7 @@ internal static class IlTreeList
     /// collapsed row.</param>
     /// <param name="collapseRow">Invoked when LeftArrow targets an expandable
     /// expanded row.</param>
-    /// <returns>A composed <see cref="ScrollPanelWidget"/>-rooted widget tree.</returns>
+    /// <returns>The composed <see cref="ScrollPanelWidget"/>-rooted tree widget.</returns>
     internal static Hex1bWidget Build(
         IReadOnlyList<IlTreeRow> rows,
         IReadOnlyList<string> formattedRows,
@@ -47,12 +59,25 @@ internal static class IlTreeList
     {
         var selectedIndex = ResolveEffectiveIndex(rows, state.IlFocusedTreeKey);
 
-        var rowWidgets = new Hex1bWidget[formattedRows.Count];
-        for (var i = 0; i < formattedRows.Count; i++)
+        // Viewport height comes from the panel arranged last frame; frame 1 renders a
+        // generous window from the current offset until the panel is captured.
+        var hasViewport = state.IlScrollPanelNode is { ViewportSize: > 0 };
+        var viewportH = hasViewport ? state.IlScrollPanelNode!.ViewportSize : FallbackViewportRows;
+
+        // Clamp the state-owned offset against the current rows (collapse shrinks them).
+        var maxOffset = Math.Max(0, rows.Count - viewportH);
+        state.IlTreeScrollOffset = Math.Clamp(state.IlTreeScrollOffset, 0, maxOffset);
+        var offset = state.IlTreeScrollOffset;
+
+        // Materialize only the visible window. Rows outside it never become widgets, so
+        // the scroll child stays viewport-sized regardless of the total row count.
+        var windowCount = Math.Max(0, Math.Min(viewportH, rows.Count - offset));
+        var rowWidgets = new Hex1bWidget[windowCount];
+        for (var i = 0; i < windowCount; i++)
         {
-            var text = formattedRows[i];
-            Hex1bWidget rowWidget = new TextBlockWidget(text);
-            if (i == selectedIndex)
+            var rowIndex = offset + i;
+            Hex1bWidget rowWidget = new TextBlockWidget(formattedRows[rowIndex]);
+            if (rowIndex == selectedIndex)
             {
                 // Pull selection colors from the active theme's ListTheme so the IL
                 // tree's selected row matches whatever the rest of the app's lists
@@ -68,12 +93,23 @@ internal static class IlTreeList
 
         var stack = new VStackWidget(rowWidgets).FillWidth();
 
-        return new ScrollPanelWidget(stack, ScrollOrientation.Vertical, showScrollbar: true)
+        // The gutter is rendered inside the panel's child so the panel's bounds cover it:
+        // Hex1b routes mouse presses to the focusable hit node, and the panel must be the
+        // tree's only focusable — presses on the gutter column reach the panel's drag
+        // binding below. When the content fits (or the viewport is not yet known), the
+        // gutter slot collapses to zero width so rows span the full pane.
+        var treeScrollable = hasViewport && rows.Count > viewportH;
+        var gutter = treeScrollable
+            ? IlTreeScrollbar.Build(state, rows.Count, viewportH)
+            : new TextBlockWidget(string.Empty).FixedWidth(0);
+        var content = new HStackWidget([stack, gutter]).FillWidth();
+
+        var panel = new ScrollPanelWidget(content, ScrollOrientation.Vertical, showScrollbar: false)
             .InputBindings(bindings =>
             {
-                // Replace the panel's default scroll-the-viewport keys with
-                // selection-driven navigation. The wheel and gutter-drag defaults
-                // (MouseScrollUpAction/MouseScrollDownAction, Drag(Left)) stay in place.
+                // The panel's own scrolling is inert (its child is viewport-sized), but
+                // its defaults would still swallow the keys and the wheel — replace them
+                // with selection-driven navigation and state-offset wheel scrolling.
                 bindings.Remove(ScrollPanelWidget.ScrollUpAction);
                 bindings.Remove(ScrollPanelWidget.ScrollDownAction);
                 bindings.Remove(ScrollPanelWidget.ScrollLeftAction);
@@ -82,6 +118,8 @@ internal static class IlTreeList
                 bindings.Remove(ScrollPanelWidget.PageDownAction);
                 bindings.Remove(ScrollPanelWidget.ScrollToStartAction);
                 bindings.Remove(ScrollPanelWidget.ScrollToEndAction);
+                bindings.Remove(ScrollPanelWidget.MouseScrollUpAction);
+                bindings.Remove(ScrollPanelWidget.MouseScrollDownAction);
 
                 bindings.Key(Hex1bKey.UpArrow).Action(e =>
                     MoveSelection(e, rows, state, selectionChanged, -1), "Move up");
@@ -121,18 +159,38 @@ internal static class IlTreeList
                 bindings.Key(Hex1bKey.RightArrow).Action(e =>
                     HandleRight(e, rows, state, selectionChanged, expandRow), "Expand / child");
 
+                // Wheel scrolls the viewport only — the selection stays put, even
+                // offscreen, mirroring the old panel's decoupled wheel behavior.
+                bindings.Mouse(MouseButton.ScrollUp).Action(_ =>
+                    ScrollViewport(state, rows.Count, -3), "Scroll up");
+
+                bindings.Mouse(MouseButton.ScrollDown).Action(_ =>
+                    ScrollViewport(state, rows.Count, +3), "Scroll down");
+
+                // Gutter presses: thumb drag or track-click paging. Row-area presses
+                // return an empty handler, which Hex1b treats as a rejected drag and
+                // falls through to the Left-click row selection below.
+                bindings.Drag(MouseButton.Left).Action((localX, localY) =>
+                {
+                    var sp = state.IlScrollPanelNode;
+                    if (sp is null || rows.Count <= sp.ViewportSize) return new DragHandler();
+                    if (localX < sp.Bounds.Width - 1) return new DragHandler();
+                    return IlTreeScrollbar.HandleDrag(state, rows.Count, sp.ViewportSize, localY);
+                }, "Drag scrollbar");
+
                 bindings.Mouse(MouseButton.Left).Action(e =>
                 {
                     if (e.FocusedNode is not ScrollPanelNode sp) return;
                     if (rows.Count == 0) return;
 
-                    // The rightmost column is the scrollbar gutter only when the panel
-                    // is actually scrollable; when content fits, that column is normal
-                    // row area and a click there must still select the row.
+                    // The rightmost column is the scrollbar gutter only when the tree
+                    // actually overflows; when content fits, that column is normal row
+                    // area and a click there must still select the row.
                     var localX = e.MouseX - sp.Bounds.X;
-                    if (sp.IsScrollable && localX >= sp.Bounds.Width - 1) return;
+                    if (localX < 0 || localX >= sp.Bounds.Width) return;
+                    if (rows.Count > sp.ViewportSize && localX >= sp.Bounds.Width - 1) return;
 
-                    var rowIndex = (e.MouseY - sp.Bounds.Y) + sp.Offset;
+                    var rowIndex = (e.MouseY - sp.Bounds.Y) + state.IlTreeScrollOffset;
                     if (rowIndex < 0 || rowIndex >= rows.Count) return;
 
                     selectionChanged?.Invoke(rowIndex);
@@ -140,6 +198,14 @@ internal static class IlTreeList
                 }, "Select row");
             })
             .Fill();
+
+        // Record the viewport this window was built against and verify it after the
+        // frame: a render that changes the pane height (search bar toggle, terminal
+        // resize) otherwise leaves a stale window with nothing scheduling a rebuild.
+        state.IlTreeWindowViewport = viewportH;
+        state.RequestIlTreeViewportCheck();
+
+        return panel;
     }
 
     /// <summary>
@@ -178,6 +244,19 @@ internal static class IlTreeList
         return -1;
     }
 
+    /// <summary>
+    /// Moves <see cref="DotsiderState.IlTreeScrollOffset"/> by <paramref name="delta"/>,
+    /// clamped to the scrollable range, without touching the selection.
+    /// </summary>
+    private static void ScrollViewport(DotsiderState state, int rowCount, int delta)
+    {
+        var viewportH = state.IlScrollPanelNode is { ViewportSize: > 0 } sp ? sp.ViewportSize : rowCount;
+        var next = Math.Clamp(state.IlTreeScrollOffset + delta, 0, Math.Max(0, rowCount - viewportH));
+        if (next == state.IlTreeScrollOffset) return;
+        state.IlTreeScrollOffset = next;
+        state.App.Invalidate();
+    }
+
     private static void MoveSelection(
         InputBindingActionContext e,
         IReadOnlyList<IlTreeRow> rows,
@@ -196,13 +275,13 @@ internal static class IlTreeList
         {
             // Boundary: keyboard nav still re-anchors the viewport on the selection
             // even when the index does not move (Up at row 0 after wheel-down, etc.).
-            IlInspectorView.EnsureSelectionVisible(sp, currentIdx);
+            IlInspectorView.EnsureSelectionVisible(state, sp, currentIdx, rows.Count);
             state.App.Invalidate();
             return;
         }
 
         selectionChanged?.Invoke(newIndex);
-        IlInspectorView.EnsureSelectionVisible(sp, newIndex);
+        IlInspectorView.EnsureSelectionVisible(state, sp, newIndex, rows.Count);
         state.App.Invalidate();
     }
 
@@ -221,13 +300,13 @@ internal static class IlTreeList
 
         if (newIndex == currentIdx)
         {
-            IlInspectorView.EnsureSelectionVisible(sp, currentIdx);
+            IlInspectorView.EnsureSelectionVisible(state, sp, currentIdx, rows.Count);
             state.App.Invalidate();
             return;
         }
 
         selectionChanged?.Invoke(newIndex);
-        IlInspectorView.EnsureSelectionVisible(sp, newIndex);
+        IlInspectorView.EnsureSelectionVisible(state, sp, newIndex, rows.Count);
         state.App.Invalidate();
     }
 
@@ -268,7 +347,7 @@ internal static class IlTreeList
             if (rows[i].Depth < row.Depth)
             {
                 selectionChanged?.Invoke(i);
-                IlInspectorView.EnsureSelectionVisible(sp, i);
+                IlInspectorView.EnsureSelectionVisible(state, sp, i, rows.Count);
                 state.App.Invalidate();
                 return;
             }
@@ -299,7 +378,7 @@ internal static class IlTreeList
         {
             var childIdx = idx + 1;
             selectionChanged?.Invoke(childIdx);
-            IlInspectorView.EnsureSelectionVisible(sp, childIdx);
+            IlInspectorView.EnsureSelectionVisible(state, sp, childIdx, rows.Count);
             state.App.Invalidate();
         }
     }

--- a/src/Dotsider/Views/IlTreeScrollbar.cs
+++ b/src/Dotsider/Views/IlTreeScrollbar.cs
@@ -1,0 +1,101 @@
+using Hex1b;
+using Hex1b.Input;
+using Hex1b.Theming;
+using Hex1b.Widgets;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// The IL tree's scrollbar gutter, driven by <see cref="DotsiderState.IlTreeScrollOffset"/>:
+/// a one-column visual (<see cref="Build"/>) rendered inside the tree panel's child, and the
+/// press resolution (<see cref="HandleDrag"/>) the panel binds on its own gutter column —
+/// thumb drag and track-click paging, mirroring the <see cref="ScrollPanelWidget"/> built-in
+/// gutter. The column carries no bindings and nothing focusable: Hex1b routes mouse presses
+/// to the focusable hit node, so the gutter must sit inside the panel's bounds for clicks
+/// to reach it, and the panel must stay the tree's only focusable.
+/// </summary>
+internal static class IlTreeScrollbar
+{
+    /// <summary>
+    /// Builds the gutter column visual for the current scroll state.
+    /// </summary>
+    /// <param name="state">The shared application state owning the scroll offset.</param>
+    /// <param name="rowCount">The total flattened tree row count (the content size).</param>
+    /// <param name="viewportSize">The tree viewport height in rows (the track length).</param>
+    /// <returns>The one-column gutter widget.</returns>
+    internal static Hex1bWidget Build(DotsiderState state, int rowCount, int viewportSize)
+    {
+        var (thumbPosition, thumbSize) = ThumbMetrics(state, rowCount, viewportSize);
+
+        var cells = new Hex1bWidget[viewportSize];
+        for (var y = 0; y < viewportSize; y++)
+        {
+            var isThumb = y >= thumbPosition && y < thumbPosition + thumbSize;
+            // Glyphs match Hex1b's ScrollTheme defaults; colors come from the live theme.
+            cells[y] = new ThemePanelWidget(
+                theme => theme.Set(GlobalTheme.ForegroundColor,
+                    theme.Get(isThumb ? ScrollTheme.ThumbColor : ScrollTheme.TrackColor)),
+                new TextBlockWidget(isThumb ? "▉" : "│"));
+        }
+
+        return new VStackWidget(cells).FixedWidth(1);
+    }
+
+    /// <summary>
+    /// Resolves a Left press on the gutter column: a drag handler when it lands on the
+    /// thumb, otherwise a one-page jump toward the press — the same behavior as the
+    /// <see cref="ScrollPanelWidget"/> gutter.
+    /// </summary>
+    /// <param name="state">The shared application state owning the scroll offset.</param>
+    /// <param name="rowCount">The total flattened tree row count.</param>
+    /// <param name="viewportSize">The tree viewport height in rows.</param>
+    /// <param name="localY">The press row relative to the panel top.</param>
+    /// <returns>The drag handler; empty when the tree is not scrollable.</returns>
+    internal static DragHandler HandleDrag(DotsiderState state, int rowCount, int viewportSize, int localY)
+    {
+        var maxOffset = Math.Max(0, rowCount - viewportSize);
+        if (maxOffset == 0) return new DragHandler();
+
+        var (thumbPosition, thumbSize) = ThumbMetrics(state, rowCount, viewportSize);
+        if (localY >= thumbPosition && localY < thumbPosition + thumbSize)
+        {
+            // Thumb drag: same content-per-cell ratio as the panel gutter. The start
+            // offset is captured once so rebuilds during the drag cannot skew the delta.
+            var startOffset = state.IlTreeScrollOffset;
+            var scrollRange = viewportSize - thumbSize;
+            var contentPerCell = scrollRange > 0 ? (double)maxOffset / scrollRange : 0;
+            return DragHandler.Simple(onMove: (_, deltaY) =>
+            {
+                if (contentPerCell <= 0) return;
+                var next = (int)Math.Round(startOffset + deltaY * contentPerCell);
+                SetOffset(state, Math.Clamp(next, 0, maxOffset));
+            });
+        }
+
+        // Track click: page toward the press, one viewport minus a row of overlap.
+        var page = Math.Max(1, viewportSize - 1);
+        var delta = localY < thumbPosition ? -page : +page;
+        SetOffset(state, Math.Clamp(state.IlTreeScrollOffset + delta, 0, maxOffset));
+        return new DragHandler();
+    }
+
+    /// <summary>Computes the thumb position and size with the ScrollPanelNode gutter math.</summary>
+    private static (int Position, int Size) ThumbMetrics(DotsiderState state, int rowCount, int viewportSize)
+    {
+        var maxOffset = Math.Max(0, rowCount - viewportSize);
+        var offset = Math.Clamp(state.IlTreeScrollOffset, 0, maxOffset);
+        var thumbSize = Math.Max(1, (int)Math.Ceiling((double)viewportSize / rowCount * viewportSize));
+        var scrollRange = viewportSize - thumbSize;
+        var thumbPosition = scrollRange > 0 && maxOffset > 0
+            ? (int)Math.Round((double)offset / maxOffset * scrollRange)
+            : 0;
+        return (thumbPosition, thumbSize);
+    }
+
+    private static void SetOffset(DotsiderState state, int next)
+    {
+        if (next == state.IlTreeScrollOffset) return;
+        state.IlTreeScrollOffset = next;
+        state.App.Invalidate();
+    }
+}

--- a/tests/Dotsider.Tests/EscapeTimeoutPresentationAdapterTests.cs
+++ b/tests/Dotsider.Tests/EscapeTimeoutPresentationAdapterTests.cs
@@ -123,18 +123,15 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(escAdapter)
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(ctx =>
             {
-                return ctx =>
-                {
-                    return ctx.TextBox()
-                        .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .InputBindings(bindings =>
-                        {
-                            bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
-                            bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
-                        });
-                };
+                return ctx.TextBox()
+                    .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
+                    .InputBindings(bindings =>
+                    {
+                        bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
+                        bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
+                    });
             })
             .Build();
 
@@ -167,18 +164,15 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(escAdapter)
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(ctx =>
             {
-                return ctx =>
-                {
-                    return ctx.TextBox()
-                        .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .InputBindings(bindings =>
-                        {
-                            bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
-                            bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
-                        });
-                };
+                return ctx.TextBox()
+                    .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
+                    .InputBindings(bindings =>
+                    {
+                        bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
+                        bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
+                    });
             })
             .Build();
 
@@ -214,18 +208,15 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(escAdapter)
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(ctx =>
             {
-                return ctx =>
-                {
-                    return ctx.TextBox()
-                        .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .InputBindings(bindings =>
-                        {
-                            bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
-                            bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
-                        });
-                };
+                return ctx.TextBox()
+                    .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
+                    .InputBindings(bindings =>
+                    {
+                        bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
+                        bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
+                    });
             })
             .Build();
 
@@ -260,19 +251,16 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(escAdapter)
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(ctx =>
             {
-                return ctx =>
-                {
-                    return ctx.TextBox()
-                        .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .InputBindings(bindings =>
-                        {
-                            bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
-                            bindings.Key(Hex1bKey.I).Global().Action(_ => events.Enqueue("i"), "I");
-                            bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
-                        });
-                };
+                return ctx.TextBox()
+                    .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
+                    .InputBindings(bindings =>
+                    {
+                        bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
+                        bindings.Key(Hex1bKey.I).Global().Action(_ => events.Enqueue("i"), "I");
+                        bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
+                    });
             })
             .Build();
 
@@ -310,18 +298,15 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(escAdapter)
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(ctx =>
             {
-                return ctx =>
-                {
-                    return ctx.TextBox()
-                        .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .InputBindings(bindings =>
-                        {
-                            bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
-                            bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
-                        });
-                };
+                return ctx.TextBox()
+                    .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
+                    .InputBindings(bindings =>
+                    {
+                        bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
+                        bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
+                    });
             })
             .Build();
 
@@ -366,19 +351,16 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(escAdapter)
             .WithMouse()
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(ctx =>
             {
-                return ctx =>
-                {
-                    return ctx.TextBox()
-                        .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .InputBindings(bindings =>
-                        {
-                            bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
-                            bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
-                            bindings.Mouse(MouseButton.Left).Action(_ => events.Enqueue("mouse-click"), "Click");
-                        });
-                };
+                return ctx.TextBox()
+                    .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
+                    .InputBindings(bindings =>
+                    {
+                        bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
+                        bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
+                        bindings.Mouse(MouseButton.Left).Action(_ => events.Enqueue("mouse-click"), "Click");
+                    });
             })
             .Build();
 
@@ -443,10 +425,7 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(escAdapter)
             .WithMouse()
-            .WithHex1bApp((app, options) =>
-            {
-                return ctx => ctx.TextBox();
-            })
+            .WithHex1bApp(ctx => ctx.TextBox())
             .Build();
 
         escAdapter.Terminal = terminal;
@@ -490,18 +469,15 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(escAdapter)
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(ctx =>
             {
-                return ctx =>
-                {
-                    return ctx.TextBox()
-                        .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
-                        .InputBindings(bindings =>
-                        {
-                            bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
-                            bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
-                        });
-                };
+                return ctx.TextBox()
+                    .OnTextChanged(args => events.Enqueue($"text:{args.NewText}"))
+                    .InputBindings(bindings =>
+                    {
+                        bindings.Key(Hex1bKey.Escape).Global().Action(_ => events.Enqueue("escape"), "Esc");
+                        bindings.Key(Hex1bKey.UpArrow).Global().Action(_ => events.Enqueue("up"), "Up");
+                    });
             })
             .Build();
 
@@ -548,16 +524,15 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(escAdapter)
             .WithDimensions(120, 30)
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(options =>
             {
                 options.Theme = DotsiderTheme.Create();
                 options.EnableMouse = true;
-                return ctx =>
-                {
-                    state ??= new DotsiderState(app, samples.HelloWorldDll);
-                    dotsiderApp ??= new DotsiderApp(state);
-                    return dotsiderApp.Build(ctx);
-                };
+            }, app => ctx =>
+            {
+                state ??= new DotsiderState(app, samples.HelloWorldDll);
+                dotsiderApp ??= new DotsiderApp(state);
+                return dotsiderApp.Build(ctx);
             })
             .Build();
 
@@ -605,16 +580,15 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(escAdapter)
             .WithDimensions(120, 30)
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(options =>
             {
                 options.Theme = DotsiderTheme.Create();
                 options.EnableMouse = true;
-                return ctx =>
-                {
-                    state ??= new DotsiderState(app, samples.HelloWorldDll);
-                    dotsiderApp ??= new DotsiderApp(state);
-                    return dotsiderApp.Build(ctx);
-                };
+            }, app => ctx =>
+            {
+                state ??= new DotsiderState(app, samples.HelloWorldDll);
+                dotsiderApp ??= new DotsiderApp(state);
+                return dotsiderApp.Build(ctx);
             })
             .Build();
 
@@ -660,28 +634,38 @@ public class EscapeTimeoutPresentationAdapterTests(SampleAssemblyFixture samples
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(escAdapter)
             .WithDimensions(120, 30)
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(options =>
             {
                 options.Theme = DotsiderTheme.Create();
                 options.EnableMouse = true;
-                return ctx =>
-                {
-                    state ??= new DotsiderState(app, samples.HelloWorldDll);
-                    dotsiderApp ??= new DotsiderApp(state);
-                    return dotsiderApp.Build(ctx);
-                };
+            }, app => ctx =>
+            {
+                state ??= new DotsiderState(app, samples.HelloWorldDll);
+                dotsiderApp ??= new DotsiderApp(state);
+                return dotsiderApp.Build(ctx);
             })
             .Build();
 
         escAdapter.Terminal = terminal;
         var runTask = terminal.RunAsync(ct);
 
-        // Activate search, type query, confirm with Enter
+        // Activate search, then wait for the search TextBox to take focus so the query
+        // keystrokes below land in it. The old wait matched the TextBox's "[" chrome on
+        // screen, which is a rendering detail that changes across Hex1b versions.
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
             .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
             .Key(Hex1bKey.OemQuestion) // '/' activates search
-            .WaitUntil(s => s.ContainsText("/ ["), TimeSpan.FromSeconds(10)) // search bar visible
+            .Build()
+            .ApplyAsync(terminal, ct);
+        await TestHelpers.WaitUntilAsync(
+            () => state is not null
+                  && state.Search[state.CurrentTab].IsActive
+                  && state.App.FocusedNode is TextBoxNode,
+            TimeSpan.FromSeconds(10));
+
+        // Type the query and confirm with Enter
+        await new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.S).Key(Hex1bKey.Y).Key(Hex1bKey.S) // "sys"
             .Key(Hex1bKey.Enter) // Confirm search
             .Build()

--- a/tests/Dotsider.Tests/IlEditorLifecycleTests.cs
+++ b/tests/Dotsider.Tests/IlEditorLifecycleTests.cs
@@ -1,4 +1,5 @@
 using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
 using Dotsider.Views;
 using Hex1b;
 using Hex1b.Automation;
@@ -88,14 +89,34 @@ public class IlEditorLifecycleTests(SampleAssemblyFixture samples) : IDisposable
         var ns = !string.IsNullOrEmpty(typeDef.Namespace) ? typeDef.Namespace : "(global)";
         _state.IlTreeExpansionState[$"ns:{ns}"] = true;
         _state.IlTreeExpansionState[$"type:{method.DeclaringType}"] = true;
-        _state.IlSelectedMethod = method;
-        _state.IlFocusedTreeKey = $"method:{method.Token}";
-        _state.App.Invalidate();
+        SelectMethodForRender(method);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.ContainsText("IL_0000"), TimeSpan.FromSeconds(10))
             .Build()
             .ApplyAsync(terminal, ct);
+    }
+
+    /// <summary>
+    /// Programmatically selects a method using the same extra-frame path as
+    /// non-user-driven navigation. A plain Invalidate can race an in-flight frame on
+    /// slower CI legs and leave the editor on the previous method until another input.
+    /// </summary>
+    private void SelectMethodForRender(MethodDefInfo method)
+    {
+        _state!.IlSelectedMethod = method;
+        _state.SetIlFocusedTreeKey($"method:{method.Token}");
+    }
+
+    /// <summary>
+    /// Requests editor focus and nudges a follow-up frame so the focus-ring update is
+    /// observed even if the immediate invalidate lands during an in-flight render.
+    /// </summary>
+    private void RequestEditorFocusForRender()
+    {
+        _state!.App.RequestFocus(node => node is EditorNode);
+        _state.App.Invalidate();
+        _state.RequestExtraFrame();
     }
 
     // ── State-level unit tests ────────────────────────────────
@@ -255,8 +276,7 @@ public class IlEditorLifecycleTests(SampleAssemblyFixture samples) : IDisposable
         await SelectMethodByName(methodA.Name, terminal, ct);
 
         // Focus editor and scroll down
-        _state.App.RequestFocus(node => node is EditorNode);
-        _state.App.Invalidate();
+        RequestEditorFocusForRender();
         await auto.WaitUntilAsync(_ => app.FocusedNode is EditorNode, description: "editor focused");
         for (var i = 0; i < 10; i++)
             await auto.KeyAsync(Hex1bKey.DownArrow, ct: ct);
@@ -270,17 +290,13 @@ public class IlEditorLifecycleTests(SampleAssemblyFixture samples) : IDisposable
 
         // Switch to a different method via tree
         var methodB = _state.Analyzer.MethodDefs.First(m => m.Token != methodA.Token && m.Rva > 0);
-        _state.IlSelectedMethod = methodB;
-        _state.IlFocusedTreeKey = $"method:{methodB.Token}";
-        _state.App.Invalidate();
+        SelectMethodForRender(methodB);
         await auto.WaitUntilAsync(_ => _state.IlEditorMethod?.Token == methodB.Token,
             description: "method B loaded");
 
         // Switch back to original method
-        _state.IlSelectedMethod = methodA;
-        _state.IlFocusedTreeKey = $"method:{methodA.Token}";
-        _state.App.RequestFocus(node => node is EditorNode);
-        _state.App.Invalidate();
+        SelectMethodForRender(methodA);
+        RequestEditorFocusForRender();
         await auto.WaitUntilAsync(_ => _state.IlEditorMethod?.Token == methodA.Token,
             description: "method A reloaded");
         // Wait for StatePanelWidget reconciliation to settle
@@ -314,8 +330,7 @@ public class IlEditorLifecycleTests(SampleAssemblyFixture samples) : IDisposable
         await SelectMethodByName(firstMethod.Name, terminal, ct);
 
         // Focus editor programmatically
-        _state.App.RequestFocus(node => node is EditorNode);
-        _state.App.Invalidate();
+        RequestEditorFocusForRender();
         await auto.WaitUntilAsync(_ => app.FocusedNode is EditorNode, description: "editor focused");
 
         // Find a search query that matches in a DIFFERENT method
@@ -402,9 +417,7 @@ public class IlEditorLifecycleTests(SampleAssemblyFixture samples) : IDisposable
 
         // Populate cached editors by switching methods
         var methodB = _state.Analyzer.MethodDefs.First(m => m.Token != method.Token && m.Rva > 0);
-        _state.IlSelectedMethod = methodB;
-        _state.IlFocusedTreeKey = $"method:{methodB.Token}";
-        _state.App.Invalidate();
+        SelectMethodForRender(methodB);
         await auto.WaitUntilAsync(_ => _state.IlEditorMethod?.Token == methodB.Token,
             description: "method B loaded");
 

--- a/tests/Dotsider.Tests/IlEditorLifecycleTests.cs
+++ b/tests/Dotsider.Tests/IlEditorLifecycleTests.cs
@@ -419,6 +419,9 @@ public class IlEditorLifecycleTests(SampleAssemblyFixture samples) : IDisposable
         _cts!.Cancel();
         await runTask;
 
+        // Give the tree a non-zero scroll offset so the reset below is observable.
+        _state.IlTreeScrollOffset = 7;
+
         // PushAssemblyDirect calls ResetViewState (same path as CommitAnalyzer)
         using var otherAnalyzer = new AssemblyAnalyzer(samples.HelloWorldDll);
         _state.PushAssemblyDirect(otherAnalyzer);
@@ -428,6 +431,7 @@ public class IlEditorLifecycleTests(SampleAssemblyFixture samples) : IDisposable
         Assert.Null(_state.IlEditorField);
         Assert.Null(_state.IlScrollPanelNode);
         Assert.False(_state.IlScrollSelectionIntoViewPending);
+        Assert.Equal(0, _state.IlTreeScrollOffset);
         Assert.Empty(_state.IlEditorKeyCache);
         Assert.Empty(_state.IlCachedEditors);
     }

--- a/tests/Dotsider.Tests/IlInspectorScrollbarTests.cs
+++ b/tests/Dotsider.Tests/IlInspectorScrollbarTests.cs
@@ -122,6 +122,22 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
     private static ScrollPanelNode? FindPanel(Hex1bApp app)
         => SnapshotFocusables(app).OfType<ScrollPanelNode>().FirstOrDefault();
 
+    /// <summary>
+    /// Whether the tree overflows the panel viewport. The panel's own IsScrollable is
+    /// always false under the windowed tree (its child is viewport-sized); scrollability
+    /// is a property of the row count against the viewport.
+    /// </summary>
+    private bool TreeScrollable(ScrollPanelNode sp)
+        => sp.ViewportSize > 0
+           && Views.IlInspectorView.BuildTreeRows(_state!).Count > sp.ViewportSize;
+
+    /// <summary>The tree's maximum scroll offset for the current rows and viewport.</summary>
+    private int TreeMaxOffset(ScrollPanelNode sp)
+        => Math.Max(0, Views.IlInspectorView.BuildTreeRows(_state!).Count - sp.ViewportSize);
+
+    /// <summary>The tree's state-owned scroll offset (first visible row index).</summary>
+    private int TreeOffset => _state!.IlTreeScrollOffset;
+
     private static async Task<ScrollPanelNode> WaitForPanelAsync(
         Hex1bTerminalAutomator auto, Hex1bApp app)
     {
@@ -176,7 +192,8 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
     /// pending-scroll arming) and waits until the binding closure on the panel has
     /// actually picked up the new rows. The closure refreshes only on the next
     /// IL Inspector render; we invalidate, then poll <see cref="ScrollPanelNode.ContentSize"/>
-    /// against the current row count — when they agree, a render with the post-mutation
+    /// against the expected visible-window height — the windowed tree's child measures
+    /// min(viewport, rows) tall — so agreement proves a render with the post-mutation
     /// rows has been arranged into the panel and the binding closure is current.
     /// </summary>
     private static async Task SetSelectionDirectAsync(
@@ -193,8 +210,9 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
         await auto.WaitUntilAsync(_ =>
         {
             var sp = FindPanel(app);
-            return sp is { ViewportSize: > 0 } && sp.ContentSize == rows.Count;
-        }, description: "panel ContentSize agrees with current rows.Count");
+            return sp is { ViewportSize: > 0 }
+                && sp.ContentSize == Math.Min(sp.ViewportSize, rows.Count);
+        }, description: "panel ContentSize agrees with the visible window");
     }
 
     /// <summary>
@@ -237,7 +255,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel becomes scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree becomes scrollable");
 
         var thumbY = await WaitForThumbAsync(auto, terminal, sp);
         Assert.True(thumbY >= sp.Bounds.Y, "thumb cell rendered inside panel bounds");
@@ -258,7 +276,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => !sp.IsScrollable, description: "content fits viewport");
+        await auto.WaitUntilAsync(_ => !TreeScrollable(sp), description: "content fits viewport");
 
         var snapshot = terminal.CreateSnapshot();
         var sbCol = sp.Bounds.X + sp.Bounds.Width - 1;
@@ -333,7 +351,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.ViewportSize > 0 && sp.IsScrollable,
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp),
             description: "viewport sized and scrollable");
 
         var rows = Views.IlInspectorView.BuildTreeRows(_state!);
@@ -352,8 +370,8 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
                 description: $"DownArrow #{i + 1} advances from {prev}");
         }
 
-        Assert.True(sp.Offset > 0,
-            $"Offset should advance after walking past viewport. ViewportSize={sp.ViewportSize}, target={target}, Offset={sp.Offset}");
+        Assert.True(TreeOffset > 0,
+            $"Offset should advance after walking past viewport. ViewportSize={sp.ViewportSize}, target={target}, Offset={TreeOffset}");
 
         _cts!.Cancel();
         await runTask;
@@ -436,7 +454,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
         await auto.KeyAsync(Hex1bKey.Home, ct: ct);
         await auto.WaitUntilAsync(_ => _state!.IlFocusedTreeKey as string == rows[0].Key,
             description: "Home jumps to row 0");
-        await auto.WaitUntilAsync(_ => sp.Offset == 0, description: "Offset returns to 0");
+        await auto.WaitUntilAsync(_ => TreeOffset == 0, description: "Offset returns to 0");
 
         _cts!.Cancel();
         await runTask;
@@ -459,7 +477,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
         await auto.KeyAsync(Hex1bKey.End, ct: ct);
         await auto.WaitUntilAsync(_ => _state!.IlFocusedTreeKey as string == rows[^1].Key,
             description: "End selects last row");
-        await auto.WaitUntilAsync(_ => sp.Offset == sp.MaxOffset,
+        await auto.WaitUntilAsync(_ => TreeOffset == TreeMaxOffset(sp),
             description: "Offset hits MaxOffset");
 
         _cts!.Cancel();
@@ -480,12 +498,12 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         var rows = Views.IlInspectorView.BuildTreeRows(_state!);
         await SetSelectionDirectAsync(auto, app, _state!, rows, 0);
 
-        var initialOffset = sp.Offset;
+        var initialOffset = TreeOffset;
         var initialKey = _state!.IlFocusedTreeKey as string;
         var bodyX = sp.Bounds.X + 5;
         var bodyY = sp.Bounds.Y + 5;
@@ -494,7 +512,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
             .ScrollDown()
             .Build()
             .ApplyAsync(terminal, ct);
-        await auto.WaitUntilAsync(_ => sp.Offset == initialOffset + 3,
+        await auto.WaitUntilAsync(_ => TreeOffset == initialOffset + 3,
             description: "Offset advanced by exactly 3");
 
         Assert.Equal(initialKey, _state!.IlFocusedTreeKey as string);
@@ -515,7 +533,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         var bodyX = sp.Bounds.X + 5;
         var bodyY = sp.Bounds.Y + 5;
@@ -528,7 +546,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
             .ApplyAsync(terminal, ct);
         await Task.Delay(50, ct);
 
-        Assert.Equal(0, sp.Offset);
+        Assert.Equal(0, TreeOffset);
         Assert.Equal(initialKey, _state!.IlFocusedTreeKey as string);
 
         _cts!.Cancel();
@@ -547,10 +565,11 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
-        sp.Offset = sp.MaxOffset;
-        var initialKey = _state!.IlFocusedTreeKey as string;
+        _state!.IlTreeScrollOffset = TreeMaxOffset(sp);
+        _state.App.Invalidate();
+        var initialKey = _state.IlFocusedTreeKey as string;
         var bodyX = sp.Bounds.X + 5;
         var bodyY = sp.Bounds.Y + 5;
         await new Hex1bTerminalInputSequenceBuilder()
@@ -561,7 +580,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
             .ApplyAsync(terminal, ct);
         await Task.Delay(50, ct);
 
-        Assert.Equal(sp.MaxOffset, sp.Offset);
+        Assert.Equal(TreeMaxOffset(sp), TreeOffset);
         Assert.Equal(initialKey, _state!.IlFocusedTreeKey as string);
 
         _cts!.Cancel();
@@ -580,13 +599,13 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         // Find a thumb cell, then click below it on the track.
         var sbCol = sp.Bounds.X + sp.Bounds.Width - 1;
         var thumbY = await WaitForThumbAsync(auto, terminal, sp);
 
-        var initialOffset = sp.Offset;
+        var initialOffset = TreeOffset;
         var initialKey = _state!.IlFocusedTreeKey as string;
         var trackY = sp.Bounds.Y + sp.Bounds.Height - 2; // below the thumb
         var expectedStep = Math.Max(1, sp.ViewportSize - 1);
@@ -595,7 +614,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
             .ClickAt(sbCol, trackY)
             .Build()
             .ApplyAsync(terminal, ct);
-        await auto.WaitUntilAsync(_ => sp.Offset == Math.Min(sp.MaxOffset, initialOffset + expectedStep),
+        await auto.WaitUntilAsync(_ => TreeOffset == Math.Min(TreeMaxOffset(sp), initialOffset + expectedStep),
             description: "track click pages viewport");
 
         Assert.Equal(initialKey, _state!.IlFocusedTreeKey as string);
@@ -616,7 +635,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         var sbCol = sp.Bounds.X + sp.Bounds.Width - 1;
         var thumbY = await WaitForThumbAsync(auto, terminal, sp);
@@ -627,7 +646,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
             .Drag(sbCol, thumbY, sbCol, thumbY + dragDistance)
             .Build()
             .ApplyAsync(terminal, ct);
-        await auto.WaitUntilAsync(_ => sp.Offset > 0, description: "drag advanced offset");
+        await auto.WaitUntilAsync(_ => TreeOffset > 0, description: "drag advanced offset");
 
         Assert.Equal(initialKey, _state!.IlFocusedTreeKey as string);
 
@@ -647,12 +666,12 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         var sbCol = sp.Bounds.X + sp.Bounds.Width - 1;
         var topThumb = await WaitForThumbAsync(auto, terminal, sp);
 
-        sp.Offset = sp.MaxOffset;
+        _state!.IlTreeScrollOffset = TreeMaxOffset(sp);
         _state!.App.Invalidate();
         await auto.WaitUntilAsync(s =>
         {
@@ -678,7 +697,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         var rows = Views.IlInspectorView.BuildTreeRows(_state!);
         await SetSelectionDirectAsync(auto, app, _state!, rows, 0);
@@ -713,7 +732,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         var rows = Views.IlInspectorView.BuildTreeRows(_state!);
         await SetSelectionDirectAsync(auto, app, _state!, rows, 0);
@@ -832,16 +851,23 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
         // Search bar shows the confirmed query as static text — its appearance on
         // screen is the deterministic signal that the IL view re-rendered with the
         // search active and the panel's binding closure now closes over zero rows.
-        await auto.WaitUntilTextAsync("zzzz_no_match_zzzz");
+        // Re-nudge per poll: Hex1b drains an Invalidate that races an in-flight
+        // frame, so a single test-thread Invalidate can be dropped without a render.
+        await auto.WaitUntilAsync(s =>
+        {
+            if (s.ContainsText("zzzz_no_match_zzzz")) return true;
+            _state.App.Invalidate();
+            return false;
+        }, description: "confirmed search query renders");
 
         var beforeKey = _state.IlFocusedTreeKey as string;
-        var beforeOffset = sp.Offset;
+        var beforeOffset = TreeOffset;
 
         await auto.KeyAsync(key, ct: ct);
         await Task.Delay(50, ct);
 
         Assert.Equal(beforeKey, _state.IlFocusedTreeKey as string);
-        Assert.Equal(beforeOffset, sp.Offset);
+        Assert.Equal(beforeOffset, TreeOffset);
 
         _cts!.Cancel();
         await runTask;
@@ -875,10 +901,17 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
         // Search bar shows the confirmed query as static text — its appearance on
         // screen is the deterministic signal that the IL view re-rendered with the
         // search active and the panel's binding closure now closes over zero rows.
-        await auto.WaitUntilTextAsync("zzzz_no_match_zzzz");
+        // Re-nudge per poll: Hex1b drains an Invalidate that races an in-flight
+        // frame, so a single test-thread Invalidate can be dropped without a render.
+        await auto.WaitUntilAsync(s =>
+        {
+            if (s.ContainsText("zzzz_no_match_zzzz")) return true;
+            _state.App.Invalidate();
+            return false;
+        }, description: "confirmed search query renders");
 
         var beforeKey = _state.IlFocusedTreeKey as string;
-        var beforeOffset = sp.Offset;
+        var beforeOffset = TreeOffset;
 
         var bodyX = sp.Bounds.X + 5;
         var bodyY = sp.Bounds.Y + 1;
@@ -888,7 +921,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
         await Task.Delay(50, ct);
 
         Assert.Equal(beforeKey, _state.IlFocusedTreeKey as string);
-        Assert.Equal(beforeOffset, sp.Offset);
+        Assert.Equal(beforeOffset, TreeOffset);
 
         _cts!.Cancel();
         await runTask;
@@ -906,19 +939,19 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         await auto.KeyAsync(Hex1bKey.End, ct: ct);
-        await auto.WaitUntilAsync(_ => sp.Offset == sp.MaxOffset, description: "scrolled to end");
+        await auto.WaitUntilAsync(_ => TreeOffset == TreeMaxOffset(sp), description: "scrolled to end");
 
         // Collapse all types — content height shrinks dramatically.
         foreach (var t in _state!.Analyzer.TypeDefs)
             _state!.IlTreeExpansionState[$"type:{t.FullName}"] = false;
         _state!.App.Invalidate();
 
-        await auto.WaitUntilAsync(_ => sp.Offset <= sp.MaxOffset,
+        await auto.WaitUntilAsync(_ => TreeOffset <= TreeMaxOffset(sp),
             description: "Offset clamped after collapse");
-        Assert.True(sp.Offset <= sp.MaxOffset, $"Offset={sp.Offset} MaxOffset={sp.MaxOffset}");
+        Assert.True(TreeOffset <= TreeMaxOffset(sp), $"Offset={TreeOffset} MaxOffset={TreeMaxOffset(sp)}");
 
         _cts!.Cancel();
         await runTask;
@@ -999,7 +1032,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
         // Pick a method row index that is visible at the current Offset.
         var rows = Views.IlInspectorView.BuildTreeRows(_state!);
         var visibleMethod = -1;
-        for (var i = sp.Offset; i < Math.Min(rows.Count, sp.Offset + sp.ViewportSize); i++)
+        for (var i = TreeOffset; i < Math.Min(rows.Count, TreeOffset + sp.ViewportSize); i++)
         {
             if (rows[i].Kind == IlTreeRowKind.Method) { visibleMethod = i; break; }
         }
@@ -1009,7 +1042,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
         }
 
         var clickX = sp.Bounds.X + 5;
-        var clickY = sp.Bounds.Y + (visibleMethod - sp.Offset);
+        var clickY = sp.Bounds.Y + (visibleMethod - TreeOffset);
         await new Hex1bTerminalInputSequenceBuilder()
             .ClickAt(clickX, clickY)
             .Build()
@@ -1034,7 +1067,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         var rows = Views.IlInspectorView.BuildTreeRows(_state!);
         await SetSelectionDirectAsync(auto, app, _state!, rows, 0);
@@ -1073,7 +1106,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         // Allow a frame for layout, then check thumb only when actually scrollable.
         await Task.Delay(50, ct);
-        if (sp.IsScrollable)
+        if (TreeScrollable(sp))
         {
             var sbCol = sp.Bounds.X + sp.Bounds.Width - 1;
             await auto.WaitUntilAsync(s =>
@@ -1123,9 +1156,9 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
             var idx = IlTreeList.FindRowIndex(freshRows, $"method:{deepMethod.Token}");
             return idx >= 0
                 && sp.ViewportSize > 0
-                && sp.ContentSize == freshRows.Count
-                && sp.Offset <= idx
-                && idx < sp.Offset + sp.ViewportSize;
+                && !_state.IlScrollSelectionIntoViewPending
+                && TreeOffset <= idx
+                && idx < TreeOffset + sp.ViewportSize;
         }, description: "deep target visible after first-arrival pending scroll");
 
         _cts!.Cancel();
@@ -1144,7 +1177,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         var rows = Views.IlInspectorView.BuildTreeRows(_state!);
         await SetSelectionDirectAsync(auto, app, _state!, rows, 0);
@@ -1164,9 +1197,9 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
             .ScrollDown(ticks)
             .Build()
             .ApplyAsync(terminal, ct);
-        await auto.WaitUntilAsync(_ => sp.Offset >= Math.Min(expectedAdvance, sp.MaxOffset),
+        await auto.WaitUntilAsync(_ => TreeOffset >= Math.Min(expectedAdvance, TreeMaxOffset(sp)),
             description: "all wheel ticks applied to Offset");
-        var offsetAfterWheel = sp.Offset;
+        var offsetAfterWheel = TreeOffset;
 
         // Force a repaint and wait one render cycle. The repaint must NOT trigger any
         // EnsureSelectionVisible-style snap-back; the wheel-only path leaves the
@@ -1175,7 +1208,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
         await auto.WaitUntilAsync(_ => true, description: "render frame elapses");
 
         Assert.Equal(rows[0].Key, _state!.IlFocusedTreeKey as string);
-        Assert.Equal(offsetAfterWheel, sp.Offset);
+        Assert.Equal(offsetAfterWheel, TreeOffset);
 
         _cts!.Cancel();
         await runTask;
@@ -1277,7 +1310,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         // External set then null — flag must clear without scrolling anywhere weird.
         var rows = Views.IlInspectorView.BuildTreeRows(_state!);
@@ -1301,12 +1334,12 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
                 .Build()
                 .ApplyAsync(terminal, ct);
         }
-        var offsetAfterWheel = sp.Offset;
+        var offsetAfterWheel = TreeOffset;
         Assert.True(offsetAfterWheel > 0, "wheel advanced offset");
 
         _state!.App.Invalidate();
         await Task.Delay(80, ct);
-        Assert.Equal(offsetAfterWheel, sp.Offset);
+        Assert.Equal(offsetAfterWheel, TreeOffset);
 
         _cts!.Cancel();
         await runTask;
@@ -1324,7 +1357,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => !sp.IsScrollable,
+        await auto.WaitUntilAsync(_ => !TreeScrollable(sp),
             description: "HelloWorld content fits viewport");
 
         // Pick a method row that is visible.
@@ -1344,13 +1377,13 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
             rows = Views.IlInspectorView.BuildTreeRows(_state);
             methodIdx = rows.FindIndex(r => r.Kind == IlTreeRowKind.Method);
             // Wait for the panel's closure to pick up the expanded rows.
-            await auto.WaitUntilAsync(_ => sp.ContentSize == rows.Count,
+            await auto.WaitUntilAsync(_ => sp.ContentSize == Math.Min(sp.ViewportSize, rows.Count),
                 description: "panel ContentSize agrees with expanded rows");
         }
         Assert.True(methodIdx >= 0);
 
         var rightCol = sp.Bounds.X + sp.Bounds.Width - 1;
-        var clickY = sp.Bounds.Y + (methodIdx - sp.Offset);
+        var clickY = sp.Bounds.Y + (methodIdx - TreeOffset);
         await new Hex1bTerminalInputSequenceBuilder()
             .ClickAt(rightCol, clickY)
             .Build()
@@ -1394,9 +1427,9 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
             var idx = IlTreeList.FindRowIndex(rows, $"method:{deepMethod.Token}");
             return idx >= 0
                 && sp.ViewportSize > 0
-                && sp.ContentSize == rows.Count
-                && sp.Offset <= idx
-                && idx < sp.Offset + sp.ViewportSize;
+                && !_state.IlScrollSelectionIntoViewPending
+                && TreeOffset <= idx
+                && idx < TreeOffset + sp.ViewportSize;
         }, description: "deep target visible after expand + pending scroll");
 
         _cts!.Cancel();
@@ -1415,7 +1448,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         var rows = Views.IlInspectorView.BuildTreeRows(_state!);
         await SetSelectionDirectAsync(auto, app, _state!, rows, 0);
@@ -1431,10 +1464,10 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
                 .Build()
                 .ApplyAsync(terminal, ct);
         }
-        await auto.WaitUntilAsync(_ => sp.Offset > 0, description: "offset > 0");
+        await auto.WaitUntilAsync(_ => TreeOffset > 0, description: "offset > 0");
 
         await auto.KeyAsync(Hex1bKey.Home, ct: ct);
-        await auto.WaitUntilAsync(_ => sp.Offset == 0,
+        await auto.WaitUntilAsync(_ => TreeOffset == 0,
             description: "Home re-anchors viewport on row 0");
 
         _cts!.Cancel();
@@ -1453,7 +1486,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         var rows = Views.IlInspectorView.BuildTreeRows(_state!);
         await SetSelectionDirectAsync(auto, app, _state!, rows, 0);
@@ -1468,10 +1501,10 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
                 .Build()
                 .ApplyAsync(terminal, ct);
         }
-        await auto.WaitUntilAsync(_ => sp.Offset > 0, description: "offset > 0");
+        await auto.WaitUntilAsync(_ => TreeOffset > 0, description: "offset > 0");
 
         await auto.KeyAsync(Hex1bKey.UpArrow, ct: ct);
-        await auto.WaitUntilAsync(_ => sp.Offset == 0,
+        await auto.WaitUntilAsync(_ => TreeOffset == 0,
             description: "UpArrow at row 0 re-anchors viewport");
         Assert.Equal(rows[0].Key, _state!.IlFocusedTreeKey as string);
 
@@ -1491,7 +1524,7 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
 
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(10));
         var sp = await WaitForPanelAsync(auto, app);
-        await auto.WaitUntilAsync(_ => sp.IsScrollable, description: "panel scrollable");
+        await auto.WaitUntilAsync(_ => TreeScrollable(sp), description: "tree scrollable");
 
         var rows = Views.IlInspectorView.BuildTreeRows(_state!);
         await auto.KeyAsync(Hex1bKey.End, ct: ct);
@@ -1509,11 +1542,11 @@ public class IlInspectorScrollbarTests(SampleAssemblyFixture samples) : IDisposa
                 .Build()
                 .ApplyAsync(terminal, ct);
         }
-        await auto.WaitUntilAsync(_ => sp.Offset < sp.MaxOffset,
+        await auto.WaitUntilAsync(_ => TreeOffset < TreeMaxOffset(sp),
             description: "wheel pushed last row offscreen");
 
         await auto.KeyAsync(Hex1bKey.End, ct: ct);
-        await auto.WaitUntilAsync(_ => sp.Offset == sp.MaxOffset,
+        await auto.WaitUntilAsync(_ => TreeOffset == TreeMaxOffset(sp),
             description: "End re-anchors viewport on last row");
 
         _cts!.Cancel();

--- a/tests/Dotsider.Tests/IlTreeVirtualizationTests.cs
+++ b/tests/Dotsider.Tests/IlTreeVirtualizationTests.cs
@@ -1,0 +1,385 @@
+using Dotsider.Views;
+using Hex1b;
+using Hex1b.Automation;
+using Hex1b.Input;
+using Hex1b.Nodes;
+using Hex1b.Widgets;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Behavior tests for the IL tree's windowed virtualization (issue #188): with far more
+/// rows than Hex1b's 10,000-row render-surface clamp, the tree must still render all the
+/// way to the bottom, keep the scrollbar accurate, and preserve the #167 scroll model —
+/// wheel and gutter scrolling move the viewport without touching the selection, keyboard
+/// navigation is non-wrapping and pulls the selection into view. Drives
+/// <see cref="IlTreeList.Build"/> and <see cref="IlInspectorView.SyncTreeScroll"/> (the
+/// real capture/pending logic) over a synthetic 12,000-row tree.
+/// </summary>
+[Collection("SampleAssemblies")]
+public sealed class IlTreeVirtualizationTests(SampleAssemblyFixture samples) : IDisposable
+{
+    private const int RowCount = 12_000;
+
+    private Hex1bApp? _app;
+    private Hex1bTerminal? _terminal;
+    private Hex1bAppWorkloadAdapter? _workload;
+    private DotsiderState? _state;
+    private CancellationTokenSource? _cts;
+    private List<IlTreeRow>? _rows;
+
+    /// <summary>
+    /// Rows occupied by the harness header above the tree. Mutable mid-test so the
+    /// viewport-change test can grow the tree pane without changing the widget shape
+    /// (a shape change would reconcile a new panel node).
+    /// </summary>
+    private int _headerRows;
+
+    /// <summary>
+    /// Starts a bare app whose only content is the tree list over 12,000 synthetic rows,
+    /// mirroring the root build's generation bookkeeping and the IL view's per-render
+    /// scroll sync via <see cref="IlInspectorView.SyncTreeScroll"/> so the logic under
+    /// test is the real one.
+    /// </summary>
+    private (Hex1bTerminalAutomator auto, Task runTask, CancellationToken ct) StartTreeApp()
+    {
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        _workload = new Hex1bAppWorkloadAdapter();
+        _terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(_workload)
+            .WithHeadless()
+            .WithDimensions(80, 30)
+            .Build();
+
+        _rows = [.. Enumerable.Range(0, RowCount)
+            .Select(i => new IlTreeRow($"row:{i}", 0, IlTreeRowKind.Method, $"row-{i}", null, false, false, ""))];
+        var formatted = _rows.Select(r => r.Label).ToList();
+
+        _app = new Hex1bApp(_ =>
+        {
+            _state ??= new DotsiderState(_app!, samples.HelloWorldDll) { CurrentTab = TabId.IlInspector };
+            // Mirror DotsiderApp.Build: only the root build advances the generation.
+            unchecked { _state.BuildGeneration++; }
+            _state.ExtraFrameArmed = false;
+            IlInspectorView.SyncTreeScroll(_state, _rows!);
+            var tree = IlTreeList.Build(
+                _rows!, formatted, _state,
+                selectionChanged: i => _state!.IlFocusedTreeKey = _rows![i].Key,
+                itemActivated: null, expandRow: null, collapseRow: null);
+            return Task.FromResult<Hex1bWidget>(new VStackWidget(
+            [
+                new TextBlockWidget(string.Empty).FixedHeight(_headerRows),
+                tree,
+            ]).Fill());
+        }, new Hex1bAppOptions { WorkloadAdapter = _workload, EnableMouse = true, EnableInputCoalescing = false });
+
+        var runTask = _app.RunAsync(_cts.Token);
+        return (new Hex1bTerminalAutomator(_terminal, defaultTimeout: TimeSpan.FromSeconds(10)), runTask, _cts.Token);
+    }
+
+    /// <summary>
+    /// Waits for the panel to be captured, arranged, and focused so keyboard and offset
+    /// math have a live viewport to work against.
+    /// </summary>
+    private async Task<ScrollPanelNode> WaitForPanelAsync(Hex1bTerminalAutomator auto)
+    {
+        await auto.WaitUntilAsync(s => s.InAlternateScreen, description: "alternate screen");
+        ScrollPanelNode? sp = null;
+        await auto.WaitUntilAsync(_ =>
+            (sp = _state?.IlScrollPanelNode) is { ViewportSize: > 0 },
+            description: "panel captured and arranged");
+        _app!.RequestFocus(node => node is ScrollPanelNode);
+        await auto.WaitUntilAsync(_ => _app.FocusedNode is ScrollPanelNode,
+            description: "panel focused");
+        return sp!;
+    }
+
+    /// <summary>The gutter column: the panel's rightmost column when the tree overflows.</summary>
+    private static int GutterCol(ScrollPanelNode sp) => sp.Bounds.X + sp.Bounds.Width - 1;
+
+    /// <summary>Finds the first thumb cell in the gutter column, or -1.</summary>
+    private static int FirstThumbY(Hex1bTerminalSnapshot snapshot, ScrollPanelNode sp)
+    {
+        var col = GutterCol(sp);
+        for (var y = sp.Bounds.Y; y < sp.Bounds.Y + sp.Bounds.Height; y++)
+        {
+            if (snapshot.GetCell(col, y).Character == "▉")
+                return y;
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// Past the 10k render-surface clamp, scrolling to the very bottom still paints the
+    /// last rows — the full viewport, no blank gap. Pins the issue #188 regression.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Rows12k_ScrolledToBottom_RendersLastRows_NoGap()
+    {
+        var (auto, runTask, _) = StartTreeApp();
+        var sp = await WaitForPanelAsync(auto);
+
+        _state!.IlTreeScrollOffset = int.MaxValue; // clamps to MaxOffset in the next build
+        _state.App.Invalidate();
+
+        await auto.WaitUntilTextAsync("row-11999");
+        var expectedTop = RowCount - sp.ViewportSize;
+        Assert.Equal(expectedTop, _state.IlTreeScrollOffset);
+        // The viewport is full from its first row — a blank gap would drop this label.
+        await auto.WaitUntilTextAsync($"row-{expectedTop}");
+
+        _cts!.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// The gutter thumb sits at the top at offset zero and moves to the gutter's end at
+    /// MaxOffset — the scrollbar math spans the full 12,000 rows.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Rows12k_GutterThumb_TracksOffset_EndToEnd()
+    {
+        var (auto, runTask, _) = StartTreeApp();
+        var sp = await WaitForPanelAsync(auto);
+
+        var topThumb = -1;
+        await auto.WaitUntilAsync(s => (topThumb = FirstThumbY(s, sp)) >= 0,
+            description: "thumb painted at offset 0");
+        Assert.Equal(sp.Bounds.Y, topThumb);
+
+        _state!.IlTreeScrollOffset = RowCount; // clamps to MaxOffset
+        _state.App.Invalidate();
+        await auto.WaitUntilAsync(s =>
+        {
+            var y = FirstThumbY(s, sp);
+            return y > topThumb && y == sp.Bounds.Y + sp.Bounds.Height - 1;
+        }, description: "thumb reaches the gutter end at MaxOffset");
+
+        _cts!.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Wheel over the tree body advances the offset by 3 without changing the selection,
+    /// even when the selected row scrolls offscreen — the #167 decoupling at 12k rows.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Rows12k_Wheel_MovesViewport_NotSelection()
+    {
+        var (auto, runTask, ct) = StartTreeApp();
+        var sp = await WaitForPanelAsync(auto);
+
+        _state!.IlFocusedTreeKey = "row:0";
+        _state.App.Invalidate();
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .MouseMoveTo(sp.Bounds.X + 5, sp.Bounds.Y + 5)
+            .ScrollDown()
+            .Build()
+            .ApplyAsync(_terminal!, ct);
+        await auto.WaitUntilAsync(_ => _state.IlTreeScrollOffset == 3,
+            description: "wheel advanced offset by exactly 3");
+
+        Assert.Equal("row:0", _state.IlFocusedTreeKey as string);
+
+        _cts!.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// End selects the last of 12,000 rows, scrolls it into view, and renders it; a
+    /// further DownArrow does not wrap.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Rows12k_End_SelectsLastRow_ScrollsIntoView_NoWrap()
+    {
+        var (auto, runTask, ct) = StartTreeApp();
+        var sp = await WaitForPanelAsync(auto);
+
+        await auto.KeyAsync(Hex1bKey.End, ct: ct);
+        await auto.WaitUntilAsync(_ => _state!.IlFocusedTreeKey as string == "row:11999",
+            description: "End selects the last row");
+        await auto.WaitUntilTextAsync("row-11999");
+        Assert.Equal(RowCount - sp.ViewportSize, _state!.IlTreeScrollOffset);
+
+        await auto.KeyAsync(Hex1bKey.DownArrow, ct: ct);
+        await Task.Delay(50, ct);
+        Assert.Equal("row:11999", _state.IlFocusedTreeKey as string);
+
+        _cts!.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// A click selects the row's absolute index — viewport row plus the scroll offset —
+    /// under a deep offset where windowing bugs would select the wrong row.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Rows12k_Click_SelectsAbsoluteRow_UnderDeepOffset()
+    {
+        var (auto, runTask, ct) = StartTreeApp();
+        var sp = await WaitForPanelAsync(auto);
+
+        _state!.IlTreeScrollOffset = 11_500;
+        _state.App.Invalidate();
+        await auto.WaitUntilTextAsync("row-11500");
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .ClickAt(sp.Bounds.X + 3, sp.Bounds.Y + 5)
+            .Build()
+            .ApplyAsync(_terminal!, ct);
+        await auto.WaitUntilAsync(_ => _state.IlFocusedTreeKey as string == "row:11505",
+            description: "click selects offset + viewport row");
+
+        _cts!.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// An external jump to a deep key (the pending-scroll path used by cross-view
+    /// navigation and search) lands the row inside the rendered viewport.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Rows12k_PendingScroll_DeepKey_LandsInViewport()
+    {
+        var (auto, runTask, _) = StartTreeApp();
+        var sp = await WaitForPanelAsync(auto);
+
+        _state!.SetIlFocusedTreeKey("row:11500");
+        await auto.WaitUntilAsync(_ => !_state.IlScrollSelectionIntoViewPending,
+            description: "pending scroll consumed");
+        await auto.WaitUntilTextAsync("row-11500");
+        Assert.InRange(11_500,
+            _state.IlTreeScrollOffset, _state.IlTreeScrollOffset + sp.ViewportSize - 1);
+
+        _cts!.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// A track click below the thumb pages the viewport by one page (viewport − 1) and
+    /// leaves the selection alone — the hand-rolled gutter matches the old panel gutter.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Rows12k_GutterTrackClick_PagesViewport_WithoutChangingSelection()
+    {
+        var (auto, runTask, ct) = StartTreeApp();
+        var sp = await WaitForPanelAsync(auto);
+
+        var beforeKey = _state!.IlFocusedTreeKey as string;
+        var expected = Math.Max(1, sp.ViewportSize - 1);
+        await new Hex1bTerminalInputSequenceBuilder()
+            .ClickAt(GutterCol(sp), sp.Bounds.Y + sp.Bounds.Height - 2)
+            .Build()
+            .ApplyAsync(_terminal!, ct);
+        await auto.WaitUntilAsync(_ => _state.IlTreeScrollOffset == expected,
+            description: "track click pages the viewport");
+
+        Assert.Equal(beforeKey, _state.IlFocusedTreeKey as string);
+
+        _cts!.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Dragging the thumb scrolls proportionally across all 12,000 rows without changing
+    /// the selection, and the panel keeps keyboard focus through the drag.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Rows12k_GutterThumbDrag_UpdatesOffset_KeepsSelectionAndFocus()
+    {
+        var (auto, runTask, ct) = StartTreeApp();
+        var sp = await WaitForPanelAsync(auto);
+
+        var thumbY = -1;
+        await auto.WaitUntilAsync(s => (thumbY = FirstThumbY(s, sp)) >= 0,
+            description: "thumb painted");
+
+        var beforeKey = _state!.IlFocusedTreeKey as string;
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Drag(GutterCol(sp), thumbY, GutterCol(sp), thumbY + 3)
+            .Build()
+            .ApplyAsync(_terminal!, ct);
+        await auto.WaitUntilAsync(_ => _state.IlTreeScrollOffset > 0,
+            description: "thumb drag advanced the offset");
+
+        Assert.Equal(beforeKey, _state.IlFocusedTreeKey as string);
+
+        // The panel must still own the keyboard: DownArrow moves the selection.
+        await auto.KeyAsync(Hex1bKey.DownArrow, ct: ct);
+        await auto.WaitUntilAsync(_ => _state.IlFocusedTreeKey as string != beforeKey,
+            description: "DownArrow advances selection after gutter drag");
+
+        _cts!.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// When a render changes the pane height (search bar toggle, terminal resize), the
+    /// window was built against the old height and nothing else schedules a rebuild —
+    /// the viewport verifier must re-clamp the offset and refill the viewport without
+    /// any further input.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Rows12k_ViewportGrows_WindowRefills_WithoutInput()
+    {
+        _headerRows = 1;
+        var (auto, runTask, _) = StartTreeApp();
+        var sp = await WaitForPanelAsync(auto);
+        var oldViewport = sp.ViewportSize;
+
+        _state!.IlTreeScrollOffset = int.MaxValue; // clamps to MaxOffset for the old height
+        _state.App.Invalidate();
+        await auto.WaitUntilTextAsync("row-11999");
+        Assert.Equal(RowCount - oldViewport, _state.IlTreeScrollOffset);
+
+        // Grow the pane by removing the header; no input follows.
+        _headerRows = 0;
+        _state.App.Invalidate();
+
+        await auto.WaitUntilAsync(_ =>
+            sp.ViewportSize == oldViewport + 1
+            && _state.IlTreeScrollOffset == RowCount - sp.ViewportSize,
+            description: "offset re-clamps to the grown viewport");
+        // The viewport is full from its new first row — a stale window would leave the
+        // last pane line blank.
+        await auto.WaitUntilTextAsync($"row-{RowCount - sp.ViewportSize}");
+        await auto.WaitUntilTextAsync("row-11999");
+
+        _cts!.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Only the root build may advance the nudger generation. A mid-frame advance from
+    /// the tree sync would make a nudger armed concurrently from a socket thread
+    /// believe a later build already ran and exit without nudging.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void SyncTreeScroll_DoesNotAdvanceBuildGeneration()
+    {
+        _workload = new Hex1bAppWorkloadAdapter();
+        _terminal = Hex1bTerminal.CreateBuilder().WithWorkload(_workload).WithHeadless().WithDimensions(80, 24).Build();
+        _app = new Hex1bApp(_ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("t")),
+            new Hex1bAppOptions { WorkloadAdapter = _workload });
+        _state = new DotsiderState(_app, samples.HelloWorldDll);
+
+        _state.BuildGeneration = 41;
+        _state.ExtraFrameArmed = true;
+
+        IlInspectorView.SyncTreeScroll(_state, []);
+
+        Assert.Equal(41, _state.BuildGeneration);
+        Assert.True(_state.ExtraFrameArmed);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _app?.Dispose();
+        _terminal?.Dispose();
+        _state?.Dispose();
+        _cts?.Dispose();
+    }
+}


### PR DESCRIPTION
Scrolling a fully expanded native tree to the bottom left a blank gap under the last rows. Hex1b sizes a scroll child's render surface to at most 10,000 rows, and the scout tree flattens to 11,111 — spacer rows keep the scrollbar math correct but the visible window still lands past the surface, which a probe confirmed at 9,000 versus 12,000 rows. The tree now materializes only the rows in view. The ScrollPanel stays the owner and the only focusable, the scroll offset moves into DotsiderState, and the gutter draws inside the panel's child so presses on the thumb and track route through the panel's drag binding. Mouse wheel and gutter scrolling move the viewport without touching the selection, keyboard navigation stays non-wrapping and pulls the selected row into view, and external jumps still land through the pending-scroll path, so the #167 model carries over unchanged. Native rows also stop showing the selection marker when nothing is selected.

The branch moves Hex1b to 0.165.0. Its frame loop coalesces invalidations that arrive while a frame is rendering, so retries signaled from inside a build or from the diagnostics socket now run through a nudger that re-invalidates until the next build starts, and a post-frame check rebuilds the window when the pane height changes under it — a search bar toggle or terminal resize would otherwise leave the tree underfilled until the next input. The dep graph's scrollbar geometry refresh and the session socket's queued mutations get the same treatment. The IL editor lifecycle tests now use the same nudged path when they change selection or focus programmatically, covering the Ubuntu race that exposed a stale render. New tests drive a synthetic 12,000-row tree end to end, and the existing scrollbar suite keeps its #167 semantics against the state-owned offset.

Fixes: #188