### PR TITLE
Add Native AOT MCP analysis tools

### DIFF
--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-MstatReader.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-MstatReader.md
@@ -52,10 +52,13 @@ public static bool Probe(Stream stream)
 ### Probe(string)
 
 Cheaply tests whether a file looks like an ILC size report, without decoding any IL
-streams or node names: the PE must carry metadata, the assembly version major must be a
-known format version, and `&lt;Module&gt;` must declare a global `Methods` or
-`Types` method. A positive probe is a sniff, not a guarantee — follow it with
-[String)](/api/dotsider.core.analysis.mstatreader.read(system.string)/) for the decoded report. Never throws.
+streams or node names: the PE must carry metadata, the assembly version must be a
+known format version with the writer's unset Build/Revision sentinels, and
+`&lt;Module&gt;` must declare both the `Methods` and `Types` global
+methods — every format version emits both, and requiring the pair keeps an ordinary
+managed module that happens to define one such global method from being misclassified.
+A positive probe is a sniff, not a guarantee — follow it with [String)](/api/dotsider.core.analysis.mstatreader.read(system.string)/)
+for the decoded report. Never throws.
 
 **Parameters:**
 

--- a/docs/src/content/docs/api/Dotsider-Core-Protocol-DotsiderRequest.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Protocol-DotsiderRequest.md
@@ -102,6 +102,16 @@ Trace event category filter.
 public string? CategoryFilter { get; set; }
 ```
 
+### IncludeCompilerGenerated
+
+Whether member search includes compiler-generated members.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool IncludeCompilerGenerated { get; set; }
+```
+
 ### IncludeDebugInfo
 
 Whether IL responses should include portable PDB debug information.
@@ -120,6 +130,16 @@ Whether a diff-size response includes the delta tree.
 
 ```csharp
 public bool IncludeTree { get; set; }
+```
+
+### IncludeWhy
+
+Whether Native AOT contributor responses should include DGML why chains.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool IncludeWhy { get; set; }
 ```
 
 ### LeftPath
@@ -142,6 +162,16 @@ Byte count for read-bytes.
 public int? Length { get; set; }
 ```
 
+### MaxCandidates
+
+Maximum ambiguous candidates returned by Native AOT explanation tools.
+
+**Returns:** [Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)
+
+```csharp
+public int? MaxCandidates { get; set; }
+```
+
 ### MaxNodes
 
 The delta-tree node cap for diff-size when [IncludeTree](/api/dotsider.core.protocol.dotsiderrequest.includetree/) is set.
@@ -160,6 +190,16 @@ Maximum number of results to return.
 
 ```csharp
 public int? MaxResults { get; set; }
+```
+
+### MaxWhyChains
+
+Maximum DGML chains returned for one aggregated Native AOT contributor.
+
+**Returns:** [Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)
+
+```csharp
+public int? MaxWhyChains { get; set; }
 ```
 
 ### Method
@@ -202,6 +242,16 @@ Minimum string length for raw string extraction.
 public int? MinLength { get; set; }
 ```
 
+### NamespaceName
+
+Namespace filter for Native AOT size contributor tools.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? NamespaceName { get; set; }
+```
+
 ### Offset
 
 Byte offset for read-bytes.
@@ -232,6 +282,16 @@ Right assembly path for diff.
 public string? RightPath { get; set; }
 ```
 
+### Section
+
+mstat section filter for Native AOT size contributor tools.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? Section { get; set; }
+```
+
 ### SymbolAddress
 
 Native symbol virtual address (hex `0x…` or decimal) for disassemble-native.
@@ -260,6 +320,16 @@ Tab identifier for navigation.
 
 ```csharp
 public int? TabId { get; set; }
+```
+
+### Target
+
+Target name, path, key, or node label for Native AOT size explanation tools.
+
+**Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
+
+```csharp
+public string? Target { get; set; }
 ```
 
 ### Token

--- a/docs/src/content/docs/api/Dotsider-Core-Protocol-NativeAotPayloadBuilder.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Protocol-NativeAotPayloadBuilder.md
@@ -1,0 +1,186 @@
+---
+title: "NativeAotPayloadBuilder"
+description: "Builds JSON-ready Native AOT payloads shared by direct MCP tools and the diagnostics session protocol, so the two transports return the same facts and error semantics."
+slug: api/dotsider.core.protocol.nativeaotpayloadbuilder
+sidebar:
+  order: 4
+---
+
+**Namespace:** `Dotsider.Core.Protocol`
+
+**Assembly:** Dotsider.Core.dll
+
+Builds JSON-ready Native AOT payloads shared by direct MCP tools and the diagnostics session
+protocol, so the two transports return the same facts and error semantics.
+
+```csharp
+public static class NativeAotPayloadBuilder
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → **NativeAotPayloadBuilder**
+
+## Methods
+
+### BuildInfo(AssemblyAnalyzer)
+
+Builds a Native AOT identity and sidecar summary for an analyzer.
+
+**Parameters:**
+
+- `analyzer` ([AssemblyAnalyzer](/api/dotsider.core.analysis.assemblyanalyzer/)): 
+
+**Returns:** [Object](https://learn.microsoft.com/dotnet/api/system.object)
+
+```csharp
+public static object BuildInfo(AssemblyAnalyzer analyzer)
+```
+
+### BuildLargestMethods(AssemblyAnalyzer, int?)
+
+Builds largest-method rows, using native mstat data for Native AOT.
+
+**Parameters:**
+
+- `analyzer` ([AssemblyAnalyzer](/api/dotsider.core.analysis.assemblyanalyzer/)): 
+- `maxResults` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): 
+
+**Returns:** [Object](https://learn.microsoft.com/dotnet/api/system.object)
+
+```csharp
+public static object BuildLargestMethods(AssemblyAnalyzer analyzer, int? maxResults)
+```
+
+### BuildMemberSearch(AssemblyAnalyzer, string, int?, bool)
+
+Builds member-search results, falling back to recovered Native AOT metadata.
+
+**Parameters:**
+
+- `analyzer` ([AssemblyAnalyzer](/api/dotsider.core.analysis.assemblyanalyzer/)): 
+- `query` ([String](https://learn.microsoft.com/dotnet/api/system.string)): 
+- `maxResults` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): 
+- `includeCompilerGenerated` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): 
+
+**Returns:** [Object](https://learn.microsoft.com/dotnet/api/system.object)
+
+```csharp
+public static object BuildMemberSearch(AssemblyAnalyzer analyzer, string query, int? maxResults, bool includeCompilerGenerated)
+```
+
+### BuildMethodInventory(AssemblyAnalyzer, string?, string?, int?)
+
+Builds method-inventory rows, falling back to recovered Native AOT methods.
+
+**Parameters:**
+
+- `analyzer` ([AssemblyAnalyzer](/api/dotsider.core.analysis.assemblyanalyzer/)): 
+- `typeName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): 
+- `query` ([String](https://learn.microsoft.com/dotnet/api/system.string)): 
+- `maxResults` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): 
+
+**Returns:** [Object](https://learn.microsoft.com/dotnet/api/system.object)
+
+```csharp
+public static object BuildMethodInventory(AssemblyAnalyzer analyzer, string? typeName, string? query, int? maxResults)
+```
+
+### BuildSections(AssemblyAnalyzer)
+
+Builds the Native AOT ReadyToRun module-section table payload.
+
+**Parameters:**
+
+- `analyzer` ([AssemblyAnalyzer](/api/dotsider.core.analysis.assemblyanalyzer/)): 
+
+**Returns:** [Object](https://learn.microsoft.com/dotnet/api/system.object)
+
+```csharp
+public static object BuildSections(AssemblyAnalyzer analyzer)
+```
+
+### BuildSizeContributors(MstatSource, string?, string?, string?, string?, int?, bool, int?)
+
+Builds top Native AOT size contributors from an mstat-backed input.
+
+**Parameters:**
+
+- `source` ([MstatSource](/api/dotsider.core.analysis.models.mstatsource/)): 
+- `query` ([String](https://learn.microsoft.com/dotnet/api/system.string)): 
+- `section` ([String](https://learn.microsoft.com/dotnet/api/system.string)): 
+- `assemblyName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): 
+- `namespaceName` ([String](https://learn.microsoft.com/dotnet/api/system.string)): 
+- `topN` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): 
+- `includeWhy` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): 
+- `maxWhyChains` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): 
+
+**Returns:** [Object](https://learn.microsoft.com/dotnet/api/system.object)
+
+```csharp
+public static object BuildSizeContributors(MstatSource source, string? query, string? section, string? assemblyName, string? namespaceName, int? topN, bool includeWhy, int? maxWhyChains)
+```
+
+### BuildWhy(MstatSource, string, int?, int?)
+
+Builds a Native AOT DGML explanation for one mstat contributor target.
+
+**Parameters:**
+
+- `source` ([MstatSource](/api/dotsider.core.analysis.models.mstatsource/)): 
+- `target` ([String](https://learn.microsoft.com/dotnet/api/system.string)): 
+- `maxCandidates` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): 
+- `maxWhyChains` ([Nullable\<Int32\>](https://learn.microsoft.com/dotnet/api/system.nullable-1)): 
+
+**Returns:** [Object](https://learn.microsoft.com/dotnet/api/system.object)
+
+```csharp
+public static object BuildWhy(MstatSource source, string target, int? maxCandidates, int? maxWhyChains)
+```
+
+### ResolveMstatSource(AssemblyAnalyzer)
+
+Resolves a Native AOT analyzer's mstat source, or null when no size report exists.
+
+**Parameters:**
+
+- `analyzer` ([AssemblyAnalyzer](/api/dotsider.core.analysis.assemblyanalyzer/)): 
+
+**Returns:** [MstatSource](/api/dotsider.core.analysis.models.mstatsource/)
+
+```csharp
+public static MstatSource? ResolveMstatSource(AssemblyAnalyzer analyzer)
+```
+
+## Fields
+
+### DefaultMaxCandidates
+
+The default candidate count returned for ambiguous Native AOT why queries.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public const int DefaultMaxCandidates = 20
+```
+
+### DefaultMaxWhyChains
+
+The default number of DGML chains shown for an aggregate mstat entry.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public const int DefaultMaxWhyChains = 3
+```
+
+### DefaultTopN
+
+The default number of size contributors returned by Native AOT size tools.
+
+**Returns:** [Int32](https://learn.microsoft.com/dotnet/api/system.int32)
+
+```csharp
+public const int DefaultTopN = 20
+```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Protocol.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Protocol.md
@@ -48,6 +48,15 @@ Includes the full path and the runtime pack that provided it.
 public sealed record FrameworkAssemblyInfo : IEquatable<FrameworkAssemblyInfo>
 ```
 
+### [NativeAotPayloadBuilder](/api/dotsider.core.protocol.nativeaotpayloadbuilder/)
+
+Builds JSON-ready Native AOT payloads shared by direct MCP tools and the diagnostics session
+protocol, so the two transports return the same facts and error semantics.
+
+```csharp
+public static class NativeAotPayloadBuilder
+```
+
 ### [ResolvedAssemblyInfo](/api/dotsider.core.protocol.resolvedassemblyinfo/)
 
 Serialization-safe representation of an assembly resolution result.

--- a/src/Dotsider.Core/Protocol/DotsiderRequest.cs
+++ b/src/Dotsider.Core/Protocol/DotsiderRequest.cs
@@ -26,6 +26,9 @@ public sealed class DotsiderRequest
     /// <summary>Search query for find-members or search-il-opcodes.</summary>
     public string? Query { get; set; }
 
+    /// <summary>Target name, path, key, or node label for Native AOT size explanation tools.</summary>
+    public string? Target { get; set; }
+
     /// <summary>Metadata token for resolve-token.</summary>
     public int? Token { get; set; }
 
@@ -59,8 +62,17 @@ public sealed class DotsiderRequest
     /// <summary>Assembly name to resolve (e.g. "System.Runtime"), used by resolve-assembly and push-assembly.</summary>
     public string? AssemblyName { get; set; }
 
+    /// <summary>Namespace filter for Native AOT size contributor tools.</summary>
+    public string? NamespaceName { get; set; }
+
+    /// <summary>mstat section filter for Native AOT size contributor tools.</summary>
+    public string? Section { get; set; }
+
     /// <summary>Whether IL responses should include portable PDB debug information.</summary>
     public bool IncludeDebugInfo { get; set; }
+
+    /// <summary>Whether member search includes compiler-generated members.</summary>
+    public bool IncludeCompilerGenerated { get; set; }
 
     /// <summary>Native symbol name for disassemble-native (managed name, raw name, or suffix).</summary>
     public string? SymbolName { get; set; }
@@ -85,6 +97,15 @@ public sealed class DotsiderRequest
 
     /// <summary>How many top contributors diff-size and check-size-budgets responses carry.</summary>
     public int? TopN { get; set; }
+
+    /// <summary>Whether Native AOT contributor responses should include DGML why chains.</summary>
+    public bool IncludeWhy { get; set; }
+
+    /// <summary>Maximum ambiguous candidates returned by Native AOT explanation tools.</summary>
+    public int? MaxCandidates { get; set; }
+
+    /// <summary>Maximum DGML chains returned for one aggregated Native AOT contributor.</summary>
+    public int? MaxWhyChains { get; set; }
 
     /// <summary>Whether a diff-size response includes the delta tree.</summary>
     public bool IncludeTree { get; set; }

--- a/src/Dotsider.Core/Protocol/NativeAotPayloadBuilder.cs
+++ b/src/Dotsider.Core/Protocol/NativeAotPayloadBuilder.cs
@@ -1,0 +1,476 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Core.Protocol;
+
+/// <summary>
+/// Builds JSON-ready Native AOT payloads shared by direct MCP tools and the diagnostics session
+/// protocol, so the two transports return the same facts and error semantics.
+/// </summary>
+public static class NativeAotPayloadBuilder
+{
+    /// <summary>The default number of size contributors returned by Native AOT size tools.</summary>
+    public const int DefaultTopN = 20;
+
+    /// <summary>The default candidate count returned for ambiguous Native AOT why queries.</summary>
+    public const int DefaultMaxCandidates = 20;
+
+    /// <summary>The default number of DGML chains shown for an aggregate mstat entry.</summary>
+    public const int DefaultMaxWhyChains = 3;
+
+    /// <summary>Builds a Native AOT identity and sidecar summary for an analyzer.</summary>
+    public static object BuildInfo(AssemblyAnalyzer analyzer)
+    {
+        RequireNativeAot(analyzer);
+
+        var mstat = analyzer.Mstat;
+        var dgmlPath = analyzer.DgmlPath;
+        return new
+        {
+            analyzer.FilePath,
+            analyzer.FileName,
+            analyzer.FileSize,
+            analyzer.Architecture,
+            analyzer.BinaryKind,
+            analyzer.NativeAotInfo,
+            ReadyToRunSections = analyzer.ReadyToRunSections.Count,
+            RecoveredTypes = analyzer.RecoveredTypes.Count,
+            RecoveredMethods = analyzer.RecoveredTypes.Sum(t => t.MethodNames.Count),
+            FrozenStrings = analyzer.FrozenStrings.Count,
+            NativeSymbolCount = analyzer.NativeSymbols?.Symbols.Count ?? 0,
+            NativeSymbolSource = analyzer.NativeSymbols?.Source,
+            NativeSymbolStatus = analyzer.NativeSymbols?.Status,
+            analyzer.MstatPath,
+            HasMstat = mstat is not null,
+            MstatFormat = mstat is null ? null : $"{mstat.FormatMajorVersion}.{mstat.FormatMinorVersion}",
+            DgmlPath = dgmlPath,
+            HasDgml = dgmlPath is not null,
+            PreIlc = BuildPreIlcSummary(analyzer.PreIlcSidecars)
+        };
+    }
+
+    /// <summary>Builds the Native AOT ReadyToRun module-section table payload.</summary>
+    public static object BuildSections(AssemblyAnalyzer analyzer)
+    {
+        RequireNativeAot(analyzer);
+
+        var sections = analyzer.ReadyToRunSections.Select(s => new
+        {
+            s.SectionId,
+            s.Name,
+            Address = $"0x{s.VirtualAddress:X}",
+            s.VirtualAddress,
+            s.Size,
+            s.FileOffset,
+            IsMapped = s.FileOffset is not null
+        }).ToList();
+
+        return new
+        {
+            analyzer.FilePath,
+            SectionCount = sections.Count,
+            Sections = sections
+        };
+    }
+
+    /// <summary>Builds method-inventory rows, falling back to recovered Native AOT methods.</summary>
+    public static object BuildMethodInventory(
+        AssemblyAnalyzer analyzer, string? typeName, string? query, int? maxResults)
+    {
+        if (analyzer.HasMetadata || analyzer.RecoveredTypes.Count == 0)
+            return analyzer.MethodDefs
+                .Where(m => Matches(m.DeclaringType, typeName) && Matches(m.Name, query))
+                .Take(PositiveOrMax(maxResults))
+                .ToList();
+
+        return analyzer.RecoveredTypes
+            .Where(t => Matches(t.FullName, typeName))
+            .SelectMany(t => t.MethodNames.Select((method, index) => new
+            {
+                Source = "RecoveredNativeAot",
+                t.AssemblyName,
+                DeclaringType = t.FullName,
+                Name = method,
+                MethodIndex = index
+            }))
+            .Where(m => Matches(m.Name, query))
+            .Take(PositiveOrMax(maxResults))
+            .ToList();
+    }
+
+    /// <summary>Builds member-search results, falling back to recovered Native AOT metadata.</summary>
+    public static object BuildMemberSearch(
+        AssemblyAnalyzer analyzer, string query, int? maxResults, bool includeCompilerGenerated)
+    {
+        var max = PositiveOr(maxResults, 100);
+        if (analyzer.HasMetadata || analyzer.RecoveredTypes.Count == 0)
+        {
+            var types = analyzer.TypeDefs
+                .Where(t => t.FullName.Contains(query, StringComparison.OrdinalIgnoreCase));
+            var methods = analyzer.MethodDefs
+                .Where(m => m.Name.Contains(query, StringComparison.OrdinalIgnoreCase)
+                    || m.DeclaringType.Contains(query, StringComparison.OrdinalIgnoreCase));
+
+            if (!includeCompilerGenerated)
+            {
+                types = types.Where(t => !t.Name.StartsWith("<>", StringComparison.Ordinal)
+                    && !t.Name.Contains("__", StringComparison.Ordinal));
+                methods = methods.Where(m => !m.DeclaringType.StartsWith("<>", StringComparison.Ordinal));
+            }
+
+            return new
+            {
+                Types = types.Take(max).ToList(),
+                Methods = methods.Take(max).ToList(),
+                MemberRefs = analyzer.MemberRefs
+                    .Where(r => r.Name.Contains(query, StringComparison.OrdinalIgnoreCase))
+                    .Take(max)
+                    .ToList()
+            };
+        }
+
+        var recoveredTypes = analyzer.RecoveredTypes
+            .Where(t => t.FullName.Contains(query, StringComparison.OrdinalIgnoreCase));
+        if (!includeCompilerGenerated)
+            recoveredTypes = recoveredTypes.Where(t => !IsCompilerGenerated(t.FullName));
+
+        var typeRows = recoveredTypes.Take(max).Select(t => new
+        {
+            Source = "RecoveredNativeAot",
+            t.AssemblyName,
+            t.FullName,
+            MethodCount = t.MethodNames.Count
+        }).ToList();
+
+        var methodRows = analyzer.RecoveredTypes
+            .Where(t => includeCompilerGenerated || !IsCompilerGenerated(t.FullName))
+            .SelectMany(t => t.MethodNames.Select((method, index) => new
+            {
+                Source = "RecoveredNativeAot",
+                t.AssemblyName,
+                DeclaringType = t.FullName,
+                Name = method,
+                MethodIndex = index
+            }))
+            .Where(m => m.Name.Contains(query, StringComparison.OrdinalIgnoreCase)
+                || m.DeclaringType.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .Take(max)
+            .ToList();
+
+        return new
+        {
+            Types = typeRows,
+            Methods = methodRows,
+            MemberRefs = Array.Empty<object>()
+        };
+    }
+
+    /// <summary>Builds largest-method rows, using native mstat data for Native AOT.</summary>
+    public static object BuildLargestMethods(AssemblyAnalyzer analyzer, int? maxResults)
+    {
+        var max = PositiveOr(maxResults, 20);
+        if (analyzer.BinaryKind == BinaryKind.NativeAot)
+        {
+            if (analyzer.Mstat is { } mstat)
+            {
+                var index = MstatSizeIndex.Create(mstat);
+                return index.Entries
+                    .Where(e => e.Section == MstatSectionKind.Method)
+                    .OrderByDescending(e => e.Size)
+                    .Take(max)
+                    .Select(e => new
+                    {
+                        Source = "Mstat",
+                        Method = new
+                        {
+                            e.AssemblyName,
+                            e.Namespace,
+                            DeclaringType = e.TypeName,
+                            Name = e.DisplayName,
+                            Signature = e.LeafName == e.DisplayName ? null : e.LeafName
+                        },
+                        e.Size,
+                        e.FullPath,
+                        e.NodeNames
+                    })
+                    .ToList();
+            }
+
+            if (analyzer.NativeSymbols is { Symbols.Count: > 0 } symbols)
+            {
+                return symbols.Symbols
+                    .Where(s => s.Kind is NativeSymbolKind.Function or NativeSymbolKind.Stub)
+                    .OrderByDescending(s => s.Size)
+                    .Take(max)
+                    .Select(s => new
+                    {
+                        Source = "NativeSymbols",
+                        Method = new
+                        {
+                            Name = s.ManagedName ?? s.Name,
+                            Address = $"0x{s.VirtualAddress:X}"
+                        },
+                        s.Size,
+                        s.FileOffset,
+                        s.VirtualAddress
+                    })
+                    .ToList();
+            }
+        }
+
+        return analyzer.MethodDefs
+            .Select(m => new { Method = m, Size = GetIlSize(analyzer, m) })
+            .OrderByDescending(x => x.Size)
+            .Take(max)
+            .ToList();
+    }
+
+    /// <summary>Builds top Native AOT size contributors from an mstat-backed input.</summary>
+    public static object BuildSizeContributors(
+        MstatSource source,
+        string? query,
+        string? section,
+        string? assemblyName,
+        string? namespaceName,
+        int? topN,
+        bool includeWhy,
+        int? maxWhyChains)
+    {
+        var index = MstatSizeIndex.Create(source.Data);
+        var entries = index.Entries.AsEnumerable();
+
+        if (!string.IsNullOrWhiteSpace(section))
+        {
+            var parsed = ParseSection(section);
+            entries = entries.Where(e => e.Section == parsed);
+        }
+
+        if (!string.IsNullOrWhiteSpace(assemblyName))
+            entries = entries.Where(e => e.AssemblyName.Contains(assemblyName, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(namespaceName))
+            entries = entries.Where(e => e.Namespace.Contains(namespaceName, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(query))
+            entries = entries.Where(e => EntryMatches(e, query));
+
+        var filtered = entries.OrderByDescending(e => e.Size).ToList();
+        var top = PositiveOr(topN, DefaultTopN);
+        var dgml = includeWhy && source.DgmlPath is not null ? DgmlReader.Read(source.DgmlPath) : null;
+        var whyLimit = PositiveOr(maxWhyChains, DefaultMaxWhyChains);
+
+        return new
+        {
+            Source = BuildMstatSourceSummary(source, index),
+            Filters = new { Query = query, Section = section, AssemblyName = assemblyName, Namespace = namespaceName },
+            TotalMatches = filtered.Count,
+            Returned = Math.Min(top, filtered.Count),
+            Truncated = filtered.Count > top,
+            WhyAvailable = includeWhy ? dgml is not null : (bool?)null,
+            WhyUnavailableReason = includeWhy && dgml is null
+                ? "DGML sidecar not found; publish with IlcGenerateDgmlFile to explain dependency roots."
+                : null,
+            Contributors = filtered.Take(top).Select(e => BuildContributor(e, dgml, whyLimit)).ToList()
+        };
+    }
+
+    /// <summary>Builds a Native AOT DGML explanation for one mstat contributor target.</summary>
+    public static object BuildWhy(MstatSource source, string target, int? maxCandidates, int? maxWhyChains)
+    {
+        if (source.DgmlPath is null)
+            throw new InvalidOperationException(
+                "DGML sidecar not found; publish with IlcGenerateDgmlFile to explain dependency roots.");
+
+        var dgml = DgmlReader.Read(source.DgmlPath)
+            ?? throw new InvalidOperationException("DGML sidecar could not be read.");
+
+        var index = MstatSizeIndex.Create(source.Data);
+        var matches = ResolveContributorCandidates(index.Entries, target).ToList();
+        if (matches.Count == 0)
+        {
+            return new
+            {
+                Target = target,
+                Source = BuildMstatSourceSummary(source, index),
+                Outcome = "not_found",
+                Message = $"No Native AOT size contributor matches '{target}'."
+            };
+        }
+
+        var max = PositiveOr(maxCandidates, DefaultMaxCandidates);
+        if (matches.Count > 1)
+        {
+            return new
+            {
+                Target = target,
+                Source = BuildMstatSourceSummary(source, index),
+                Outcome = "ambiguous",
+                CandidateCount = matches.Count,
+                Candidates = matches.Take(max).Select(BuildCandidate).ToList(),
+                Truncated = matches.Count > max
+            };
+        }
+
+        var entry = matches[0];
+        return new
+        {
+            Target = target,
+            Source = BuildMstatSourceSummary(source, index),
+            Outcome = "resolved",
+            Contributor = BuildContributor(entry, dgml, PositiveOr(maxWhyChains, DefaultMaxWhyChains))
+        };
+    }
+
+    /// <summary>Resolves a Native AOT analyzer's mstat source, or null when no size report exists.</summary>
+    public static MstatSource? ResolveMstatSource(AssemblyAnalyzer analyzer)
+    {
+        RequireNativeAot(analyzer);
+        return analyzer.MstatPath is { } path && analyzer.Mstat is { } data
+            ? new MstatSource(data, path, analyzer.FilePath, analyzer.FileSize, analyzer.DgmlPath)
+            : null;
+    }
+
+    private static void RequireNativeAot(AssemblyAnalyzer analyzer)
+    {
+        if (analyzer.BinaryKind != BinaryKind.NativeAot)
+            throw new InvalidOperationException("Native AOT analysis requires a Native AOT binary.");
+    }
+
+    private static object? BuildPreIlcSummary(PreIlcSidecars? s) => s is null
+        ? null
+        : new
+        {
+            s.HasAttachableCompanion,
+            RootAssembly = s.ManagedAssemblyPath is { } p ? Path.GetFileName(p) : null,
+            Origin = s.Origin.ToString(),
+            PdbStatus = s.PdbStatus.ToString(),
+            HasMstat = s.MstatPath is not null,
+            HasDgml = (s.CodegenDgmlPath ?? s.ScanDgmlPath) is not null,
+            LocalReferenceCount = s.LocalReferencePaths.Count,
+            s.PackageReferenceCount,
+            s.OtherReferenceCount
+        };
+
+    private static object BuildMstatSourceSummary(MstatSource source, MstatSizeIndex index) => new
+    {
+        Target = source.BinaryPath ?? source.MstatPath,
+        source.BinaryPath,
+        source.BinaryFileSize,
+        source.MstatPath,
+        source.DgmlPath,
+        Format = $"{source.Data.FormatMajorVersion}.{source.Data.FormatMinorVersion}",
+        MstatTotal = index.Total,
+        FileSize = source.BinaryFileSize,
+        EntryCount = index.Entries.Count
+    };
+
+    private static object BuildContributor(MstatSizeEntry entry, DgmlGraph? dgml, int maxWhyChains) => new
+    {
+        entry.Section,
+        entry.Key,
+        entry.AssemblyName,
+        entry.Namespace,
+        entry.TypeName,
+        entry.LeafName,
+        entry.DisplayName,
+        entry.FullPath,
+        entry.Size,
+        entry.EntryCount,
+        entry.NodeNames,
+        WhyChains = dgml is null ? null : BuildWhyChains(entry, dgml, maxWhyChains)
+    };
+
+    private static object BuildCandidate(MstatSizeEntry entry) => new
+    {
+        entry.Section,
+        entry.Key,
+        entry.FullPath,
+        entry.DisplayName,
+        entry.Size,
+        entry.EntryCount,
+        entry.NodeNames
+    };
+
+    private static List<object> BuildWhyChains(MstatSizeEntry entry, DgmlGraph dgml, int maxWhyChains)
+    {
+        var shown = Math.Min(maxWhyChains, entry.NodeNames.Count);
+        var chains = new List<object>(shown);
+        for (var i = 0; i < shown; i++)
+        {
+            var nodeName = entry.NodeNames[i];
+            var steps = dgml.PathToRoot(nodeName);
+            chains.Add(new
+            {
+                NodeName = nodeName,
+                Found = steps.Count > 0,
+                Steps = steps
+            });
+        }
+
+        return chains;
+    }
+
+    private static IEnumerable<MstatSizeEntry> ResolveContributorCandidates(
+        IReadOnlyList<MstatSizeEntry> entries, string target)
+    {
+        var exact = entries.Where(e =>
+            string.Equals(e.FullPath, target, StringComparison.Ordinal)
+            || string.Equals(e.Key, target, StringComparison.Ordinal)
+            || string.Equals(e.DisplayName, target, StringComparison.Ordinal)
+            || string.Equals(e.LeafName, target, StringComparison.Ordinal)
+            || e.NodeNames.Contains(target, StringComparer.Ordinal)).ToList();
+        if (exact.Count > 0)
+            return exact.OrderByDescending(e => e.Size);
+
+        return entries
+            .Where(e => EntryMatches(e, target))
+            .OrderByDescending(e => e.Size);
+    }
+
+    private static bool EntryMatches(MstatSizeEntry entry, string query) =>
+        entry.FullPath.Contains(query, StringComparison.OrdinalIgnoreCase)
+        || entry.Key.Contains(query, StringComparison.OrdinalIgnoreCase)
+        || entry.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase)
+        || entry.LeafName.Contains(query, StringComparison.OrdinalIgnoreCase)
+        || entry.TypeName.Contains(query, StringComparison.OrdinalIgnoreCase)
+        || entry.AssemblyName.Contains(query, StringComparison.OrdinalIgnoreCase)
+        || entry.Namespace.Contains(query, StringComparison.OrdinalIgnoreCase)
+        || entry.NodeNames.Any(n => n.Contains(query, StringComparison.OrdinalIgnoreCase));
+
+    private static MstatSectionKind ParseSection(string section)
+    {
+        var normalized = section.Replace("-", "", StringComparison.Ordinal)
+            .Replace("_", "", StringComparison.Ordinal)
+            .Replace(" ", "", StringComparison.Ordinal);
+
+        foreach (var name in Enum.GetNames<MstatSectionKind>())
+        {
+            if (string.Equals(name, normalized, StringComparison.OrdinalIgnoreCase))
+                return Enum.Parse<MstatSectionKind>(name);
+        }
+
+        throw new InvalidOperationException(
+            $"Unknown Native AOT mstat section '{section}'. Expected one of: "
+            + string.Join(", ", Enum.GetNames<MstatSectionKind>()) + ".");
+    }
+
+    private static int GetIlSize(AssemblyAnalyzer analyzer, MethodDefInfo method)
+    {
+        try
+        {
+            return analyzer.GetMethodBody(method)?.GetILBytes()?.Length ?? 0;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private static bool Matches(string value, string? query) =>
+        string.IsNullOrEmpty(query) || value.Contains(query, StringComparison.OrdinalIgnoreCase);
+
+    private static int PositiveOr(int? value, int fallback) => value is > 0 ? value.Value : fallback;
+
+    private static int PositiveOrMax(int? value) => value is > 0 ? value.Value : int.MaxValue;
+
+    private static bool IsCompilerGenerated(string fullName) =>
+        fullName.StartsWith("<>", StringComparison.Ordinal) || fullName.Contains("__", StringComparison.Ordinal);
+}

--- a/src/Dotsider.Mcp/README.md
+++ b/src/Dotsider.Mcp/README.md
@@ -55,7 +55,16 @@ Most tools accept either parameter. Session-only tools (navigation, tracing) req
 | Tool | Description |
 |------|-------------|
 | `get_size_breakdown` | Hierarchical size tree: namespace > type > method |
-| `get_largest_methods` | Top methods by IL byte size |
+| `get_largest_methods` | Top methods by IL byte size, or Native AOT native size when mstat is available |
+
+### Native AOT
+
+| Tool | Description |
+|------|-------------|
+| `get_native_aot_info` | Native AOT identity, RTR header facts, recovered metadata counts, and sidecar availability |
+| `list_native_aot_sections` | Native AOT ReadyToRun module sections with VA, size, and file offset |
+| `get_native_aot_size_contributors` | Top mstat contributors, with optional filters and DGML why chains |
+| `explain_native_aot_size` | Explain why a type, method, frozen object, or data node is rooted in the binary |
 
 ### Strings
 

--- a/src/Dotsider.Mcp/Tools/AssemblyTools.cs
+++ b/src/Dotsider.Mcp/Tools/AssemblyTools.cs
@@ -189,14 +189,9 @@ public sealed partial class AssemblyTools(DotsiderSessionManager sessionManager)
         {
             ToolHelpers.ValidateAssemblyPath(assemblyPath);
             using var analyzer = ToolHelpers.OpenAnalyzer(assemblyPath);
-            var methods = analyzer.MethodDefs.AsEnumerable();
-            if (!string.IsNullOrEmpty(typeName))
-                methods = methods.Where(m => m.DeclaringType.Contains(typeName, StringComparison.OrdinalIgnoreCase));
-            if (!string.IsNullOrEmpty(query))
-                methods = methods.Where(m => m.Name.Contains(query, StringComparison.OrdinalIgnoreCase));
-            if (maxResults is > 0)
-                methods = methods.Take(maxResults.Value);
-            return JsonSerializer.Serialize(methods.ToList(), DotsiderJsonOptions.Default);
+            return JsonSerializer.Serialize(
+                NativeAotPayloadBuilder.BuildMethodInventory(analyzer, typeName, query, maxResults),
+                DotsiderJsonOptions.Default);
         }
 
         if (sessionId is not null)
@@ -231,32 +226,21 @@ public sealed partial class AssemblyTools(DotsiderSessionManager sessionManager)
         {
             ToolHelpers.ValidateAssemblyPath(assemblyPath);
             using var analyzer = ToolHelpers.OpenAnalyzer(assemblyPath);
-            var max = maxResults ?? 100;
-
-            var types = analyzer.TypeDefs
-                .Where(t => t.FullName.Contains(query, StringComparison.OrdinalIgnoreCase));
-            var methods = analyzer.MethodDefs
-                .Where(m => m.Name.Contains(query, StringComparison.OrdinalIgnoreCase)
-                    || m.DeclaringType.Contains(query, StringComparison.OrdinalIgnoreCase));
-
-            if (!includeCompilerGenerated)
-            {
-                types = types.Where(t => !t.Name.StartsWith("<>") && !t.Name.Contains("__"));
-                methods = methods.Where(m => !m.DeclaringType.StartsWith("<>"));
-            }
-
-            return JsonSerializer.Serialize(new
-            {
-                Types = types.Take(max).ToList(),
-                Methods = methods.Take(max).ToList(),
-                MemberRefs = analyzer.MemberRefs.Where(r => r.Name.Contains(query, StringComparison.OrdinalIgnoreCase)).Take(max).ToList()
-            }, DotsiderJsonOptions.Default);
+            return JsonSerializer.Serialize(
+                NativeAotPayloadBuilder.BuildMemberSearch(analyzer, query, maxResults, includeCompilerGenerated),
+                DotsiderJsonOptions.Default);
         }
 
         if (sessionId is not null)
         {
             return await sessionManager.GetTarget(sessionId.Value)
-                .SendAndUnwrapAsync(new DotsiderRequest { Method = "find-members", Query = query, MaxResults = maxResults }, ct);
+                .SendAndUnwrapAsync(new DotsiderRequest
+                {
+                    Method = "find-members",
+                    Query = query,
+                    MaxResults = maxResults,
+                    IncludeCompilerGenerated = includeCompilerGenerated
+                }, ct);
         }
 
         return "Error: Either assemblyPath or sessionId is required.";

--- a/src/Dotsider.Mcp/Tools/NativeAotTools.cs
+++ b/src/Dotsider.Mcp/Tools/NativeAotTools.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+using Dotsider.Core.Protocol;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+
+namespace Dotsider.Mcp.Tools;
+
+/// <summary>
+/// MCP tools for Native AOT-specific binary, section, size, and dependency-root analysis.
+/// </summary>
+[McpServerToolType]
+public sealed partial class NativeAotTools(DotsiderSessionManager sessionManager)
+{
+    /// <summary>
+    /// Gets Native AOT identity, recovered metadata counts, native symbol provenance, and sidecar availability.
+    /// </summary>
+    /// <param name="assemblyPath">Path to a Native AOT binary.</param>
+    /// <param name="sessionId">PID of a running dotsider instance.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>JSON Native AOT summary.</returns>
+    [McpServerTool(ReadOnly = true, OpenWorld = false)]
+    public async partial Task<string> GetNativeAotInfo(
+        string? assemblyPath = null,
+        int? sessionId = null,
+        CancellationToken ct = default)
+    {
+        if (assemblyPath is not null)
+        {
+            ToolHelpers.ValidateAssemblyPath(assemblyPath);
+            using var analyzer = ToolHelpers.OpenAnalyzer(assemblyPath);
+            return Serialize(() => NativeAotPayloadBuilder.BuildInfo(analyzer));
+        }
+
+        if (sessionId is not null)
+        {
+            return await sessionManager.GetTarget(sessionId.Value)
+                .SendAndUnwrapAsync(new DotsiderRequest { Method = "get-native-aot-info" }, ct);
+        }
+
+        return "Error: Either assemblyPath or sessionId is required.";
+    }
+
+    /// <summary>
+    /// Lists the Native AOT ReadyToRun module sections, distinct from ordinary PE sections.
+    /// </summary>
+    /// <param name="assemblyPath">Path to a Native AOT binary.</param>
+    /// <param name="sessionId">PID of a running dotsider instance.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>JSON section table.</returns>
+    [McpServerTool(ReadOnly = true, OpenWorld = false)]
+    public async partial Task<string> ListNativeAotSections(
+        string? assemblyPath = null,
+        int? sessionId = null,
+        CancellationToken ct = default)
+    {
+        if (assemblyPath is not null)
+        {
+            ToolHelpers.ValidateAssemblyPath(assemblyPath);
+            using var analyzer = ToolHelpers.OpenAnalyzer(assemblyPath);
+            return Serialize(() => NativeAotPayloadBuilder.BuildSections(analyzer));
+        }
+
+        if (sessionId is not null)
+        {
+            return await sessionManager.GetTarget(sessionId.Value)
+                .SendAndUnwrapAsync(new DotsiderRequest { Method = "list-native-aot-sections" }, ct);
+        }
+
+        return "Error: Either assemblyPath or sessionId is required.";
+    }
+
+    /// <summary>
+    /// Gets top Native AOT size contributors from an mstat-backed binary or .mstat file.
+    /// </summary>
+    /// <param name="assemblyPath">Path to a Native AOT binary or .mstat file.</param>
+    /// <param name="sessionId">PID of a running dotsider instance.</param>
+    /// <param name="query">Optional contributor search string.</param>
+    /// <param name="section">Optional mstat section filter, such as Method or FrozenObject.</param>
+    /// <param name="assemblyName">Optional assembly attribution filter.</param>
+    /// <param name="namespaceName">Optional namespace attribution filter.</param>
+    /// <param name="topN">Maximum contributors to return (default: 20).</param>
+    /// <param name="includeWhy">Include DGML root chains when available.</param>
+    /// <param name="maxWhyChains">Maximum DGML chains per aggregated contributor.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>JSON contributor rows.</returns>
+    [McpServerTool(ReadOnly = true, OpenWorld = false)]
+    public async partial Task<string> GetNativeAotSizeContributors(
+        string? assemblyPath = null,
+        int? sessionId = null,
+        string? query = null,
+        string? section = null,
+        string? assemblyName = null,
+        string? namespaceName = null,
+        int? topN = null,
+        bool includeWhy = false,
+        int? maxWhyChains = null,
+        CancellationToken ct = default)
+    {
+        if (assemblyPath is not null)
+        {
+            ToolHelpers.ValidateFilePath(assemblyPath, "assemblyPath");
+            var source = ResolveMstatSource(assemblyPath, "assemblyPath");
+            return Serialize(() => NativeAotPayloadBuilder.BuildSizeContributors(
+                source, query, section, assemblyName, namespaceName, topN, includeWhy, maxWhyChains));
+        }
+
+        if (sessionId is not null)
+        {
+            return await sessionManager.GetTarget(sessionId.Value)
+                .SendAndUnwrapAsync(new DotsiderRequest
+                {
+                    Method = "get-native-aot-size-contributors",
+                    Query = query,
+                    Section = section,
+                    AssemblyName = assemblyName,
+                    NamespaceName = namespaceName,
+                    TopN = topN,
+                    IncludeWhy = includeWhy,
+                    MaxWhyChains = maxWhyChains
+                }, ct);
+        }
+
+        return "Error: Either assemblyPath or sessionId is required.";
+    }
+
+    /// <summary>
+    /// Explains why a Native AOT mstat contributor is rooted by walking its DGML dependency chain.
+    /// </summary>
+    /// <param name="target">Contributor full path, key, node label, display name, or substring.</param>
+    /// <param name="assemblyPath">Path to a Native AOT binary or .mstat file.</param>
+    /// <param name="sessionId">PID of a running dotsider instance.</param>
+    /// <param name="maxCandidates">Maximum ambiguous candidates to return.</param>
+    /// <param name="maxWhyChains">Maximum DGML chains for an aggregate contributor.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>JSON resolved why chain or candidate list.</returns>
+    [McpServerTool(ReadOnly = true, OpenWorld = false)]
+    public async partial Task<string> ExplainNativeAotSize(
+        string target,
+        string? assemblyPath = null,
+        int? sessionId = null,
+        int? maxCandidates = null,
+        int? maxWhyChains = null,
+        CancellationToken ct = default)
+    {
+        if (assemblyPath is not null)
+        {
+            ToolHelpers.ValidateFilePath(assemblyPath, "assemblyPath");
+            var source = ResolveMstatSource(assemblyPath, "assemblyPath");
+            return Serialize(() => NativeAotPayloadBuilder.BuildWhy(
+                source, target, maxCandidates, maxWhyChains));
+        }
+
+        if (sessionId is not null)
+        {
+            return await sessionManager.GetTarget(sessionId.Value)
+                .SendAndUnwrapAsync(new DotsiderRequest
+                {
+                    Method = "explain-native-aot-size",
+                    Target = target,
+                    MaxCandidates = maxCandidates,
+                    MaxWhyChains = maxWhyChains
+                }, ct);
+        }
+
+        return "Error: Either assemblyPath or sessionId is required.";
+    }
+
+    private static MstatSource ResolveMstatSource(string path, string label) =>
+        MstatLocator.Resolve(path)
+        ?? throw new McpException(
+            $"{label} is not mstat-backed: pass a .mstat size report or a Native AOT binary "
+            + "published with IlcGenerateMstatFile.");
+
+    private static string Serialize(Func<object> build)
+    {
+        try
+        {
+            return JsonSerializer.Serialize(build(), DotsiderJsonOptions.Default);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new McpException(ex.Message);
+        }
+    }
+}

--- a/src/Dotsider.Mcp/Tools/SizeTools.cs
+++ b/src/Dotsider.Mcp/Tools/SizeTools.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Protocol;
-using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 
 namespace Dotsider.Mcp.Tools;
@@ -10,7 +9,7 @@ namespace Dotsider.Mcp.Tools;
 /// MCP tools for analyzing assembly size: hierarchical size trees and largest method ranking.
 /// </summary>
 [McpServerToolType]
-public sealed partial class SizeTools(DotsiderSessionManager sessionManager, ILogger<SizeTools> logger)
+public sealed partial class SizeTools(DotsiderSessionManager sessionManager)
 {
     /// <summary>
     /// Gets a hierarchical size breakdown of namespaces, types, and methods.
@@ -61,26 +60,9 @@ public sealed partial class SizeTools(DotsiderSessionManager sessionManager, ILo
         {
             ToolHelpers.ValidateAssemblyPath(assemblyPath);
             using var analyzer = ToolHelpers.OpenAnalyzer(assemblyPath);
-            var max = maxResults ?? 20;
-            var methods = analyzer.MethodDefs
-                .Select(m =>
-                {
-                    try
-                    {
-                        var body = analyzer.GetMethodBody(m);
-                        return new { Method = m, Size = body?.GetILBytes()?.Length ?? 0 };
-                    }
-                    catch (Exception ex)
-                    {
-                        LogIlBodyError(logger, ex, m.DeclaringType, m.Name);
-                        return new { Method = m, Size = 0 };
-                    }
-                })
-                .OrderByDescending(x => x.Size)
-                .Take(max)
-                .ToList();
-
-            return JsonSerializer.Serialize(methods, DotsiderJsonOptions.Default);
+            return JsonSerializer.Serialize(
+                NativeAotPayloadBuilder.BuildLargestMethods(analyzer, maxResults),
+                DotsiderJsonOptions.Default);
         }
 
         if (sessionId is not null)
@@ -91,7 +73,4 @@ public sealed partial class SizeTools(DotsiderSessionManager sessionManager, ILo
 
         return "Error: Either assemblyPath or sessionId is required.";
     }
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Cannot read IL body for {Type}.{Method}")]
-    private static partial void LogIlBodyError(ILogger logger, Exception exception, string type, string method);
 }

--- a/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
+++ b/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
@@ -216,6 +216,8 @@ internal sealed class DotsiderDiagnosticsListener(
                 "list-types" => HandleListTypes(request),
                 "list-methods" => HandleListMethods(request),
                 "find-members" => HandleFindMembers(request),
+                "get-native-aot-info" => HandleGetNativeAotInfo(),
+                "list-native-aot-sections" => HandleListNativeAotSections(),
 
                 // IL
                 "disassemble" => HandleDisassemble(request),
@@ -243,6 +245,8 @@ internal sealed class DotsiderDiagnosticsListener(
                 // Size
                 "get-size-tree" => HandleGetSizeTree(),
                 "get-largest-methods" => HandleGetLargestMethods(request),
+                "get-native-aot-size-contributors" => HandleGetNativeAotSizeContributors(request),
+                "explain-native-aot-size" => HandleExplainNativeAotSize(request),
 
                 // Symbols
                 "get-native-symbols" => HandleGetNativeSymbols(),
@@ -383,23 +387,8 @@ internal sealed class DotsiderDiagnosticsListener(
 
     private DotsiderResponse HandleListMethods(DotsiderRequest request)
     {
-        var methods = RequireAnalyzer().MethodDefs;
-        if (!string.IsNullOrEmpty(request.TypeName))
-        {
-            methods = [.. methods.Where(m =>
-                m.DeclaringType.Contains(request.TypeName, StringComparison.OrdinalIgnoreCase))];
-        }
-
-        if (!string.IsNullOrEmpty(request.Query))
-        {
-            methods = [.. methods.Where(m =>
-                m.Name.Contains(request.Query, StringComparison.OrdinalIgnoreCase))];
-        }
-
-        if (request.MaxResults is > 0)
-            methods = [.. methods.Take(request.MaxResults.Value)];
-
-        return DotsiderResponse.Ok(methods);
+        return DotsiderResponse.Ok(NativeAotPayloadBuilder.BuildMethodInventory(
+            RequireAnalyzer(), request.TypeName, request.Query, request.MaxResults));
     }
 
     private DotsiderResponse HandleFindMembers(DotsiderRequest request)
@@ -407,32 +396,32 @@ internal sealed class DotsiderDiagnosticsListener(
         if (string.IsNullOrEmpty(request.Query))
             return DotsiderResponse.Fail("Query is required for find-members");
 
-        var analyzer = RequireAnalyzer();
-        var query = request.Query;
-        var max = request.MaxResults ?? 100;
+        return DotsiderResponse.Ok(NativeAotPayloadBuilder.BuildMemberSearch(
+            RequireAnalyzer(), request.Query, request.MaxResults, request.IncludeCompilerGenerated));
+    }
 
-        var matchingTypes = analyzer.TypeDefs
-            .Where(t => t.FullName.Contains(query, StringComparison.OrdinalIgnoreCase))
-            .Take(max)
-            .ToList();
-
-        var matchingMethods = analyzer.MethodDefs
-            .Where(m => m.Name.Contains(query, StringComparison.OrdinalIgnoreCase)
-                || m.DeclaringType.Contains(query, StringComparison.OrdinalIgnoreCase))
-            .Take(max)
-            .ToList();
-
-        var matchingMemberRefs = analyzer.MemberRefs
-            .Where(r => r.Name.Contains(query, StringComparison.OrdinalIgnoreCase))
-            .Take(max)
-            .ToList();
-
-        return DotsiderResponse.Ok(new
+    private DotsiderResponse HandleGetNativeAotInfo()
+    {
+        try
         {
-            Types = matchingTypes,
-            Methods = matchingMethods,
-            MemberRefs = matchingMemberRefs
-        });
+            return DotsiderResponse.Ok(NativeAotPayloadBuilder.BuildInfo(RequireAnalyzer()));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return DotsiderResponse.Fail(ex.Message);
+        }
+    }
+
+    private DotsiderResponse HandleListNativeAotSections()
+    {
+        try
+        {
+            return DotsiderResponse.Ok(NativeAotPayloadBuilder.BuildSections(RequireAnalyzer()));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return DotsiderResponse.Fail(ex.Message);
+        }
     }
 
     // --- IL Handlers ---
@@ -631,25 +620,52 @@ internal sealed class DotsiderDiagnosticsListener(
 
     private DotsiderResponse HandleGetLargestMethods(DotsiderRequest request)
     {
-        var state = RequireState();
-        var max = request.MaxResults ?? 20;
-        var methods = state.Analyzer.MethodDefs
-            .Select(m =>
-            {
-                try
-                {
-                    var body = state.Analyzer.GetMethodBody(m);
-                    return new { Method = m, Size = body?.GetILBytes()?.Length ?? 0 };
-                }
-                catch
-                {
-                    return new { Method = m, Size = 0 };
-                }
-            })
-            .OrderByDescending(x => x.Size)
-            .Take(max);
+        return DotsiderResponse.Ok(NativeAotPayloadBuilder.BuildLargestMethods(
+            RequireAnalyzer(), request.MaxResults));
+    }
 
-        return DotsiderResponse.Ok(methods);
+    private DotsiderResponse HandleGetNativeAotSizeContributors(DotsiderRequest request)
+    {
+        try
+        {
+            var source = NativeAotPayloadBuilder.ResolveMstatSource(RequireAnalyzer());
+            if (source is null)
+            {
+                return DotsiderResponse.Fail(
+                    "Native AOT size contributors require an mstat sidecar; publish with IlcGenerateMstatFile.");
+            }
+
+            return DotsiderResponse.Ok(NativeAotPayloadBuilder.BuildSizeContributors(
+                source, request.Query, request.Section, request.AssemblyName, request.NamespaceName,
+                request.TopN, request.IncludeWhy, request.MaxWhyChains));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return DotsiderResponse.Fail(ex.Message);
+        }
+    }
+
+    private DotsiderResponse HandleExplainNativeAotSize(DotsiderRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Target))
+            return DotsiderResponse.Fail("target is required");
+
+        try
+        {
+            var source = NativeAotPayloadBuilder.ResolveMstatSource(RequireAnalyzer());
+            if (source is null)
+            {
+                return DotsiderResponse.Fail(
+                    "Native AOT size explanations require an mstat sidecar; publish with IlcGenerateMstatFile.");
+            }
+
+            return DotsiderResponse.Ok(NativeAotPayloadBuilder.BuildWhy(
+                source, request.Target, request.MaxCandidates, request.MaxWhyChains));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return DotsiderResponse.Fail(ex.Message);
+        }
     }
 
     // --- Symbols Handler ---

--- a/tests/Dotsider.Mcp.Tests/AssemblyToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/AssemblyToolsTests.cs
@@ -417,4 +417,59 @@ public class AssemblyToolsTests(SampleAssemblyFixture samples) : McpServerTestBa
         var names = json.EnumerateArray().Select(e => e.GetProperty("fullName").GetString()).ToList();
         Assert.Contains("Program", names);
     }
+
+    /// <summary>
+    /// list_methods falls back to recovered Native AOT method names when ECMA metadata is absent.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task ListMethods_NativeAot_ReturnsRecoveredMethods()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync("list_methods",
+            new Dictionary<string, object?>
+            {
+                ["assemblyPath"] = samples.NativeAotConsoleExe,
+                ["typeName"] = "Program"
+            },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+        Assert.Equal(JsonValueKind.Array, json.ValueKind);
+        Assert.True(json.GetArrayLength() > 0);
+        Assert.All(json.EnumerateArray(), e =>
+            Assert.Equal("RecoveredNativeAot", e.GetProperty("source").GetString()));
+    }
+
+    /// <summary>
+    /// find_members searches recovered Native AOT types and methods instead of metadata-only tables.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task FindMembers_NativeAot_SearchesRecoveredInventory()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync("find_members",
+            new Dictionary<string, object?>
+            {
+                ["assemblyPath"] = samples.NativeAotConsoleExe,
+                ["query"] = "Program"
+            },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+        Assert.True(json.GetProperty("types").GetArrayLength() > 0
+            || json.GetProperty("methods").GetArrayLength() > 0);
+        Assert.Equal(0, json.GetProperty("memberRefs").GetArrayLength());
+    }
 }

--- a/tests/Dotsider.Mcp.Tests/NativeAotToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/NativeAotToolsTests.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+
+namespace Dotsider.Mcp.Tests;
+
+/// <summary>
+/// Tests for Native AOT-specific MCP tools.
+/// </summary>
+[Collection("SampleAssemblies")]
+public class NativeAotToolsTests(SampleAssemblyFixture samples) : McpServerTestBase
+{
+    /// <summary>get_native_aot_info reports Native AOT identity and sidecar availability.</summary>
+    [Fact(Timeout = 30_000)]
+    public async Task GetNativeAotInfo_NativeAot_ReturnsSummary()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "get_native_aot_info",
+            new Dictionary<string, object?> { ["assemblyPath"] = samples.NativeAotConsoleExe },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+        Assert.Equal("nativeAot", json.GetProperty("binaryKind").GetString());
+        Assert.True(json.GetProperty("readyToRunSections").GetInt32() > 0);
+        Assert.True(json.GetProperty("recoveredTypes").GetInt32() > 0);
+        Assert.True(json.TryGetProperty("hasMstat", out _));
+    }
+
+    /// <summary>list_native_aot_sections returns Native AOT RTR module sections.</summary>
+    [Fact(Timeout = 30_000)]
+    public async Task ListNativeAotSections_NativeAot_ReturnsRtrSections()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "list_native_aot_sections",
+            new Dictionary<string, object?> { ["assemblyPath"] = samples.NativeAotConsoleExe },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+        Assert.True(json.GetProperty("sectionCount").GetInt32() > 0);
+        var first = json.GetProperty("sections").EnumerateArray().First();
+        Assert.True(first.TryGetProperty("sectionId", out _));
+        Assert.True(first.TryGetProperty("address", out _));
+    }
+
+    /// <summary>get_native_aot_size_contributors returns normalized mstat contributors.</summary>
+    [Fact(Timeout = 30_000)]
+    public async Task GetNativeAotSizeContributors_NativeAot_ReturnsTopMstatRows()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "get_native_aot_size_contributors",
+            new Dictionary<string, object?>
+            {
+                ["assemblyPath"] = samples.NativeAotConsoleExe,
+                ["section"] = "Method",
+                ["topN"] = 5
+            },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+        Assert.True(json.GetProperty("totalMatches").GetInt32() > 0);
+        var rows = json.GetProperty("contributors");
+        Assert.True(rows.GetArrayLength() > 0);
+        Assert.All(rows.EnumerateArray(), row =>
+        {
+            Assert.Equal("method", row.GetProperty("section").GetString());
+            Assert.True(row.GetProperty("size").GetInt64() > 0);
+        });
+    }
+
+    /// <summary>explain_native_aot_size returns a DGML root chain for a real contributor.</summary>
+    [Fact(Timeout = 30_000)]
+    public async Task ExplainNativeAotSize_NativeAot_ReturnsRootChain()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleDgml is null, "DGML sidecar was not produced");
+
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var contributors = await client.CallToolAsync(
+            "get_native_aot_size_contributors",
+            new Dictionary<string, object?>
+            {
+                ["assemblyPath"] = samples.NativeAotConsoleExe,
+                ["section"] = "Method",
+                ["topN"] = 20
+            },
+            cancellationToken: TestCancellationToken);
+
+        var contributorText = GetTextContent(contributors);
+        Assert.NotNull(contributorText);
+        var contributorJson = JsonSerializer.Deserialize<JsonElement>(contributorText);
+        var target = contributorJson.GetProperty("contributors")
+            .EnumerateArray()
+            .First(e => e.GetProperty("nodeNames").GetArrayLength() > 0)
+            .GetProperty("fullPath")
+            .GetString();
+        Assert.NotNull(target);
+
+        var result = await client.CallToolAsync(
+            "explain_native_aot_size",
+            new Dictionary<string, object?>
+            {
+                ["assemblyPath"] = samples.NativeAotConsoleExe,
+                ["target"] = target
+            },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+        Assert.Equal("resolved", json.GetProperty("outcome").GetString());
+        var chains = json.GetProperty("contributor").GetProperty("whyChains");
+        Assert.True(chains.GetArrayLength() > 0);
+    }
+}

--- a/tests/Dotsider.Mcp.Tests/SizeToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/SizeToolsTests.cs
@@ -99,4 +99,35 @@ public class SizeToolsTests(SampleAssemblyFixture samples) : McpServerTestBase
         Assert.Contains("category", text);
         Assert.Contains("System.Private.CoreLib", text);
     }
+
+    /// <summary>
+    /// get_largest_methods uses Native AOT mstat method sizes when IL bodies are absent.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task GetLargestMethods_NativeAot_ReturnsMstatMethods()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "get_largest_methods",
+            new Dictionary<string, object?>
+            {
+                ["assemblyPath"] = samples.NativeAotConsoleExe,
+                ["maxResults"] = 5
+            },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.NotNull(text);
+        var methods = JsonSerializer.Deserialize<JsonElement>(text);
+        Assert.True(methods.GetArrayLength() > 0);
+        Assert.All(methods.EnumerateArray(), m =>
+        {
+            Assert.Equal("Mstat", m.GetProperty("source").GetString());
+            Assert.True(m.GetProperty("size").GetInt64() > 0);
+        });
+    }
 }

--- a/tests/Dotsider.Mcp.Tests/ToolRegistrationTests.cs
+++ b/tests/Dotsider.Mcp.Tests/ToolRegistrationTests.cs
@@ -54,6 +54,12 @@ public class ToolRegistrationTests : McpServerTestBase
         Assert.Contains("get_native_symbols", names);
         Assert.Contains("get_native_disassembly", names);
 
+        // Native AOT tools
+        Assert.Contains("get_native_aot_info", names);
+        Assert.Contains("list_native_aot_sections", names);
+        Assert.Contains("get_native_aot_size_contributors", names);
+        Assert.Contains("explain_native_aot_size", names);
+
         // Correlation tools
         Assert.Contains("correlate_method", names);
         Assert.Contains("correlate_r2r_method", names);

--- a/tests/Dotsider.Tests/NativeAotSessionSocketTests.cs
+++ b/tests/Dotsider.Tests/NativeAotSessionSocketTests.cs
@@ -1,0 +1,133 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Dotsider.Core.Protocol;
+using Dotsider.Diagnostics;
+using Dotsider.Infrastructure;
+using Hex1b;
+using Hex1b.Widgets;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// End-to-end diagnostics-socket tests for Native AOT analysis commands used by MCP session tools.
+/// </summary>
+[Collection("SampleAssemblies")]
+public class NativeAotSessionSocketTests(SampleAssemblyFixture samples) : IAsyncDisposable
+{
+    private Hex1bAppWorkloadAdapter? _workload;
+    private Hex1bTerminal? _terminal;
+    private Hex1bApp? _app;
+    private DotsiderState? _state;
+    private DotsiderDiagnosticsListener? _listener;
+    private CancellationTokenSource? _appCts;
+
+    private async Task<string> StartTuiWithDiagnosticsAsync(string path, CancellationToken ct)
+    {
+        var pendingMutations = new ConcurrentQueue<Action<DotsiderState>>();
+
+        _workload = new Hex1bAppWorkloadAdapter();
+        _terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(_workload)
+            .WithHeadless()
+            .WithDimensions(120, 30)
+            .Build();
+
+        _app = new Hex1bApp(
+            ctx =>
+            {
+                _state ??= new DotsiderState(_app!, path, pendingMutations);
+                var dotsiderApp = new DotsiderApp(_state);
+                return Task.FromResult<Hex1bWidget>(dotsiderApp.Build(ctx));
+            },
+            new Hex1bAppOptions
+            {
+                WorkloadAdapter = _workload,
+                EnableInputCoalescing = false
+            });
+
+        _listener = new DotsiderDiagnosticsListener(() => _state);
+        _listener.StartListening();
+
+        _appCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _ = _app.RunAsync(_appCts.Token);
+        await Task.Delay(100, ct);
+
+        await TestHelpers.WaitUntilAsync(
+            () => _state is not null,
+            TimeSpan.FromSeconds(10));
+
+        return _listener.SocketPath!;
+    }
+
+    /// <summary>get-native-aot-info returns identity facts from a running Native AOT session.</summary>
+    [Fact(Timeout = 30_000)]
+    public async Task GetNativeAotInfo_ReturnsSummary()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        var ct = TestContext.Current.CancellationToken;
+        var socketPath = await StartTuiWithDiagnosticsAsync(samples.NativeAotConsoleExe!, ct);
+
+        var response = await DotsiderClient.SendAsync(socketPath,
+            new DotsiderRequest { Method = "get-native-aot-info" }, ct);
+
+        Assert.True(response.Success, response.Error);
+        var data = (response.Data as JsonElement?)!.Value;
+        Assert.Equal("nativeAot", data.GetProperty("binaryKind").GetString());
+        Assert.True(data.GetProperty("readyToRunSections").GetInt32() > 0);
+    }
+
+    /// <summary>get-native-aot-size-contributors returns mstat contributors from a running session.</summary>
+    [Fact(Timeout = 30_000)]
+    public async Task GetNativeAotSizeContributors_ReturnsRows()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+
+        var ct = TestContext.Current.CancellationToken;
+        var socketPath = await StartTuiWithDiagnosticsAsync(samples.NativeAotConsoleExe!, ct);
+
+        var response = await DotsiderClient.SendAsync(socketPath,
+            new DotsiderRequest
+            {
+                Method = "get-native-aot-size-contributors",
+                Section = "Method",
+                TopN = 5
+            }, ct);
+
+        Assert.True(response.Success, response.Error);
+        var data = (response.Data as JsonElement?)!.Value;
+        Assert.True(data.GetProperty("contributors").GetArrayLength() > 0);
+    }
+
+    /// <summary>list-methods uses the recovered Native AOT inventory through the session socket.</summary>
+    [Fact(Timeout = 30_000)]
+    public async Task ListMethods_ReturnsRecoveredNativeAotMethods()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        var ct = TestContext.Current.CancellationToken;
+        var socketPath = await StartTuiWithDiagnosticsAsync(samples.NativeAotConsoleExe!, ct);
+
+        var response = await DotsiderClient.SendAsync(socketPath,
+            new DotsiderRequest { Method = "list-methods", TypeName = "Program" }, ct);
+
+        Assert.True(response.Success, response.Error);
+        var data = (response.Data as JsonElement?)!.Value;
+        Assert.True(data.GetArrayLength() > 0);
+        Assert.All(data.EnumerateArray(), row =>
+            Assert.Equal("RecoveredNativeAot", row.GetProperty("source").GetString()));
+    }
+
+    /// <summary>Disposes the diagnostics listener, state, and terminal.</summary>
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        _appCts?.Cancel();
+        if (_listener is not null)
+            await _listener.DisposeAsync();
+        _state?.Dispose();
+        if (_terminal is not null)
+            await _terminal.DisposeAsync();
+        _appCts?.Dispose();
+    }
+}


### PR DESCRIPTION
Adds Native AOT MCP tools for identity, RTR sections, mstat contributors, and DGML why chains, with direct and session-backed paths sharing the same payloads. Existing member and size tools now return recovered Native AOT methods and mstat native sizes instead of empty metadata-only results.

Validated with dotnet build Dotsider.slnx -nodeReuse:false, dotnet test tests/Dotsider.Mcp.Tests/Dotsider.Mcp.Tests.csproj, and focused NativeAotSessionSocketTests.

Fixes: #182