### PR TITLE
Force readable search highlight foregrounds

### DIFF
--- a/src/Dotsider/HighlightHelper.cs
+++ b/src/Dotsider/HighlightHelper.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Hex1b.Documents;
 using Hex1b;
 using Hex1b.Theming;
 using Hex1b.Widgets;
@@ -15,11 +16,27 @@ public static class HighlightHelper
     /// <summary>The highlight background color applied to matching substrings (warm yellow).</summary>
     public static readonly Hex1bColor MatchBgColor = Hex1bColor.FromRgb(255, 220, 100);
 
+    /// <summary>The highlight foreground color applied to matching substrings.</summary>
+    public static readonly Hex1bColor MatchFgColor = Hex1bColor.Black;
+
+    /// <summary>The current-match background color applied to the active editor match.</summary>
+    public static readonly Hex1bColor CurrentMatchBgColor = Hex1bColor.FromRgb(255, 165, 0);
+
     /// <summary>The dim color applied to non-matching items in spatial views.</summary>
     public static readonly Hex1bColor DimColor = Hex1bColor.FromRgb(50, 50, 60);
 
     private static readonly string MatchBgAnsi = MatchBgColor.ToBackgroundAnsi();
-    private static readonly string BlackFgAnsi = Hex1bColor.Black.ToForegroundAnsi();
+    private static readonly string MatchFgAnsi = MatchFgColor.ToForegroundAnsi();
+
+    /// <summary>
+    /// Creates an editor search decoration with both foreground and background set so
+    /// syntax colors cannot reduce contrast against the match background.
+    /// </summary>
+    public static TextDecoration CreateSearchMatchDecoration(bool current = false) => new()
+    {
+        Foreground = MatchFgColor,
+        Background = current ? CurrentMatchBgColor : MatchBgColor
+    };
 
     /// <summary>
     /// Wraps each case-insensitive match of <paramref name="query"/> in <paramref name="text"/>
@@ -54,7 +71,7 @@ public static class HighlightHelper
                 sb.Append(text, pos, idx - pos);
 
             sb.Append(MatchBgAnsi);
-            sb.Append(BlackFgAnsi);
+            sb.Append(MatchFgAnsi);
             sb.Append(text, idx, query.Length);
             sb.Append(restoreAnsi);
 

--- a/src/Dotsider/Views/DiffSearchDecorationProvider.cs
+++ b/src/Dotsider/Views/DiffSearchDecorationProvider.cs
@@ -8,10 +8,8 @@ namespace Dotsider.Views;
 /// </summary>
 public sealed class DiffSearchDecorationProvider : ITextDecorationProvider
 {
-    private static readonly TextDecoration MatchDecoration = new()
-    {
-        Background = HighlightHelper.MatchBgColor
-    };
+    private static readonly TextDecoration MatchDecoration =
+        HighlightHelper.CreateSearchMatchDecoration();
 
     /// <summary>The current search query, or null/empty when no search is active.</summary>
     public string? Query { get; set; }

--- a/src/Dotsider/Views/IlSearchDecorationProvider.cs
+++ b/src/Dotsider/Views/IlSearchDecorationProvider.cs
@@ -1,5 +1,4 @@
 using Hex1b.Documents;
-using Hex1b.Theming;
 
 namespace Dotsider.Views;
 
@@ -9,17 +8,11 @@ namespace Dotsider.Views;
 /// </summary>
 public sealed class IlSearchDecorationProvider : ITextDecorationProvider
 {
-    private static readonly TextDecoration MatchDecoration = new()
-    {
-        Background = HighlightHelper.MatchBgColor
-        // Foreground is null — syntax colors show through
-    };
+    private static readonly TextDecoration MatchDecoration =
+        HighlightHelper.CreateSearchMatchDecoration();
 
-    private static readonly TextDecoration CurrentMatchDecoration = new()
-    {
-        Background = Hex1bColor.FromRgb(255, 165, 0),
-        Foreground = Hex1bColor.Black
-    };
+    private static readonly TextDecoration CurrentMatchDecoration =
+        HighlightHelper.CreateSearchMatchDecoration(current: true);
 
     /// <summary>The current search query, or null/empty when no search is active.</summary>
     public string? Query { get; set; }

--- a/tests/Dotsider.Tests/DiffDecorationProviderTests.cs
+++ b/tests/Dotsider.Tests/DiffDecorationProviderTests.cs
@@ -1,5 +1,6 @@
 using Dotsider.Views;
 using Hex1b.Documents;
+using Hex1b.Theming;
 
 namespace Dotsider.Tests;
 
@@ -25,6 +26,24 @@ public class DiffDecorationProviderTests
         Assert.Equal(2, spans.Count);
         Assert.Equal(1, spans[0].Start.Line);
         Assert.Equal(3, spans[1].Start.Line);
+    }
+
+    /// <summary>
+    /// Verifies diff search matches own foreground and background colors.
+    /// </summary>
+    [Fact]
+    public void DiffSearch_MatchesOwnForegroundAndBackground()
+    {
+        var provider = new DiffSearchDecorationProvider { Query = "rich" };
+        var doc = new Hex1bDocument("RichLibrary");
+
+        var spans = provider.GetDecorations(1, 1, doc);
+
+        var span = Assert.Single(spans);
+        Assert.NotNull(span.Decoration.Foreground);
+        Assert.NotNull(span.Decoration.Background);
+        AssertColorEquals(HighlightHelper.MatchFgColor, span.Decoration.Foreground.Value);
+        AssertColorEquals(HighlightHelper.MatchBgColor, span.Decoration.Background.Value);
     }
 
     /// <summary>
@@ -148,5 +167,12 @@ public class DiffDecorationProviderTests
         var doc = new Hex1bDocument("\n\n");
 
         Assert.Empty(provider.GetDecorations(1, 3, doc));
+    }
+
+    private static void AssertColorEquals(Hex1bColor expected, Hex1bColor actual)
+    {
+        Assert.Equal(expected.R, actual.R);
+        Assert.Equal(expected.G, actual.G);
+        Assert.Equal(expected.B, actual.B);
     }
 }

--- a/tests/Dotsider.Tests/IlSearchDecorationProviderTests.cs
+++ b/tests/Dotsider.Tests/IlSearchDecorationProviderTests.cs
@@ -39,10 +39,10 @@ public class IlSearchDecorationProviderTests
     }
 
     /// <summary>
-    /// Verifies single match returns match bg span.
+    /// Verifies single match returns a readable match span.
     /// </summary>
     [Fact(Timeout = 30_000)]
-    public void SingleMatch_ReturnsMatchBgSpan()
+    public void SingleMatch_ReturnsReadableMatchSpan()
     {
         var doc = new Hex1bDocument("hello world");
         var provider = new IlSearchDecorationProvider { Query = "world" };
@@ -58,7 +58,8 @@ public class IlSearchDecorationProviderTests
         Assert.Equal(10, span.Priority);
         Assert.NotNull(span.Decoration.Background);
         AssertColorEquals(HighlightHelper.MatchBgColor, span.Decoration.Background.Value);
-        Assert.Null(span.Decoration.Foreground);
+        Assert.NotNull(span.Decoration.Foreground);
+        AssertColorEquals(HighlightHelper.MatchFgColor, span.Decoration.Foreground.Value);
     }
 
     /// <summary>
@@ -84,9 +85,19 @@ public class IlSearchDecorationProviderTests
         Assert.Equal(new DocumentPosition(1, 12), span.End);
         Assert.Equal(20, span.Priority);
         Assert.NotNull(span.Decoration.Background);
-        AssertColorEquals(Hex1bColor.FromRgb(255, 165, 0), span.Decoration.Background.Value);
+        AssertColorEquals(HighlightHelper.CurrentMatchBgColor, span.Decoration.Background.Value);
         Assert.NotNull(span.Decoration.Foreground);
-        AssertColorEquals(Hex1bColor.Black, span.Decoration.Foreground.Value);
+        AssertColorEquals(HighlightHelper.MatchFgColor, span.Decoration.Foreground.Value);
+    }
+
+    /// <summary>
+    /// Verifies editor search colors clear WCAG AA contrast for normal and current matches.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void SearchMatchColors_ClearWcagAa()
+    {
+        Assert.True(ContrastRatio(HighlightHelper.MatchFgColor, HighlightHelper.MatchBgColor) >= 4.5);
+        Assert.True(ContrastRatio(HighlightHelper.MatchFgColor, HighlightHelper.CurrentMatchBgColor) >= 4.5);
     }
 
     /// <summary>
@@ -154,5 +165,27 @@ public class IlSearchDecorationProviderTests
         Assert.Equal(expected.R, actual.R);
         Assert.Equal(expected.G, actual.G);
         Assert.Equal(expected.B, actual.B);
+    }
+
+    private static double ContrastRatio(Hex1bColor a, Hex1bColor b)
+    {
+        var l1 = RelativeLuminance(a);
+        var l2 = RelativeLuminance(b);
+        if (l1 < l2)
+            (l1, l2) = (l2, l1);
+        return (l1 + 0.05) / (l2 + 0.05);
+    }
+
+    private static double RelativeLuminance(Hex1bColor color)
+    {
+        static double Channel(byte value)
+        {
+            var c = value / 255.0;
+            return c <= 0.03928 ? c / 12.92 : Math.Pow((c + 0.055) / 1.055, 2.4);
+        }
+
+        return 0.2126 * Channel(color.R)
+            + 0.7152 * Channel(color.G)
+            + 0.0722 * Channel(color.B);
     }
 }


### PR DESCRIPTION
Editor search matches now force black foregrounds over the yellow and current-match backgrounds, matching the readable table and list highlight behavior. This keeps IL, native disassembly, and diff editor results legible when a match overlaps syntax-colored tokens.

Validated with the focused decoration-provider tests and a warnings-clean build.

Fixes: #190