### PR TITLE
Improve size-diff popup readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ Grab a standalone binary from [Releases](https://github.com/willibrandon/dotside
 
 ## What it does
 
-dotsider opens any .NET DLL or EXE and lets you explore it across 8 tabs. If you open an apphost `.exe` that has no .NET metadata, dotsider detects the missing metadata and offers to open the companion managed `.dll` instead. If you open a self-contained single-file executable, dotsider reads the bundle, extracts the entry assembly, and analyzes it directly — no unpacking needed. If you open a Native AOT executable, dotsider validates its embedded ReadyToRun header and walks its runtime sections — surfacing the binary kind, toolchain format version, runtime version, native import/export/load-config tables, the ReadyToRun section table, the types and methods recovered from the embedded metadata, and frozen string literals. It also probes the build tree for the binary's pre-ILC managed assemblies and their mstat/DGML sidecars and offers to attach them, filling the metadata tabs and showing each method's IL beside its native code. If you open a ReadyToRun (crossgen2) image, dotsider keeps its full metadata and surfaces which managed methods carry precompiled native bodies — IL beside native code, call targets resolved through the import tables, and composite images followed across their component assemblies in both directions.
+dotsider opens any .NET DLL or EXE and lets you explore it across 8 tabs. Apphost executables are handled as first-class inputs: when an `.exe` has no .NET metadata, dotsider offers to open the companion managed `.dll`. Self-contained single-file apps work too — dotsider reads the bundle, extracts the entry assembly, and analyzes it directly.
+
+Native AOT binaries get native treatment instead of an empty metadata view. dotsider validates the embedded ReadyToRun header, walks the runtime sections, surfaces imports, exports, load config, recovered AOT types, recovered methods, and frozen string literals, then renders x86-64 or AArch64 disassembly for native functions.
+
+When the Native AOT build tree is available, dotsider can attach the pre-ILC managed assemblies plus their mstat/DGML sidecars. That fills the metadata tabs from the original managed inputs and shows each method's IL beside its native code.
+
+ReadyToRun (crossgen2) images keep their full managed metadata, and dotsider joins that metadata to the precompiled method bodies in the same file or composite image. You can see IL beside native code, named call targets from import tables, and component assemblies followed in both directions.
 
 | Tab | What you see |
 |-----|-------------|
@@ -210,7 +216,7 @@ Info panels (Assembly Info, PE Headers, CLR Header, detail popups, string detail
 
 In insert mode, type two hex digits (0-9, a-f) to overwrite one byte. The first digit sets the high nibble; the second commits the edit. Saving validates the PE image before writing — invalid edits are rejected.
 
-Diff mode adds `f` to cycle filters (All / Added / Removed / Changed). The size-diff view (mstat inputs) adds Grown and Shrunk to the filter cycle, `Enter`/`Esc` to drill and back out of the delta treemap, `w` for the dependency chain that keeps an entry in the binary (again to flip sides on a changed entry), and `d` to disassemble a method's native body. NuGet mode uses `Esc` to return from DLL inspection to the package browser.
+Diff mode adds `f` to cycle filters (All / Added / Removed / Changed). The size-diff view (mstat inputs) adds Grown and Shrunk to the filter cycle, `Enter`/`Esc` to drill and back out of the delta treemap, `w` for the dependency chain that keeps an entry in the binary (aggregate tiles show representative child chains; press again to flip sides on a changed entry), and `d` to disassemble a method's native body. NuGet mode uses `Esc` to return from DLL inspection to the package browser.
 
 ## How it works
 

--- a/docs/src/content/docs/reference/keyboard.md
+++ b/docs/src/content/docs/reference/keyboard.md
@@ -89,7 +89,7 @@ description: All keyboard shortcuts for navigating dotsider.
 | `Esc` / right-click | Go up one level (dismisses popups and search first) |
 | `←` `→` | Cycle rectangle selection |
 | `/` then `n` `N` | Search the current level, jump between matches |
-| `w` | Why is this in the binary — dependency chain; press again on a changed entry to flip sides |
+| `w` | Why is this in the binary — dependency chain; aggregate tiles show representative child chains; press again on a changed entry to flip sides |
 | `d` | Disassemble the native body (binary-backed pairs); repeated presses cycle an aggregate's symbols and, for changed entries, both builds' bodies |
 | `y` | Yank selected text in the summary or popups |
 

--- a/docs/src/content/docs/usage/diff-mode.md
+++ b/docs/src/content/docs/usage/diff-mode.md
@@ -86,12 +86,15 @@ Keys: `Enter`/click drills into a subtree, `Esc`/right-click goes back up, `←`
 selection, `/` searches with `n`/`N`, and `f` cycles five direction filters (All, Added,
 Removed, Grown, Shrunk). `w` opens the dependency chain that keeps the entry in the binary —
 added entries answer from the new build's graph, removed entries from the old build's, and
-pressing `w` again on a changed entry flips sides (the popup header names the side). `d` on a
-method disassembles its native body, resolved by the entry's mangled ILC node name — exact
-per overload and per instantiation. Repeated presses cycle through every candidate body: an
-aggregate's symbols, and for a changed entry both builds — new first, then baseline — so a
-grown method's before and after are one key apart. The popup header names the side and which
-of how many is showing.
+pressing `w` again on a changed entry flips sides (the popup header names the side).
+Namespace, type, assembly, and category tiles roll up the child DGML node names and show
+representative root-first chains, so you do not have to drill to a method leaf just to ask
+why a large subtree grew. Entries that truly have no DGML node, such as metadata blobs or
+resources, say that directly. `d` on a method disassembles its native body, resolved by the
+entry's mangled ILC node name — exact per overload and per instantiation. Repeated presses
+cycle through every candidate body: an aggregate's symbols, and for a changed entry both
+builds — new first, then baseline — so a grown method's before and after are one key apart.
+The popup header names the side and which of how many is showing.
 
 The **Summary** tab prints the same figures the headless `size-check` report does: totals on
 every applicable basis, per-kind direction counts, and the top regressions and improvements.

--- a/src/Dotsider.Core/Analysis/MstatDiffer.cs
+++ b/src/Dotsider.Core/Analysis/MstatDiffer.cs
@@ -250,13 +250,21 @@ public static class MstatDiffer
             : children.All(c => c.Diff == DiffKind.Added) ? DiffKind.Added
             : children.All(c => c.Diff == DiffKind.Removed) ? DiffKind.Removed
             : DiffKind.Changed;
+        var leftNodeNames = MergeNodeNames(children, static c => c.LeftNodeNames);
+        var rightNodeNames = MergeNodeNames(children, static c => c.RightNodeNames);
         return new SizeDiffNode(
             name, fullPath, kind, diff,
             children.Sum(c => c.LeftSize), children.Sum(c => c.RightSize), children.Sum(c => c.Delta),
             children,
             children.Sum(c => c.LeftEntryCount), children.Sum(c => c.RightEntryCount),
-            [], []);
+            leftNodeNames, rightNodeNames);
     }
+
+    private static List<string> MergeNodeNames(
+        List<SizeDiffNode> children, Func<SizeDiffNode, IReadOnlyList<string>> selector) =>
+        [.. children
+            .SelectMany(selector)
+            .Distinct(StringComparer.Ordinal)];
 
     private static List<SizeDiffNode> Order(List<SizeDiffNode> nodes) => [.. nodes
         .OrderByDescending(n => Math.Abs(n.Delta))

--- a/src/Dotsider/Views/InfoLabelDecorationProvider.cs
+++ b/src/Dotsider/Views/InfoLabelDecorationProvider.cs
@@ -11,10 +11,25 @@ namespace Dotsider.Views;
 /// </summary>
 public sealed class InfoLabelDecorationProvider : ITextDecorationProvider
 {
-    private static readonly TextDecoration LabelDecoration = new()
+    private static readonly Hex1bColor DefaultLabelColor = Hex1bColor.FromRgb(100, 130, 160);
+    private readonly TextDecoration _labelDecoration;
+
+    /// <summary>
+    /// Creates the default info label provider.
+    /// </summary>
+    public InfoLabelDecorationProvider()
+        : this(DefaultLabelColor)
     {
-        Foreground = Hex1bColor.FromRgb(100, 130, 160)
-    };
+    }
+
+    /// <summary>
+    /// Creates an info label provider with a caller-supplied label color.
+    /// </summary>
+    /// <param name="labelColor">The foreground color applied to label spans.</param>
+    public InfoLabelDecorationProvider(Hex1bColor labelColor)
+    {
+        _labelDecoration = new TextDecoration { Foreground = labelColor };
+    }
 
     /// <inheritdoc />
     public IReadOnlyList<TextDecorationSpan> GetDecorations(
@@ -76,7 +91,7 @@ public sealed class InfoLabelDecorationProvider : ITextDecorationProvider
                     spans.Add(new TextDecorationSpan(
                         new DocumentPosition(line, spanCol),
                         new DocumentPosition(line, colonIdx + 2),
-                        LabelDecoration,
+                        _labelDecoration,
                         5));
                     isFirstOnLine = false;
                 }

--- a/src/Dotsider/Views/SizeDiffTreemapView.cs
+++ b/src/Dotsider/Views/SizeDiffTreemapView.cs
@@ -26,6 +26,12 @@ public static class SizeDiffTreemapView
     private static readonly Hex1bColor ShrunkColor = Hex1bColor.FromRgb(95, 150, 100);
     private static readonly Hex1bColor MixedColor = Hex1bColor.FromRgb(110, 110, 140);
     private static readonly Hex1bColor SelectionBorder = Hex1bColor.FromRgb(255, 255, 255);
+    internal static readonly Hex1bColor PopupPanelBackground = Hex1bColor.FromRgb(24, 24, 32);
+    internal static readonly Hex1bColor PopupForeground = Hex1bColor.FromRgb(230, 230, 240);
+    internal static readonly Hex1bColor PopupLabelForeground = Hex1bColor.FromRgb(140, 170, 205);
+    internal static readonly Hex1bColor PopupBorderColor = Hex1bColor.FromRgb(120, 150, 190);
+    private static readonly Hex1bColor PopupSelectionForeground = Hex1bColor.White;
+    private static readonly Hex1bColor PopupSelectionBackground = Hex1bColor.FromRgb(65, 70, 90);
 
     /// <summary>
     /// Builds the size-diff treemap widget tree.
@@ -182,6 +188,7 @@ public static class SizeDiffTreemapView
                             state.VimPending = VimMotionState.Idle;
                             CloseWhyPopup(state);
                             CloseDisasmPopup(state);
+                            state.RequestContentFocus();
                             state.App.Invalidate();
                         }, "Dismiss popup");
                     }
@@ -453,38 +460,52 @@ public static class SizeDiffTreemapView
         string? content, EditorState? editorState, string title, Action close)
     {
         if (content is null || editorState is null) return null;
-        return z.Backdrop(
-            z.Border(
-                z.ThemePanel(t => t
-                    .Set(EditorTheme.SelectionForegroundColor, Hex1bColor.Default)
-                    .Set(EditorTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(79, 82, 88)),
-                z.Editor(editorState)
-                    .ViewRenderer(InfoEditorViewRenderer.Instance)
-                    .Decorations(new InfoLabelDecorationProvider())
-                    .InputBindings(bindings =>
+
+        var editor = z.Editor(editorState)
+            .ViewRenderer(InfoEditorViewRenderer.Instance)
+            .Decorations(new InfoLabelDecorationProvider(PopupLabelForeground))
+            .InputBindings(bindings =>
+            {
+                TextObjectHelper.ConfigureReadOnlyEditorBindings(
+                    bindings,
+                    editorState,
+                    () => state.VimPending,
+                    () => state.VimPendingEditor,
+                    () => state.VimPendingCursorOffset,
+                    () => state.VimPendingTimestamp,
+                    (s, e, o) =>
                     {
-                        TextObjectHelper.ConfigureReadOnlyEditorBindings(
-                            bindings,
-                            editorState,
-                            () => state.VimPending,
-                            () => state.VimPendingEditor,
-                            () => state.VimPendingCursorOffset,
-                            () => state.VimPendingTimestamp,
-                            (s, e, o) =>
-                            {
-                                state.VimPending = s;
-                                state.VimPendingEditor = e;
-                                state.VimPendingCursorOffset = o;
-                                state.VimPendingTimestamp = DateTime.UtcNow;
-                            },
-                            state.PerformEditorYank,
-                            () => state.App.Invalidate());
-                    })
-                    .FillWidth().FillHeight())
-            ).Title(title).FixedWidth(100).FixedHeight(24)
-        ).OnClickAway(() =>
+                        state.VimPending = s;
+                        state.VimPendingEditor = e;
+                        state.VimPendingCursorOffset = o;
+                        state.VimPendingTimestamp = DateTime.UtcNow;
+                    },
+                    state.PerformEditorYank,
+                    () => state.App.Invalidate());
+            })
+            .FillWidth().FillHeight();
+
+        var popup = z.ThemePanel(t => t
+                .Set(GlobalTheme.ForegroundColor, PopupForeground)
+                .Set(GlobalTheme.BackgroundColor, PopupPanelBackground)
+                .Set(EditorTheme.ForegroundColor, PopupForeground)
+                .Set(EditorTheme.BackgroundColor, PopupPanelBackground)
+                .Set(EditorTheme.SelectionForegroundColor, PopupSelectionForeground)
+                .Set(EditorTheme.SelectionBackgroundColor, PopupSelectionBackground)
+                .Set(BorderTheme.BorderColor, PopupBorderColor)
+                .Set(BorderTheme.TitleColor, PopupForeground)
+                .Set(BorderTheme.TopBorderColor, PopupBorderColor)
+                .Set(BorderTheme.BottomBorderColor, PopupBorderColor)
+                .Set(BorderTheme.LeftBorderColor, PopupBorderColor)
+                .Set(BorderTheme.RightBorderColor, PopupBorderColor),
+            new BackgroundPanelWidget(
+                PopupPanelBackground,
+                z.Border(editor).Title(title).FixedWidth(100).FixedHeight(24)));
+
+        return z.Backdrop(popup).OnClickAway(() =>
         {
             close();
+            state.RequestContentFocus();
             state.App.Invalidate();
         });
     }
@@ -542,8 +563,16 @@ public static class SizeDiffTreemapView
             Delta = children.Sum(c => c.Delta),
             LeftEntryCount = children.Sum(c => c.LeftEntryCount),
             RightEntryCount = children.Sum(c => c.RightEntryCount),
+            LeftNodeNames = MergeNodeNames(children, static c => c.LeftNodeNames),
+            RightNodeNames = MergeNodeNames(children, static c => c.RightNodeNames),
         };
     }
+
+    private static List<string> MergeNodeNames(
+        List<SizeDiffNode> children, Func<SizeDiffNode, IReadOnlyList<string>> selector) =>
+        [.. children
+            .SelectMany(selector)
+            .Distinct(StringComparer.Ordinal)];
 
     /// <summary>
     /// The treemap area weight of a node: its absolute delta, or for an interior whose

--- a/src/Dotsider/Views/WhyChainFormatter.cs
+++ b/src/Dotsider/Views/WhyChainFormatter.cs
@@ -52,7 +52,7 @@ public static class WhyChainFormatter
     {
         if (nodeNames.Count == 0)
         {
-            return $"{displayPath}\n\nNo dependency-graph node names recorded for this entry\n(format 1.x mstat, or names stripped). Publish with a\n2.0+ SDK to join sizes to dependency chains.";
+            return $"{displayPath}\n\nNo dependency-graph node names recorded for this entry.\nSome data-only entries, such as metadata blobs or\nresources, have size rows but no DGML node. Format\n1.x mstat files can also lack these names.";
         }
 
         if (nodeNames.Count == 1)

--- a/tests/Dotsider.Tests/InfoDecorationProviderTests.cs
+++ b/tests/Dotsider.Tests/InfoDecorationProviderTests.cs
@@ -1,5 +1,6 @@
 using Dotsider.Views;
 using Hex1b.Documents;
+using Hex1b.Theming;
 
 namespace Dotsider.Tests;
 
@@ -25,6 +26,22 @@ public class InfoDecorationProviderTests
         Assert.Equal(1, spans[0].Start.Column);
         // Second span covers "  Version:" on line 2
         Assert.Equal(2, spans[1].Start.Line);
+    }
+
+    /// <summary>
+    /// Verifies callers can supply a contrast-safe label color for popup surfaces.
+    /// </summary>
+    [Fact]
+    public void InfoLabel_UsesCustomLabelColor()
+    {
+        var color = Hex1bColor.FromRgb(140, 170, 205);
+        var provider = new InfoLabelDecorationProvider(color);
+        var doc = new Hex1bDocument("  Side: current");
+
+        var span = Assert.Single(provider.GetDecorations(1, 1, doc));
+
+        Assert.NotNull(span.Decoration.Foreground);
+        AssertColorEquals(color, span.Decoration.Foreground.Value);
     }
 
     /// <summary>
@@ -232,5 +249,12 @@ public class InfoDecorationProviderTests
         var spans = provider.GetDecorations(1, 1, doc);
 
         Assert.Equal(4, spans.Count);
+    }
+
+    private static void AssertColorEquals(Hex1bColor expected, Hex1bColor actual)
+    {
+        Assert.Equal(expected.R, actual.R);
+        Assert.Equal(expected.G, actual.G);
+        Assert.Equal(expected.B, actual.B);
     }
 }

--- a/tests/Dotsider.Tests/SizeDiffViewTests.cs
+++ b/tests/Dotsider.Tests/SizeDiffViewTests.cs
@@ -236,8 +236,29 @@ public class SizeDiffViewTests(SampleAssemblyFixture samples) : IDisposable
         await auto.WaitUntilAsync(
             _ => _state is { TreemapSelectedIndex: >= 0 }, description: "an item is selected");
         await auto.KeyAsync(Hex1bKey.W, ct: cts.Token);
-        await auto.WaitUntilTextAsync("Why in binary");
+        Hex1b.Automation.Hex1bTerminalSnapshot? popupSnapshot = null;
+        await auto.WaitUntilAsync(s =>
+        {
+            if (!ScreenText(s).Contains("Why in binary", StringComparison.Ordinal))
+                return false;
+            popupSnapshot = s;
+            return true;
+        }, description: "why popup rendered");
         Assert.NotNull(_state!.WhyContent);
+        AssertPopupSurfaceReadable(popupSnapshot!, "Why in binary", "[right/current:");
+        var selectedBeforeDismiss = _state.TreemapSelectedIndex;
+        var visibleCount = (_state.TreemapCurrentLevel ?? _state.FilteredRoot)!.Children.Count;
+        Assert.True(visibleCount > 1, "The fixture must expose more than one treemap item.");
+        var expectedSelection = (selectedBeforeDismiss + 1) % visibleCount;
+
+        await auto.KeyAsync(Hex1bKey.Escape, ct: cts.Token);
+        await auto.WaitUntilAsync(
+            _ => _state is { WhyContent: null },
+            description: "why popup dismissed");
+        await auto.KeyAsync(Hex1bKey.RightArrow, ct: cts.Token);
+        await auto.WaitUntilAsync(
+            _ => _state!.TreemapSelectedIndex == expectedSelection,
+            description: "treemap focus restored after popup dismiss");
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -263,8 +284,19 @@ public class SizeDiffViewTests(SampleAssemblyFixture samples) : IDisposable
         await auto.WaitUntilAsync(
             _ => _state is { TreemapSelectedIndex: >= 0 }, description: "an item is selected");
         await auto.KeyAsync(Hex1bKey.D, ct: cts.Token);
-        await auto.WaitUntilAsync(
-            _ => _state is { DisasmContent: not null }, description: "disasm popup content set");
+        Hex1b.Automation.Hex1bTerminalSnapshot? popupSnapshot = null;
+        await auto.WaitUntilAsync(s =>
+        {
+            if (_state is not { DisasmContent: not null }
+                || !ScreenText(s).Contains("Native disassembly", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            popupSnapshot = s;
+            return true;
+        }, description: "disasm popup rendered");
+        AssertPopupSurfaceReadable(popupSnapshot!, "Native disassembly");
 
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -293,26 +325,45 @@ public class SizeDiffViewTests(SampleAssemblyFixture samples) : IDisposable
                 ? predicate(node)
                 : node.Children.Any(c => ContainsLeaf(c, predicate));
 
+        static void AssertRecomputedNodeNames(SizeDiffNode node)
+        {
+            if (node.Children.Count == 0) return;
+
+            Assert.Equal(
+                node.Children.SelectMany(c => c.LeftNodeNames).Distinct(StringComparer.Ordinal),
+                node.LeftNodeNames);
+            Assert.Equal(
+                node.Children.SelectMany(c => c.RightNodeNames).Distinct(StringComparer.Ordinal),
+                node.RightNodeNames);
+            foreach (var child in node.Children)
+                AssertRecomputedNodeNames(child);
+        }
+
         // The V2 build pulls new BCL surface in, so common accessor names like get_Name()
         // exist as *added* entries elsewhere — the fixture's own members are identified by
         // their full paths, never by bare display names.
         const string GetNamePath = "NativeAotConsole/Greeter::get_Name()";
         const string GreetStringPath = "NativeAotConsole/Greeter::Greet(string)";
 
+        AssertRecomputedNodeNames(diff.Root);
+
         var removed = SizeDiffTreemapView.ApplyFilter(diff.Root, SizeDiffFilterMode.Removed);
         Assert.True(ContainsLeaf(removed, n => n.FullPath == GetNamePath));
         Assert.False(ContainsLeaf(removed, n => n.FullPath.Contains("Telemetry")));
         Assert.All(removed.Children, AssertRecomputedSums);
         Assert.All(removed.Children, n => AssertAllDirections(n, DiffKind.Removed));
+        AssertRecomputedNodeNames(removed);
 
         var added = SizeDiffTreemapView.ApplyFilter(diff.Root, SizeDiffFilterMode.Added);
         Assert.False(ContainsLeaf(added, n => n.FullPath == GetNamePath));
         Assert.True(ContainsLeaf(added, n => n.FullPath.Contains("Telemetry")));
         Assert.All(added.Children, n => AssertAllDirections(n, DiffKind.Added));
+        AssertRecomputedNodeNames(added);
 
         var grown = SizeDiffTreemapView.ApplyFilter(diff.Root, SizeDiffFilterMode.Grown);
         Assert.True(ContainsLeaf(grown, n => n.FullPath == GreetStringPath));
         Assert.False(ContainsLeaf(grown, n => n.FullPath == GetNamePath));
+        AssertRecomputedNodeNames(grown);
 
         static void AssertRecomputedSums(SizeDiffNode node)
         {
@@ -442,6 +493,23 @@ public class SizeDiffViewTests(SampleAssemblyFixture samples) : IDisposable
     }
 
     /// <summary>
+    /// Verifies the popup palette clears WCAG AA on its owned dark surface.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void PopupPalette_ClearsWcagAa()
+    {
+        Assert.True(ContrastRatio(
+            SizeDiffTreemapView.PopupForeground,
+            SizeDiffTreemapView.PopupPanelBackground) >= 4.5);
+        Assert.True(ContrastRatio(
+            SizeDiffTreemapView.PopupLabelForeground,
+            SizeDiffTreemapView.PopupPanelBackground) >= 4.5);
+        Assert.True(ContrastRatio(
+            SizeDiffTreemapView.PopupBorderColor,
+            SizeDiffTreemapView.PopupPanelBackground) >= 4.5);
+    }
+
+    /// <summary>
     /// Verifies the two-sided why-chain data: an added Telemetry method's node names resolve
     /// to chains in the V2 graph, and the removed accessor's node names resolve in the V1
     /// graph — each side answers only for its own build.
@@ -469,6 +537,41 @@ public class SizeDiffViewTests(SampleAssemblyFixture samples) : IDisposable
         Assert.Empty(removed.RightNodeNames);
         var removedChain = WhyChainFormatter.FormatWhyChains(leftDgml, removed.FullPath, removed.LeftNodeNames);
         Assert.Contains("Kept by", removedChain);
+    }
+
+    /// <summary>
+    /// Verifies an aggregate treemap tile can explain its growth directly by rolling up the
+    /// child dependency-graph node names, so users do not need to drill to a leaf first.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void WhyChains_AggregateNodeRollsUpDescendantNames()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleV2Dgml is null, "V2 DGML sidecar was not produced");
+        var diff = DiffV1V2();
+        var rightDgml = DgmlReader.Read(samples.NativeAotConsoleV2Dgml!);
+        Assert.NotNull(rightDgml);
+
+        static SizeDiffNode? FindNode(SizeDiffNode node, string fullPath)
+        {
+            if (node.FullPath == fullPath) return node;
+            foreach (var child in node.Children)
+            {
+                if (FindNode(child, fullPath) is { } found) return found;
+            }
+
+            return null;
+        }
+
+        var aggregate = FindNode(diff.Root, "System.Private.TypeLoader/Internal.Runtime.TypeLoader");
+        Assert.NotNull(aggregate);
+        Assert.NotEmpty(aggregate.RightNodeNames);
+        Assert.True(aggregate.Children.Count > 0);
+
+        var chain = WhyChainFormatter.FormatWhyChains(
+            rightDgml, aggregate.FullPath, aggregate.RightNodeNames);
+
+        Assert.Contains("aggregated nodes", chain);
+        Assert.Contains("root first", chain);
     }
 
     /// <summary>
@@ -513,6 +616,117 @@ public class SizeDiffViewTests(SampleAssemblyFixture samples) : IDisposable
         for (var y = 0; y < s.Height; y++)
             lines.Add(s.GetLine(y));
         return string.Join('\n', lines);
+    }
+
+    private static void AssertPopupSurfaceReadable(
+        Hex1b.Automation.Hex1bTerminalSnapshot snapshot,
+        string title,
+        string? contentNeedle = null)
+    {
+        var titleY = FindLine(snapshot, title);
+        Assert.True(titleY >= 0, $"Could not locate popup title '{title}'.");
+
+        var panelCells = 0;
+        var sampleY = Math.Min(snapshot.Height - 1, titleY + 1);
+        for (var x = 0; x < snapshot.Width; x++)
+        {
+            if (ColorsEqual(snapshot.GetCell(x, sampleY).Background,
+                    SizeDiffTreemapView.PopupPanelBackground))
+            {
+                panelCells++;
+            }
+        }
+
+        Assert.True(panelCells >= 90, $"Popup row only had {panelCells} cells with the panel background.");
+
+        int contentX;
+        int contentY;
+        if (contentNeedle is not null)
+        {
+            contentY = FindLine(snapshot, contentNeedle);
+            Assert.True(contentY >= 0, $"Could not locate popup content '{contentNeedle}'.");
+            contentX = snapshot.GetLine(contentY).IndexOf(contentNeedle, StringComparison.Ordinal);
+            Assert.True(contentX >= 0);
+        }
+        else
+        {
+            (contentX, contentY) = FindPopupTextCell(snapshot, titleY);
+            Assert.True(contentX >= 0 && contentY >= 0, "Could not locate popup text.");
+        }
+
+        var cell = snapshot.GetCell(contentX, contentY);
+        Assert.NotNull(cell.Foreground);
+        Assert.NotNull(cell.Background);
+        AssertColorEquals(SizeDiffTreemapView.PopupPanelBackground, cell.Background.Value);
+        Assert.True(ContrastRatio(cell.Foreground.Value, cell.Background.Value) >= 4.5);
+    }
+
+    private static int FindLine(Hex1b.Automation.Hex1bTerminalSnapshot snapshot, string text)
+    {
+        for (var y = 0; y < snapshot.Height; y++)
+        {
+            if (snapshot.GetLine(y).Contains(text, StringComparison.Ordinal))
+                return y;
+        }
+
+        return -1;
+    }
+
+    private static (int X, int Y) FindPopupTextCell(
+        Hex1b.Automation.Hex1bTerminalSnapshot snapshot, int titleY)
+    {
+        for (var y = titleY + 1; y < snapshot.Height; y++)
+        {
+            for (var x = 0; x < snapshot.Width; x++)
+            {
+                var cell = snapshot.GetCell(x, y);
+                if (!ColorsEqual(cell.Background, SizeDiffTreemapView.PopupPanelBackground)
+                    || string.IsNullOrWhiteSpace(cell.Character)
+                    || IsBorderGlyph(cell.Character))
+                {
+                    continue;
+                }
+
+                return (x, y);
+            }
+        }
+
+        return (-1, -1);
+    }
+
+    private static bool IsBorderGlyph(string value) =>
+        value is "┌" or "┐" or "└" or "┘" or "─" or "│";
+
+    private static bool ColorsEqual(Hex1bColor? actual, Hex1bColor expected) =>
+        actual is { } color
+        && color.R == expected.R
+        && color.G == expected.G
+        && color.B == expected.B;
+
+    private static void AssertColorEquals(Hex1bColor expected, Hex1bColor actual)
+    {
+        Assert.Equal(expected.R, actual.R);
+        Assert.Equal(expected.G, actual.G);
+        Assert.Equal(expected.B, actual.B);
+    }
+
+    private static double ContrastRatio(Hex1bColor a, Hex1bColor b)
+    {
+        var la = Luminance(a);
+        var lb = Luminance(b);
+        var (lighter, darker) = la >= lb ? (la, lb) : (lb, la);
+        return (lighter + 0.05) / (darker + 0.05);
+    }
+
+    private static double Luminance(Hex1bColor c)
+    {
+        static double Channel(byte v)
+        {
+            var s = v / 255.0;
+            return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+        }
+
+        return 0.2126 * Channel(c.R) + 0.7152 * Channel(c.G) + 0.0722 * Channel(c.B);
     }
 
     /// <summary>


### PR DESCRIPTION
Size-diff why and disassembly popups now render on an opaque high-contrast surface instead of blending into the treemap beneath them. The popup label color is configurable so labels stay readable on darker surfaces, and closing a popup restores focus to the treemap so arrow-key navigation keeps working.

Aggregate size-diff tiles now carry rolled-up child DGML node names, so pressing w on a namespace, type, assembly, or category tile shows representative root-first why chains instead of forcing users to drill down to a leaf first. Filtered views recompute those rollups from the visible children only, and entries that truly have no DGML node now say so more accurately.

Validated with the focused size-diff and info-decoration tests plus a solution build.

Fixes: #196