### PR TITLE
Make tab 3 label reflect active code view

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 root = true
 
 [*.cs]
+dotnet_sort_system_directives_first = false
 
 # XML documentation
 dotnet_diagnostic.CS1591.severity = warning

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A TUI for analyzing .NET assemblies — structure, metadata, IL, strings, depend
 dotsider HelloWorld.dll
 ```
 
-![dotsider IL Inspector](https://raw.githubusercontent.com/willibrandon/dotsider/main/assets/tinytooltown.png)
+![dotsider IL and native inspection](https://raw.githubusercontent.com/willibrandon/dotsider/main/assets/tinytooltown.png)
 
 ## Installation
 
@@ -53,7 +53,7 @@ ReadyToRun (crossgen2) images keep their full managed metadata, and dotsider joi
 |-----|-------------|
 | **1 General** | Assembly identity, target framework, architecture, dependency table. Press Enter on a reference to drill into it. |
 | **2 PE/Metadata** | COFF headers, CLR header, sections, TypeDefs, MethodDefs, AssemblyRefs, custom attributes, resources, debug directory, native imports, exports, load config, ReadyToRun sections, and recovered AOT types. Press `g` on a TypeDef or MethodDef to jump to its IL. |
-| **3 IL Inspector** | Namespace/Type/Method tree with IL disassembly. Portable PDBs add source spans, Source Link markers, and local names when available. Press `u` on a `[source link]` marker to copy its resolved URL. Press `Enter` or `gd` on a `call`, `ldfld`, `newobj`, etc. to go to the target — works across assemblies. Press `Esc` to go back. Press `x` to jump to the method body in the hex dump. For a Native AOT binary the same tree lists recovered functions and the right pane shows real **x86-64 or AArch64 disassembly** (a from-scratch, VEX/EVEX-aware x64 decoder and an A64 decoder incl. SVE), with call/branch/data targets resolved to names, `Foo+0x12`, `loc_…` labels, and `MODULE!Function` imports. For a ReadyToRun image the tree keeps its managed shape, a glyph marks the precompiled methods, and the right pane shows the method's IL beside its native code ranges (hot, funclets, cold). |
+| **3 IL / Native** | The label reflects the loaded image: **IL Inspector** for managed IL, **Disassembly** for native-only views, and **IL + Native** when IL is paired with native code. Managed assemblies show a namespace/type/method tree with IL disassembly, PDB source spans, Source Link markers, locals, go-to-definition, and hex jumps. Native AOT binaries list recovered functions and render real **x86-64 or AArch64 disassembly** (from-scratch x64 and A64 decoders, including VEX/EVEX and SVE) with named call/branch/data targets, `Foo+0x12`, `loc_…` labels, and `MODULE!Function` imports. ReadyToRun images keep the managed tree, mark precompiled methods, and show IL beside native ranges (hot, funclets, cold). Attached pre-ILC sidecars do the same for Native AOT methods. |
 | **4 Strings** | User strings, metadata strings, raw ASCII and UTF-16 binary scans, and frozen AOT string literals, with configurable minimum length. |
 | **5 Hex Dump** | Hex editor with vi-style modal editing (read-only by default), byte category coloring, data interpretation panel, jump-to-offset, and vim navigation. |
 | **6 Dep Graph** | Visual dependency graph — your assembly at the root, references as nodes, edge weights by TypeRef count. Press Enter on a node to open that assembly. |
@@ -191,10 +191,10 @@ Supported `--ai` providers: claude, gemini, copilot, cursor-agent, opencode, cod
 | `iW` | Select inner WORD (whitespace-delimited — grabs fully-qualified names) |
 | `yiw` / `yiW` | Select + yank word/WORD in one motion |
 | `Tab` | Cycle focus between info panels and tables |
-| `Enter` / `gd` | Go to definition (IL Inspector tab, cursor on a token-bearing instruction) |
-| `g` | Go to IL Inspector for the focused TypeDef/MethodDef (PE/Metadata tab) |
-| `u` | Copy Source Link URL from a `[source link]` marker in the IL Inspector |
-| `x` | Jump to method body in Hex Dump (IL Inspector tab, when a method with RVA is selected) |
+| `Enter` / `gd` | Go to definition (tab 3 IL/native view, cursor on a token-bearing instruction) |
+| `g` | Go to tab 3 for the focused TypeDef/MethodDef (PE/Metadata tab) |
+| `u` | Copy Source Link URL from a `[source link]` marker in tab 3's IL view |
+| `x` | Jump to method body in Hex Dump (tab 3, when a file-backed method or symbol is selected) |
 | `/` | Search (highlights matches inline) |
 | `n` / `N` | Next / previous search match |
 | `s` | Toggle human-readable sizes |

--- a/benchmarks/Dotsider.Benchmarks/ApphostDetectorBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/ApphostDetectorBenchmarks.cs
@@ -1,7 +1,7 @@
-using System.Text;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using Dotsider.Core.Analysis;
+using System.Text;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/AssemblyAnalyzerBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/AssemblyAnalyzerBenchmarks.cs
@@ -1,7 +1,7 @@
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using Dotsider.Core.Analysis;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/AssemblyDifferBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/AssemblyDifferBenchmarks.cs
@@ -1,7 +1,7 @@
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/DependencyGraphBuilderBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/DependencyGraphBuilderBenchmarks.cs
@@ -1,7 +1,7 @@
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/HexSearchBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/HexSearchBenchmarks.cs
@@ -1,6 +1,6 @@
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Dotsider.Views;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/IlDisassemblerBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/IlDisassemblerBenchmarks.cs
@@ -1,8 +1,8 @@
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/ImplementationAssemblyResolverBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/ImplementationAssemblyResolverBenchmarks.cs
@@ -1,7 +1,7 @@
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using Dotsider.Core.Analysis;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/McpToolBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/McpToolBenchmarks.cs
@@ -1,7 +1,3 @@
-using System.IO.Pipelines;
-using System.Net.Sockets;
-using System.Runtime.InteropServices;
-using System.Text.Json;
 using BenchmarkDotNet.Attributes;
 using Dotsider.Core.Protocol;
 using Dotsider.Mcp;
@@ -10,6 +6,10 @@ using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using System.IO.Pipelines;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text.Json;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/NativeAotDetectorBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/NativeAotDetectorBenchmarks.cs
@@ -1,7 +1,7 @@
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/NativeSymbolReaderBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/NativeSymbolReaderBenchmarks.cs
@@ -1,8 +1,8 @@
-using System.Buffers.Binary;
 using BenchmarkDotNet.Attributes;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Core.Analysis.NativePdb;
+using System.Buffers.Binary;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/NuGetPackageAnalyzerBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/NuGetPackageAnalyzerBenchmarks.cs
@@ -1,8 +1,8 @@
-using System.IO.Compression;
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using Dotsider.Core.Analysis;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/PeDirectoryReaderBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/PeDirectoryReaderBenchmarks.cs
@@ -1,7 +1,7 @@
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/RuntimeTracerBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/RuntimeTracerBenchmarks.cs
@@ -1,8 +1,8 @@
-using System.Diagnostics;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Diagnostics;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/SingleFileBundleReaderBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/SingleFileBundleReaderBenchmarks.cs
@@ -1,8 +1,8 @@
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/SizeAnalyzerBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/SizeAnalyzerBenchmarks.cs
@@ -1,7 +1,7 @@
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/StringExtractorBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/StringExtractorBenchmarks.cs
@@ -1,7 +1,7 @@
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Benchmarks;
 

--- a/benchmarks/Dotsider.Benchmarks/TreemapLayoutBenchmarks.cs
+++ b/benchmarks/Dotsider.Benchmarks/TreemapLayoutBenchmarks.cs
@@ -1,8 +1,8 @@
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Views;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Benchmarks;
 

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -23,7 +23,7 @@ Press `1` through `8` to switch between tabs:
 |-----|-----|
 | `1` | General |
 | `2` | PE / Metadata |
-| `3` | IL Inspector |
+| `3` | IL / Native |
 | `4` | Strings |
 | `5` | Hex Dump |
 | `6` | Dep Graph |

--- a/docs/src/content/docs/reference/keyboard.md
+++ b/docs/src/content/docs/reference/keyboard.md
@@ -28,9 +28,9 @@ description: All keyboard shortcuts for navigating dotsider.
 | Key | Action |
 |-----|--------|
 | `Tab` | Cycle focus: PE Headers → CLR Header → metadata table |
-| `g` | Jump to IL Inspector for focused TypeDef/MethodDef |
+| `g` | Jump to tab 3's IL view for focused TypeDef/MethodDef |
 
-## IL Inspector tab
+## Tab 3: IL / Native
 
 | Key | Action |
 |-----|--------|

--- a/docs/src/content/docs/usage/dynamic.md
+++ b/docs/src/content/docs/usage/dynamic.md
@@ -35,7 +35,7 @@ On the Counters and Summary editors, select text with click-drag or `Shift` + ar
 
 ## Cross-tab navigation
 
-Press `Enter` on a JIT compilation event to jump to that method's IL disassembly in tab 3.
+Press `Enter` on a JIT compilation event to jump to that method's IL disassembly in tab 3's IL view.
 
 ## Re-running
 

--- a/docs/src/content/docs/usage/general.md
+++ b/docs/src/content/docs/usage/general.md
@@ -28,7 +28,7 @@ Opening a Native AOT executable adds a block below the standard fields. ILC stri
 
 ## ReadyToRun images
 
-A ReadyToRun (crossgen2) image keeps its full metadata and adds precompiled native bodies, so the standard fields stay and a **ReadyToRun** block is added, reporting the format version and status (`Valid`, `Corrupt`, or `UnsupportedVersion` — a broken header is surfaced, never hidden), the architecture, whether the image is a composite or a component (and its owner), and how many methods are precompiled. Inspect a method's native code in the IL Inspector or via `--r2r-correlate`.
+A ReadyToRun (crossgen2) image keeps its full metadata and adds precompiled native bodies, so the standard fields stay and a **ReadyToRun** block is added, reporting the format version and status (`Valid`, `Corrupt`, or `UnsupportedVersion` — a broken header is surfaced, never hidden), the architecture, whether the image is a composite or a component (and its owner), and how many methods are precompiled. Inspect a method's native code in tab 3's **IL + Native** view or via `--r2r-correlate`.
 
 ## Text selection and copy
 

--- a/docs/src/content/docs/usage/il-inspector.md
+++ b/docs/src/content/docs/usage/il-inspector.md
@@ -1,11 +1,11 @@
 ---
 title: IL Inspector
-description: Namespace/type/method tree with IL disassembly.
+description: Managed IL, native disassembly, and side-by-side IL/native views.
 ---
 
 ![IL Inspector tab](../../../assets/screenshots/il-inspector.png)
 
-The **IL Inspector** tab (`3`) shows a tree of all namespaces, types, and methods. Select a method to see its IL bytecode in the right pane.
+Tab `3` is the IL/native code view. Its label changes with the loaded image: **IL Inspector** for managed IL, **Disassembly** for native-only views, and **IL + Native** when managed IL is paired with native code. For ordinary managed assemblies, it shows a tree of all namespaces, types, and methods. Select a method to see its IL bytecode in the right pane.
 
 Each instruction shows:
 
@@ -44,7 +44,7 @@ Press `/` to search method names or IL content. Matches are highlighted in both 
 
 ## Native mode (Native AOT)
 
-Open a Native AOT binary and the IL Inspector switches to native mode: the left tree lists the recovered **functions** bucketed namespace → type → function (managed-named functions parsed from the symbols), plus `(runtime)`, `(stubs)`, and `(functions)` buckets for the rest. Selecting a function disassembles it to real x86-64 or AArch64 assembly on the right, with the same subtle syntax highlighting as the IL pane — address, mnemonic, registers, immediates, and the resolved target comment.
+Open a Native AOT binary and tab `3` is labeled **Disassembly** in native mode: the left tree lists the recovered **functions** bucketed namespace → type → function (managed-named functions parsed from the symbols), plus `(runtime)`, `(stubs)`, and `(functions)` buckets for the rest. Selecting a function disassembles it to real x86-64 or AArch64 assembly on the right, with the same subtle syntax highlighting as the IL pane — address, mnemonic, registers, immediates, and the resolved target comment.
 
 Call and branch targets are resolved to names: a direct call shows `call Foo`, a target landing inside a function shows `Foo+0x12`, an intra-function jump becomes a synthesized `loc_…` label, a RIP-relative load names the referenced data symbol, and an indirect call through the import table resolves to `MODULE!Function`. Where the debug sidecar carries line data, `// file:line` annotations mark the source.
 
@@ -52,7 +52,7 @@ Call and branch targets are resolved to names: a direct call shows `call Foo`, a
 
 ## ReadyToRun images
 
-A ReadyToRun (crossgen2) image keeps its full metadata, so the tree stays in its managed namespace → type → method shape. A glyph marks each method: `✓` precompiled, `–` IL only (not in this image). Selecting a precompiled method splits the right pane — IL on the left, its native code ranges (hot, funclets, cold) on the right — with call targets resolved through the import tables (`call Console.WriteLine`, `call WriteBarrier`, a generic instantiation named with its type arguments). A composite `*.r2r.dll` shows its component assemblies in the tree and navigates across them; a component DLL disassembles from the owner composite it belongs to.
+A ReadyToRun (crossgen2) image keeps its full metadata, so tab `3` is labeled **IL + Native** and the tree stays in its managed namespace → type → method shape. A glyph marks each method: `✓` precompiled, `–` IL only (not in this image). Selecting a precompiled method splits the right pane — IL on the left, its native code ranges (hot, funclets, cold) on the right — with call targets resolved through the import tables (`call Console.WriteLine`, `call WriteBarrier`, a generic instantiation named with its type arguments). A composite `*.r2r.dll` shows its component assemblies in the tree and navigates across them; a component DLL disassembles from the owner composite it belongs to.
 
 ## Pre-ILC sidecar correlation (Native AOT)
 
@@ -64,12 +64,12 @@ Publishing a Native AOT binary leaves its pre-ILC inputs behind in the build tre
  Enter: Attach | Esc: No, native only
 ```
 
-Press `Enter` to attach or `Esc` to stay native-only. When attached, the metadata tabs (PE/Metadata, Strings, General references) fill from the managed assembly while the binary tabs stay native, and a method's IL and native code show **side by side**.
+Press `Enter` to attach or `Esc` to stay native-only. When attached, the metadata tabs (PE/Metadata, Strings, General references) fill from the managed assembly while the binary tabs stay native, and tab `3` is labeled **IL + Native** so a method's IL and native code can show side by side.
 
 - The tree shows correlation markers: `✓` correlated exactly, `~` shared with overloads (ambiguous), `±` size-only (mstat evidence but no native symbol), `–` not in the native image (trimmed or inlined).
 - Selecting a correlated method splits the right pane: pre-ILC IL on the left, native disassembly on the right, with call targets named from the companion metadata. A status line reports the native address and size.
 - Overloads that ILC's mangling collapses are reported as ambiguous with the shared size, never guessed apart. A generic method with several instantiations shows every native symbol.
-- `t` toggles between the managed and native tree; `l` cycles focus between the IL and native panes (and swaps the visible pane when the terminal is too narrow to split); `Tab` steps tree → IL → native. Search (`/`) follows the focused pane. `x` opens the Hex Dump at the correlated symbol's file offset.
+- `t` toggles between the managed and native tree; the tab label switches between **IL + Native** and **Disassembly** with that mode. `l` cycles focus between the IL and native panes (and swaps the visible pane when the terminal is too narrow to split); `Tab` steps tree → IL → native. Search (`/`) follows the focused pane. `x` opens the Hex Dump at the correlated symbol's file offset.
 - On the **General** tab, `a` re-opens the offer and `d` detaches; the tab also reports the correlation counts (`{exact} of {total} methods in native image`).
 
 The same correlation is available headlessly:

--- a/docs/src/content/docs/usage/pe-metadata.md
+++ b/docs/src/content/docs/usage/pe-metadata.md
@@ -39,4 +39,4 @@ On table rows, press `y` to copy the focused row as tab-separated values.
 
 ## Jump to IL
 
-Select a TypeDef or MethodDef and press `g` to jump directly to its IL disassembly in tab 3. The IL Inspector opens with that item pre-selected.
+Select a TypeDef or MethodDef and press `g` to jump directly to its IL disassembly in tab 3. The IL view opens with that item pre-selected.

--- a/docs/src/content/docs/usage/size-map.md
+++ b/docs/src/content/docs/usage/size-map.md
@@ -14,7 +14,7 @@ The **Size Map** tab (`7`) shows a treemap of IL code size:
 
 ## Drill in
 
-Click or press `Enter` on any region to drill into it. When you reach a method leaf, pressing `Enter` jumps to its IL disassembly in tab 3.
+Click or press `Enter` on any region to drill into it. When you reach a method leaf, pressing `Enter` jumps to its IL disassembly in tab 3's IL view.
 
 This is useful for finding unexpectedly large methods or identifying which parts of your codebase contribute the most to assembly size.
 

--- a/samples/ComplexApp/Program.cs
+++ b/samples/ComplexApp/Program.cs
@@ -1,5 +1,5 @@
-using System.Reflection;
 using ComplexApp.Pipeline;
+using System.Reflection;
 
 // Load and display embedded resource
 var assembly = Assembly.GetExecutingAssembly();

--- a/samples/RichLibrary/Services/JsonSerializer.cs
+++ b/samples/RichLibrary/Services/JsonSerializer.cs
@@ -1,6 +1,6 @@
-using System.Text.Json;
 using Newtonsoft.Json;
 using RichLibrary.Models;
+using System.Text.Json;
 
 namespace RichLibrary.Services;
 

--- a/samples/RichLibrary/Services/ProductCatalog.cs
+++ b/samples/RichLibrary/Services/ProductCatalog.cs
@@ -1,5 +1,5 @@
-using System.Runtime.CompilerServices;
 using RichLibrary.Models;
+using System.Runtime.CompilerServices;
 
 namespace RichLibrary.Services;
 

--- a/samples/RichLibrary/Services/UserService.cs
+++ b/samples/RichLibrary/Services/UserService.cs
@@ -1,5 +1,5 @@
-using System.Collections.Concurrent;
 using RichLibrary.Models;
+using System.Collections.Concurrent;
 
 namespace RichLibrary.Services;
 

--- a/samples/RichLibraryV2/Services/ProductCatalog.cs
+++ b/samples/RichLibraryV2/Services/ProductCatalog.cs
@@ -1,5 +1,5 @@
-using System.Runtime.CompilerServices;
 using RichLibrary.Models;
+using System.Runtime.CompilerServices;
 
 namespace RichLibrary.Services;
 

--- a/samples/RichLibraryV2/Services/UserService.cs
+++ b/samples/RichLibraryV2/Services/UserService.cs
@@ -1,5 +1,5 @@
-using System.Collections.Concurrent;
 using RichLibrary.Models;
+using System.Collections.Concurrent;
 
 namespace RichLibrary.Services;
 

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -1,3 +1,4 @@
+using Dotsider.Core.Analysis.Models;
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
@@ -5,7 +6,6 @@ using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/AssemblyDiffer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyDiffer.cs
@@ -1,7 +1,7 @@
+using Dotsider.Core.Analysis.Models;
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/CorrelationQuery.cs
+++ b/src/Dotsider.Core/Analysis/CorrelationQuery.cs
@@ -1,6 +1,6 @@
-using System.Globalization;
 using Dotsider.Core.Analysis.Disasm;
 using Dotsider.Core.Analysis.Models;
+using System.Globalization;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/DehydratedDataReader.cs
+++ b/src/Dotsider.Core/Analysis/DehydratedDataReader.cs
@@ -1,5 +1,5 @@
-using System.Buffers.Binary;
 using Dotsider.Core.Analysis.Models;
+using System.Buffers.Binary;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/DgmlReader.cs
+++ b/src/Dotsider.Core/Analysis/DgmlReader.cs
@@ -1,5 +1,5 @@
-using System.Xml;
 using Dotsider.Core.Analysis.Models;
+using System.Xml;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/Disasm/NativeDisassembler.cs
+++ b/src/Dotsider.Core/Analysis/Disasm/NativeDisassembler.cs
@@ -1,7 +1,7 @@
+using Dotsider.Core.Analysis.Models;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis.Disasm;
 

--- a/src/Dotsider.Core/Analysis/Disasm/NativeImportResolver.cs
+++ b/src/Dotsider.Core/Analysis/Disasm/NativeImportResolver.cs
@@ -1,7 +1,7 @@
+using Dotsider.Core.Analysis.Models;
 using System.Buffers.Binary;
 using System.Reflection.PortableExecutable;
 using System.Text;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis.Disasm;
 

--- a/src/Dotsider.Core/Analysis/Disasm/arm64/Arm64Decoder.cs
+++ b/src/Dotsider.Core/Analysis/Disasm/arm64/Arm64Decoder.cs
@@ -1,5 +1,5 @@
-using System.Buffers.Binary;
 using Dotsider.Core.Analysis.Models;
+using System.Buffers.Binary;
 
 namespace Dotsider.Core.Analysis.Disasm.arm64;
 

--- a/src/Dotsider.Core/Analysis/Disasm/x64/XarchOperandFormatter.cs
+++ b/src/Dotsider.Core/Analysis/Disasm/x64/XarchOperandFormatter.cs
@@ -1,5 +1,5 @@
-using System.Text;
 using Dotsider.Core.Analysis.Models;
+using System.Text;
 
 namespace Dotsider.Core.Analysis.Disasm.x64;
 

--- a/src/Dotsider.Core/Analysis/Disasm/x64/XarchTableAvx512.cs
+++ b/src/Dotsider.Core/Analysis/Disasm/x64/XarchTableAvx512.cs
@@ -1,7 +1,7 @@
 namespace Dotsider.Core.Analysis.Disasm.x64;
 
-using K = OperandKind;
 using F = OpFlags;
+using K = OperandKind;
 
 /// <summary>
 /// Registers the EVEX-only AVX-512 / AVX10 / VNNI opcodes — the ones without a legacy or VEX form:

--- a/src/Dotsider.Core/Analysis/Disasm/x64/XarchTableBmi.cs
+++ b/src/Dotsider.Core/Analysis/Disasm/x64/XarchTableBmi.cs
@@ -1,7 +1,7 @@
 namespace Dotsider.Core.Analysis.Disasm.x64;
 
-using K = OperandKind;
 using F = OpFlags;
+using K = OperandKind;
 
 /// <summary>
 /// Registers BMI1, BMI2, and the ADX opcodes. The BMI ops are VEX-encoded but keep their plain

--- a/src/Dotsider.Core/Analysis/Disasm/x64/XarchTableLegacy.cs
+++ b/src/Dotsider.Core/Analysis/Disasm/x64/XarchTableLegacy.cs
@@ -1,7 +1,7 @@
 namespace Dotsider.Core.Analysis.Disasm.x64;
 
-using K = OperandKind;
 using F = OpFlags;
+using K = OperandKind;
 
 /// <summary>
 /// Registers the legacy x86-64 surface: the full one-byte opcode map, the 0F integer / control /

--- a/src/Dotsider.Core/Analysis/DotNetRuntimeLocator.cs
+++ b/src/Dotsider.Core/Analysis/DotNetRuntimeLocator.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Protocol;
 using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
-using Dotsider.Core.Protocol;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/ElfImageReader.cs
+++ b/src/Dotsider.Core/Analysis/ElfImageReader.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Analysis.Models;
 using System.Buffers.Binary;
 using System.Text;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/FrozenObjectReader.cs
+++ b/src/Dotsider.Core/Analysis/FrozenObjectReader.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Analysis.Models;
 using System.Buffers.Binary;
 using System.Text;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/IlDisassembler.cs
+++ b/src/Dotsider.Core/Analysis/IlDisassembler.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Analysis.Models;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/IlNavigationResolver.cs
+++ b/src/Dotsider.Core/Analysis/IlNavigationResolver.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Analysis.Models;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/IlcNameDemangler.cs
+++ b/src/Dotsider.Core/Analysis/IlcNameDemangler.cs
@@ -1,5 +1,5 @@
-using System.Text;
 using Dotsider.Core.Analysis.Models;
+using System.Text;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/ImplementationAssemblyResolver.cs
+++ b/src/Dotsider.Core/Analysis/ImplementationAssemblyResolver.cs
@@ -1,7 +1,7 @@
+using Dotsider.Core.Analysis.Models;
 using System.Collections.Concurrent;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/MachOImageReader.cs
+++ b/src/Dotsider.Core/Analysis/MachOImageReader.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Analysis.Models;
 using System.Buffers.Binary;
 using System.Text;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/MstatReader.cs
+++ b/src/Dotsider.Core/Analysis/MstatReader.cs
@@ -1,8 +1,8 @@
+using Dotsider.Core.Analysis.Models;
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/NativeAotDetector.cs
+++ b/src/Dotsider.Core/Analysis/NativeAotDetector.cs
@@ -1,7 +1,7 @@
+using Dotsider.Core.Analysis.Models;
 using System.Buffers.Binary;
 using System.Text;
 using System.Text.RegularExpressions;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/NativeMetadataReader.cs
+++ b/src/Dotsider.Core/Analysis/NativeMetadataReader.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Analysis.Models;
 using System.Buffers.Binary;
 using System.Text;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
+++ b/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
@@ -1,6 +1,6 @@
-using System.Buffers.Binary;
 using Dotsider.Core.Analysis.Dwarf;
 using Dotsider.Core.Analysis.Models;
+using System.Buffers.Binary;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/NetFxBinder.cs
+++ b/src/Dotsider.Core/Analysis/NetFxBinder.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Analysis.Models;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/NuGetDepsJsonResolver.cs
+++ b/src/Dotsider.Core/Analysis/NuGetDepsJsonResolver.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Analysis.Models;
 using System.Runtime.InteropServices;
 using System.Text.Json;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/NuGetPackageAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/NuGetPackageAnalyzer.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Analysis.Models;
 using System.IO.Compression;
 using System.Xml.Linq;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/PeDirectoryReader.cs
+++ b/src/Dotsider.Core/Analysis/PeDirectoryReader.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Analysis.Models;
 using System.Reflection.PortableExecutable;
 using System.Text;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/PortablePdbUtilities.cs
+++ b/src/Dotsider.Core/Analysis/PortablePdbUtilities.cs
@@ -1,8 +1,8 @@
+using Dotsider.Core.Analysis.Models;
 using System.IO.Compression;
 using System.Reflection.Metadata;
 using System.Text;
 using System.Text.Json;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/PreIlcSidecarDetector.cs
+++ b/src/Dotsider.Core/Analysis/PreIlcSidecarDetector.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Analysis.Models;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/ReadyToRun/ClassicReadyToRunDetector.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRun/ClassicReadyToRunDetector.cs
@@ -1,5 +1,5 @@
-using System.Buffers.Binary;
 using Dotsider.Core.Analysis.Models;
+using System.Buffers.Binary;
 
 namespace Dotsider.Core.Analysis.ReadyToRun;
 

--- a/src/Dotsider.Core/Analysis/ReadyToRun/ClassicReadyToRunHeaderReader.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRun/ClassicReadyToRunHeaderReader.cs
@@ -1,5 +1,5 @@
-using System.Buffers.Binary;
 using Dotsider.Core.Analysis.Models;
+using System.Buffers.Binary;
 
 namespace Dotsider.Core.Analysis.ReadyToRun;
 

--- a/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunCompositeReader.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunCompositeReader.cs
@@ -1,8 +1,8 @@
+using Dotsider.Core.Analysis.Models;
 using System.Buffers.Binary;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.InteropServices;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis.ReadyToRun;
 

--- a/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunImageReader.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunImageReader.cs
@@ -1,6 +1,6 @@
-using System.Runtime.InteropServices;
-using System.Reflection.Metadata;
 using Dotsider.Core.Analysis.Models;
+using System.Reflection.Metadata;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Core.Analysis.ReadyToRun;
 

--- a/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunImportReader.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunImportReader.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Analysis.Models;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis.ReadyToRun;
 

--- a/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunMethodMapReader.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunMethodMapReader.cs
@@ -1,5 +1,5 @@
-using System.Reflection.Metadata;
 using Dotsider.Core.Analysis.Models;
+using System.Reflection.Metadata;
 
 namespace Dotsider.Core.Analysis.ReadyToRun;
 

--- a/src/Dotsider.Core/Analysis/ReadyToRunCorrelationQuery.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRunCorrelationQuery.cs
@@ -1,7 +1,7 @@
-using System.Globalization;
 using Dotsider.Core.Analysis.Disasm;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Core.Analysis.ReadyToRun;
+using System.Globalization;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/ReadyToRunReader.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRunReader.cs
@@ -1,5 +1,5 @@
-using System.Buffers.Binary;
 using Dotsider.Core.Analysis.Models;
+using System.Buffers.Binary;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/RuntimeTracer.cs
+++ b/src/Dotsider.Core/Analysis/RuntimeTracer.cs
@@ -1,11 +1,11 @@
-using System.Collections.Concurrent;
-using System.Diagnostics;
-using System.Diagnostics.Tracing;
-using System.Globalization;
 using Dotsider.Core.Analysis.Models;
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Parsers;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Globalization;
 using TraceEventCategory = Dotsider.Core.Analysis.Models.TraceEventCategory;
 using TraceEventEntry = Dotsider.Core.Analysis.Models.TraceEventEntry;
 

--- a/src/Dotsider.Core/Analysis/SingleFileBundleReader.cs
+++ b/src/Dotsider.Core/Analysis/SingleFileBundleReader.cs
@@ -1,11 +1,10 @@
+using Dotsider.Core.Analysis.Models;
 using System.IO.Compression;
 using System.IO.MemoryMappedFiles;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Text;
-
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/SizeBudgetFile.cs
+++ b/src/Dotsider.Core/Analysis/SizeBudgetFile.cs
@@ -1,5 +1,5 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis.Models;
+using System.Text.Json;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/SizeBudgetParser.cs
+++ b/src/Dotsider.Core/Analysis/SizeBudgetParser.cs
@@ -1,5 +1,5 @@
-using System.Globalization;
 using Dotsider.Core.Analysis.Models;
+using System.Globalization;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Core/Analysis/StringExtractor.cs
+++ b/src/Dotsider.Core/Analysis/StringExtractor.cs
@@ -1,9 +1,9 @@
+using Dotsider.Core.Analysis.Models;
 using System.Numerics;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Text;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Core.Analysis;
 

--- a/src/Dotsider.Mcp/Program.cs
+++ b/src/Dotsider.Mcp/Program.cs
@@ -1,9 +1,9 @@
-using System.Diagnostics;
-using System.Reflection;
 using Dotsider.Mcp;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+using System.Reflection;
 
 if (args is ["--help" or "-h"])
 {

--- a/src/Dotsider.Mcp/RemoteDotsiderTarget.cs
+++ b/src/Dotsider.Mcp/RemoteDotsiderTarget.cs
@@ -1,7 +1,7 @@
+using Dotsider.Core.Protocol;
 using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
-using Dotsider.Core.Protocol;
 
 namespace Dotsider.Mcp;
 

--- a/src/Dotsider.Mcp/Tools/AssemblyTools.cs
+++ b/src/Dotsider.Mcp/Tools/AssemblyTools.cs
@@ -1,6 +1,6 @@
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/BundleTools.cs
+++ b/src/Dotsider.Mcp/Tools/BundleTools.cs
@@ -1,7 +1,7 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/CorrelationTools.cs
+++ b/src/Dotsider.Mcp/Tools/CorrelationTools.cs
@@ -1,9 +1,9 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/DependencyTools.cs
+++ b/src/Dotsider.Mcp/Tools/DependencyTools.cs
@@ -1,7 +1,7 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/DiffTools.cs
+++ b/src/Dotsider.Mcp/Tools/DiffTools.cs
@@ -1,9 +1,9 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/FieldTools.cs
+++ b/src/Dotsider.Mcp/Tools/FieldTools.cs
@@ -1,6 +1,6 @@
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/IlTools.cs
+++ b/src/Dotsider.Mcp/Tools/IlTools.cs
@@ -1,9 +1,9 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Core.Protocol;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/MetadataTools.cs
+++ b/src/Dotsider.Mcp/Tools/MetadataTools.cs
@@ -1,6 +1,6 @@
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/NativeAotTools.cs
+++ b/src/Dotsider.Mcp/Tools/NativeAotTools.cs
@@ -1,9 +1,9 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/NavigationTools.cs
+++ b/src/Dotsider.Mcp/Tools/NavigationTools.cs
@@ -1,6 +1,6 @@
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/NavigationTools.cs
+++ b/src/Dotsider.Mcp/Tools/NavigationTools.cs
@@ -29,7 +29,7 @@ public sealed partial class NavigationTools(DotsiderSessionManager sessionManage
     /// Navigates to a specific tab in the running dotsider TUI.
     /// </summary>
     /// <param name="sessionId">PID of the running dotsider instance.</param>
-    /// <param name="tabId">Tab number (1=General, 2=PE/Metadata, 3=IL Inspector, 4=Strings, 5=Hex Dump, 6=Dep Graph, 7=Size Map, 8=Dynamic).</param>
+    /// <param name="tabId">Tab number (1=General, 2=PE/Metadata, 3=IL / Native, 4=Strings, 5=Hex Dump, 6=Dep Graph, 7=Size Map, 8=Dynamic).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>JSON confirmation that navigation was queued.</returns>
     [McpServerTool(ReadOnly = false, Destructive = false, OpenWorld = false)]
@@ -74,7 +74,7 @@ public sealed partial class NavigationTools(DotsiderSessionManager sessionManage
     }
 
     /// <summary>
-    /// Navigates to the definition of a metadata token in the IL Inspector.
+    /// Navigates to the definition of a metadata token in tab 3's IL view.
     /// Works for method calls, field accesses, type references, and other
     /// token-bearing IL instructions. Cross-assembly navigation is supported.
     /// </summary>

--- a/src/Dotsider.Mcp/Tools/NuGetTools.cs
+++ b/src/Dotsider.Mcp/Tools/NuGetTools.cs
@@ -1,7 +1,7 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/ReadyToRunTools.cs
+++ b/src/Dotsider.Mcp/Tools/ReadyToRunTools.cs
@@ -1,9 +1,9 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/RuntimeTools.cs
+++ b/src/Dotsider.Mcp/Tools/RuntimeTools.cs
@@ -1,8 +1,8 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/SessionTools.cs
+++ b/src/Dotsider.Mcp/Tools/SessionTools.cs
@@ -1,7 +1,7 @@
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/SizeTools.cs
+++ b/src/Dotsider.Mcp/Tools/SizeTools.cs
@@ -1,7 +1,7 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/StringTools.cs
+++ b/src/Dotsider.Mcp/Tools/StringTools.cs
@@ -1,7 +1,7 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Mcp/Tools/SymbolTools.cs
+++ b/src/Dotsider.Mcp/Tools/SymbolTools.cs
@@ -1,7 +1,7 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis.Disasm;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tools;
 

--- a/src/Dotsider.Website/Program.cs
+++ b/src/Dotsider.Website/Program.cs
@@ -1,10 +1,10 @@
-using System.Collections.Concurrent;
-using System.Net;
-using System.Net.WebSockets;
 using Dotsider;
 using Dotsider.Infrastructure;
 using Dotsider.Website;
 using Hex1b;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.WebSockets;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/Dotsider/Commands/AgentCommand.cs
+++ b/src/Dotsider/Commands/AgentCommand.cs
@@ -1,6 +1,6 @@
+using Dotsider.Infrastructure;
 using System.CommandLine;
 using System.Diagnostics;
-using Dotsider.Infrastructure;
 
 namespace Dotsider.Commands;
 

--- a/src/Dotsider/Commands/AgentCommand.cs
+++ b/src/Dotsider/Commands/AgentCommand.cs
@@ -299,7 +299,7 @@ internal static class AgentCommand
 
         - All commands support `--json` for machine-readable output
         - Session commands require a running dotsider TUI instance
-        - Tab numbers: 1=General, 2=PE/Metadata, 3=IL Inspector, 4=Strings, 5=Hex Dump, 6=Dep Graph, 7=Size Map, 8=Dynamic
+        - Tab numbers: 1=General, 2=PE/Metadata, 3=IL / Native, 4=Strings, 5=Hex Dump, 6=Dep Graph, 7=Size Map, 8=Dynamic
         - Capture outputs plain text of the current TUI screen
         """;
 }

--- a/src/Dotsider/Commands/AnalyzeCommand.cs
+++ b/src/Dotsider/Commands/AnalyzeCommand.cs
@@ -1,8 +1,8 @@
-using System.CommandLine;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Disasm;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Infrastructure;
+using System.CommandLine;
 
 namespace Dotsider.Commands;
 

--- a/src/Dotsider/Commands/DiffCommand.cs
+++ b/src/Dotsider/Commands/DiffCommand.cs
@@ -1,10 +1,10 @@
-using System.CommandLine;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
 using Hex1b.Diagnostics;
+using System.CommandLine;
 
 namespace Dotsider.Commands;
 

--- a/src/Dotsider/Commands/SessionsCommand.cs
+++ b/src/Dotsider/Commands/SessionsCommand.cs
@@ -12,15 +12,21 @@ internal static class SessionsCommand
 {
     /// <summary>Tab index → display name mapping (matches TabId constants).</summary>
     private static readonly string[] s_tabNames =
-        ["General", "PE/Metadata", "IL Inspector", "Strings", "Hex Dump", "Dep Graph", "Size Map", "Dynamic"];
+        ["General", "PE/Metadata", "IL / Native", "Strings", "Hex Dump", "Dep Graph", "Size Map", "Dynamic"];
 
     /// <summary>Returns a human-readable tab name for a numeric tab index.</summary>
-    private static string FormatTabName(JsonElement? element)
+    private static string FormatTabName(JsonElement? element, JsonElement? labelElement = null)
     {
         if (element is null) return "unknown";
         if (element.Value.ValueKind == JsonValueKind.Number)
         {
             var tab = element.Value.GetInt32();
+            var label = labelElement?.ValueKind == JsonValueKind.String
+                ? labelElement.Value.GetString()
+                : null;
+            if (!string.IsNullOrWhiteSpace(label))
+                return $"{label} ({tab})";
+
             var idx = tab - 1;
             return idx >= 0 && idx < s_tabNames.Length ? $"{s_tabNames[idx]} ({tab})" : tab.ToString();
         }
@@ -197,7 +203,7 @@ internal static class SessionsCommand
                 formatter.WriteLine($"Traceable:  {(traceable ? "yes" : "no")}");
 
                 formatter.WriteLine("");
-                formatter.WriteLine($"Tab:        {FormatTabName(view?.GetPropertyOrNull("tab"))}");
+                formatter.WriteLine($"Tab:        {FormatTabName(view?.GetPropertyOrNull("tab"), view?.GetPropertyOrNull("tabLabel"))}");
                 formatter.WriteLine($"Tracer:     {view?.GetPropertyOrNull("tracerState")?.GetDisplayString("none") ?? "none"}");
             }
 
@@ -231,7 +237,7 @@ internal static class SessionsCommand
             else
             {
                 var data = response.Data as JsonElement?;
-                formatter.WriteLine($"Tab:           {FormatTabName(data?.GetPropertyOrNull("tab"))}");
+                formatter.WriteLine($"Tab:           {FormatTabName(data?.GetPropertyOrNull("tab"), data?.GetPropertyOrNull("tabLabel"))}");
                 formatter.WriteLine($"PE Sub-tab:    {data?.GetPropertyOrNull("peSubTab")?.GetDisplayString() ?? ""}");
                 formatter.WriteLine($"Dynamic Sub:   {data?.GetPropertyOrNull("dynamicSubTab")?.GetDisplayString() ?? ""}");
                 formatter.WriteLine($"Assembly:      {data?.GetPropertyOrNull("assemblyPath")?.GetDisplayString() ?? ""}");
@@ -249,7 +255,7 @@ internal static class SessionsCommand
     {
         var tabArg = new Argument<int>("tab")
         {
-            Description = "Tab to navigate to (1=General, 2=PE/Metadata, 3=IL Inspector, 4=Strings, 5=Hex Dump, 6=Dep Graph, 7=Size Map, 8=Dynamic)"
+            Description = "Tab to navigate to (1=General, 2=PE/Metadata, 3=IL / Native, 4=Strings, 5=Hex Dump, 6=Dep Graph, 7=Size Map, 8=Dynamic)"
         };
 
         var command = new Command("navigate", "Switch to a specific tab in a running instance")

--- a/src/Dotsider/Commands/SessionsCommand.cs
+++ b/src/Dotsider/Commands/SessionsCommand.cs
@@ -1,7 +1,7 @@
-using System.CommandLine;
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using Dotsider.Infrastructure;
+using System.CommandLine;
+using System.Text.Json;
 
 namespace Dotsider.Commands;
 

--- a/src/Dotsider/Commands/SizeCheckCommand.cs
+++ b/src/Dotsider/Commands/SizeCheckCommand.cs
@@ -1,7 +1,7 @@
-using System.CommandLine;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Infrastructure;
+using System.CommandLine;
 
 namespace Dotsider.Commands;
 

--- a/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
+++ b/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
@@ -1,8 +1,8 @@
-using System.Net.Sockets;
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Core.Protocol;
+using System.Net.Sockets;
+using System.Text.Json;
 
 namespace Dotsider.Diagnostics;
 

--- a/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
+++ b/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
@@ -971,6 +971,7 @@ internal sealed class DotsiderDiagnosticsListener(
         return DotsiderResponse.Ok(new
         {
             Tab = state.CurrentTab + 1,
+            TabLabel = CurrentTabLabel(state),
             state.PeSubTab,
             state.DynamicSubTab,
             AssemblyPath = state.Analyzer.FilePath,
@@ -982,6 +983,20 @@ internal sealed class DotsiderDiagnosticsListener(
             state.IsNetFramework
         });
     }
+
+    private static string CurrentTabLabel(DotsiderState state) =>
+        state.CurrentTab switch
+        {
+            TabId.General => "General",
+            TabId.PeMetadata => "PE/Metadata",
+            TabId.IlInspector => IlInspectorTabLabel.For(state),
+            TabId.Strings => "Strings",
+            TabId.HexDump => "Hex Dump",
+            TabId.DepGraph => "Dep Graph",
+            TabId.SizeMap => "Size Map",
+            TabId.Dynamic => "Dynamic",
+            _ => state.CurrentTab.ToString()
+        };
 
     private DotsiderResponse HandleNavigate(DotsiderRequest request)
     {

--- a/src/Dotsider/DllInspectorBindings.cs
+++ b/src/Dotsider/DllInspectorBindings.cs
@@ -1,7 +1,7 @@
+using Dotsider.Views;
 using Hex1b;
 using Hex1b.Input;
 using Hex1b.Widgets;
-using Dotsider.Views;
 
 namespace Dotsider;
 

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -94,7 +94,7 @@ public sealed class DotsiderApp(DotsiderState state)
             [
                 tp.Tab("General", _ => []).Selected(_state.CurrentTab == TabId.General),
                 tp.Tab("PE/Metadata", _ => []).Selected(_state.CurrentTab == TabId.PeMetadata),
-                tp.Tab("IL Inspector", _ => []).Selected(_state.CurrentTab == TabId.IlInspector),
+                tp.Tab(IlInspectorTabLabel.For(_state), _ => []).Selected(_state.CurrentTab == TabId.IlInspector),
                 tp.Tab("Strings", _ => []).Selected(_state.CurrentTab == TabId.Strings),
                 tp.Tab("Hex Dump", _ => []).Selected(_state.CurrentTab == TabId.HexDump),
                 tp.Tab("Dep Graph", _ => []).Selected(_state.CurrentTab == TabId.DepGraph),

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Views;
@@ -6,6 +5,7 @@ using Hex1b;
 using Hex1b.Documents;
 using Hex1b.Nodes;
 using Hex1b.Widgets;
+using System.Collections.Concurrent;
 
 namespace Dotsider;
 

--- a/src/Dotsider/HighlightHelper.cs
+++ b/src/Dotsider/HighlightHelper.cs
@@ -1,8 +1,8 @@
-using System.Text;
-using Hex1b.Documents;
 using Hex1b;
+using Hex1b.Documents;
 using Hex1b.Theming;
 using Hex1b.Widgets;
+using System.Text;
 
 namespace Dotsider;
 

--- a/src/Dotsider/IlInspectorTabLabel.cs
+++ b/src/Dotsider/IlInspectorTabLabel.cs
@@ -1,0 +1,23 @@
+namespace Dotsider;
+
+/// <summary>
+/// Chooses the user-facing label for tab 3. The internal tab id stays
+/// <see cref="TabId.IlInspector"/> because navigation and keybindings are stable.
+/// </summary>
+internal static class IlInspectorTabLabel
+{
+    public const string IlInspector = "IL Inspector";
+    public const string Disassembly = "Disassembly";
+    public const string IlAndNative = "IL + Native";
+
+    public static string For(DotsiderState state)
+    {
+        if (state.Analyzer.IsReadyToRun)
+            return IlAndNative;
+
+        if (state.Analyzer.PreIlcCompanions is not null)
+            return state.IlAotTreeNativeView ? Disassembly : IlAndNative;
+
+        return state.Analyzer.HasManagedMetadata ? IlInspector : Disassembly;
+    }
+}

--- a/src/Dotsider/Infrastructure/DotsiderClient.cs
+++ b/src/Dotsider/Infrastructure/DotsiderClient.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Protocol;
 using System.Net.Sockets;
 using System.Text.Json;
-using Dotsider.Core.Protocol;
 
 namespace Dotsider.Infrastructure;
 

--- a/src/Dotsider/Infrastructure/OutputFormatter.cs
+++ b/src/Dotsider/Infrastructure/OutputFormatter.cs
@@ -1,5 +1,5 @@
-using System.Text.Json;
 using Dotsider.Core.Protocol;
+using System.Text.Json;
 
 namespace Dotsider.Infrastructure;
 

--- a/src/Dotsider/Infrastructure/SizeDiffReportWriter.cs
+++ b/src/Dotsider/Infrastructure/SizeDiffReportWriter.cs
@@ -1,7 +1,7 @@
-using System.Text;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Views;
+using System.Text;
 
 namespace Dotsider.Infrastructure;
 

--- a/src/Dotsider/NuGetApp.cs
+++ b/src/Dotsider/NuGetApp.cs
@@ -516,7 +516,7 @@ public sealed class NuGetApp(NuGetState state)
                 .Selected(dllState.CurrentTab == 0),
             tp.Tab("PE/Metadata", t => [PeMetadataView.Build(t, dllState)])
                 .Selected(dllState.CurrentTab == 1),
-            tp.Tab("IL Inspector", t => [IlInspectorView.Build(t, dllState)])
+            tp.Tab(IlInspectorTabLabel.For(dllState), t => [IlInspectorView.Build(t, dllState)])
                 .Selected(dllState.CurrentTab == 2),
             tp.Tab("Strings", t => [StringsView.Build(t, dllState)])
                 .Selected(dllState.CurrentTab == 3),

--- a/src/Dotsider/Program.cs
+++ b/src/Dotsider/Program.cs
@@ -1,12 +1,12 @@
-using System.Collections.Concurrent;
-using System.CommandLine;
-using System.Text;
 using Dotsider;
 using Dotsider.Commands;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
 using Hex1b.Diagnostics;
+using System.Collections.Concurrent;
+using System.CommandLine;
+using System.Text;
 
 Console.OutputEncoding = Encoding.UTF8;
 

--- a/src/Dotsider/README.md
+++ b/src/Dotsider/README.md
@@ -4,7 +4,7 @@
 
 ## Modes
 
-- **TUI mode** — `dotsider MyApp.dll` opens an interactive terminal UI with tabbed navigation. The IL Inspector shows portable PDB source spans, local names, and compact Source Link markers when available.
+- **TUI mode** — `dotsider MyApp.dll` opens an interactive terminal UI with tabbed navigation. Tab 3 shows managed IL, native disassembly, or paired IL/native code depending on the loaded image, with portable PDB source spans, local names, and compact Source Link markers when available.
 - **Diff mode** — `dotsider diff Left.dll Right.dll` compares two assemblies side-by-side; two mstat-backed inputs (Native AOT) open the size-diff view with a delta treemap instead
 - **NuGet mode** — `dotsider MyPackage.nupkg` inspects package contents and embedded assemblies
 - **CLI mode** — `dotsider analyze`, `dotsider size-check`, `dotsider sessions`, `dotsider agent` for headless scripting

--- a/src/Dotsider/Views/DataInterpViewRenderer.cs
+++ b/src/Dotsider/Views/DataInterpViewRenderer.cs
@@ -1,9 +1,9 @@
-using System.Text;
 using Hex1b;
 using Hex1b.Documents;
 using Hex1b.Layout;
 using Hex1b.Theming;
 using Hex1b.Widgets;
+using System.Text;
 
 namespace Dotsider.Views;
 

--- a/src/Dotsider/Views/DataInterpretationPanel.cs
+++ b/src/Dotsider/Views/DataInterpretationPanel.cs
@@ -1,8 +1,8 @@
-using System.Buffers.Binary;
 using Hex1b;
 using Hex1b.Documents;
 using Hex1b.Theming;
 using Hex1b.Widgets;
+using System.Buffers.Binary;
 
 namespace Dotsider.Views;
 

--- a/src/Dotsider/Views/DependencyGraphView.cs
+++ b/src/Dotsider/Views/DependencyGraphView.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
 using Hex1b.Input;
@@ -6,6 +5,7 @@ using Hex1b.Nodes;
 using Hex1b.Surfaces;
 using Hex1b.Theming;
 using Hex1b.Widgets;
+using System.Text;
 
 namespace Dotsider.Views;
 

--- a/src/Dotsider/Views/DotsiderHexRenderer.cs
+++ b/src/Dotsider/Views/DotsiderHexRenderer.cs
@@ -1,9 +1,9 @@
-using System.Text;
 using Hex1b;
 using Hex1b.Documents;
 using Hex1b.Layout;
 using Hex1b.Theming;
 using Hex1b.Widgets;
+using System.Text;
 
 namespace Dotsider.Views;
 

--- a/src/Dotsider/Views/HexDumpView.cs
+++ b/src/Dotsider/Views/HexDumpView.cs
@@ -1,8 +1,8 @@
-using System.Diagnostics;
-using System.Globalization;
 using Hex1b;
 using Hex1b.Input;
 using Hex1b.Widgets;
+using System.Diagnostics;
+using System.Globalization;
 
 namespace Dotsider.Views;
 

--- a/src/Dotsider/Views/IlEditorHost.cs
+++ b/src/Dotsider/Views/IlEditorHost.cs
@@ -1,10 +1,10 @@
-using System.Diagnostics;
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
 using Hex1b.Documents;
 using Hex1b.Input;
 using Hex1b.Theming;
 using Hex1b.Widgets;
+using System.Diagnostics;
 
 namespace Dotsider.Views;
 

--- a/tests/Dotsider.Mcp.Tests/McpCliTests.cs
+++ b/tests/Dotsider.Mcp.Tests/McpCliTests.cs
@@ -1,8 +1,8 @@
+using Hex1b;
+using ModelContextProtocol.Client;
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
-using Hex1b;
-using ModelContextProtocol.Client;
 
 namespace Dotsider.Mcp.Tests;
 

--- a/tests/Dotsider.Mcp.Tests/McpServerTestBase.cs
+++ b/tests/Dotsider.Mcp.Tests/McpServerTestBase.cs
@@ -1,8 +1,8 @@
-using System.IO.Pipelines;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
+using System.IO.Pipelines;
 
 namespace Dotsider.Mcp.Tests;
 

--- a/tests/Dotsider.Mcp.Tests/NavigationToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/NavigationToolsTests.cs
@@ -1,8 +1,8 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Diagnostics;
 using Hex1b;
 using Hex1b.Widgets;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tests;
 

--- a/tests/Dotsider.Mcp.Tests/SessionToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/SessionToolsTests.cs
@@ -1,7 +1,7 @@
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
+using System.Text.Json;
 
 namespace Dotsider.Mcp.Tests;
 

--- a/tests/Dotsider.Mcp.Tests/TestDotsiderSocket.cs
+++ b/tests/Dotsider.Mcp.Tests/TestDotsiderSocket.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Protocol;
 using System.Net.Sockets;
 using System.Text.Json;
-using Dotsider.Core.Protocol;
 
 namespace Dotsider.Mcp.Tests;
 

--- a/tests/Dotsider.Tests/ApphostDetectorTests.cs
+++ b/tests/Dotsider.Tests/ApphostDetectorTests.cs
@@ -1,5 +1,5 @@
-using System.Text;
 using Dotsider.Core.Analysis;
+using System.Text;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/AssemblyAnalyzerTests.cs
+++ b/tests/Dotsider.Tests/AssemblyAnalyzerTests.cs
@@ -1,6 +1,6 @@
-using System.Reflection.PortableExecutable;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Reflection.PortableExecutable;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/AssemblyResolutionTests.cs
+++ b/tests/Dotsider.Tests/AssemblyResolutionTests.cs
@@ -1,9 +1,9 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-using Dotsider.Core.Analysis;
-using Dotsider.Core.Analysis.Models;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/ClipboardCapturingWorkloadAdapter.cs
+++ b/tests/Dotsider.Tests/ClipboardCapturingWorkloadAdapter.cs
@@ -1,8 +1,8 @@
+using Hex1b;
+using Hex1b.Input;
 using System.Collections.Concurrent;
 using System.Text;
 using System.Threading.Channels;
-using Hex1b;
-using Hex1b.Input;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/ConnectionLimitTests.cs
+++ b/tests/Dotsider.Tests/ConnectionLimitTests.cs
@@ -1,10 +1,10 @@
-using System.Collections.Concurrent;
-using System.Net.Sockets;
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+using System.Text.Json;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/DgmlReaderTests.cs
+++ b/tests/Dotsider.Tests/DgmlReaderTests.cs
@@ -1,5 +1,5 @@
-using System.Text;
 using Dotsider.Core.Analysis;
+using System.Text;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/DotNetRuntimeLocatorTests.cs
+++ b/tests/Dotsider.Tests/DotNetRuntimeLocatorTests.cs
@@ -1,5 +1,5 @@
-using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/DotsiderStateTests.cs
+++ b/tests/Dotsider.Tests/DotsiderStateTests.cs
@@ -719,6 +719,66 @@ public class DotsiderStateTests(SampleAssemblyFixture samples) : IDisposable
     }
 
     /// <summary>
+    /// Verifies tab 3 keeps its managed label for ordinary IL inspection.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void IlInspectorTabLabel_ManagedAssembly_IsIlInspector()
+    {
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.HelloWorldDll);
+
+        Assert.Equal(IlInspectorTabLabel.IlInspector, IlInspectorTabLabel.For(state));
+    }
+
+    /// <summary>
+    /// Verifies tab 3 names the native-only AOT surface as disassembly.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void IlInspectorTabLabel_NativeAotWithoutAttachment_IsDisassembly()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.NativeAotConsoleExe!);
+
+        Assert.Equal(IlInspectorTabLabel.Disassembly, IlInspectorTabLabel.For(state));
+    }
+
+    /// <summary>
+    /// Verifies tab 3 names ReadyToRun as an IL plus native surface.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void IlInspectorTabLabel_ReadyToRun_IsIlAndNative()
+    {
+        Assert.SkipWhen(samples.ReadyToRunConsoleDll is null, "ReadyToRun crossgen2 publish did not run on this leg.");
+
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.ReadyToRunConsoleDll!);
+
+        Assert.Equal(IlInspectorTabLabel.IlAndNative, IlInspectorTabLabel.For(state));
+    }
+
+    /// <summary>
+    /// Verifies the pre-ILC sidecar toggle switches tab 3 between paired IL/native and native disassembly.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void IlInspectorTabLabel_PreIlcAttachment_FollowsTreeToggle()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+        Assert.SkipWhen(samples.NativeAotConsoleManagedDll is null, "pre-ILC companion was not produced");
+
+        var app = CreateApp();
+        using var state = new DotsiderState(app, samples.NativeAotConsoleExe!);
+
+        Assert.True(state.AttachPreIlc());
+        Assert.Equal(IlInspectorTabLabel.IlAndNative, IlInspectorTabLabel.For(state));
+
+        state.IlAotTreeNativeView = true;
+
+        Assert.Equal(IlInspectorTabLabel.Disassembly, IlInspectorTabLabel.For(state));
+    }
+
+    /// <summary>
     /// Disposes test resources created during the run.
     /// </summary>
     public void Dispose()

--- a/tests/Dotsider.Tests/DynamicTabGuardTests.cs
+++ b/tests/Dotsider.Tests/DynamicTabGuardTests.cs
@@ -1,8 +1,8 @@
-using System.Runtime.InteropServices;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
 using Hex1b.Widgets;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/ElfSymtabReaderTests.cs
+++ b/tests/Dotsider.Tests/ElfSymtabReaderTests.cs
@@ -1,5 +1,5 @@
-using System.Buffers.Binary;
 using Dotsider.Core.Analysis;
+using System.Buffers.Binary;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/EscapeTimeoutPresentationAdapterTests.cs
+++ b/tests/Dotsider.Tests/EscapeTimeoutPresentationAdapterTests.cs
@@ -1,9 +1,9 @@
-using System.Collections.Concurrent;
-using System.Threading.Channels;
 using Dotsider.Infrastructure;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
+using System.Collections.Concurrent;
+using System.Threading.Channels;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
+++ b/tests/Dotsider.Tests/IlGoToDefinitionTests.cs
@@ -1,5 +1,3 @@
-using System.Reflection.Metadata;
-using System.Reflection.Metadata.Ecma335;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Dotsider.Views;
@@ -8,6 +6,8 @@ using Hex1b.Automation;
 using Hex1b.Documents;
 using Hex1b.Input;
 using Hex1b.Widgets;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/MalformedPeTests.cs
+++ b/tests/Dotsider.Tests/MalformedPeTests.cs
@@ -1,5 +1,5 @@
-using System.Buffers.Binary;
 using Dotsider.Core.Analysis;
+using System.Buffers.Binary;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/ManagedNativeIndexTests.cs
+++ b/tests/Dotsider.Tests/ManagedNativeIndexTests.cs
@@ -1,6 +1,6 @@
-using System.Reflection;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Reflection;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NativeAddressSpaceTests.cs
+++ b/tests/Dotsider.Tests/NativeAddressSpaceTests.cs
@@ -1,5 +1,5 @@
-using System.Buffers.Binary;
 using Dotsider.Core.Analysis;
+using System.Buffers.Binary;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NativeAotDetectorTests.cs
+++ b/tests/Dotsider.Tests/NativeAotDetectorTests.cs
@@ -1,5 +1,5 @@
-using System.Buffers.Binary;
 using Dotsider.Core.Analysis;
+using System.Buffers.Binary;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NativeAotSessionSocketTests.cs
+++ b/tests/Dotsider.Tests/NativeAotSessionSocketTests.cs
@@ -1,10 +1,10 @@
-using System.Collections.Concurrent;
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
 using Hex1b.Widgets;
+using System.Collections.Concurrent;
+using System.Text.Json;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NativeAotSessionSocketTests.cs
+++ b/tests/Dotsider.Tests/NativeAotSessionSocketTests.cs
@@ -77,6 +77,29 @@ public class NativeAotSessionSocketTests(SampleAssemblyFixture samples) : IAsync
         Assert.True(data.GetProperty("readyToRunSections").GetInt32() > 0);
     }
 
+    /// <summary>get-current-view reports the native tab 3 label for Native AOT sessions.</summary>
+    [Fact(Timeout = 30_000)]
+    public async Task GetCurrentView_NativeAot_Tab3LabelIsDisassembly()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        var ct = TestContext.Current.CancellationToken;
+        var socketPath = await StartTuiWithDiagnosticsAsync(samples.NativeAotConsoleExe!, ct);
+
+        var navigate = await DotsiderClient.SendAsync(socketPath,
+            new DotsiderRequest { Method = "navigate", TabId = TabId.IlInspector + 1 }, ct);
+        Assert.True(navigate.Success, navigate.Error);
+        await Task.Delay(500, ct);
+
+        var response = await DotsiderClient.SendAsync(socketPath,
+            new DotsiderRequest { Method = "get-current-view" }, ct);
+
+        Assert.True(response.Success, response.Error);
+        var data = (response.Data as JsonElement?)!.Value;
+        Assert.Equal(3, data.GetProperty("tab").GetInt32());
+        Assert.Equal("Disassembly", data.GetProperty("tabLabel").GetString());
+    }
+
     /// <summary>get-native-aot-size-contributors returns mstat contributors from a running session.</summary>
     [Fact(Timeout = 30_000)]
     public async Task GetNativeAotSizeContributors_ReturnsRows()

--- a/tests/Dotsider.Tests/NativeImportResolverTests.cs
+++ b/tests/Dotsider.Tests/NativeImportResolverTests.cs
@@ -1,8 +1,8 @@
-using System.Buffers.Binary;
-using System.Text;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Disasm;
 using Dotsider.Core.Analysis.Models;
+using System.Buffers.Binary;
+using System.Text;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NativeRecordCompatTests.cs
+++ b/tests/Dotsider.Tests/NativeRecordCompatTests.cs
@@ -1,5 +1,5 @@
-using System.Reflection.PortableExecutable;
 using Dotsider.Core.Analysis.Models;
+using System.Reflection.PortableExecutable;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NativeSymbolReaderMachOTests.cs
+++ b/tests/Dotsider.Tests/NativeSymbolReaderMachOTests.cs
@@ -1,6 +1,6 @@
-using System.Buffers.Binary;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Buffers.Binary;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NetFxAssemblyResolutionClr2Tests.cs
+++ b/tests/Dotsider.Tests/NetFxAssemblyResolutionClr2Tests.cs
@@ -1,6 +1,6 @@
-using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NetFxAssemblyResolutionTests.cs
+++ b/tests/Dotsider.Tests/NetFxAssemblyResolutionTests.cs
@@ -1,6 +1,6 @@
-using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NetFxBinderClr2Tests.cs
+++ b/tests/Dotsider.Tests/NetFxBinderClr2Tests.cs
@@ -1,6 +1,6 @@
-using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NetFxBinderOracleClr2Tests.cs
+++ b/tests/Dotsider.Tests/NetFxBinderOracleClr2Tests.cs
@@ -1,7 +1,7 @@
-using System.Reflection;
-using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NetFxBinderOracleTests.cs
+++ b/tests/Dotsider.Tests/NetFxBinderOracleTests.cs
@@ -1,7 +1,7 @@
-using System.Reflection;
-using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NetFxBinderTests.cs
+++ b/tests/Dotsider.Tests/NetFxBinderTests.cs
@@ -1,6 +1,6 @@
-using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NetFxBindingContextClr2Tests.cs
+++ b/tests/Dotsider.Tests/NetFxBindingContextClr2Tests.cs
@@ -1,6 +1,6 @@
-using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/NetFxBindingContextTests.cs
+++ b/tests/Dotsider.Tests/NetFxBindingContextTests.cs
@@ -1,6 +1,6 @@
-using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/PeDirectoryReaderTests.cs
+++ b/tests/Dotsider.Tests/PeDirectoryReaderTests.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Analysis;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
-using Dotsider.Core.Analysis;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/PeMetadataViewTests.cs
+++ b/tests/Dotsider.Tests/PeMetadataViewTests.cs
@@ -1,8 +1,8 @@
-using System.Runtime.InteropServices;
 using Hex1b;
 using Hex1b.Automation;
 using Hex1b.Input;
 using Hex1b.Widgets;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/PeerCredentialTests.cs
+++ b/tests/Dotsider.Tests/PeerCredentialTests.cs
@@ -1,9 +1,9 @@
-using System.Collections.Concurrent;
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
+using System.Collections.Concurrent;
+using System.Text.Json;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/PreIlcSessionSocketTests.cs
+++ b/tests/Dotsider.Tests/PreIlcSessionSocketTests.cs
@@ -1,10 +1,10 @@
-using System.Collections.Concurrent;
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
 using Hex1b.Widgets;
+using System.Collections.Concurrent;
+using System.Text.Json;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/ProtocolVersionTests.cs
+++ b/tests/Dotsider.Tests/ProtocolVersionTests.cs
@@ -1,9 +1,9 @@
-using System.Collections.Concurrent;
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
+using System.Collections.Concurrent;
+using System.Text.Json;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/ReadyToRunReaderTests.cs
+++ b/tests/Dotsider.Tests/ReadyToRunReaderTests.cs
@@ -1,5 +1,5 @@
-using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/RootCauseInvestigation.cs
+++ b/tests/Dotsider.Tests/RootCauseInvestigation.cs
@@ -1,7 +1,7 @@
+using Dotsider.Core.Analysis;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.InteropServices;
-using Dotsider.Core.Analysis;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/SessionBundleTests.cs
+++ b/tests/Dotsider.Tests/SessionBundleTests.cs
@@ -130,6 +130,7 @@ public class SessionBundleTests(SampleAssemblyFixture samples) : IAsyncDisposabl
         Assert.True(response.Success);
 
         var data = (response.Data as JsonElement?)!.Value;
+        Assert.Equal("General", data.GetProperty("tabLabel").GetString());
         Assert.True(data.GetProperty("hasEntryPoint").GetBoolean());
         Assert.False(data.GetProperty("hexIsDirty").GetBoolean());
         Assert.False(data.GetProperty("isNativeAot").GetBoolean());

--- a/tests/Dotsider.Tests/SessionBundleTests.cs
+++ b/tests/Dotsider.Tests/SessionBundleTests.cs
@@ -1,11 +1,11 @@
-using System.Collections.Concurrent;
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
 using Hex1b.Documents;
 using Hex1b.Widgets;
+using System.Collections.Concurrent;
+using System.Text.Json;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/SessionCliTests.cs
+++ b/tests/Dotsider.Tests/SessionCliTests.cs
@@ -1,6 +1,6 @@
+using Dotsider.Infrastructure;
 using System.Diagnostics;
 using System.Text.Json;
-using Dotsider.Infrastructure;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/SessionDiagnosticsSocketTests.cs
+++ b/tests/Dotsider.Tests/SessionDiagnosticsSocketTests.cs
@@ -1,10 +1,10 @@
-using System.Collections.Concurrent;
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
 using Hex1b.Diagnostics;
+using System.Collections.Concurrent;
+using System.Text.Json;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/SessionDiffModeTests.cs
+++ b/tests/Dotsider.Tests/SessionDiffModeTests.cs
@@ -1,9 +1,9 @@
-using System.Diagnostics;
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
+using System.Diagnostics;
+using System.Text.Json;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/SessionNavigateTests.cs
+++ b/tests/Dotsider.Tests/SessionNavigateTests.cs
@@ -1,10 +1,10 @@
-using System.Collections.Concurrent;
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
 using Hex1b.Widgets;
+using System.Collections.Concurrent;
+using System.Text.Json;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/SessionNugetModeTests.cs
+++ b/tests/Dotsider.Tests/SessionNugetModeTests.cs
@@ -1,9 +1,9 @@
-using System.Diagnostics;
-using System.Text.Json;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
+using System.Diagnostics;
+using System.Text.Json;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/SessionNugetNavigateTests.cs
+++ b/tests/Dotsider.Tests/SessionNugetNavigateTests.cs
@@ -1,9 +1,9 @@
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
 using Hex1b.Widgets;
+using System.Text.Json;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/SessionSymbolTests.cs
+++ b/tests/Dotsider.Tests/SessionSymbolTests.cs
@@ -1,10 +1,10 @@
-using System.Collections.Concurrent;
-using System.Text.Json;
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
 using Hex1b;
 using Hex1b.Widgets;
+using System.Collections.Concurrent;
+using System.Text.Json;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/SocketDirectoryTests.cs
+++ b/tests/Dotsider.Tests/SocketDirectoryTests.cs
@@ -1,7 +1,7 @@
-using System.Collections.Concurrent;
-using System.Runtime.InteropServices;
 using Dotsider.Diagnostics;
 using Hex1b;
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -164,8 +164,75 @@ public class StandardModeViewTests(SampleAssemblyFixture samples) : IDisposable
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
             .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
-            .Key(Hex1bKey.D3) // Tab 3 — IL Inspector
+            .Key(Hex1bKey.D3) // Tab 3 — IL / Native
             .WaitUntil(s => s.ContainsText("Select a method") || s.ContainsText("IL"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Verifies tab3 keeps the managed IL Inspector label for ordinary managed assemblies.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Tab3_Label_ManagedAssembly_IsIlInspector()
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.RichLibraryDll);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("IL Inspector"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Verifies tab3 is labeled as disassembly for a native-only AOT view.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Tab3_Label_NativeAot_IsDisassembly()
+    {
+        Assert.SkipWhen(samples.NativeAotConsoleExe is null, "NativeAOT sample was not built");
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.NativeAotConsoleExe!);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("Disassembly"), TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
+    /// Verifies tab3 is labeled as IL plus native for ReadyToRun images.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Tab3_Label_ReadyToRun_IsIlAndNative()
+    {
+        Assert.SkipWhen(samples.ReadyToRunConsoleDll is null, "ReadyToRun crossgen2 publish did not run on this leg.");
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(samples.ReadyToRunConsoleDll!);
+        var runTask = app.RunAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => s.ContainsText("IL + Native"), TimeSpan.FromSeconds(10))
             .Build()
             .ApplyAsync(terminal, cts.Token);
 

--- a/tests/Dotsider.Tests/StringExtractorTests.cs
+++ b/tests/Dotsider.Tests/StringExtractorTests.cs
@@ -1,6 +1,6 @@
-using System.Runtime.InteropServices;
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Tests/TestDotsiderSocket.cs
+++ b/tests/Dotsider.Tests/TestDotsiderSocket.cs
@@ -1,6 +1,6 @@
+using Dotsider.Core.Protocol;
 using System.Net.Sockets;
 using System.Text.Json;
-using Dotsider.Core.Protocol;
 
 namespace Dotsider.Tests;
 

--- a/tests/Dotsider.Website.Tests/SearchInputTests.cs
+++ b/tests/Dotsider.Website.Tests/SearchInputTests.cs
@@ -1,9 +1,9 @@
+using Hex1b;
+using Hex1b.Widgets;
 using System.Net;
 using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Text;
-using Hex1b;
-using Hex1b.Widgets;
 
 namespace Dotsider.Website.Tests;
 

--- a/vhs/screenshots-hidpi.tape
+++ b/vhs/screenshots-hidpi.tape
@@ -36,7 +36,7 @@ Sleep 4s
 Screenshot docs/src/assets/screenshots/pe-metadata.png
 Sleep 2s
 
-# Tab 3: IL Inspector — navigate to a method to show IL disassembly
+# Tab 3: IL view — navigate to a method to show IL disassembly
 Type "3"
 Sleep 4s
 


### PR DESCRIPTION
Tab 3 now names what it is actually showing: IL Inspector for managed IL, Disassembly for native-only code, and IL + Native when managed IL is paired with native code. The internal TabId stays stable, and session/MCP/help/docs use neutral wording so automation and users still talk about the same view.

Validated with dotnet test locally: 1975 total, 1970 passed, 5 skipped.

Fixes: #200