### PR TITLE
Contain NuGet package extraction paths

### DIFF
--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
@@ -74,6 +74,10 @@ Opens and analyzes the specified .NET assembly file.
 
 - `filePath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Absolute path to the assembly file.
 
+**Exceptions:**
+
+- [FileNotFoundException](https://learn.microsoft.com/dotnet/api/system.io.filenotfoundexception): The file does not exist.
+
 ```csharp
 public AssemblyAnalyzer(string filePath)
 ```

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NuGetFileEntry.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-NuGetFileEntry.md
@@ -32,12 +32,14 @@ Represents a file entry within a NuGet package (.nupkg).
 
 **Parameters:**
 
-- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): File name without directory path.
-- `FullPath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Full path of the entry within the package archive.
-- `Directory` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Directory portion of the entry path.
+- `Name` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Raw, untrusted file-name portion of the archive entry path. This value is not display-safe.
+- `FullPath` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Raw, untrusted path of the entry within the package archive. This value is not a filesystem
+path and must be validated before extraction.
+- `Directory` ([String](https://learn.microsoft.com/dotnet/api/system.string)): Raw, untrusted directory portion of the archive entry path, normalized only to use forward
+slashes. This value is not a filesystem-safe path or display-safe text.
 - `CompressedSize` ([Int64](https://learn.microsoft.com/dotnet/api/system.int64)): Compressed size in bytes inside the .nupkg.
 - `UncompressedSize` ([Int64](https://learn.microsoft.com/dotnet/api/system.int64)): Uncompressed size in bytes.
-- `IsDll` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether the entry is a .NET assembly (.dll).
+- `IsDll` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)): Whether the archive entry name has a .dll file extension.
 
 ```csharp
 public NuGetFileEntry(string Name, string FullPath, string Directory, long CompressedSize, long UncompressedSize, bool IsDll)
@@ -57,7 +59,8 @@ public long CompressedSize { get; init; }
 
 ### Directory
 
-Directory portion of the entry path.
+Raw, untrusted directory portion of the archive entry path, normalized only to use forward
+slashes. This value is not a filesystem-safe path or display-safe text.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 
@@ -67,7 +70,8 @@ public string Directory { get; init; }
 
 ### FullPath
 
-Full path of the entry within the package archive.
+Raw, untrusted path of the entry within the package archive. This value is not a filesystem
+path and must be validated before extraction.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 
@@ -77,7 +81,7 @@ public string FullPath { get; init; }
 
 ### IsDll
 
-Whether the entry is a .NET assembly (.dll).
+Whether the archive entry name has a .dll file extension.
 
 **Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
 
@@ -87,7 +91,7 @@ public bool IsDll { get; init; }
 
 ### Name
 
-File name without directory path.
+Raw, untrusted file-name portion of the archive entry path. This value is not display-safe.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-NuGetPackageAnalyzer.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-NuGetPackageAnalyzer.md
@@ -43,7 +43,8 @@ public NuGetPackageAnalyzer(string nupkgPath)
 
 ### Authors
 
-The package authors from the .nuspec manifest, or null.
+The raw, untrusted package authors from the .nuspec manifest, or null. This value is not
+display-safe.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 
@@ -53,7 +54,8 @@ public string? Authors { get; }
 
 ### Description
 
-The package description from the .nuspec manifest, or null.
+The raw, untrusted package description from the .nuspec manifest, or null. This value is
+not display-safe.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 
@@ -103,7 +105,8 @@ public IReadOnlyList<NuGetFileEntry> Files { get; }
 
 ### PackageId
 
-The NuGet package ID from the .nuspec manifest, or null.
+The raw, untrusted NuGet package ID from the .nuspec manifest, or null. This value is not
+display-safe.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 
@@ -113,7 +116,8 @@ public string? PackageId { get; }
 
 ### PackageVersion
 
-The package version from the .nuspec manifest, or null.
+The raw, untrusted package version from the .nuspec manifest, or null. This value is not
+display-safe.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 
@@ -133,13 +137,24 @@ public void Dispose()
 
 ### OpenDll(NuGetFileEntry)
 
-Extracts a DLL from the package to a temp file and creates an AssemblyAnalyzer.
+Extracts a DLL from the package into a private temporary directory and creates an analyzer.
 
 **Parameters:**
 
-- `entry` ([NuGetFileEntry](/api/dotsider.core.analysis.models.nugetfileentry/)): 
+- `entry` ([NuGetFileEntry](/api/dotsider.core.analysis.models.nugetfileentry/)): The exact [NuGetFileEntry](/api/dotsider.core.analysis.models.nugetfileentry/) instance returned by this analyzer.
 
 **Returns:** [AssemblyAnalyzer](/api/dotsider.core.analysis.assemblyanalyzer/)
+
+An analyzer for the selected DLL. Dispose it before disposing this package analyzer.
+
+**Exceptions:**
+
+- [ArgumentNullException](https://learn.microsoft.com/dotnet/api/system.argumentnullexception): entry is null.
+- [ArgumentException](https://learn.microsoft.com/dotnet/api/system.argumentexception): entry was not returned by this analyzer or does not represent a DLL.
+- [UnsafePackageEntryException](/api/dotsider.core.analysis.unsafepackageentryexception/): The package entry has an unsafe or ambiguous extraction path.
+- [ObjectDisposedException](https://learn.microsoft.com/dotnet/api/system.objectdisposedexception): This analyzer has been disposed.
+- [IOException](https://learn.microsoft.com/dotnet/api/system.io.ioexception): The DLL could not be extracted or read.
+- [BadImageFormatException](https://learn.microsoft.com/dotnet/api/system.badimageformatexception): The extracted file has an invalid format.
 
 ```csharp
 public AssemblyAnalyzer OpenDll(NuGetFileEntry entry)

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-SingleFileBundleReader.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-SingleFileBundleReader.md
@@ -124,6 +124,10 @@ Reads the bundle manifest from a stream positioned at the header.
 
 The parsed bundle manifest.
 
+**Exceptions:**
+
+- [InvalidDataException](https://learn.microsoft.com/dotnet/api/system.io.invaliddataexception): The bundle version is unsupported.
+
 ```csharp
 public static BundleManifest ReadManifest(Stream stream)
 ```
@@ -140,6 +144,10 @@ Reads the bundle manifest from the file at filePath.
 **Returns:** [BundleManifest](/api/dotsider.core.analysis.models.bundlemanifest/)
 
 The parsed bundle manifest.
+
+**Exceptions:**
+
+- [InvalidDataException](https://learn.microsoft.com/dotnet/api/system.io.invaliddataexception): The bundle version is unsupported.
 
 ```csharp
 public static BundleManifest ReadManifest(string filePath, long headerOffset)

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-SizeBudgetEvaluator.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-SizeBudgetEvaluator.md
@@ -43,6 +43,10 @@ Evaluates budgets against a diff.
 
 The report, failing only on error-severity breaches.
 
+**Exceptions:**
+
+- [ArgumentException](https://learn.microsoft.com/dotnet/api/system.argumentexception): A total-scope growth budget was supplied without a baseline; callers reject that combination before evaluating.
+
 ```csharp
 public static SizeBudgetReport Evaluate(IReadOnlyList<SizeBudget> budgets, MstatDiffResult diff, SizeBasis totalBasis, long currentTotalBytes, long? baselineTotalBytes, int defaultTopN = 10)
 ```

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-SizeBudgetFile.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-SizeBudgetFile.md
@@ -39,6 +39,11 @@ Loads a budget document from a file.
 
 The parsed budgets, in document order.
 
+**Exceptions:**
+
+- [FormatException](https://learn.microsoft.com/dotnet/api/system.formatexception): The document is not valid JSON or an entry is malformed.
+- [IOException](https://learn.microsoft.com/dotnet/api/system.io.ioexception): The file cannot be read.
+
 ```csharp
 public static IReadOnlyList<SizeBudget> Load(string path)
 ```
@@ -54,6 +59,10 @@ Parses a budget document from its JSON text.
 **Returns:** [IReadOnlyList\<SizeBudget\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
 
 The parsed budgets, in document order.
+
+**Exceptions:**
+
+- [FormatException](https://learn.microsoft.com/dotnet/api/system.formatexception): The document is not valid JSON or an entry is malformed.
 
 ```csharp
 public static IReadOnlyList<SizeBudget> Parse(string json)

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-SizeBudgetParser.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-SizeBudgetParser.md
@@ -40,6 +40,10 @@ Parses one budget spec.
 
 The parsed budget, at error severity.
 
+**Exceptions:**
+
+- [FormatException](https://learn.microsoft.com/dotnet/api/system.formatexception): The spec does not match the grammar; the message names the offending part.
+
 ```csharp
 public static SizeBudget Parse(string spec)
 ```

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-UnsafePackageEntryException.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-UnsafePackageEntryException.md
@@ -1,0 +1,63 @@
+---
+title: "UnsafePackageEntryException"
+description: "The exception that is thrown when a package entry cannot be safely extracted beneath its destination directory."
+slug: api/dotsider.core.analysis.unsafepackageentryexception
+sidebar:
+  order: 0
+---
+
+**Namespace:** `Dotsider.Core.Analysis`
+
+**Assembly:** Dotsider.Core.dll
+
+The exception that is thrown when a package entry cannot be safely extracted beneath its
+destination directory.
+
+```csharp
+public sealed class UnsafePackageEntryException : IOException, ISerializable
+```
+
+## Inheritance
+
+[Object](https://learn.microsoft.com/dotnet/api/system.object) → [Exception](https://learn.microsoft.com/dotnet/api/system.exception) → [SystemException](https://learn.microsoft.com/dotnet/api/system.systemexception) → [IOException](https://learn.microsoft.com/dotnet/api/system.io.ioexception) → **UnsafePackageEntryException**
+
+## Implements
+
+- [ISerializable](https://learn.microsoft.com/dotnet/api/system.runtime.serialization.iserializable)
+
+## Constructors
+
+### UnsafePackageEntryException()
+
+Initializes a new instance of the [UnsafePackageEntryException](/api/dotsider.core.analysis.unsafepackageentryexception/) class.
+
+```csharp
+public UnsafePackageEntryException()
+```
+
+### UnsafePackageEntryException(string?, Exception?)
+
+Initializes a new instance of the [UnsafePackageEntryException](/api/dotsider.core.analysis.unsafepackageentryexception/) class with a
+specified error message and a reference to the inner exception that caused this exception.
+
+**Parameters:**
+
+- `message` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The message that describes the error.
+- `innerException` ([Exception](https://learn.microsoft.com/dotnet/api/system.exception)): The exception that caused the current exception, or null.
+
+```csharp
+public UnsafePackageEntryException(string? message, Exception? innerException)
+```
+
+### UnsafePackageEntryException(string?)
+
+Initializes a new instance of the [UnsafePackageEntryException](/api/dotsider.core.analysis.unsafepackageentryexception/) class with a
+specified error message.
+
+**Parameters:**
+
+- `message` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The message that describes the error.
+
+```csharp
+public UnsafePackageEntryException(string? message)
+```

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis.md
@@ -384,3 +384,12 @@ and raw printable character sequences from the binary.
 public sealed class StringExtractor
 ```
 
+### [UnsafePackageEntryException](/api/dotsider.core.analysis.unsafepackageentryexception/)
+
+The exception that is thrown when a package entry cannot be safely extracted beneath its
+destination directory.
+
+```csharp
+public sealed class UnsafePackageEntryException : IOException, ISerializable
+```
+

--- a/docs/src/content/docs/usage/nuget-mode.md
+++ b/docs/src/content/docs/usage/nuget-mode.md
@@ -13,7 +13,11 @@ dotsider package.nupkg
 
 dotsider lists the package contents — the `.nuspec` manifest, lib folders per target framework, and any other files. Select a DLL and press `Enter` to open it in the full analyzer with all 8 tabs.
 
-NuGet packages are ZIP files. dotsider extracts assemblies to a temp directory for analysis, so everything works exactly as it does with regular DLLs.
+NuGet packages are ZIP files. When you open a DLL, dotsider extracts only that assembly into a private temporary directory, analyzes it like a regular DLL, and removes the directory when NuGet mode closes.
+
+Package paths are treated as untrusted. DLLs with rooted, directory-traversing, or ambiguous paths remain visible in the file list, but dotsider refuses to extract them and shows an error instead.
+
+Control characters in package metadata and archive paths are shown in a visible escaped form. Copying a file row still copies its exact archive path.
 
 ## Navigation
 

--- a/src/Dotsider.Core/Analysis/ContainedPathResolver.cs
+++ b/src/Dotsider.Core/Analysis/ContainedPathResolver.cs
@@ -1,0 +1,188 @@
+using System.Security;
+using System.Text;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Resolves untrusted relative paths beneath a trusted directory.
+/// </summary>
+internal static class ContainedPathResolver
+{
+    private static StringComparison PathComparison { get; } = OperatingSystem.IsWindows()
+        || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Gets the comparer used for canonical filesystem paths on the current platform.
+    /// </summary>
+    internal static StringComparer PathComparer { get; } = OperatingSystem.IsWindows()
+        || OperatingSystem.IsMacOS()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+
+    /// <summary>
+    /// Gets a canonical key for filesystem-equivalence comparisons on the current platform.
+    /// </summary>
+    /// <param name="path">The canonical filesystem path.</param>
+    /// <returns>The platform comparison key.</returns>
+    internal static string GetComparisonKey(string path) => OperatingSystem.IsMacOS()
+        ? path.Normalize(NormalizationForm.FormD)
+        : path;
+
+    /// <summary>
+    /// Determines whether a path has a portable, non-traversing relative form.
+    /// </summary>
+    /// <param name="relativePath">The untrusted relative path.</param>
+    /// <returns>
+    /// <see langword="true"/> when the path is relative and contains no parent traversal;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
+    internal static bool IsSafeRelativePath(string? relativePath)
+    {
+        if (string.IsNullOrEmpty(relativePath) ||
+            IsDirectorySeparator(relativePath[0]) ||
+            HasDrivePrefix(relativePath) ||
+            ContainsInvalidCharacter(relativePath))
+        {
+            return false;
+        }
+
+        var segmentStart = 0;
+        for (var index = 0; index <= relativePath.Length; index++)
+        {
+            if (index != relativePath.Length && !IsDirectorySeparator(relativePath[index]))
+                continue;
+
+            var segmentLength = index - segmentStart;
+            if (segmentLength == 2 &&
+                relativePath[segmentStart] == '.' &&
+                relativePath[segmentStart + 1] == '.')
+            {
+                return false;
+            }
+
+            if (segmentLength > 0 &&
+                !(segmentLength == 1 && relativePath[segmentStart] == '.') &&
+                (relativePath[index - 1] is ' ' or '.' ||
+                    IsWindowsDeviceName(relativePath.AsSpan(segmentStart, segmentLength))))
+            {
+                return false;
+            }
+
+            segmentStart = index + 1;
+        }
+
+        try
+        {
+            return !Path.IsPathRooted(NormalizeSeparators(relativePath));
+        }
+        catch (Exception exception) when (IsPathException(exception))
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Resolves an untrusted relative path and verifies that it is strictly beneath a trusted
+    /// directory.
+    /// </summary>
+    /// <param name="rootDirectory">The trusted root directory.</param>
+    /// <param name="relativePath">The untrusted relative path.</param>
+    /// <param name="fullPath">The canonical contained path when resolution succeeds.</param>
+    /// <returns>
+    /// <see langword="true"/> when the path resolves beneath <paramref name="rootDirectory"/>;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
+    internal static bool TryResolve(
+        string rootDirectory,
+        string relativePath,
+        out string fullPath)
+    {
+        fullPath = string.Empty;
+        if (!IsSafeRelativePath(relativePath))
+            return false;
+
+        try
+        {
+            var canonicalRoot = Path.GetFullPath(rootDirectory);
+            var rootWithSeparator = Path.EndsInDirectorySeparator(canonicalRoot)
+                ? canonicalRoot
+                : string.Concat(canonicalRoot, Path.DirectorySeparatorChar);
+            var candidate = Path.GetFullPath(Path.Combine(
+                rootWithSeparator,
+                NormalizeSeparators(relativePath)));
+
+            if (!IsStrictDescendant(rootWithSeparator, candidate))
+            {
+                return false;
+            }
+
+            fullPath = candidate;
+            return true;
+        }
+        catch (Exception exception) when (IsPathException(exception))
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether one canonical path is strictly beneath a canonical directory path.
+    /// </summary>
+    /// <param name="canonicalRoot">The canonical directory path, with or without a trailing separator.</param>
+    /// <param name="canonicalCandidate">The canonical candidate path.</param>
+    /// <returns>
+    /// <see langword="true"/> when <paramref name="canonicalCandidate"/> is a strict descendant
+    /// of <paramref name="canonicalRoot"/>; otherwise, <see langword="false"/>.
+    /// </returns>
+    internal static bool IsStrictDescendant(string canonicalRoot, string canonicalCandidate)
+    {
+        var rootWithSeparator = Path.EndsInDirectorySeparator(canonicalRoot)
+            ? canonicalRoot
+            : string.Concat(canonicalRoot, Path.DirectorySeparatorChar);
+        return canonicalCandidate.Length > rootWithSeparator.Length &&
+            canonicalCandidate.StartsWith(rootWithSeparator, PathComparison);
+    }
+
+    private static bool HasDrivePrefix(string path) =>
+        path.Length >= 2 && char.IsAsciiLetter(path[0]) && path[1] == ':';
+
+    private static bool ContainsInvalidCharacter(string path)
+    {
+        foreach (var character in path)
+        {
+            if (character is < ' ' or '\u007F' or ':' or '*' or '?' or '"' or '<' or '>' or '|')
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsDirectorySeparator(char value) => value is '/' or '\\';
+
+    private static bool IsPathException(Exception exception) =>
+        exception is ArgumentException or IOException or NotSupportedException or SecurityException;
+
+    private static bool IsWindowsDeviceName(ReadOnlySpan<char> segment)
+    {
+        var extensionIndex = segment.IndexOf('.');
+        var name = extensionIndex < 0 ? segment : segment[..extensionIndex];
+        return name.Equals("CON", StringComparison.OrdinalIgnoreCase) ||
+            name.Equals("PRN", StringComparison.OrdinalIgnoreCase) ||
+            name.Equals("AUX", StringComparison.OrdinalIgnoreCase) ||
+            name.Equals("NUL", StringComparison.OrdinalIgnoreCase) ||
+            name.Equals("CONIN$", StringComparison.OrdinalIgnoreCase) ||
+            name.Equals("CONOUT$", StringComparison.OrdinalIgnoreCase) ||
+            IsNumberedDeviceName(name, "COM") ||
+            IsNumberedDeviceName(name, "LPT");
+    }
+
+    private static bool IsNumberedDeviceName(ReadOnlySpan<char> name, ReadOnlySpan<char> prefix) =>
+        name.Length == prefix.Length + 1 &&
+        name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
+        name[^1] is (>= '1' and <= '9') or '\u00B9' or '\u00B2' or '\u00B3';
+
+    private static string NormalizeSeparators(string path) =>
+        path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+}

--- a/src/Dotsider.Core/Analysis/ContainedPathTrie.cs
+++ b/src/Dotsider.Core/Analysis/ContainedPathTrie.cs
@@ -1,0 +1,52 @@
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Tracks canonical extraction destinations and identifies file-versus-directory conflicts in
+/// work proportional to the total number of path segments.
+/// </summary>
+/// <param name="comparer">The platform filesystem segment comparer.</param>
+internal sealed class ContainedPathTrie(StringComparer comparer)
+{
+    private readonly ContainedPathTrieNode _root = new(comparer);
+
+    /// <summary>
+    /// Adds a canonical destination and marks it and every conflicting entry as unsafe.
+    /// </summary>
+    /// <param name="path">The canonical platform comparison key.</param>
+    /// <param name="entry">The package entry that owns the destination.</param>
+    /// <param name="unsafeEntries">The set that receives conflicting entries.</param>
+    internal void Add(
+        string path,
+        NuGetFileEntry entry,
+        HashSet<NuGetFileEntry> unsafeEntries)
+    {
+        var node = _root;
+        foreach (var segment in path.Split(
+            Path.DirectorySeparatorChar,
+            StringSplitOptions.RemoveEmptyEntries))
+        {
+            MarkConflicts(node.TerminalEntries, entry, unsafeEntries);
+            node.SubtreeEntries.Add(entry);
+            node = node.GetOrAddChild(segment);
+        }
+
+        MarkConflicts(node.SubtreeEntries, entry, unsafeEntries);
+        node.SubtreeEntries.Add(entry);
+        node.TerminalEntries.Add(entry);
+    }
+
+    private static void MarkConflicts(
+        List<NuGetFileEntry> conflictingEntries,
+        NuGetFileEntry entry,
+        HashSet<NuGetFileEntry> unsafeEntries)
+    {
+        if (conflictingEntries.Count == 0)
+            return;
+
+        unsafeEntries.Add(entry);
+        foreach (var conflictingEntry in conflictingEntries)
+            unsafeEntries.Add(conflictingEntry);
+    }
+}

--- a/src/Dotsider.Core/Analysis/ContainedPathTrieNode.cs
+++ b/src/Dotsider.Core/Analysis/ContainedPathTrieNode.cs
@@ -1,0 +1,38 @@
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Represents one canonical path segment in a <see cref="ContainedPathTrie"/>.
+/// </summary>
+/// <param name="comparer">The platform filesystem segment comparer.</param>
+internal sealed class ContainedPathTrieNode(StringComparer comparer)
+{
+    private readonly Dictionary<string, ContainedPathTrieNode> _children = new(comparer);
+
+    /// <summary>
+    /// Gets every package entry whose destination is at or beneath this node.
+    /// </summary>
+    internal List<NuGetFileEntry> SubtreeEntries { get; } = [];
+
+    /// <summary>
+    /// Gets the package entries whose destinations end at this node.
+    /// </summary>
+    internal List<NuGetFileEntry> TerminalEntries { get; } = [];
+
+    /// <summary>
+    /// Gets or creates the child for a canonical path segment.
+    /// </summary>
+    /// <param name="segment">The canonical path segment.</param>
+    /// <returns>The existing or newly created child node.</returns>
+    internal ContainedPathTrieNode GetOrAddChild(string segment)
+    {
+        if (!_children.TryGetValue(segment, out var child))
+        {
+            child = new ContainedPathTrieNode(comparer);
+            _children.Add(segment, child);
+        }
+
+        return child;
+    }
+}

--- a/src/Dotsider.Core/Analysis/DependencyGraphBuildCheckpoint.cs
+++ b/src/Dotsider.Core/Analysis/DependencyGraphBuildCheckpoint.cs
@@ -1,0 +1,13 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Identifies a completed unit of dependency-graph traversal work.
+/// </summary>
+internal enum DependencyGraphBuildCheckpoint
+{
+    /// <summary>A managed assembly reference was resolved and recorded in the graph.</summary>
+    ManagedAssemblyReferenceProcessed,
+
+    /// <summary>A Native AOT DGML link was inspected for assembly-level aggregation.</summary>
+    DgmlLinkProcessed,
+}

--- a/src/Dotsider.Core/Analysis/DependencyGraphBuilder.cs
+++ b/src/Dotsider.Core/Analysis/DependencyGraphBuilder.cs
@@ -21,10 +21,43 @@ public static class DependencyGraphBuilder
     /// <param name="analyzer">The root assembly analyzer. The caller retains ownership and disposal
     /// responsibility; the builder does not dispose it.</param>
     /// <returns>The computed nodes, edges, and per-node navigation metadata.</returns>
-    public static DependencyGraphResult Build(AssemblyAnalyzer analyzer)
+    public static DependencyGraphResult Build(AssemblyAnalyzer analyzer) =>
+        BuildWithCancellation(analyzer, CancellationToken.None);
+
+    /// <summary>
+    /// Builds the transitive dependency graph and cooperatively stops at traversal boundaries when
+    /// cancellation is requested.
+    /// </summary>
+    /// <param name="analyzer">
+    /// The root assembly analyzer. The caller retains ownership and disposal responsibility.
+    /// </param>
+    /// <param name="cancellationToken">The token used to cancel graph traversal.</param>
+    /// <returns>The computed nodes, edges, and per-node navigation metadata.</returns>
+    internal static DependencyGraphResult BuildWithCancellation(
+        AssemblyAnalyzer analyzer,
+        CancellationToken cancellationToken) =>
+        BuildWithCancellation(analyzer, cancellationToken, progressObserver: null);
+
+    /// <summary>
+    /// Builds the transitive dependency graph, cooperatively stops when cancellation is requested,
+    /// and reports completed traversal units to <paramref name="progressObserver"/>.
+    /// </summary>
+    /// <param name="analyzer">
+    /// The root assembly analyzer. The caller retains ownership and disposal responsibility.
+    /// </param>
+    /// <param name="cancellationToken">The token used to cancel graph traversal.</param>
+    /// <param name="progressObserver">
+    /// An optional observer invoked synchronously after each reported unit of work completes.
+    /// </param>
+    /// <returns>The computed nodes, edges, and per-node navigation metadata.</returns>
+    internal static DependencyGraphResult BuildWithCancellation(
+        AssemblyAnalyzer analyzer,
+        CancellationToken cancellationToken,
+        Action<DependencyGraphBuildCheckpoint>? progressObserver)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (analyzer.BinaryKind == BinaryKind.NativeAot)
-            return BuildForNativeAot(analyzer);
+            return BuildForNativeAot(analyzer, cancellationToken, progressObserver);
 
         var byId = new Dictionary<string, GraphNode>(StringComparer.Ordinal);
         var edges = new List<GraphEdge>();
@@ -36,6 +69,7 @@ public static class DependencyGraphBuilder
         // The root's NetFxBindingContext is shared by every subsequent bind in the graph,
         // matching the CLR's app-domain-wide binding policy semantics.
         var netFxContext = NetFxBindingContext.TryBuild(analyzer);
+        cancellationToken.ThrowIfCancellationRequested();
 
         var rootIdentity = IdentityFromAnalyzer(analyzer);
         var rootId = AssemblyIdentityFormat.Format(
@@ -67,72 +101,98 @@ public static class DependencyGraphBuilder
 
         var parentCounter = 1;
 
-        while (queue.Count > 0)
+        try
         {
-            var (current, currentId, ownsDispose) = queue.Dequeue();
-            var currentDepth = depthById[currentId];
-
-            try
+            while (queue.Count > 0)
             {
-                var refs = current.HasMetadata ? current.AssemblyRefs : [];
-                var typeRefs = current.HasMetadata ? current.TypeRefs : [];
+                cancellationToken.ThrowIfCancellationRequested();
+                var (current, currentId, ownsDispose) = queue.Dequeue();
+                var currentDepth = depthById[currentId];
 
-                var counts = CountTypeRefsByScopeId(typeRefs);
-
-                foreach (var asmRef in refs)
+                try
                 {
-                    var requestedId = AssemblyIdentityFormat.Format(
-                        asmRef.Name, asmRef.Version, asmRef.Culture, asmRef.PublicKeyToken);
+                    var refs = current.HasMetadata ? current.AssemblyRefs : [];
+                    var typeRefs = current.HasMetadata ? current.TypeRefs : [];
 
-                    // Resolve first so that net48 nodes get keyed on the bound (post-redirect)
-                    // identity instead of the requested one. Two parents whose distinct requested
-                    // versions both redirect to the same loaded version therefore land on a single
-                    // graph node, while each edge still records its own requested identity below.
-                    var resolution = ResolveOnce(current, currentId, asmRef, requestedId,
-                        netFxContext, resolutionCache);
-                    var (childId, childIdentity) = SelectChildId(asmRef, resolution, requestedId);
+                    var counts = CountTypeRefsByScopeId(typeRefs, cancellationToken);
 
-                    counts.TryGetValue(requestedId, out var count);
-                    var requestedDifferent = !string.Equals(childId, requestedId, StringComparison.Ordinal);
-
-                    if (byId.TryGetValue(childId, out var existing))
+                    foreach (var asmRef in refs)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var requestedId = AssemblyIdentityFormat.Format(
+                            asmRef.Name, asmRef.Version, asmRef.Culture, asmRef.PublicKeyToken);
+
+                        // Resolve first so that net48 nodes get keyed on the bound (post-redirect)
+                        // identity instead of the requested one. Two parents whose distinct requested
+                        // versions both redirect to the same loaded version therefore land on a single
+                        // graph node, while each edge still records its own requested identity below.
+                        var resolution = ResolveOnce(current, currentId, asmRef, requestedId,
+                            netFxContext, resolutionCache);
+                        var (childId, childIdentity) = SelectChildId(asmRef, resolution, requestedId);
+
+                        counts.TryGetValue(requestedId, out var count);
+                        var requestedDifferent = !string.Equals(
+                            childId,
+                            requestedId,
+                            StringComparison.Ordinal);
+
+                        if (byId.TryGetValue(childId, out var existing))
+                        {
+                            edges.Add(new GraphEdge(
+                                currentId, childId, count,
+                                RequestedIdentity: requestedDifferent ? asmRef : null));
+
+                            if (existing.Unresolved && resolution.Resolved is not null)
+                            {
+                                UpgradeAndQueue(
+                                    current, asmRef, childId, resolution,
+                                    byId, navById, queue, existing);
+                            }
+
+                            ReportProgress(
+                                progressObserver,
+                                DependencyGraphBuildCheckpoint.ManagedAssemblyReferenceProcessed,
+                                cancellationToken);
+                            continue;
+                        }
+
                         edges.Add(new GraphEdge(
                             currentId, childId, count,
                             RequestedIdentity: requestedDifferent ? asmRef : null));
 
-                        if (existing.Unresolved && resolution.Resolved is not null)
-                        {
-                            UpgradeAndQueue(
-                                current, asmRef, childId, resolution,
-                                byId, navById, queue, existing);
-                        }
-
-                        continue;
+                        AddNewNodeAndQueue(
+                            current, asmRef, childId, childIdentity, resolution,
+                            byId, navById, depthById, parentOrderById,
+                            queue, ref parentCounter, currentDepth);
+                        ReportProgress(
+                            progressObserver,
+                            DependencyGraphBuildCheckpoint.ManagedAssemblyReferenceProcessed,
+                            cancellationToken);
                     }
-
-                    edges.Add(new GraphEdge(
-                        currentId, childId, count,
-                        RequestedIdentity: requestedDifferent ? asmRef : null));
-
-                    AddNewNodeAndQueue(
-                        current, asmRef, childId, childIdentity, resolution,
-                        byId, navById, depthById, parentOrderById,
-                        queue, ref parentCounter, currentDepth);
+                }
+                finally
+                {
+                    if (ownsDispose)
+                        current.Dispose();
                 }
             }
-            finally
+        }
+        finally
+        {
+            while (queue.TryDequeue(out var queued))
             {
-                if (ownsDispose)
-                    current.Dispose();
+                if (queued.OwnsDispose)
+                    queued.Analyzer.Dispose();
             }
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         var orderedNodes = byId.Values
             .OrderBy(n => n.Depth)
             .ThenBy(n => parentOrderById.TryGetValue(n.Id, out var o) ? o : int.MaxValue)
             .ThenBy(n => n.Id, StringComparer.Ordinal)
             .ToList();
+        cancellationToken.ThrowIfCancellationRequested();
 
         return new DependencyGraphResult(orderedNodes, edges, navById);
     }
@@ -145,20 +205,37 @@ public static class DependencyGraphBuilder
     /// binary's native import modules join at depth 1. Without sidecars the graph is the
     /// root plus the import star — the only dependency facts the binary itself records.
     /// </summary>
-    private static DependencyGraphResult BuildForNativeAot(AssemblyAnalyzer analyzer)
+    private static DependencyGraphResult BuildForNativeAot(
+        AssemblyAnalyzer analyzer,
+        CancellationToken cancellationToken,
+        Action<DependencyGraphBuildCheckpoint>? progressObserver)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var nodes = new List<GraphNode>();
         var edges = new List<GraphEdge>();
         var navById = new Dictionary<string, GraphNavigationContext>(StringComparer.Ordinal);
 
         var rootIdentity = IdentityFromAnalyzer(analyzer);
         var mstat = analyzer.Mstat;
+        cancellationToken.ThrowIfCancellationRequested();
 
         // The mstat lists the app's own assembly among its references; promote that identity
         // to the root so the graph is keyed on real assembly identity when available.
         var stem = Path.GetFileNameWithoutExtension(analyzer.FileName);
-        var appIdentity = mstat?.Assemblies.FirstOrDefault(
-            a => string.Equals(a.Name, stem, StringComparison.OrdinalIgnoreCase));
+        AssemblyRefInfo? appIdentity = null;
+        if (mstat is not null)
+        {
+            foreach (var assembly in mstat.Assemblies)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (string.Equals(assembly.Name, stem, StringComparison.OrdinalIgnoreCase))
+                {
+                    appIdentity = assembly;
+                    break;
+                }
+            }
+        }
+
         if (appIdentity is not null) rootIdentity = appIdentity;
 
         var rootId = AssemblyIdentityFormat.Format(
@@ -183,6 +260,7 @@ public static class DependencyGraphBuilder
 
             foreach (var assembly in mstat.Assemblies)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (ReferenceEquals(assembly, appIdentity)) continue;
                 var id = AssemblyIdentityFormat.Format(
                     assembly.Name, assembly.Version, assembly.Culture, assembly.PublicKeyToken);
@@ -204,13 +282,24 @@ public static class DependencyGraphBuilder
                         analyzer.TargetFramework, analyzer.PreferredRuntimePack));
             }
 
-            AggregateDgmlEdges(analyzer, mstat, idByAssemblyName, rootId, nodes, edges);
+            AggregateDgmlEdges(
+                analyzer,
+                mstat,
+                idByAssemblyName,
+                rootId,
+                nodes,
+                edges,
+                cancellationToken,
+                progressObserver);
         }
 
         // Native import modules: the exe's own dependency facts, present with or without
         // sidecars, at depth 1 off the root. Edge weight = imported function count.
-        foreach (var module in analyzer.Imports)
+        var imports = analyzer.Imports;
+        cancellationToken.ThrowIfCancellationRequested();
+        foreach (var module in imports)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var id = $"native:{module.ModuleName.ToLowerInvariant()}";
             if (navById.ContainsKey(id)) continue;
 
@@ -229,11 +318,13 @@ public static class DependencyGraphBuilder
             edges.Add(new GraphEdge(rootId, id, module.Functions.Count));
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         var ordered = nodes
             .OrderBy(n => n.Depth)
             .ThenBy(n => n.Kind)
             .ThenBy(n => n.Id, StringComparer.Ordinal)
             .ToList();
+        cancellationToken.ThrowIfCancellationRequested();
         return new DependencyGraphResult(ordered, edges, navById);
     }
 
@@ -249,61 +340,90 @@ public static class DependencyGraphBuilder
         Dictionary<string, string> idByAssemblyName,
         string rootId,
         List<GraphNode> nodes,
-        List<GraphEdge> edges)
+        List<GraphEdge> edges,
+        CancellationToken cancellationToken,
+        Action<DependencyGraphBuildCheckpoint>? progressObserver)
     {
-        if (analyzer.Dgml is not { } dgml) return;
+        cancellationToken.ThrowIfCancellationRequested();
+        var dgml = analyzer.Dgml;
+        cancellationToken.ThrowIfCancellationRequested();
+        if (dgml is null) return;
 
         // mstat node name -> owning assembly's node id.
         var assemblyByNodeName = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var method in mstat.Methods)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (method.NodeName is { } n && idByAssemblyName.TryGetValue(method.AssemblyName, out var id))
                 assemblyByNodeName.TryAdd(n, id);
         }
 
         foreach (var type in mstat.Types)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (type.NodeName is { } n && idByAssemblyName.TryGetValue(type.AssemblyName, out var id))
                 assemblyByNodeName.TryAdd(n, id);
         }
 
         var labelById = new Dictionary<int, string>(dgml.Nodes.Count);
         foreach (var node in dgml.Nodes)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             labelById.TryAdd(node.Id, node.Label);
+        }
 
         var counts = new Dictionary<(string Source, string Target), int>();
         foreach (var link in dgml.Links)
         {
-            if (!labelById.TryGetValue(link.SourceId, out var sourceLabel)
-                || !labelById.TryGetValue(link.TargetId, out var targetLabel)
-                || !assemblyByNodeName.TryGetValue(sourceLabel, out var sourceAssembly)
-                || !assemblyByNodeName.TryGetValue(targetLabel, out var targetAssembly)
-                || sourceAssembly == targetAssembly)
+            cancellationToken.ThrowIfCancellationRequested();
+            if (labelById.TryGetValue(link.SourceId, out var sourceLabel)
+                && labelById.TryGetValue(link.TargetId, out var targetLabel)
+                && assemblyByNodeName.TryGetValue(sourceLabel, out var sourceAssembly)
+                && assemblyByNodeName.TryGetValue(targetLabel, out var targetAssembly)
+                && sourceAssembly != targetAssembly)
             {
-                continue;
+                counts.TryGetValue((sourceAssembly, targetAssembly), out var count);
+                counts[(sourceAssembly, targetAssembly)] = count + 1;
             }
 
-            counts.TryGetValue((sourceAssembly, targetAssembly), out var count);
-            counts[(sourceAssembly, targetAssembly)] = count + 1;
+            ReportProgress(
+                progressObserver,
+                DependencyGraphBuildCheckpoint.DgmlLinkProcessed,
+                cancellationToken);
         }
 
         foreach (var ((source, target), count) in counts.OrderBy(kvp => kvp.Key.Source, StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             edges.Add(new GraphEdge(source, target, count));
+        }
 
         // Re-derive depths from the aggregated topology, keeping every assembly reachable:
         // anything the BFS cannot reach from the root stays at depth 1.
         var depths = new Dictionary<string, int>(StringComparer.Ordinal) { [rootId] = 0 };
         var queue = new Queue<string>();
         queue.Enqueue(rootId);
-        var adjacency = edges
-            .GroupBy(e => e.SourceId)
-            .ToDictionary(g => g.Key, g => g.Select(e => e.TargetId).ToList(), StringComparer.Ordinal);
+        var adjacency = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var edge in edges)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!adjacency.TryGetValue(edge.SourceId, out var targets))
+            {
+                targets = [];
+                adjacency.Add(edge.SourceId, targets);
+            }
+
+            targets.Add(edge.TargetId);
+        }
+
         while (queue.Count > 0)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var current = queue.Dequeue();
             if (!adjacency.TryGetValue(current, out var children)) continue;
             foreach (var child in children)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (depths.ContainsKey(child)) continue;
                 depths[child] = depths[current] + 1;
                 queue.Enqueue(child);
@@ -312,6 +432,7 @@ public static class DependencyGraphBuilder
 
         for (var i = 0; i < nodes.Count; i++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (nodes[i].Kind == GraphNodeKind.Assembly
                 && depths.TryGetValue(nodes[i].Id, out var depth)
                 && nodes[i].Depth != depth)
@@ -319,6 +440,15 @@ public static class DependencyGraphBuilder
                 nodes[i] = nodes[i] with { Depth = depth };
             }
         }
+    }
+
+    private static void ReportProgress(
+        Action<DependencyGraphBuildCheckpoint>? progressObserver,
+        DependencyGraphBuildCheckpoint checkpoint,
+        CancellationToken cancellationToken)
+    {
+        progressObserver?.Invoke(checkpoint);
+        cancellationToken.ThrowIfCancellationRequested();
     }
 
     /// <summary>
@@ -482,11 +612,14 @@ public static class DependencyGraphBuilder
         }
     }
 
-    private static Dictionary<string, int> CountTypeRefsByScopeId(IReadOnlyList<TypeRefInfo> typeRefs)
+    private static Dictionary<string, int> CountTypeRefsByScopeId(
+        IReadOnlyList<TypeRefInfo> typeRefs,
+        CancellationToken cancellationToken)
     {
         var result = new Dictionary<string, int>(StringComparer.Ordinal);
         foreach (var t in typeRefs)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (string.IsNullOrEmpty(t.ResolutionScopeId)) continue;
             result.TryGetValue(t.ResolutionScopeId, out var n);
             result[t.ResolutionScopeId] = n + 1;

--- a/src/Dotsider.Core/Analysis/Models/NuGetFileEntry.cs
+++ b/src/Dotsider.Core/Analysis/Models/NuGetFileEntry.cs
@@ -3,12 +3,20 @@ namespace Dotsider.Core.Analysis.Models;
 /// <summary>
 /// Represents a file entry within a NuGet package (.nupkg).
 /// </summary>
-/// <param name="Name">File name without directory path.</param>
-/// <param name="FullPath">Full path of the entry within the package archive.</param>
-/// <param name="Directory">Directory portion of the entry path.</param>
+/// <param name="Name">
+/// Raw, untrusted file-name portion of the archive entry path. This value is not display-safe.
+/// </param>
+/// <param name="FullPath">
+/// Raw, untrusted path of the entry within the package archive. This value is not a filesystem
+/// path and must be validated before extraction.
+/// </param>
+/// <param name="Directory">
+/// Raw, untrusted directory portion of the archive entry path, normalized only to use forward
+/// slashes. This value is not a filesystem-safe path or display-safe text.
+/// </param>
 /// <param name="CompressedSize">Compressed size in bytes inside the .nupkg.</param>
 /// <param name="UncompressedSize">Uncompressed size in bytes.</param>
-/// <param name="IsDll">Whether the entry is a .NET assembly (.dll).</param>
+/// <param name="IsDll">Whether the archive entry name has a .dll file extension.</param>
 public sealed record NuGetFileEntry(
     string Name,
     string FullPath,

--- a/src/Dotsider.Core/Analysis/NuGetPackageAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/NuGetPackageAnalyzer.cs
@@ -11,7 +11,18 @@ namespace Dotsider.Core.Analysis;
 public sealed class NuGetPackageAnalyzer : IDisposable
 {
     private readonly ZipArchive _archive;
-    private readonly string _tempDir;
+    private readonly Dictionary<NuGetFileEntry, ZipArchiveEntry> _archiveEntries =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<NuGetFileEntry> _dllEntries =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<NuGetFileEntry, string> _extractedPaths =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly Lock _gate = new();
+    private Dictionary<NuGetFileEntry, string>? _destinationPaths;
+    private HashSet<NuGetFileEntry>? _unsafeEntries;
+    private string? _tempDirectory;
+    private int _topologyDestinationCount;
+    private bool _disposed;
 
     /// <summary>
     /// Opens and analyzes the specified NuGet package file.
@@ -21,10 +32,18 @@ public sealed class NuGetPackageAnalyzer : IDisposable
     {
         FilePath = nupkgPath;
         FileName = Path.GetFileName(nupkgPath);
-        _tempDir = Path.Combine(Path.GetTempPath(), "dotsider-" + Guid.NewGuid().ToString("N")[..8]);
         _archive = ZipFile.OpenRead(nupkgPath);
-        ReadNuspec();
-        BuildFileList();
+
+        try
+        {
+            ReadNuspec();
+            BuildFileList();
+        }
+        catch
+        {
+            _archive.Dispose();
+            throw;
+        }
     }
 
     /// <summary>The full path to the .nupkg file.</summary>
@@ -33,16 +52,28 @@ public sealed class NuGetPackageAnalyzer : IDisposable
     /// <summary>The file name of the .nupkg file.</summary>
     public string FileName { get; }
 
-    /// <summary>The NuGet package ID from the .nuspec manifest, or null.</summary>
+    /// <summary>
+    /// The raw, untrusted NuGet package ID from the .nuspec manifest, or null. This value is not
+    /// display-safe.
+    /// </summary>
     public string? PackageId { get; private set; }
 
-    /// <summary>The package version from the .nuspec manifest, or null.</summary>
+    /// <summary>
+    /// The raw, untrusted package version from the .nuspec manifest, or null. This value is not
+    /// display-safe.
+    /// </summary>
     public string? PackageVersion { get; private set; }
 
-    /// <summary>The package authors from the .nuspec manifest, or null.</summary>
+    /// <summary>
+    /// The raw, untrusted package authors from the .nuspec manifest, or null. This value is not
+    /// display-safe.
+    /// </summary>
     public string? Authors { get; private set; }
 
-    /// <summary>The package description from the .nuspec manifest, or null.</summary>
+    /// <summary>
+    /// The raw, untrusted package description from the .nuspec manifest, or null. This value is
+    /// not display-safe.
+    /// </summary>
     public string? Description { get; private set; }
 
     /// <summary>All files in the package.</summary>
@@ -52,24 +83,189 @@ public sealed class NuGetPackageAnalyzer : IDisposable
     public IReadOnlyList<NuGetFileEntry> DllFiles { get; private set; } = [];
 
     /// <summary>
-    /// Extracts a DLL from the package to a temp file and creates an AssemblyAnalyzer.
+    /// Gets the private extraction directory, or <see langword="null"/> before extraction is
+    /// required.
     /// </summary>
+    internal string? ExtractionDirectory
+    {
+        get
+        {
+            lock (_gate)
+                return _tempDirectory;
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of unique canonical destinations examined for file-versus-directory
+    /// conflicts in the current extraction plan.
+    /// </summary>
+    internal int TopologyDestinationCount
+    {
+        get
+        {
+            lock (_gate)
+                return _topologyDestinationCount;
+        }
+    }
+
+    /// <summary>
+    /// Extracts a DLL from the package into a private temporary directory and creates an analyzer.
+    /// </summary>
+    /// <param name="entry">
+    /// The exact <see cref="NuGetFileEntry"/> instance returned by this analyzer.
+    /// </param>
+    /// <returns>
+    /// An analyzer for the selected DLL. Dispose it before disposing this package analyzer.
+    /// </returns>
+    /// <remarks>
+    /// Dispose the returned analyzer before disposing this package analyzer so that its temporary
+    /// extraction directory can be removed.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="entry"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="entry"/> was not returned by this analyzer or does not represent a DLL.
+    /// </exception>
+    /// <exception cref="UnsafePackageEntryException">
+    /// The package entry has an unsafe or ambiguous extraction path.
+    /// </exception>
+    /// <exception cref="ObjectDisposedException">This analyzer has been disposed.</exception>
+    /// <exception cref="IOException">The DLL could not be extracted or read.</exception>
+    /// <exception cref="BadImageFormatException">The extracted file has an invalid format.</exception>
     public AssemblyAnalyzer OpenDll(NuGetFileEntry entry)
     {
-        var tempPath = Path.Combine(_tempDir, entry.FullPath);
-        var dir = Path.GetDirectoryName(tempPath)!;
-        Directory.CreateDirectory(dir);
+        ArgumentNullException.ThrowIfNull(entry);
 
-        var zipEntry = _archive.GetEntry(entry.FullPath)
-            ?? throw new FileNotFoundException($"Entry not found in package: {entry.FullPath}");
-
-        using (var source = zipEntry.Open())
-        using (var target = File.Create(tempPath))
+        lock (_gate)
         {
-            source.CopyTo(target);
-        }
+            ObjectDisposedException.ThrowIf(_disposed, this);
 
-        return new AssemblyAnalyzer(tempPath);
+            if (!_archiveEntries.TryGetValue(entry, out var archiveEntry) ||
+                !_dllEntries.Contains(entry))
+            {
+                throw new ArgumentException(
+                    "The entry was not returned by this analyzer or does not represent a DLL.",
+                    nameof(entry));
+            }
+
+            if (!ContainedPathResolver.IsSafeRelativePath(archiveEntry.FullName))
+                throw new UnsafePackageEntryException();
+
+            EnsureExtractionPlan();
+
+            if (_unsafeEntries!.Contains(entry) ||
+                !_destinationPaths!.TryGetValue(entry, out var destinationPath))
+            {
+                throw new UnsafePackageEntryException();
+            }
+
+            if (_extractedPaths.TryGetValue(entry, out var extractedPath))
+                return new AssemblyAnalyzer(extractedPath);
+
+            return ExtractDll(entry, archiveEntry, destinationPath);
+        }
+    }
+
+    private AssemblyAnalyzer ExtractDll(
+        NuGetFileEntry entry,
+        ZipArchiveEntry archiveEntry,
+        string destinationPath)
+    {
+        var destinationDirectory = Path.GetDirectoryName(destinationPath)!;
+        Directory.CreateDirectory(destinationDirectory);
+
+        AssemblyAnalyzer? analyzer = null;
+        var destinationCreated = false;
+
+        try
+        {
+            using (var source = archiveEntry.Open())
+            using (var target = new FileStream(
+                destinationPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None))
+            {
+                destinationCreated = true;
+                source.CopyTo(target);
+            }
+
+            analyzer = new AssemblyAnalyzer(destinationPath);
+            _extractedPaths.Add(entry, destinationPath);
+            return analyzer;
+        }
+        catch
+        {
+            analyzer?.Dispose();
+            if (destinationCreated)
+                TryDeleteFile(destinationPath);
+            throw;
+        }
+    }
+
+    private void EnsureExtractionPlan()
+    {
+        if (_destinationPaths is not null)
+            return;
+
+        var tempDirectory = Directory.CreateTempSubdirectory("dotsider-").FullName;
+        try
+        {
+            var destinationPaths = new Dictionary<NuGetFileEntry, string>(
+                ReferenceEqualityComparer.Instance);
+            var destinationOwners = new Dictionary<string, NuGetFileEntry>(
+                ContainedPathResolver.PathComparer);
+            var unsafeEntries = new HashSet<NuGetFileEntry>(ReferenceEqualityComparer.Instance);
+
+            foreach (var entry in _dllEntries)
+            {
+                var archiveEntry = _archiveEntries[entry];
+                if (!ContainedPathResolver.TryResolve(
+                    tempDirectory,
+                    archiveEntry.FullName,
+                    out var destinationPath))
+                {
+                    unsafeEntries.Add(entry);
+                    continue;
+                }
+
+                destinationPaths.Add(entry, destinationPath);
+                var destinationKey = ContainedPathResolver.GetComparisonKey(destinationPath);
+                if (destinationOwners.TryGetValue(destinationKey, out var existingEntry))
+                {
+                    unsafeEntries.Add(existingEntry);
+                    unsafeEntries.Add(entry);
+                }
+                else
+                {
+                    destinationOwners.Add(destinationKey, entry);
+                }
+            }
+
+            var topologyDestinationCount = MarkTopologyConflicts(
+                destinationOwners,
+                unsafeEntries);
+
+            _tempDirectory = tempDirectory;
+            _destinationPaths = destinationPaths;
+            _unsafeEntries = unsafeEntries;
+            _topologyDestinationCount = topologyDestinationCount;
+        }
+        catch
+        {
+            TryDeleteDirectory(tempDirectory);
+            throw;
+        }
+    }
+
+    private static int MarkTopologyConflicts(
+        Dictionary<string, NuGetFileEntry> destinationOwners,
+        HashSet<NuGetFileEntry> unsafeEntries)
+    {
+        var destinations = new ContainedPathTrie(ContainedPathResolver.PathComparer);
+        foreach (var (destinationPath, entry) in destinationOwners)
+            destinations.Add(destinationPath, entry, unsafeEntries);
+
+        return destinationOwners.Count;
     }
 
     private void ReadNuspec()
@@ -77,7 +273,8 @@ public sealed class NuGetPackageAnalyzer : IDisposable
         var nuspecEntry = _archive.Entries.FirstOrDefault(e =>
             e.FullName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase));
 
-        if (nuspecEntry is null) return;
+        if (nuspecEntry is null)
+            return;
 
         using var stream = nuspecEntry.Open();
         var doc = XDocument.Load(stream);
@@ -95,30 +292,86 @@ public sealed class NuGetPackageAnalyzer : IDisposable
         var files = new List<NuGetFileEntry>();
         var dlls = new List<NuGetFileEntry>();
 
-        foreach (var entry in _archive.Entries)
+        foreach (var archiveEntry in _archive.Entries)
         {
-            if (string.IsNullOrEmpty(entry.Name)) continue; // Skip directories
+            var fullPath = archiveEntry.FullName;
+            var separatorIndex = Math.Max(fullPath.LastIndexOf('/'), fullPath.LastIndexOf('\\'));
+            var name = fullPath[(separatorIndex + 1)..];
+            if (name.Length == 0)
+                continue;
 
-            var isDll = entry.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase);
-            var dir = Path.GetDirectoryName(entry.FullName)?.Replace('\\', '/') ?? "";
+            var isDll = name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase);
+            var directory = separatorIndex < 0
+                ? string.Empty
+                : fullPath[..separatorIndex].Replace('\\', '/');
+            var entry = new NuGetFileEntry(
+                name,
+                fullPath,
+                directory,
+                archiveEntry.CompressedLength,
+                archiveEntry.Length,
+                isDll);
 
-            var fileEntry = new NuGetFileEntry(
-                entry.Name, entry.FullName, dir,
-                entry.CompressedLength, entry.Length, isDll);
-
-            files.Add(fileEntry);
-            if (isDll) dlls.Add(fileEntry);
+            _archiveEntries.Add(entry, archiveEntry);
+            files.Add(entry);
+            if (isDll)
+            {
+                _dllEntries.Add(entry);
+                dlls.Add(entry);
+            }
         }
 
-        Files = [.. files.OrderBy(f => f.FullPath)];
-        DllFiles = [.. dlls.OrderBy(f => f.FullPath)];
+        Files = [.. files.OrderBy(static file => file.FullPath, StringComparer.Ordinal)];
+        DllFiles = [.. dlls.OrderBy(static file => file.FullPath, StringComparer.Ordinal)];
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
     }
 
     /// <inheritdoc/>
     public void Dispose()
     {
-        _archive.Dispose();
-        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort cleanup */ }
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            try
+            {
+                _archive.Dispose();
+            }
+            finally
+            {
+                if (_tempDirectory is not null)
+                    TryDeleteDirectory(_tempDirectory);
+                GC.SuppressFinalize(this);
+            }
+        }
     }
 }

--- a/src/Dotsider.Core/Analysis/UnsafePackageEntryException.cs
+++ b/src/Dotsider.Core/Analysis/UnsafePackageEntryException.cs
@@ -1,0 +1,42 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// The exception that is thrown when a package entry cannot be safely extracted beneath its
+/// destination directory.
+/// </summary>
+public sealed class UnsafePackageEntryException : IOException
+{
+    private const string DefaultMessage =
+        "The package entry cannot be extracted because its path is unsafe or ambiguous.";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnsafePackageEntryException"/> class.
+    /// </summary>
+    public UnsafePackageEntryException()
+        : base(DefaultMessage)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnsafePackageEntryException"/> class with a
+    /// specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public UnsafePackageEntryException(string? message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnsafePackageEntryException"/> class with a
+    /// specified error message and a reference to the inner exception that caused this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">
+    /// The exception that caused the current exception, or <see langword="null"/>.
+    /// </param>
+    public UnsafePackageEntryException(string? message, Exception? innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Dotsider.Core/Dotsider.Core.csproj
+++ b/src/Dotsider.Core/Dotsider.Core.csproj
@@ -12,8 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Dotsider.Tests" />
     <InternalsVisibleTo Include="Dotsider.Benchmarks" />
+    <InternalsVisibleTo Include="Dotsider" />
+    <InternalsVisibleTo Include="Dotsider.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dotsider.Core/README.md
+++ b/src/Dotsider.Core/README.md
@@ -24,7 +24,7 @@ Core library for .NET assembly analysis. Provides analyzers, models, and the dia
 | `WebcilImageReader` | Unwraps Webcil app assemblies from browser-wasm publishes, including Wasm-wrapped payloads, so metadata, IL method bodies, debug directory entries, embedded PDBs, sidecar PDBs, and Source Link flow through the normal managed analyzer path |
 | `AssemblyDiffer` | Compares two assemblies and reports added, removed, and changed types, methods, and references. Method body comparison uses normalized IL instruction walks with semantic token resolution, deep local signature decoding, and exception region analysis |
 | `RuntimeTracer` | Launches a .NET process with EventPipe tracing for JIT, GC, exception, and counter events |
-| `NuGetPackageAnalyzer` | Reads `.nupkg` files for package metadata and DLL listing |
+| `NuGetPackageAnalyzer` | Reads `.nupkg` metadata and file listings, and extracts selected DLLs within a private temporary directory |
 | `NuGetDepsJsonResolver` | Resolves assembly references by consulting the referencing assembly's `.deps.json` to locate NuGet dependencies in the global packages folder |
 | `SingleFileBundleReader` | Detects and reads .NET single-file bundles — parses the manifest and extracts individual entries |
 | `DotNetRuntimeLocator` | Discovers system .NET installations and resolves shared framework assembly paths |

--- a/src/Dotsider.DocGenerator/ApiItem.cs
+++ b/src/Dotsider.DocGenerator/ApiItem.cs
@@ -76,6 +76,11 @@ public sealed class ApiItem
     public List<string> Children { get; } = [];
 
     /// <summary>
+    /// Gets the exceptions documented for this API item.
+    /// </summary>
+    public List<ExceptionItem> Exceptions { get; } = [];
+
+    /// <summary>
     /// Gets the UIDs of types in the inheritance chain.
     /// </summary>
     public List<string> Inheritance { get; } = [];

--- a/src/Dotsider.DocGenerator/ExceptionItem.cs
+++ b/src/Dotsider.DocGenerator/ExceptionItem.cs
@@ -1,0 +1,17 @@
+namespace Dotsider.DocGenerator;
+
+/// <summary>
+/// Represents an exception documented for an API item.
+/// </summary>
+public sealed class ExceptionItem
+{
+    /// <summary>
+    /// Gets or sets the XML doc description for this exception.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the exception type UID.
+    /// </summary>
+    public string? Type { get; set; }
+}

--- a/src/Dotsider.DocGenerator/README.md
+++ b/src/Dotsider.DocGenerator/README.md
@@ -13,7 +13,7 @@ No arguments required. The tool discovers the repo root automatically and writes
 ## Pipeline
 
 1. **DocFX metadata** — runs DocFX against `Dotsider.Core.csproj` to produce YAML files in `_metadata/`
-2. **YAML → Markdown** — converts each YAML file to a Starlight markdown page with frontmatter, syntax blocks, parameter tables, and cross-reference links
+2. **YAML → Markdown** — converts each YAML file to a Starlight markdown page with frontmatter, syntax blocks, parameter and exception documentation, and cross-reference links
 
 Hand-written `index.md` files in the output directory are preserved across regeneration.
 
@@ -24,6 +24,7 @@ Hand-written `index.md` files in the output directory are preserved across regen
 | `Program` | Entry point — discovers repo root, orchestrates DocFX then conversion |
 | `YamlToMarkdownConverter` | Parses DocFX YAML into `ApiItem` trees and emits Starlight markdown |
 | `ApiItem` | In-memory model for an API element (namespace, type, method, property, etc.) |
+| `ExceptionItem` | Exception type and description from XML docs |
 | `ParameterItem` | Parameter name, type, and description from XML docs |
 
 ## Output Format
@@ -35,6 +36,6 @@ Each generated page includes:
 - C# syntax block
 - Inheritance chain and implemented interfaces
 - Member sections (constructors, properties, methods, fields, events)
-- Parameters and return types
+- Parameters, return types, and documented exceptions
 - Remarks and examples from XML doc comments
 - Links to related types (internal cross-refs and Microsoft Learn)

--- a/src/Dotsider.DocGenerator/YamlToMarkdownConverter.cs
+++ b/src/Dotsider.DocGenerator/YamlToMarkdownConverter.cs
@@ -144,6 +144,9 @@ public partial class YamlToMarkdownConverter(string yamlDir, string outputDir)
                         item.Example = string.Join("\n\n", examples);
                     }
                     break;
+                case "exceptions":
+                    ParseExceptions(value, item);
+                    break;
                 case "parent":
                     item.Parent = GetScalarValue(value);
                     break;
@@ -175,6 +178,32 @@ public partial class YamlToMarkdownConverter(string yamlDir, string outputDir)
         }
 
         return string.IsNullOrEmpty(item.Uid) ? null : item;
+    }
+
+    private static void ParseExceptions(YamlNode value, ApiItem item)
+    {
+        if (value is not YamlSequenceNode exceptions)
+            return;
+
+        foreach (var exception in exceptions.OfType<YamlMappingNode>())
+        {
+            var exceptionItem = new ExceptionItem();
+            foreach (var (key, exceptionValue) in exception.Children)
+            {
+                switch ((key as YamlScalarNode)?.Value)
+                {
+                    case "description":
+                        exceptionItem.Description = GetScalarValue(exceptionValue);
+                        break;
+                    case "type":
+                        exceptionItem.Type = GetScalarValue(exceptionValue);
+                        break;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(exceptionItem.Type))
+                item.Exceptions.Add(exceptionItem);
+        }
     }
 
     private static void ParseSyntax(YamlNode value, ApiItem item)
@@ -340,6 +369,19 @@ public partial class YamlToMarkdownConverter(string yamlDir, string outputDir)
                         {
                             sb.AppendLine();
                             sb.AppendLine(ConvertXmlToMarkdown(child.ReturnDescription));
+                        }
+                        sb.AppendLine();
+                    }
+
+                    if (child.Exceptions.Count > 0)
+                    {
+                        sb.AppendLine("**Exceptions:**");
+                        sb.AppendLine();
+                        foreach (var exception in child.Exceptions)
+                        {
+                            var typeLink = FormatTypeLink(exception.Type!);
+                            var description = ConvertXmlToMarkdown(exception.Description ?? "");
+                            sb.AppendLine($"- {typeLink}: {description}");
                         }
                         sb.AppendLine();
                     }

--- a/src/Dotsider/DependencyGraphSnapshot.cs
+++ b/src/Dotsider/DependencyGraphSnapshot.cs
@@ -1,0 +1,40 @@
+using Dotsider.Core.Analysis.Models;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
+
+namespace Dotsider;
+
+/// <summary>
+/// An immutable dependency-graph publication containing topology and its matching navigation
+/// metadata.
+/// </summary>
+internal sealed class DependencyGraphSnapshot
+{
+    /// <summary>
+    /// Creates an immutable snapshot from the specified graph components.
+    /// </summary>
+    /// <param name="nodes">The graph nodes.</param>
+    /// <param name="edges">The graph edges.</param>
+    /// <param name="navigationById">Navigation metadata keyed by node id, if available.</param>
+    internal DependencyGraphSnapshot(
+        IEnumerable<GraphNode> nodes,
+        IEnumerable<GraphEdge> edges,
+        IEnumerable<KeyValuePair<string, GraphNavigationContext>>? navigationById)
+    {
+        Nodes = ImmutableArray.CreateRange(nodes);
+        Edges = ImmutableArray.CreateRange(edges);
+        NavigationById = navigationById?.ToFrozenDictionary(
+            static pair => pair.Key,
+            static pair => pair.Value,
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>Gets the immutable graph nodes.</summary>
+    internal ImmutableArray<GraphNode> Nodes { get; }
+
+    /// <summary>Gets the immutable graph edges.</summary>
+    internal ImmutableArray<GraphEdge> Edges { get; }
+
+    /// <summary>Gets immutable navigation metadata keyed by node id, if available.</summary>
+    internal FrozenDictionary<string, GraphNavigationContext>? NavigationById { get; }
+}

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -32,8 +32,7 @@ public sealed class DotsiderApp(DotsiderState state)
     {
         // A new build is running: advance the generation so any in-flight extra-frame
         // nudger stops, and allow this build's views to arm a fresh one if needed.
-        unchecked { _state.BuildGeneration++; }
-        _state.ExtraFrameArmed = false;
+        _state.NotifyBuildStarted();
 
         // Drain pending mutations from the diagnostics socket listener
         while (_state.PendingMutations.TryDequeue(out var mutation))
@@ -880,6 +879,7 @@ public sealed class DotsiderApp(DotsiderState state)
         // Phase 2: replace analyzer. After Dispose(), every path must
         // commit a live replacement before returning — no exceptions
         // may propagate without first restoring state.Analyzer.
+        state.ResetDependencyGraphForAnalyzerReplacement();
         state.Analyzer.Dispose();
 
         // Move temp → original. If move fails, the file is still at tempPath.
@@ -956,7 +956,6 @@ public sealed class DotsiderApp(DotsiderState state)
         state.CachedUserStrings = null;
         state.CachedMetadataStrings = null;
         state.CachedRawStrings = null;
-        state.CachedGraph = null;
         state.CachedSizeTree = null;
         state.TreemapCurrentLevel = null;
         state.TreemapBreadcrumb.Clear();

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -6,6 +6,7 @@ using Hex1b.Documents;
 using Hex1b.Nodes;
 using Hex1b.Widgets;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 
 namespace Dotsider;
 
@@ -15,6 +16,19 @@ namespace Dotsider;
 /// </summary>
 public sealed class DotsiderState : IDisposable
 {
+    private readonly Lock _graphBuildLock = new();
+    private readonly CancellationTokenSource _lifetimeCancellation = new();
+    private readonly List<Task> _renderNudgerTasks = [];
+    private DependencyGraphSnapshot? _dependencyGraphSnapshot;
+    private CancellationTokenSource? _graphBuildCancellation;
+    private Task _graphBuildTask = Task.CompletedTask;
+    private int _graphBuildGeneration;
+    private bool _graphBuildFailed;
+    private bool _graphBuildInProgress;
+    private string? _graphNavigationError;
+    private IReadOnlyDictionary<string, GraphNavigationContext>? _legacyGraphNavigation;
+    private bool _disposed;
+
     /// <summary>
     /// Creates a new application state for the specified assembly file.
     /// </summary>
@@ -418,17 +432,11 @@ public sealed class DotsiderState : IDisposable
 
     /// <summary>
     /// The viewport height the current tree window was built against, recorded by
-    /// <see cref="Views.IlTreeList.Build"/>. The verifier behind
-    /// <see cref="RequestIlTreeViewportCheck"/> compares it to the panel's arranged
-    /// <see cref="ScrollPanelNode.ViewportSize"/> after the frame.
+    /// <see cref="Views.IlTreeList.Build"/>. The tree's layout observer compares it to
+    /// the actual height assigned during arrange and requests a follow-up build when
+    /// they differ.
     /// </summary>
     internal int IlTreeWindowViewport { get; set; }
-
-    /// <summary>
-    /// Whether a tree viewport verifier is in flight. At most one runs at a time; it
-    /// disarms itself on exit.
-    /// </summary>
-    internal bool IlTreeViewportCheckArmed { get; set; }
 
     /// <summary>One-shot flag set by <see cref="SetIlFocusedTreeKey"/> so the next IL
     /// Inspector render scrolls the focused row into view. Cleared by the consumer in
@@ -681,14 +689,69 @@ public sealed class DotsiderState : IDisposable
 
     // --- Dependency Graph Tab State ---
 
-    /// <summary>Cached dependency graph (nodes + edges) for the current analyzer.</summary>
-    public (IReadOnlyList<GraphNode> Nodes, IReadOnlyList<GraphEdge> Edges)? CachedGraph { get; set; }
+    /// <summary>Gets or sets the cached dependency graph topology for the current analyzer.</summary>
+    public (IReadOnlyList<GraphNode> Nodes, IReadOnlyList<GraphEdge> Edges)? CachedGraph
+    {
+        get
+        {
+            var snapshot = GraphSnapshot;
+            return snapshot is null ? null : (snapshot.Nodes, snapshot.Edges);
+        }
+        set
+        {
+            lock (_graphBuildLock)
+            {
+                if (value is not { } graph)
+                {
+                    Volatile.Write(ref _dependencyGraphSnapshot, null);
+                    return;
+                }
+
+                Volatile.Write(
+                    ref _dependencyGraphSnapshot,
+                    new DependencyGraphSnapshot(
+                        graph.Nodes,
+                        graph.Edges,
+                        _legacyGraphNavigation));
+            }
+        }
+    }
 
     /// <summary>
-    /// Per-node navigation metadata for the cached graph, keyed by <see cref="GraphNode.Id"/>.
-    /// Populated alongside <see cref="CachedGraph"/>. Never serialized; TUI-only.
+    /// Gets or sets per-node navigation metadata for the cached graph, keyed by
+    /// <see cref="GraphNode.Id"/>. This data is never serialized and is used only by the TUI.
     /// </summary>
-    public IReadOnlyDictionary<string, GraphNavigationContext>? GraphNavigation { get; set; }
+    public IReadOnlyDictionary<string, GraphNavigationContext>? GraphNavigation
+    {
+        get
+        {
+            var snapshot = GraphSnapshot;
+            return snapshot?.NavigationById ?? Volatile.Read(ref _legacyGraphNavigation);
+        }
+        set
+        {
+            lock (_graphBuildLock)
+            {
+                Volatile.Write(ref _legacyGraphNavigation, value);
+                var snapshot = GraphSnapshot;
+                if (snapshot is not null)
+                {
+                    Volatile.Write(
+                        ref _dependencyGraphSnapshot,
+                        new DependencyGraphSnapshot(
+                            snapshot.Nodes,
+                            snapshot.Edges,
+                            value));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the immutable dependency graph snapshot consumed by production readers.
+    /// </summary>
+    internal DependencyGraphSnapshot? GraphSnapshot =>
+        Volatile.Read(ref _dependencyGraphSnapshot);
 
     /// <summary>
     /// Whether the Dep Graph view currently hides framework assemblies. Toggled by the
@@ -723,13 +786,52 @@ public sealed class DotsiderState : IDisposable
     /// True while the transitive dependency-graph build is in flight on a background task.
     /// The view shows a status message while this is set.
     /// </summary>
-    public bool GraphBuildInProgress { get; set; }
+    public bool GraphBuildInProgress
+    {
+        get => Volatile.Read(ref _graphBuildInProgress);
+        set => Volatile.Write(ref _graphBuildInProgress, value);
+    }
 
     /// <summary>
-    /// Error message produced by the most recent Enter-to-open attempt on the Dep Graph,
-    /// or <see langword="null"/> when the last attempt succeeded or none has been made.
+    /// Gets the current dependency-graph build task. Tests and internal coordinators can await the
+    /// real operation instead of polling rendered output.
     /// </summary>
-    public string? GraphNavigationError { get; set; }
+    internal Task GraphBuildTask
+    {
+        get
+        {
+            lock (_graphBuildLock)
+                return _graphBuildTask;
+        }
+    }
+
+    /// <summary>
+    /// Gets a task that completes when every currently-owned render nudger completes.
+    /// </summary>
+    internal Task RenderNudgerTask
+    {
+        get
+        {
+            lock (_graphBuildLock)
+                return Task.WhenAll([.. _renderNudgerTasks]);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the dependency-graph builder used by the owned background operation.
+    /// </summary>
+    internal Func<AssemblyAnalyzer, CancellationToken, DependencyGraphResult> GraphBuilder { get; set; } =
+        DependencyGraphBuilder.BuildWithCancellation;
+
+    /// <summary>
+    /// Error message produced by the dependency-graph build or the most recent Enter-to-open
+    /// attempt, or <see langword="null"/> when no error has occurred.
+    /// </summary>
+    public string? GraphNavigationError
+    {
+        get => Volatile.Read(ref _graphNavigationError);
+        set => Volatile.Write(ref _graphNavigationError, value);
+    }
 
     /// <summary>The currently hovered/selected node name in the graph view.</summary>
     public string? GraphSelectedNode { get; set; }
@@ -1543,70 +1645,85 @@ public sealed class DotsiderState : IDisposable
     }
 
     /// <summary>
+    /// Records the start of a widget build and releases the extra-frame request slot for work
+    /// produced by that build.
+    /// </summary>
+    internal void NotifyBuildStarted()
+    {
+        lock (_graphBuildLock)
+        {
+            if (_disposed)
+                return;
+
+            unchecked { BuildGeneration++; }
+            ExtraFrameArmed = false;
+        }
+    }
+
+    /// <summary>
     /// Guarantees a follow-up widget build. An <see cref="Hex1bApp.Invalidate"/> that
     /// lands while a frame is still rendering is drained by the Hex1b main loop's
     /// frame-rate guard without producing another frame — and the frame in flight can
     /// be arbitrarily slow (a first IL render disassembles the selected method). The
-    /// nudger keeps invalidating on a short period until it observes
-    /// <see cref="BuildGeneration"/> advance (a new build ran) or its attempt budget
-    /// runs out. At most one nudger is in flight; each build re-arms eligibility.
+    /// lifetime-owned nudger keeps invalidating on a short period until it observes
+    /// <see cref="BuildGeneration"/> advance (a new build ran), its attempt budget
+    /// runs out, or this state is disposed. Each build re-arms eligibility.
     /// </summary>
     internal void RequestExtraFrame()
     {
-        if (ExtraFrameArmed) return;
+        lock (_graphBuildLock)
+            RequestExtraFrameUnderLock();
+    }
+
+    private void RequestExtraFrameUnderLock()
+    {
+        if (_disposed || ExtraFrameArmed)
+            return;
+
         ExtraFrameArmed = true;
+        RemoveCompletedRenderNudgers();
 
         var generation = BuildGeneration;
-        _ = Task.Run(async () =>
+        var cancellationToken = _lifetimeCancellation.Token;
+        _renderNudgerTasks.Add(Task.Run(
+            () => NudgeExtraFramesAsync(generation, cancellationToken),
+            CancellationToken.None));
+    }
+
+    private async Task NudgeExtraFramesAsync(int generation, CancellationToken cancellationToken)
+    {
+        try
         {
             for (var attempt = 0; attempt < 50; attempt++)
             {
-                await Task.Delay(16).ConfigureAwait(false);
-                // The first nudge is unconditional: a caller racing the top of a root
-                // build can capture that build's generation, and a build already in
-                // flight when the request was made cannot have honored it. One extra
-                // frame at worst; later ticks stop as soon as a new build runs.
-                if (attempt > 0 && BuildGeneration != generation) return;
+                await Task.Delay(16, cancellationToken).ConfigureAwait(false);
+
+                lock (_graphBuildLock)
+                {
+                    if (_disposed || cancellationToken.IsCancellationRequested)
+                        return;
+
+                    // The first nudge is unconditional: a caller racing the top of a root
+                    // build can capture that build's generation, and a build already in
+                    // flight when the request was made cannot have honored it. One extra
+                    // frame at worst; later ticks stop as soon as a new build runs.
+                    if (attempt > 0 && BuildGeneration != generation)
+                        return;
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                    return;
+
                 App.Invalidate();
             }
-        });
-    }
-
-    /// <summary>
-    /// Verifies, after the frame, that the tree window was built against the viewport
-    /// height the panel actually arranged to. The window is sized from the previous
-    /// frame's layout, so a render that changes the pane height (search bar toggle,
-    /// terminal resize) leaves the tree underfilled or over-scrolled with nothing else
-    /// scheduling a rebuild. The verifier polls the live panel and nudges builds until
-    /// <see cref="IlTreeWindowViewport"/> matches the arranged
-    /// <see cref="ScrollPanelNode.ViewportSize"/> or its budget runs out. At most one
-    /// is in flight; it disarms on exit so the next build can re-arm.
-    /// </summary>
-    internal void RequestIlTreeViewportCheck()
-    {
-        if (CurrentTab != TabId.IlInspector) return;
-        if (IlTreeViewportCheckArmed) return;
-        IlTreeViewportCheckArmed = true;
-
-        _ = Task.Run(async () =>
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            try
-            {
-                for (var attempt = 0; attempt < 50; attempt++)
-                {
-                    await Task.Delay(16).ConfigureAwait(false);
-                    var live = IlScrollPanelNode?.ViewportSize ?? 0;
-                    if (live <= 0) continue;
-                    if (live == IlTreeWindowViewport) return;
-                    App.Invalidate();
-                }
-            }
-            finally
-            {
-                IlTreeViewportCheckArmed = false;
-            }
-        });
+        }
     }
+
+    private void RemoveCompletedRenderNudgers() =>
+        _renderNudgerTasks.RemoveAll(static task => task.IsCompleted);
 
     /// <summary>
     /// Returns a stable identity key for the given method/field token within an analyzer.
@@ -1943,6 +2060,7 @@ public sealed class DotsiderState : IDisposable
         _focusedDepStack.Push(GeneralFocusedDep);
         _tabStack.Push(CurrentTab);
         _graphSelectionStack.Push(GraphSelectedIndex);
+        ResetDependencyGraphForAnalyzerReplacement();
         NavigationStack.Push(Analyzer);
         Analyzer = analyzer;
         StringExtractor = new StringExtractor(Analyzer);
@@ -2034,6 +2152,7 @@ public sealed class DotsiderState : IDisposable
         _focusedDepStack.Push(GeneralFocusedDep);
         _tabStack.Push(CurrentTab);
         _graphSelectionStack.Push(GraphSelectedIndex);
+        ResetDependencyGraphForAnalyzerReplacement();
         NavigationStack.Push(Analyzer);
         Analyzer = newAnalyzer;
         StringExtractor = new StringExtractor(Analyzer);
@@ -2090,6 +2209,7 @@ public sealed class DotsiderState : IDisposable
         _focusedDepStack.Push(GeneralFocusedDep);
         _tabStack.Push(CurrentTab);
         _graphSelectionStack.Push(GraphSelectedIndex);
+        ResetDependencyGraphForAnalyzerReplacement();
         NavigationStack.Push(Analyzer);
         Analyzer = newAnalyzer;
         StringExtractor = new StringExtractor(Analyzer);
@@ -2112,6 +2232,7 @@ public sealed class DotsiderState : IDisposable
     {
         if (NavigationStack.Count == 0) return TabId.General;
         NavigationError = null;
+        ResetDependencyGraphForAnalyzerReplacement();
         Analyzer.Dispose();
         Analyzer = NavigationStack.Pop();
         StringExtractor = new StringExtractor(Analyzer);
@@ -2210,18 +2331,9 @@ public sealed class DotsiderState : IDisposable
         CachedRawStrings = null;
         CachedRawUtf16Strings = null;
         CachedFrozenStrings = null;
-        CachedGraph = null;
-        GraphNavigation = null;
-        GraphBuildInProgress = false;
-        GraphNavigationError = null;
-        GraphSelectedNode = null;
-        GraphMatchIndex = -1;
-        GraphSelectedIndex = -1;
         DepGraphScope = DependencyGraphScope.All;
         DepGraphHideFramework = false;
         DepGraphScrollY = 0;
-        CachedGraphRenderLayout = null;
-        CachedGraphRenderLayoutKey = null;
         CachedSizeTree = null;
         TreemapCurrentLevel = null;
         TreemapBreadcrumb.Clear();
@@ -2311,6 +2423,18 @@ public sealed class DotsiderState : IDisposable
     /// <inheritdoc/>
     public void Dispose()
     {
+        lock (_graphBuildLock)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _lifetimeCancellation.Cancel();
+        }
+
+        CancelAndDrainGraphBuild();
+        CancelAndDrainRenderNudgers();
+        _lifetimeCancellation.Dispose();
         Tracer?.Dispose();
         foreach (var analyzer in NavigationStack)
             analyzer.Dispose();
@@ -2343,38 +2467,170 @@ public sealed class DotsiderState : IDisposable
     /// Kicks off a background build of the transitive dependency graph when the Dep Graph
     /// view is first rendered for the current analyzer. While the build runs, the view
     /// displays a placeholder message; when the build completes, the result is published
-    /// to <see cref="CachedGraph"/> and <see cref="GraphNavigation"/> and the UI is
-    /// invalidated to trigger a re-render. Calls made while a build is already in flight
-    /// or after the graph is cached are no-ops. If the analyzer changes before the build
-    /// completes, the stale result is discarded.
+    /// to <see cref="CachedGraph"/> and the UI is invalidated to trigger a re-render. Calls made
+    /// while a build is already in flight or after the graph is cached are no-ops. If the analyzer
+    /// changes before the build completes, the stale result is discarded.
     /// </summary>
     public void EnsureCachedGraphAsync()
     {
-        if (CachedGraph is not null || GraphBuildInProgress)
-            return;
-
-        GraphBuildInProgress = true;
-        var capturedAnalyzer = Analyzer;
-
-        _ = QueueDedicatedBackgroundWork(() =>
+        lock (_graphBuildLock)
         {
-            try
+            if (_disposed || GraphSnapshot is not null || GraphBuildInProgress ||
+                _graphBuildFailed)
+                return;
+
+            _graphBuildCancellation?.Dispose();
+            _graphBuildCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                _lifetimeCancellation.Token);
+            GraphBuildInProgress = true;
+            var capturedAnalyzer = Analyzer;
+            var capturedGeneration = _graphBuildGeneration;
+            var cancellation = _graphBuildCancellation;
+            var graphBuilder = GraphBuilder;
+
+            _graphBuildTask = Task.Factory.StartNew(
+                () => BuildAndPublishGraph(
+                    capturedAnalyzer,
+                    capturedGeneration,
+                    cancellation,
+                    graphBuilder),
+                CancellationToken.None,
+                TaskCreationOptions.DenyChildAttach | TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+        }
+    }
+
+    private void BuildAndPublishGraph(
+        AssemblyAnalyzer capturedAnalyzer,
+        int capturedGeneration,
+        CancellationTokenSource cancellation,
+        Func<AssemblyAnalyzer, CancellationToken, DependencyGraphResult> graphBuilder)
+    {
+        DependencyGraphResult? result = null;
+        Exception? error = null;
+        try
+        {
+            result = graphBuilder(capturedAnalyzer, cancellation.Token);
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            error = exception;
+        }
+
+        var snapshot = result is null
+            ? null
+            : new DependencyGraphSnapshot(result.Nodes, result.Edges, result.NavigationById);
+
+        bool invalidate;
+        lock (_graphBuildLock)
+        {
+            var ownsCurrentBuild = ReferenceEquals(_graphBuildCancellation, cancellation);
+            var canPublish = ownsCurrentBuild &&
+                capturedGeneration == _graphBuildGeneration &&
+                ReferenceEquals(Analyzer, capturedAnalyzer) &&
+                !_disposed &&
+                !cancellation.IsCancellationRequested;
+
+            if (canPublish && snapshot is not null)
             {
-                var result = DependencyGraphBuilder.Build(capturedAnalyzer);
-
-                if (!ReferenceEquals(Analyzer, capturedAnalyzer))
-                    return;
-
-                GraphNavigation = result.NavigationById;
-                CachedGraph = (result.Nodes, result.Edges);
+                Volatile.Write(ref _legacyGraphNavigation, snapshot.NavigationById);
+                Volatile.Write(ref _dependencyGraphSnapshot, snapshot);
             }
-            finally
+            else if (canPublish && error is not null)
             {
+                _graphBuildFailed = true;
+                GraphNavigationError = "Cannot build dependency graph";
+            }
+
+            if (ownsCurrentBuild)
                 GraphBuildInProgress = false;
-                App.Invalidate();
-                RequestExtraFrame();
+
+            invalidate = canPublish;
+        }
+
+        if (error is not null)
+            Debug.WriteLine($"Failed to build dependency graph: {error}");
+
+        if (invalidate)
+            InvalidateGraphCompletion();
+    }
+
+    private void InvalidateGraphCompletion()
+    {
+        lock (_graphBuildLock)
+        {
+            if (_disposed || _lifetimeCancellation.IsCancellationRequested)
+                return;
+        }
+
+        App.Invalidate();
+        RequestExtraFrame();
+    }
+
+    private void CancelAndDrainGraphBuild()
+    {
+        Task graphBuildTask;
+        CancellationTokenSource? cancellation;
+        lock (_graphBuildLock)
+        {
+            _graphBuildGeneration++;
+            cancellation = _graphBuildCancellation;
+            cancellation?.Cancel();
+            graphBuildTask = _graphBuildTask;
+        }
+
+        graphBuildTask.GetAwaiter().GetResult();
+
+        lock (_graphBuildLock)
+        {
+            if (ReferenceEquals(_graphBuildCancellation, cancellation))
+            {
+                _graphBuildCancellation = null;
+                _graphBuildTask = Task.CompletedTask;
+                GraphBuildInProgress = false;
             }
-        });
+        }
+
+        cancellation?.Dispose();
+    }
+
+    private void CancelAndDrainRenderNudgers()
+    {
+        Task[] tasks;
+        lock (_graphBuildLock)
+            tasks = [.. _renderNudgerTasks];
+
+        Task.WhenAll(tasks).GetAwaiter().GetResult();
+
+        lock (_graphBuildLock)
+            _renderNudgerTasks.Clear();
+    }
+
+    /// <summary>
+    /// Cancels and drains dependency-graph work before the active analyzer is replaced,
+    /// then clears every graph result and view cache owned by that analyzer.
+    /// </summary>
+    internal void ResetDependencyGraphForAnalyzerReplacement()
+    {
+        CancelAndDrainGraphBuild();
+
+        lock (_graphBuildLock)
+        {
+            Volatile.Write(ref _dependencyGraphSnapshot, null);
+            Volatile.Write(ref _legacyGraphNavigation, null);
+            GraphBuildInProgress = false;
+            GraphNavigationError = null;
+            _graphBuildFailed = false;
+        }
+
+        GraphSelectedNode = null;
+        GraphMatchIndex = -1;
+        GraphSelectedIndex = -1;
+        CachedGraphRenderLayout = null;
+        CachedGraphRenderLayoutKey = null;
     }
 
     private static Task QueueDedicatedBackgroundWork(Action work) =>

--- a/src/Dotsider/NuGetApp.cs
+++ b/src/Dotsider/NuGetApp.cs
@@ -35,8 +35,7 @@ public sealed class NuGetApp(NuGetState state)
         // build generation stops any in-flight extra-frame nudger armed by the listener.
         if (_state.SelectedDllState is { } dllState)
         {
-            unchecked { dllState.BuildGeneration++; }
-            dllState.ExtraFrameArmed = false;
+            dllState.NotifyBuildStarted();
             while (dllState.PendingMutations.TryDequeue(out var mutation))
                 mutation(dllState);
         }
@@ -50,7 +49,7 @@ public sealed class NuGetApp(NuGetState state)
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.Black)
                     .Set(GlobalTheme.BackgroundColor, Hex1bColor.FromRgb(160, 100, 200))),
                 bar.Divider(" "),
-                bar.Section(_state.Package.FileName).Theme(t => t
+                bar.Section(UntrustedTerminalText.Escape(_state.Package.FileName)).Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(80, 80, 100))),
                 bar.Spacer(),
                 bar.Section(_state.IsBrowsingPackage ? "Package Browser" : "DLL Inspector").Theme(t => t
@@ -114,6 +113,13 @@ public sealed class NuGetApp(NuGetState state)
                 {
                     hints.Add(s.Section(yankNotification).Theme(t => t
                         .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(120, 180, 120))));
+                    hints.Add(s.Divider(" "));
+                }
+
+                if (_state.IsBrowsingPackage && _state.OpenError is { } openError)
+                {
+                    hints.Add(s.Section(openError).Theme(t => t
+                        .Set(GlobalTheme.ForegroundColor, Hex1bColor.FromRgb(200, 80, 60))));
                     hints.Add(s.Divider(" "));
                 }
 
@@ -201,19 +207,7 @@ public sealed class NuGetApp(NuGetState state)
 
                     if (entry is null) return;
 
-                    try
-                    {
-                        var analyzer = _state.Package.OpenDll(entry);
-                        _state.SelectedDllState?.Dispose();
-                        _state.SelectedDllState = new DotsiderState(_state.App, analyzer);
-                        _state.SelectedDllEntry = entry;
-                        _state.IsBrowsingPackage = false;
-                        _state.App.Invalidate();
-                    }
-                    catch (Exception ex)
-                    {
-                        System.Diagnostics.Debug.WriteLine($"Failed to open DLL: {ex.Message}");
-                    }
+                    _state.TryOpenDll(entry);
                 }, "Open DLL");
             }
 
@@ -489,9 +483,10 @@ public sealed class NuGetApp(NuGetState state)
     private void ShowYankNotification(string text)
     {
         var gen = ++_state.YankGeneration;
+        var displayText = UntrustedTerminalText.Escape(text);
         _state.YankNotification = text.Contains('\n')
             ? $"Yanked {text.Count(c => c == '\n') + 1} lines"
-            : $"Yanked: {(text.Length > 40 ? text[..37] + "..." : text)}";
+            : $"Yanked: {UntrustedTerminalText.TruncateWithEllipsis(displayText, 40)}";
         _state.App.Invalidate();
         _ = Task.Delay(TimeSpan.FromMilliseconds(1500)).ContinueWith(_ =>
         {

--- a/src/Dotsider/NuGetState.cs
+++ b/src/Dotsider/NuGetState.cs
@@ -2,6 +2,7 @@ using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using Hex1b;
 using Hex1b.Widgets;
+using System.Diagnostics;
 
 namespace Dotsider;
 
@@ -15,6 +16,8 @@ namespace Dotsider;
 /// <param name="nupkgPath">File path to the .nupkg file.</param>
 public sealed class NuGetState(Hex1bApp app, string nupkgPath) : IDisposable
 {
+    private bool _disposed;
+
     /// <summary>The Hex1b application instance.</summary>
     public Hex1bApp App { get; } = app;
 
@@ -85,10 +88,97 @@ public sealed class NuGetState(Hex1bApp app, string nupkgPath) : IDisposable
     /// <summary>Generation counter for yank notification timer race prevention.</summary>
     public long YankGeneration { get; set; }
 
+    /// <summary>
+    /// Gets the sanitized error from the most recent DLL open attempt, or <see langword="null"/>.
+    /// </summary>
+    internal string? OpenError { get; private set; }
+
+    /// <summary>
+    /// Opens a package DLL and transitions to the DLL inspector when successful.
+    /// </summary>
+    /// <param name="entry">The package-owned DLL entry to open.</param>
+    /// <returns><see langword="true"/> when the DLL inspector was opened; otherwise, <see langword="false"/>.</returns>
+    internal bool TryOpenDll(NuGetFileEntry entry)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        try
+        {
+            var analyzer = Package.OpenDll(entry);
+            DotsiderState nextState;
+            try
+            {
+                nextState = new DotsiderState(App, analyzer);
+            }
+            catch
+            {
+                analyzer.Dispose();
+                throw;
+            }
+
+            try
+            {
+                SelectedDllState?.Dispose();
+            }
+            catch
+            {
+                nextState.Dispose();
+                throw;
+            }
+
+            SavedFileTreeFocusedKey = FileTreeFocusedKey;
+            SelectedDllState = nextState;
+            SelectedDllEntry = entry;
+            IsBrowsingPackage = false;
+            OpenError = null;
+            App.RequestFocus(node => node.GetType().Name.StartsWith("TableNode", StringComparison.Ordinal));
+            App.Invalidate();
+            return true;
+        }
+        catch (UnsafePackageEntryException ex)
+        {
+            return FailOpen("Cannot open DLL: unsafe package entry path", ex);
+        }
+        catch (BadImageFormatException ex)
+        {
+            return FailOpen("Cannot open DLL: invalid .NET assembly", ex);
+        }
+        catch (IOException ex)
+        {
+            return FailOpen("Cannot open DLL: extraction failed", ex);
+        }
+        catch (Exception ex)
+        {
+            return FailOpen("Cannot open DLL", ex);
+        }
+    }
+
     /// <inheritdoc/>
     public void Dispose()
     {
-        SelectedDllState?.Dispose();
-        Package.Dispose();
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        var selectedDllState = SelectedDllState;
+        SelectedDllState = null;
+        SelectedDllEntry = null;
+
+        try
+        {
+            selectedDllState?.Dispose();
+        }
+        finally
+        {
+            Package.Dispose();
+        }
+    }
+
+    private bool FailOpen(string message, Exception exception)
+    {
+        OpenError = message;
+        Debug.WriteLine($"Failed to open package DLL: {exception}");
+        App.Invalidate();
+        return false;
     }
 }

--- a/src/Dotsider/Program.cs
+++ b/src/Dotsider/Program.cs
@@ -160,8 +160,24 @@ static async Task<int> RunTui(string[] args, string filePath)
         }
         finally
         {
-            CursorColorHelper.ResetCursorColor();
-            nugetHex1bApp.Dispose();
+            var nugetState = capturedNugetState;
+            capturedNugetState = null;
+
+            try
+            {
+                nugetState?.Dispose();
+            }
+            finally
+            {
+                try
+                {
+                    CursorColorHelper.ResetCursorColor();
+                }
+                finally
+                {
+                    nugetHex1bApp.Dispose();
+                }
+            }
         }
 
         return 0;

--- a/src/Dotsider/Views/DependencyGraphView.cs
+++ b/src/Dotsider/Views/DependencyGraphView.cs
@@ -39,10 +39,11 @@ public static class DependencyGraphView
         // existing startup-focus tests still land on the graph surface.
         state.EnsureCachedGraphAsync();
 
-        var ready = state.CachedGraph is not null;
-        IReadOnlyList<GraphNode> allNodes = ready ? state.CachedGraph!.Value.Nodes : [];
-        IReadOnlyList<GraphEdge> allEdges = ready ? state.CachedGraph!.Value.Edges : [];
-        var nav = state.GraphNavigation;
+        var graph = state.GraphSnapshot;
+        var ready = graph is not null;
+        IReadOnlyList<GraphNode> allNodes = graph?.Nodes ?? [];
+        IReadOnlyList<GraphEdge> allEdges = graph?.Edges ?? [];
+        var nav = graph?.NavigationById;
         var visible = BuildVisibleModel(
             allNodes, allEdges, nav, state.DepGraphScope, state.DepGraphHideFramework);
         var nodes = visible.Nodes;
@@ -113,9 +114,11 @@ public static class DependencyGraphView
 
             // Scroll position now lives in the vertical scrollbar widget composed with the
             // graph surface below; the status line no longer carries a Scroll: N/M suffix.
-            var statusLeft = !ready
-                ? " Building dependency graph..."
-                : $" {baseCounts}";
+            var statusLeft = ready
+                ? $" {baseCounts}"
+                : state.GraphBuildInProgress
+                    ? " Building dependency graph..."
+                    : $" {state.GraphNavigationError ?? "Cannot build dependency graph"}";
 
             string scopeSuffix, filterSuffix;
             if (!ready)
@@ -141,7 +144,7 @@ public static class DependencyGraphView
                     : "  | Hover over a node for details").Fill()
             ]).FixedHeight(1));
 
-            if (state.GraphNavigationError is not null)
+            if (ready && state.GraphNavigationError is not null)
                 widgets.Add(outer.Text($" {state.GraphNavigationError}").FixedHeight(1));
 
             SearchBarHelper.AddSearchBar(widgets, outer, search, state.App);
@@ -171,7 +174,7 @@ public static class DependencyGraphView
                 row.Interactable(ic =>
                     ic.Surface(s =>
                     [
-                        s.Layer(surface => DrawGraph(surface, visible, nav, disambig,
+                        s.Layer(surface => DrawGraph(surface, visible, allNodes, nav, disambig,
                             state, s.MouseX, s.MouseY, query))
                     ]).Fill()
                 ).InputBindings(bindings =>
@@ -338,6 +341,7 @@ public static class DependencyGraphView
     private static void DrawGraph(
         Surface surface,
         VisibleGraphModel visible,
+        object nodesReference,
         IReadOnlyDictionary<string, GraphNavigationContext>? nav,
         IReadOnlyDictionary<string, IdentityDiscriminator> disambig,
         DotsiderState state,
@@ -349,7 +353,8 @@ public static class DependencyGraphView
         var h = surface.Height;
         if (w < 10 || h < 5) return;
 
-        var layout = GetOrBuildRenderLayout(state, visible, nav, disambig, w, h);
+        var layout = GetOrBuildRenderLayout(
+            state, visible, nodesReference, nav, disambig, w, h);
         var renderNodes = layout.Nodes;
         if (renderNodes.Count == 0) return;
 
@@ -558,14 +563,14 @@ public static class DependencyGraphView
     private static GraphRenderLayout GetOrBuildRenderLayout(
         DotsiderState state,
         VisibleGraphModel visible,
+        object nodesReference,
         IReadOnlyDictionary<string, GraphNavigationContext>? nav,
         IReadOnlyDictionary<string, IdentityDiscriminator> disambig,
         int width,
         int height)
     {
-        object? nodesRef = state.CachedGraph is { } cg ? cg.Nodes : null;
         var key = new GraphRenderLayoutKey(
-            nodesRef, state.DepGraphScope, state.DepGraphHideFramework, width, height);
+            nodesReference, state.DepGraphScope, state.DepGraphHideFramework, width, height);
 
         if (state.CachedGraphRenderLayoutKey is { } existingKey
             && existingKey.Equals(key)

--- a/src/Dotsider/Views/IlTreeList.cs
+++ b/src/Dotsider/Views/IlTreeList.cs
@@ -51,7 +51,7 @@ internal static class IlTreeList
     /// collapsed row.</param>
     /// <param name="collapseRow">Invoked when LeftArrow targets an expandable
     /// expanded row.</param>
-    /// <returns>The composed <see cref="ScrollPanelWidget"/>-rooted tree widget.</returns>
+    /// <returns>The composed tree widget.</returns>
     internal static Hex1bWidget Build(
         IReadOnlyList<IlTreeRow> rows,
         IReadOnlyList<string> formattedRows,
@@ -211,13 +211,31 @@ internal static class IlTreeList
             })
             .Fill();
 
-        // Record the viewport this window was built against and verify it after the
-        // frame: a render that changes the pane height (search bar toggle, terminal
-        // resize) otherwise leaves a stale window with nothing scheduling a rebuild.
+        // Record the viewport this window was built against. The responsive wrapper's
+        // condition runs during layout with the actual pane height and schedules one
+        // follow-up build when this window no longer fills that height.
         state.IlTreeWindowViewport = viewportH;
-        state.RequestIlTreeViewportCheck();
 
-        return panel;
+        return new ResponsiveWidget(
+        [
+            new ConditionalWidget(
+                (_, availableHeight) => ObserveViewportHeight(state, availableHeight),
+                panel)
+        ]).Fill();
+    }
+
+    private static bool ObserveViewportHeight(DotsiderState state, int availableHeight)
+    {
+        // VStack measures children with unbounded height, then ResponsiveNode evaluates
+        // its condition again from the finite arranged bounds. Only the latter is the
+        // tree's real viewport and can justify a follow-up build.
+        if (availableHeight is > 0 and < int.MaxValue
+            && availableHeight != state.IlTreeWindowViewport)
+        {
+            state.RequestExtraFrame();
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Dotsider/Views/NuGetBrowserView.cs
+++ b/src/Dotsider/Views/NuGetBrowserView.cs
@@ -23,6 +23,7 @@ public static class NuGetBrowserView
         var pkg = state.Package;
         var search = state.BrowserSearch;
         var query = search.Query;
+        var displayQuery = UntrustedTerminalText.Escape(query ?? string.Empty);
 
         // Filter DLL list by search query
         var dlls = (IReadOnlyList<NuGetFileEntry>)pkg.DllFiles;
@@ -44,10 +45,10 @@ public static class NuGetBrowserView
 
         // Build Package Info text for read-only editor
         var infoText = string.Join("\n",
-            $"  Package ID:   {pkg.PackageId ?? "(unknown)"}",
-            $"  Version:      {pkg.PackageVersion ?? "(unknown)"}",
-            $"  Authors:      {pkg.Authors ?? "(unknown)"}",
-            $"  Description:  {pkg.Description ?? "(none)"}",
+            $"  Package ID:   {UntrustedTerminalText.Escape(pkg.PackageId ?? "(unknown)")}",
+            $"  Version:      {UntrustedTerminalText.Escape(pkg.PackageVersion ?? "(unknown)")}",
+            $"  Authors:      {UntrustedTerminalText.Escape(pkg.Authors ?? "(unknown)")}",
+            $"  Description:  {UntrustedTerminalText.Escape(pkg.Description ?? "(none)")}",
             "",
             $"  Total Files:  {pkg.Files.Count}",
             $"  DLL Files:    {pkg.DllFiles.Count}",
@@ -113,6 +114,8 @@ public static class NuGetBrowserView
                     ])
                     .Row((r, entry, rowState) =>
                     {
+                        var displayName = UntrustedTerminalText.Escape(entry.Name);
+                        var displayDirectory = UntrustedTerminalText.Escape(entry.Directory);
                         var flash = rowState.IsFocused && state.YankFlashRow;
                         var fg = flash ? Hex1bColor.FromRgb(24, 24, 37)
                             : rowState.IsFocused ? Hex1bColor.Black
@@ -125,12 +128,12 @@ public static class NuGetBrowserView
                         [
                             r.Cell(c => rowState.IsFocused
                                 ? c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg!.Value).Set(GlobalTheme.BackgroundColor, bg!.Value),
-                                    HighlightHelper.HighlightCell(c, entry.Name, query, !string.IsNullOrEmpty(query), fg, bg))
-                                : HighlightHelper.HighlightCell(c, entry.Name, query, !string.IsNullOrEmpty(query), fg, bg)),
+                                    HighlightHelper.HighlightCell(c, displayName, displayQuery, !string.IsNullOrEmpty(query), fg, bg))
+                                : HighlightHelper.HighlightCell(c, displayName, displayQuery, !string.IsNullOrEmpty(query), fg, bg)),
                             r.Cell(c => rowState.IsFocused
                                 ? c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg!.Value).Set(GlobalTheme.BackgroundColor, bg!.Value),
-                                    HighlightHelper.HighlightCell(c, entry.Directory, query, !string.IsNullOrEmpty(query), fg, bg))
-                                : HighlightHelper.HighlightCell(c, entry.Directory, query, !string.IsNullOrEmpty(query), fg, bg)),
+                                    HighlightHelper.HighlightCell(c, displayDirectory, displayQuery, !string.IsNullOrEmpty(query), fg, bg))
+                                : HighlightHelper.HighlightCell(c, displayDirectory, displayQuery, !string.IsNullOrEmpty(query), fg, bg)),
                             r.Cell(c => rowState.IsFocused
                                 ? c.ThemePanel(t => t.Set(GlobalTheme.ForegroundColor, fg!.Value).Set(GlobalTheme.BackgroundColor, bg!.Value),
                                     c.Text(DotsiderState.FormatSize(entry.UncompressedSize)))
@@ -139,25 +142,7 @@ public static class NuGetBrowserView
                     })
                     .Focus(state.App.FocusedNode is EditorNode ? null : state.FileTreeFocusedKey)
                     .OnFocusChanged(key => state.FileTreeFocusedKey = key)
-                    .OnRowActivated((_, entry) =>
-                    {
-                        try
-                        {
-                            state.SavedFileTreeFocusedKey = state.FileTreeFocusedKey;
-                            var analyzer = pkg.OpenDll(entry);
-                            state.SelectedDllState?.Dispose();
-                            state.SelectedDllState = new DotsiderState(state.App, analyzer);
-                            state.SelectedDllEntry = entry;
-                            state.IsBrowsingPackage = false;
-                            state.App.RequestFocus(node =>
-                                node.GetType().Name.StartsWith("TableNode"));
-                            state.App.Invalidate();
-                        }
-                        catch (Exception ex)
-                        {
-                            System.Diagnostics.Debug.WriteLine($"Failed to open DLL: {ex.Message}");
-                        }
-                    })
+                    .OnRowActivated((_, entry) => state.TryOpenDll(entry))
                     .Compact()
                     .Empty(e => e.Text("  No DLL files in package"))
                     .FillWidth()

--- a/src/Dotsider/Views/UntrustedTerminalText.cs
+++ b/src/Dotsider/Views/UntrustedTerminalText.cs
@@ -1,0 +1,130 @@
+using System.Globalization;
+using System.Text;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// Converts untrusted text to a printable terminal representation without changing the source
+/// value used for identity or application behavior.
+/// </summary>
+internal static class UntrustedTerminalText
+{
+    /// <summary>
+    /// Replaces terminal controls, Unicode formatting controls, and invalid surrogate code units
+    /// with visible text while preserving ordinary Unicode characters.
+    /// </summary>
+    /// <param name="value">The untrusted text.</param>
+    /// <returns>The original string when it is printable; otherwise, a printable representation.</returns>
+    internal static string Escape(string value)
+    {
+        StringBuilder? builder = null;
+        var index = 0;
+        while (index < value.Length)
+        {
+            var characterCount = 1;
+            Rune rune;
+            if (char.IsHighSurrogate(value[index]) &&
+                index + 1 < value.Length &&
+                char.IsLowSurrogate(value[index + 1]))
+            {
+                rune = new Rune(value[index], value[index + 1]);
+                characterCount = 2;
+            }
+            else if (char.IsSurrogate(value[index]))
+            {
+                builder ??= CreateBuilder(value, index);
+                AppendUnicodeEscape(builder, value[index]);
+                index++;
+                continue;
+            }
+            else
+            {
+                rune = new Rune(value[index]);
+            }
+
+            var category = Rune.GetUnicodeCategory(rune);
+            if (category is UnicodeCategory.Control or
+                UnicodeCategory.Format or
+                UnicodeCategory.LineSeparator or
+                UnicodeCategory.ParagraphSeparator)
+            {
+                builder ??= CreateBuilder(value, index);
+                AppendEscapedRune(builder, rune);
+            }
+            else if (builder is not null)
+            {
+                builder.Append(value.AsSpan(index, characterCount));
+            }
+
+            index += characterCount;
+        }
+
+        return builder?.ToString() ?? value;
+    }
+
+    /// <summary>
+    /// Truncates printable text without splitting a UTF-16 surrogate pair and appends an ellipsis
+    /// when truncation is required.
+    /// </summary>
+    /// <param name="value">The printable text.</param>
+    /// <param name="maximumLength">The maximum UTF-16 length, including the ellipsis.</param>
+    /// <returns>The original text or its safely truncated representation.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="maximumLength"/> is less than the length of the ellipsis.
+    /// </exception>
+    internal static string TruncateWithEllipsis(string value, int maximumLength)
+    {
+        const string Ellipsis = "...";
+        ArgumentOutOfRangeException.ThrowIfLessThan(maximumLength, Ellipsis.Length);
+
+        if (value.Length <= maximumLength)
+            return value;
+
+        var prefixLength = maximumLength - Ellipsis.Length;
+        if (prefixLength > 0 &&
+            char.IsHighSurrogate(value[prefixLength - 1]) &&
+            char.IsLowSurrogate(value[prefixLength]))
+        {
+            prefixLength--;
+        }
+
+        return string.Concat(value.AsSpan(0, prefixLength), Ellipsis);
+    }
+
+    private static void AppendEscapedRune(StringBuilder builder, Rune rune)
+    {
+        if (rune.Value <= 0x1F)
+        {
+            builder.Append((char)(0x2400 + rune.Value));
+        }
+        else if (rune.Value == 0x7F)
+        {
+            builder.Append('\u2421');
+        }
+        else
+        {
+            AppendUnicodeEscape(builder, rune.Value);
+        }
+    }
+
+    private static void AppendUnicodeEscape(StringBuilder builder, int value)
+    {
+        if (value <= ushort.MaxValue)
+        {
+            builder.Append("\\u");
+            builder.Append(value.ToString("X4", CultureInfo.InvariantCulture));
+        }
+        else
+        {
+            builder.Append("\\U");
+            builder.Append(value.ToString("X8", CultureInfo.InvariantCulture));
+        }
+    }
+
+    private static StringBuilder CreateBuilder(string value, int safePrefixLength)
+    {
+        var builder = new StringBuilder(value.Length + 8);
+        builder.Append(value.AsSpan(0, safePrefixLength));
+        return builder;
+    }
+}

--- a/src/Dotsider/Views/YankHelper.cs
+++ b/src/Dotsider/Views/YankHelper.cs
@@ -161,7 +161,7 @@ public static class YankHelper
         if (state.GraphSelectedNode is not null)
             return state.GraphSelectedNode;
 
-        if (state.GraphSelectedIndex < 0 || state.CachedGraph is not { } graph)
+        if (state.GraphSelectedIndex < 0 || state.GraphSnapshot is not { } graph)
             return null;
 
         // Selection indices and the rendered label both come from the visible model the view
@@ -169,7 +169,7 @@ public static class YankHelper
         // view with selection index 1 would yank the underlying cached node at index 1,
         // which is a hidden framework assembly, not the assembly the user sees.
         var visible = DependencyGraphView.BuildVisibleModel(
-            graph.Nodes, graph.Edges, state.GraphNavigation,
+            graph.Nodes, graph.Edges, graph.NavigationById,
             state.DepGraphScope, state.DepGraphHideFramework);
 
         if (state.GraphSelectedIndex >= visible.Nodes.Count)

--- a/tests/Dotsider.Tests/ClipboardCapturingWorkloadAdapter.cs
+++ b/tests/Dotsider.Tests/ClipboardCapturingWorkloadAdapter.cs
@@ -28,12 +28,22 @@ internal sealed class ClipboardCapturingWorkloadAdapter : IHex1bAppTerminalWorkl
     /// <inheritdoc />
     public void Write(string text)
     {
-        // Intercept OSC 52 clipboard sequences: ESC ] 52 ; c ; <base64> BEL
-        if (text.StartsWith("\x1b]52;c;") && text.EndsWith('\x07'))
+        // Intercept OSC 52 clipboard sequences: ESC ] 52 ; c ; <base64> BEL. Search the
+        // complete write so a regression that embeds an OSC sequence in rendered text is visible.
+        const string Prefix = "\x1b]52;c;";
+        var searchStart = 0;
+        while (text.IndexOf(Prefix, searchStart, StringComparison.Ordinal) is var sequenceStart &&
+            sequenceStart >= 0)
         {
-            var base64 = text["\x1b]52;c;".Length..^1];
+            var payloadStart = sequenceStart + Prefix.Length;
+            var sequenceEnd = text.IndexOf('\x07', payloadStart);
+            if (sequenceEnd < 0)
+                break;
+
+            var base64 = text[payloadStart..sequenceEnd];
             var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(base64));
             ClipboardWrites.Enqueue(decoded);
+            searchStart = sequenceEnd + 1;
         }
 
         _inner.Write(text);

--- a/tests/Dotsider.Tests/DependencyGraphBuilderTests.cs
+++ b/tests/Dotsider.Tests/DependencyGraphBuilderTests.cs
@@ -6,8 +6,8 @@ namespace Dotsider.Tests;
 /// <summary>
 /// Tests for <see cref="DependencyGraphBuilder"/> covering transitive traversal, identity-based
 /// dedupe, cycle and diamond preservation, unresolved and identity-mismatch leaves, per-edge
-/// TypeRef counts by full identity, determinism, and behavior across bundle, apphost, and
-/// native deployment shapes.
+/// TypeRef counts by full identity, cancellation, determinism, and behavior across bundle,
+/// apphost, and native deployment shapes.
 /// </summary>
 [TestClass]
 public class DependencyGraphBuilderTests
@@ -383,6 +383,68 @@ public class DependencyGraphBuilderTests
     }
 
     /// <summary>
+    /// A token canceled before the build begins is observed before any traversal work is reported.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void BuildWithCancellation_AlreadyCanceled_StopsBeforeTraversal()
+    {
+        using var analyzer = new AssemblyAnalyzer(Samples.HelloWorldDll);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var observed = new List<DependencyGraphBuildCheckpoint>();
+
+        var exception = Assert.ThrowsExactly<OperationCanceledException>(() =>
+            DependencyGraphBuilder.BuildWithCancellation(
+                analyzer,
+                cancellation.Token,
+                observed.Add));
+
+        Assert.AreEqual(cancellation.Token, exception.CancellationToken);
+        Assert.IsEmpty(observed);
+    }
+
+    /// <summary>
+    /// Cancellation requested after the first managed reference has been resolved stops the walk
+    /// and disposes a child analyzer that was already queued for transitive traversal.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void BuildWithCancellation_AfterManagedReferenceProcessed_StopsAndCleansUp()
+    {
+        using var scope = SyntheticAssemblyScope.Create();
+        scope.WriteAssembly("CancelChild");
+        var rootPath = scope.WriteAssembly(
+            "CancelRoot",
+            refs: [("CancelChild", new Version(1, 0, 0, 0))]);
+        var directory = scope.Directory;
+        var observed = new List<DependencyGraphBuildCheckpoint>();
+        using var cancellation = new CancellationTokenSource();
+
+        OperationCanceledException exception;
+        using (var analyzer = new AssemblyAnalyzer(rootPath))
+        {
+            exception = Assert.ThrowsExactly<OperationCanceledException>(() =>
+                DependencyGraphBuilder.BuildWithCancellation(
+                    analyzer,
+                    cancellation.Token,
+                    checkpoint =>
+                    {
+                        observed.Add(checkpoint);
+                        cancellation.Cancel();
+                    }));
+        }
+
+        scope.Dispose();
+
+        Assert.AreEqual(cancellation.Token, exception.CancellationToken);
+        Assert.AreSequenceEqual(
+            [DependencyGraphBuildCheckpoint.ManagedAssemblyReferenceProcessed],
+            observed);
+        Assert.IsFalse(System.IO.Directory.Exists(directory));
+    }
+
+    /// <summary>
     /// A Native AOT binary with mstat and DGML sidecars produces a real graph: the compiled
     /// assemblies as nodes, DGML links aggregated to assembly-pair edges, and the native
     /// import modules at depth 1.
@@ -404,6 +466,41 @@ public class DependencyGraphBuilderTests
 
         if (Samples.NativeAotConsoleDgml is not null)
             Assert.Contains(e => e.SourceId == root.Id && e.TypeRefCount > 0, graph.Edges);
+    }
+
+    /// <summary>
+    /// Cancellation requested after a real DGML link has been inspected stops Native AOT
+    /// assembly-edge aggregation before the remaining links are visited.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void BuildWithCancellation_AfterDgmlLinkProcessed_StopsAggregation()
+    {
+        TestSkip.When(Samples.NativeAotConsoleMstat is null, "mstat sidecar was not produced");
+        TestSkip.When(Samples.NativeAotConsoleDgml is null, "DGML sidecar was not produced");
+
+        using var analyzer = new AssemblyAnalyzer(Samples.NativeAotConsoleExe!);
+        Assert.IsNotEmpty(analyzer.Dgml!.Links);
+        var observed = new List<DependencyGraphBuildCheckpoint>();
+        using var cancellation = new CancellationTokenSource();
+
+        var exception = Assert.ThrowsExactly<OperationCanceledException>(() =>
+            DependencyGraphBuilder.BuildWithCancellation(
+                analyzer,
+                cancellation.Token,
+                checkpoint =>
+                {
+                    if (checkpoint != DependencyGraphBuildCheckpoint.DgmlLinkProcessed)
+                        return;
+
+                    observed.Add(checkpoint);
+                    cancellation.Cancel();
+                }));
+
+        Assert.AreEqual(cancellation.Token, exception.CancellationToken);
+        Assert.AreSequenceEqual(
+            [DependencyGraphBuildCheckpoint.DgmlLinkProcessed],
+            observed);
     }
 
     /// <summary>

--- a/tests/Dotsider.Tests/DotsiderGraphBuildTests.cs
+++ b/tests/Dotsider.Tests/DotsiderGraphBuildTests.cs
@@ -1,0 +1,449 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+using Hex1b;
+using Hex1b.Widgets;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests dependency-graph background-work ownership, publication, cancellation, and disposal.
+/// </summary>
+/// <param name="testContext">The current test context.</param>
+[TestClass]
+public sealed class DotsiderGraphBuildTests(TestContext testContext) : IDisposable
+{
+    private static SampleAssemblyFixture Samples => SampleAssemblyHost.Instance;
+
+    private readonly TestContext _testContext = testContext;
+    private Hex1bAppWorkloadAdapter? _workload;
+    private Hex1bTerminal? _terminal;
+    private Hex1bApp? _app;
+
+    /// <summary>
+    /// Verifies repeated requests share one in-flight operation and publish its result once.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task EnsureCachedGraphAsync_ConcurrentRequests_AreSingleFlight()
+    {
+        var cancellationToken = _testContext.CancellationToken;
+        using var release = new ManualResetEventSlim();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var invocationCount = 0;
+        using var state = new DotsiderState(CreateApp(), Samples.HelloWorldDll)
+        {
+            GraphBuilder = (_, token) =>
+            {
+                Interlocked.Increment(ref invocationCount);
+                started.TrySetResult();
+                release.Wait(token);
+                return CreateResult("single-flight");
+            }
+        };
+
+        state.EnsureCachedGraphAsync();
+        await started.Task.WaitAsync(cancellationToken);
+        var graphBuildTask = state.GraphBuildTask;
+
+        state.EnsureCachedGraphAsync();
+
+        Assert.AreSame(graphBuildTask, state.GraphBuildTask);
+        Assert.AreEqual(1, Volatile.Read(ref invocationCount));
+        release.Set();
+        await graphBuildTask.WaitAsync(cancellationToken);
+
+        Assert.IsFalse(state.GraphBuildInProgress);
+        Assert.IsNull(state.GraphNavigationError);
+        Assert.AreEqual(
+            "single-flight",
+            Assert.ContainsSingle(state.GraphSnapshot!.Nodes).Name);
+    }
+
+    /// <summary>
+    /// Verifies topology and navigation metadata remain unavailable until one complete graph
+    /// snapshot is atomically published.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task EnsureCachedGraphAsync_PublishesOneCompleteSnapshot()
+    {
+        var cancellationToken = _testContext.CancellationToken;
+        using var release = new ManualResetEventSlim();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var node = new GraphNode(
+            Id: "snapshot",
+            Name: "snapshot",
+            Version: null,
+            Culture: "neutral",
+            PublicKeyToken: null,
+            IsRoot: true,
+            Depth: 0,
+            Unresolved: false);
+        var navigation = new GraphNavigationContext(
+            Resolved: null,
+            ReferencingFilePath: null,
+            ReferencingBundlePath: null,
+            ReferencingTargetFramework: null,
+            ReferencingPreferredRuntimePack: null,
+            Provenance: AssemblyProvenance.Unresolved,
+            IsFrameworkAssembly: false,
+            CandidateProbePath: null);
+        var expected = new DependencyGraphResult(
+            [node],
+            [],
+            new Dictionary<string, GraphNavigationContext>(StringComparer.Ordinal)
+            {
+                [node.Id] = navigation
+            });
+        using var state = new DotsiderState(CreateApp(), Samples.HelloWorldDll)
+        {
+            GraphBuilder = (_, token) =>
+            {
+                started.TrySetResult();
+                release.Wait(token);
+                return expected;
+            }
+        };
+
+        state.EnsureCachedGraphAsync();
+        await started.Task.WaitAsync(cancellationToken);
+
+        Assert.IsNull(state.CachedGraph);
+
+        release.Set();
+        await state.GraphBuildTask.WaitAsync(cancellationToken);
+
+        var snapshot = state.GraphSnapshot;
+        Assert.IsNotNull(snapshot);
+        Assert.IsInstanceOfType<ImmutableArray<GraphNode>>(snapshot.Nodes);
+        Assert.IsInstanceOfType<ImmutableArray<GraphEdge>>(snapshot.Edges);
+        Assert.IsInstanceOfType<FrozenDictionary<string, GraphNavigationContext>>(
+            snapshot.NavigationById);
+        Assert.AreSame(node, Assert.ContainsSingle(snapshot.Nodes));
+        Assert.AreSame(navigation, snapshot.NavigationById[node.Id]);
+
+        var compatibleTopology = state.CachedGraph;
+        Assert.IsNotNull(compatibleTopology);
+        Assert.AreSame(node, Assert.ContainsSingle(compatibleTopology.Value.Nodes));
+        Assert.AreSame(navigation, state.GraphNavigation![node.Id]);
+    }
+
+    /// <summary>
+    /// Verifies the existing public topology and navigation setters preserve their signatures and
+    /// bridge legacy separate assignments into the internal snapshot.
+    /// </summary>
+    [TestMethod]
+    public void CachedGraph_PublicSettersBridgeToInternalSnapshot()
+    {
+        var result = CreateResult("compatible");
+        using var state = new DotsiderState(CreateApp(), Samples.HelloWorldDll);
+
+        state.GraphNavigation = null;
+        state.CachedGraph = (result.Nodes, result.Edges);
+
+        var topologyOnly = state.GraphSnapshot;
+        Assert.IsNotNull(topologyOnly);
+        Assert.IsNull(topologyOnly.NavigationById);
+
+        state.GraphNavigation = result.NavigationById;
+
+        var complete = state.GraphSnapshot;
+        Assert.IsNotNull(complete);
+        Assert.IsNotNull(complete.NavigationById);
+        var compatibleTopology = state.CachedGraph;
+        Assert.IsNotNull(compatibleTopology);
+        Assert.AreEqual(
+            "compatible",
+            Assert.ContainsSingle(compatibleTopology.Value.Nodes).Name);
+
+        state.CachedGraph = null;
+
+        Assert.IsNull(state.GraphSnapshot);
+        Assert.AreSame(result.NavigationById, state.GraphNavigation);
+    }
+
+    /// <summary>
+    /// Verifies changing analyzers cancels and drains the old build before a new graph can publish.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task PushAssembly_DrainsOldBuildBeforePublishingNewGraph()
+    {
+        var cancellationToken = _testContext.CancellationToken;
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var state = new DotsiderState(CreateApp(), Samples.HelloWorldDll)
+        {
+            GraphBuilder = (_, token) =>
+            {
+                started.TrySetResult();
+                token.WaitHandle.WaitOne();
+                cancellationObserved.TrySetResult();
+                return CreateResult("stale");
+            }
+        };
+
+        state.EnsureCachedGraphAsync();
+        await started.Task.WaitAsync(cancellationToken);
+        var staleTask = state.GraphBuildTask;
+
+        Assert.IsTrue(state.PushAssembly(Samples.RichLibraryDll));
+
+        await cancellationObserved.Task.WaitAsync(cancellationToken);
+        Assert.IsTrue(staleTask.IsCompleted);
+        Assert.IsNull(state.CachedGraph);
+        Assert.IsFalse(state.GraphBuildInProgress);
+
+        state.GraphBuilder = (_, _) => CreateResult("current");
+        state.EnsureCachedGraphAsync();
+        await state.GraphBuildTask.WaitAsync(cancellationToken);
+
+        Assert.AreEqual(
+            "current",
+            Assert.ContainsSingle(state.GraphSnapshot!.Nodes).Name);
+    }
+
+    /// <summary>
+    /// Verifies a graph failure is observed, clears the building state, and does not start a hot
+    /// retry loop on subsequent renders.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task EnsureCachedGraphAsync_Fault_ReportsStableFailureWithoutRetryLoop()
+    {
+        var cancellationToken = _testContext.CancellationToken;
+        var invocationCount = 0;
+        using var state = new DotsiderState(CreateApp(), Samples.HelloWorldDll)
+        {
+            GraphBuilder = (_, _) =>
+            {
+                Interlocked.Increment(ref invocationCount);
+                throw new InvalidOperationException("synthetic graph failure");
+            }
+        };
+
+        state.EnsureCachedGraphAsync();
+        var graphBuildTask = state.GraphBuildTask;
+        await graphBuildTask.WaitAsync(cancellationToken);
+
+        Assert.IsFalse(state.GraphBuildInProgress);
+        Assert.IsNull(state.CachedGraph);
+        Assert.AreEqual("Cannot build dependency graph", state.GraphNavigationError);
+
+        state.EnsureCachedGraphAsync();
+
+        Assert.AreSame(graphBuildTask, state.GraphBuildTask);
+        Assert.AreEqual(1, Volatile.Read(ref invocationCount));
+    }
+
+    /// <summary>
+    /// Verifies disposal cancels and drains graph work before disposing the owned analyzer.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task Dispose_CancelsAndDrainsGraphBuild()
+    {
+        var cancellationToken = _testContext.CancellationToken;
+        using var releaseAfterCancellation = new ManualResetEventSlim();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var state = new DotsiderState(CreateApp(), Samples.HelloWorldDll)
+        {
+            GraphBuilder = (analyzer, token) =>
+            {
+                started.TrySetResult();
+                try
+                {
+                    token.WaitHandle.WaitOne();
+                    token.ThrowIfCancellationRequested();
+                    return CreateResult("unexpected");
+                }
+                catch (OperationCanceledException)
+                {
+                    cancellationObserved.TrySetResult();
+                    releaseAfterCancellation.Wait(cancellationToken);
+                    _ = analyzer.RawBytes.Length;
+                    throw;
+                }
+            }
+        };
+
+        state.EnsureCachedGraphAsync();
+        await started.Task.WaitAsync(cancellationToken);
+        var graphBuildTask = state.GraphBuildTask;
+
+        var disposeTask = Task.Run(state.Dispose, cancellationToken);
+        await cancellationObserved.Task.WaitAsync(cancellationToken);
+        bool completedBeforeRelease;
+        bool analyzerUsableBeforeRelease;
+        try
+        {
+            completedBeforeRelease = disposeTask.IsCompleted;
+            analyzerUsableBeforeRelease = state.Analyzer.RawBytes.Length > 0;
+        }
+        finally
+        {
+            releaseAfterCancellation.Set();
+        }
+
+        await disposeTask.WaitAsync(cancellationToken);
+        state.Dispose();
+
+        Assert.IsFalse(completedBeforeRelease);
+        Assert.IsTrue(analyzerUsableBeforeRelease);
+        Assert.IsTrue(graphBuildTask.IsCompleted);
+        Assert.IsFalse(state.GraphBuildInProgress);
+    }
+
+    /// <summary>
+    /// Verifies a successfully-published graph's completion nudger is lifetime-owned and fully
+    /// drained before disposal returns.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task Dispose_AfterGraphPublication_DrainsRenderNudgers()
+    {
+        var cancellationToken = _testContext.CancellationToken;
+        using var state = new DotsiderState(CreateApp(), Samples.HelloWorldDll)
+        {
+            CurrentTab = TabId.IlInspector,
+            GraphBuilder = (_, _) => CreateResult("complete")
+        };
+
+        state.EnsureCachedGraphAsync();
+        await state.GraphBuildTask.WaitAsync(cancellationToken);
+
+        Assert.IsNotNull(state.CachedGraph);
+        var renderNudgerTask = state.RenderNudgerTask;
+
+        state.Dispose();
+
+        Assert.IsTrue(renderNudgerTask.IsCompleted);
+        state.RequestExtraFrame();
+        Assert.IsTrue(state.RenderNudgerTask.IsCompleted);
+    }
+
+    /// <summary>
+    /// Verifies saving edited bytes drains graph work before disposing its analyzer and permits
+    /// the replacement analyzer to build a fresh graph.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task SaveHexChanges_DrainsOldGraphBeforeReplacingAnalyzer()
+    {
+        var cancellationToken = _testContext.CancellationToken;
+        var directory = Directory.CreateTempSubdirectory("dotsider-graph-save-test-").FullName;
+        var assemblyPath = Path.Combine(directory, "HelloWorld.dll");
+        File.Copy(Samples.HelloWorldDll, assemblyPath);
+
+        var state = new DotsiderState(CreateApp(), assemblyPath);
+        using var releaseAfterCancellation = new ManualResetEventSlim();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var analyzerRemainedUsable = false;
+        var oldAnalyzer = state.Analyzer;
+        state.GraphBuilder = (analyzer, token) =>
+        {
+            started.TrySetResult();
+            try
+            {
+                token.WaitHandle.WaitOne();
+                token.ThrowIfCancellationRequested();
+                return CreateResult("unexpected");
+            }
+            catch (OperationCanceledException)
+            {
+                cancellationObserved.TrySetResult();
+                releaseAfterCancellation.Wait(cancellationToken);
+                analyzerRemainedUsable = analyzer.RawBytes.Length > 0;
+                throw;
+            }
+        };
+
+        try
+        {
+            state.EnsureCachedGraphAsync();
+            await started.Task.WaitAsync(cancellationToken);
+            var staleTask = state.GraphBuildTask;
+
+            var saveTask = Task.Run(
+                () => DotsiderApp.SaveHexChanges(
+                    state,
+                    (_, bytes, path) => (new AssemblyAnalyzer(bytes, path), null)),
+                cancellationToken);
+            await cancellationObserved.Task.WaitAsync(cancellationToken);
+
+            Assert.IsFalse(saveTask.IsCompleted);
+            Assert.AreSame(oldAnalyzer, state.Analyzer);
+            releaseAfterCancellation.Set();
+            await saveTask.WaitAsync(cancellationToken);
+
+            Assert.IsTrue(staleTask.IsCompleted);
+            Assert.IsTrue(analyzerRemainedUsable);
+            Assert.AreNotSame(oldAnalyzer, state.Analyzer);
+            Assert.IsNull(state.CachedGraph);
+            Assert.IsNull(state.GraphNavigationError);
+
+            state.GraphBuilder = (_, _) => CreateResult("replacement");
+            state.EnsureCachedGraphAsync();
+            await state.GraphBuildTask.WaitAsync(cancellationToken);
+
+            Assert.AreEqual(
+                "replacement",
+                Assert.ContainsSingle(state.GraphSnapshot!.Nodes).Name);
+        }
+        finally
+        {
+            releaseAfterCancellation.Set();
+            state.Dispose();
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Disposes the test terminal and application resources.
+    /// </summary>
+    public void Dispose()
+    {
+        _app?.Dispose();
+        _terminal?.Dispose();
+        _workload?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static DependencyGraphResult CreateResult(string name)
+    {
+        var node = new GraphNode(
+            Id: name,
+            Name: name,
+            Version: null,
+            Culture: "neutral",
+            PublicKeyToken: null,
+            IsRoot: true,
+            Depth: 0,
+            Unresolved: false);
+        return new DependencyGraphResult(
+            [node],
+            [],
+            new Dictionary<string, GraphNavigationContext>(StringComparer.Ordinal));
+    }
+
+    private Hex1bApp CreateApp()
+    {
+        _workload = new Hex1bAppWorkloadAdapter();
+        _terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(_workload)
+            .WithHeadless()
+            .WithDimensions(80, 24)
+            .Build();
+        _app = new Hex1bApp(
+            _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+            new Hex1bAppOptions { WorkloadAdapter = _workload });
+        return _app;
+    }
+}

--- a/tests/Dotsider.Tests/IlInspectorViewTests.cs
+++ b/tests/Dotsider.Tests/IlInspectorViewTests.cs
@@ -68,11 +68,15 @@ public class IlInspectorViewTests : IDisposable
         var toTitleCase = _state!.Analyzer.MethodDefs.First(m => m.Name == "ToTitleCase");
         var typeDef = _state.Analyzer.TypeDefs.First(t => t.FullName == toTitleCase.DeclaringType);
         var ns = !string.IsNullOrEmpty(typeDef.Namespace) ? typeDef.Namespace : "(global)";
-        _state.IlTreeExpansionState[$"ns:{ns}"] = true;
-        _state.IlTreeExpansionState[$"type:{toTitleCase.DeclaringType}"] = true;
-        _state.IlSelectedMethod = toTitleCase;
-        _state.IlFocusedTreeKey = $"method:{toTitleCase.Token}";
-        _state.App.Invalidate();
+        _state.PendingMutations.Enqueue(state =>
+        {
+            state.IlTreeExpansionState[$"ns:{ns}"] = true;
+            state.IlTreeExpansionState[$"type:{toTitleCase.DeclaringType}"] = true;
+            state.IlSelectedMethod = toTitleCase;
+            state.IlSelectedMethodOwner = null;
+            state.SetIlFocusedTreeKey($"method:{toTitleCase.Token}");
+        });
+        _state.RequestExtraFrame();
 
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.ContainsText("IL_0000"), TimeSpan.FromSeconds(10))
@@ -154,11 +158,15 @@ public class IlInspectorViewTests : IDisposable
         var firstMethod = _state!.Analyzer.MethodDefs.First(m => m.Rva > 0);
         var firstTypeDef = _state.Analyzer.TypeDefs.First(t => t.FullName == firstMethod.DeclaringType);
         var firstNs = !string.IsNullOrEmpty(firstTypeDef.Namespace) ? firstTypeDef.Namespace : "(global)";
-        _state.IlTreeExpansionState[$"ns:{firstNs}"] = true;
-        _state.IlTreeExpansionState[$"type:{firstMethod.DeclaringType}"] = true;
-        _state.IlSelectedMethod = firstMethod;
-        _state.IlFocusedTreeKey = $"method:{firstMethod.Token}";
-        _state.App.Invalidate();
+        _state.PendingMutations.Enqueue(state =>
+        {
+            state.IlTreeExpansionState[$"ns:{firstNs}"] = true;
+            state.IlTreeExpansionState[$"type:{firstMethod.DeclaringType}"] = true;
+            state.IlSelectedMethod = firstMethod;
+            state.IlSelectedMethodOwner = null;
+            state.SetIlFocusedTreeKey($"method:{firstMethod.Token}");
+        });
+        _state.RequestExtraFrame();
 
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.ContainsText("IL_0000") || s.ContainsText("IL_"), TimeSpan.FromSeconds(10))

--- a/tests/Dotsider.Tests/IlTreeVirtualizationTests.cs
+++ b/tests/Dotsider.Tests/IlTreeVirtualizationTests.cs
@@ -61,8 +61,7 @@ public sealed class IlTreeVirtualizationTests : IDisposable
         {
             _state ??= new DotsiderState(_app!, Samples.HelloWorldDll) { CurrentTab = TabId.IlInspector };
             // Mirror DotsiderApp.Build: only the root build advances the generation.
-            unchecked { _state.BuildGeneration++; }
-            _state.ExtraFrameArmed = false;
+            _state.NotifyBuildStarted();
             IlInspectorView.SyncTreeScroll(_state, _rows!);
             var tree = IlTreeList.Build(
                 _rows!,
@@ -337,8 +336,8 @@ public sealed class IlTreeVirtualizationTests : IDisposable
     /// <summary>
     /// When a render changes the pane height (search bar toggle, terminal resize), the
     /// window was built against the old height and nothing else schedules a rebuild —
-    /// the viewport verifier must re-clamp the offset and refill the viewport without
-    /// any further input.
+    /// the layout observer must re-clamp the offset and refill the viewport without any
+    /// further input.
     /// </summary>
     [TestMethod]
     [Timeout(30_000, CooperativeCancellation = true)]

--- a/tests/Dotsider.Tests/NuGetPackageAnalyzerSecurityTests.cs
+++ b/tests/Dotsider.Tests/NuGetPackageAnalyzerSecurityTests.cs
@@ -1,0 +1,1037 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+using System.IO.Compression;
+using System.Xml;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Security tests for opening files from NuGet package archives.
+/// </summary>
+/// <param name="testContext">The current test context.</param>
+[TestClass]
+public sealed class NuGetPackageAnalyzerSecurityTests(TestContext testContext)
+{
+    private const string ValidManifest =
+        "<package><metadata><id>SecurityTests</id><version>1.0.0</version>" +
+        "<authors>Dotsider.Tests</authors><description>Security regression package</description>" +
+        "</metadata></package>";
+
+    private static SampleAssemblyFixture Samples => SampleAssemblyHost.Instance;
+
+    private readonly TestContext _testContext = testContext;
+
+    /// <summary>
+    /// Verifies traversal cannot overwrite an existing file or create a directory outside the
+    /// private extraction root.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_ParentTraversal_DoesNotWriteOutsideExtractionRoot()
+    {
+        var existingDirectoryName = "dotsider-nupkg-existing-" + Guid.NewGuid().ToString("N");
+        var absentDirectoryName = "dotsider-nupkg-absent-" + Guid.NewGuid().ToString("N");
+        var existingDirectory = Path.Combine(Path.GetTempPath(), existingDirectoryName);
+        var absentDirectory = Path.Combine(Path.GetTempPath(), absentDirectoryName);
+        var outsideFile = Path.Combine(existingDirectory, "RichLibrary.dll");
+        byte[] sentinel = [0x21, 0x09, 0x20, 0x99];
+        Directory.CreateDirectory(existingDirectory);
+        File.WriteAllBytes(outsideFile, sentinel);
+
+        var packagePath = CreatePackage(
+            ($"../{existingDirectoryName}/RichLibrary.dll", ReadSampleAssembly()),
+            ($"../{absentDirectoryName}/RichLibrary.dll", ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            Assert.HasCount(2, package.DllFiles);
+
+            TestAssert.All(
+                package.DllFiles,
+                entry => Assert.ThrowsExactly<UnsafePackageEntryException>(() => package.OpenDll(entry)));
+
+            Assert.AreSequenceEqual(sentinel, File.ReadAllBytes(outsideFile));
+            Assert.IsFalse(Directory.Exists(absentDirectory));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+            DeleteDirectory(existingDirectory);
+            DeleteDirectory(absentDirectory);
+        }
+    }
+
+    /// <summary>
+    /// Verifies portable traversal separators are rejected on every operating system.
+    /// </summary>
+    /// <param name="entryName">The hostile archive entry name.</param>
+    [TestMethod]
+    [DataRow(@"..\outside\RichLibrary.dll")]
+    [DataRow(@"lib\..\..//outside/RichLibrary.dll")]
+    [DataRow(@"lib/../..\outside/RichLibrary.dll")]
+    [DataRow("lib/../RichLibrary.dll")]
+    public void OpenDll_PortableTraversal_ThrowsUnsafePackageEntryException(string entryName)
+    {
+        var packagePath = CreatePackage((entryName, ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            var entry = Assert.ContainsSingle(package.DllFiles);
+
+            var exception = Assert.ThrowsExactly<UnsafePackageEntryException>(() =>
+                package.OpenDll(entry));
+            Assert.AreEqual(
+                "The package entry cannot be extracted because its path is unsafe or ambiguous.",
+                exception.Message);
+            Assert.DoesNotContain(entry.FullPath, exception.Message);
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies rooted paths in the host operating system's syntax are rejected without writing
+    /// to the requested destination.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_HostRootedPath_DoesNotWriteToRequestedDestination()
+    {
+        var outsideDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "dotsider-nupkg-rooted-" + Guid.NewGuid().ToString("N"));
+        var outsideFile = Path.Combine(outsideDirectory, "RichLibrary.dll");
+        var packagePath = CreatePackage((outsideFile, ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            var entry = Assert.ContainsSingle(package.DllFiles);
+
+            Assert.ThrowsExactly<UnsafePackageEntryException>(() => package.OpenDll(entry));
+            Assert.IsFalse(Directory.Exists(outsideDirectory));
+            Assert.IsFalse(File.Exists(outsideFile));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+            DeleteDirectory(outsideDirectory);
+        }
+    }
+
+    /// <summary>
+    /// Verifies Windows drive, UNC, and device path syntax is rejected without consulting the
+    /// filesystem, including on non-Windows hosts.
+    /// </summary>
+    /// <param name="entryName">The hostile archive entry name.</param>
+    [TestMethod]
+    [DataRow("/RichLibrary.dll")]
+    [DataRow(@"\RichLibrary.dll")]
+    [DataRow(@"C:\outside\RichLibrary.dll")]
+    [DataRow(@"C:outside\RichLibrary.dll")]
+    [DataRow(@"\\server\share\RichLibrary.dll")]
+    [DataRow(@"\\?\C:\outside\RichLibrary.dll")]
+    [DataRow(@"\\.\C:\outside\RichLibrary.dll")]
+    public void OpenDll_PortableRootedPath_ThrowsUnsafePackageEntryException(string entryName)
+    {
+        var packagePath = CreatePackage((entryName, ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            var entry = Assert.ContainsSingle(package.DllFiles);
+
+            Assert.ThrowsExactly<UnsafePackageEntryException>(() => package.OpenDll(entry));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies malformed portable file names are rejected before the extraction root is created.
+    /// </summary>
+    /// <param name="entryName">The malformed archive entry name.</param>
+    [TestMethod]
+    [DataRow("lib/base.dll:payload.dll")]
+    [DataRow("lib/evil?.dll")]
+    [DataRow("lib/evil*.dll")]
+    [DataRow("lib/evil|.dll")]
+    [DataRow("lib/evil<.dll")]
+    [DataRow("lib/evil>.dll")]
+    [DataRow("lib/evil\".dll")]
+    [DataRow("lib/control\u0001.dll")]
+    [DataRow("lib/trailing /RichLibrary.dll")]
+    [DataRow("lib/trailing./RichLibrary.dll")]
+    [DataRow("lib/NUL.dll")]
+    [DataRow("lib/COM1.dll")]
+    [DataRow("lib/COM¹.dll")]
+    [DataRow("lib/LPT².dll")]
+    [DataRow("lib/COM³.dll")]
+    public void OpenDll_MalformedPortableFileName_ThrowsBeforeExtraction(string entryName)
+    {
+        var packagePath = CreatePackage((entryName, ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            var entry = Assert.ContainsSingle(package.DllFiles);
+            Assert.IsNull(package.ExtractionDirectory);
+
+            Assert.ThrowsExactly<UnsafePackageEntryException>(() => package.OpenDll(entry));
+
+            Assert.IsNull(package.ExtractionDirectory);
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies an alternate-stream entry is rejected whether it is activated before or after its
+    /// ordinary base-file entry.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_AlternateStreamAndBaseEntry_HasOrderIndependentOutcome()
+    {
+        var packagePath = CreatePackage(
+            ("lib/base.dll", ReadSampleAssembly()),
+            ("lib/base.dll:payload.dll", ReadSampleAssembly()));
+
+        try
+        {
+            using (var package = new NuGetPackageAnalyzer(packagePath))
+            {
+                var baseEntry = Assert.ContainsSingle(
+                    package.DllFiles.Where(entry => entry.FullPath == "lib/base.dll"));
+                var streamEntry = Assert.ContainsSingle(
+                    package.DllFiles.Where(entry => entry.FullPath != "lib/base.dll"));
+
+                Assert.ThrowsExactly<UnsafePackageEntryException>(
+                    () => package.OpenDll(streamEntry));
+                Assert.IsNull(package.ExtractionDirectory);
+                using var analyzer = package.OpenDll(baseEntry);
+                Assert.AreEqual("RichLibrary", analyzer.AssemblyName);
+            }
+
+            using (var package = new NuGetPackageAnalyzer(packagePath))
+            {
+                var baseEntry = Assert.ContainsSingle(
+                    package.DllFiles.Where(entry => entry.FullPath == "lib/base.dll"));
+                var streamEntry = Assert.ContainsSingle(
+                    package.DllFiles.Where(entry => entry.FullPath != "lib/base.dll"));
+
+                using var analyzer = package.OpenDll(baseEntry);
+                Assert.AreEqual("RichLibrary", analyzer.AssemblyName);
+                Assert.ThrowsExactly<UnsafePackageEntryException>(
+                    () => package.OpenDll(streamEntry));
+            }
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the containment check does not confuse the extraction root with a sibling whose
+    /// name begins with the root name, and rejects the root itself as a file destination.
+    /// </summary>
+    [TestMethod]
+    public void ContainedPathResolver_RootAndPrefixSibling_ReturnsFalse()
+    {
+        var root = Directory.CreateTempSubdirectory("dotsider-containment-root-").FullName;
+        var rootName = Path.GetFileName(root);
+        var child = Path.Combine(root, "lib", "RichLibrary.dll");
+        var parent = Path.GetDirectoryName(root);
+        Assert.IsNotNull(parent);
+        var sibling = Path.Combine(
+            parent,
+            rootName + "bell",
+            "RichLibrary.dll");
+
+        try
+        {
+            Assert.IsFalse(ContainedPathResolver.TryResolve(root, ".", out _));
+            Assert.IsTrue(ContainedPathResolver.IsStrictDescendant(root, child));
+            Assert.IsFalse(ContainedPathResolver.IsStrictDescendant(root, root));
+            Assert.IsFalse(ContainedPathResolver.IsStrictDescendant(root, sibling));
+        }
+        finally
+        {
+            DeleteDirectory(root);
+        }
+    }
+
+    /// <summary>
+    /// Verifies safe portable archive paths extract and open as real managed assemblies.
+    /// </summary>
+    /// <param name="entryName">The safe archive entry name.</param>
+    [TestMethod]
+    [DataRow("lib/net10.0/RichLibrary.dll")]
+    [DataRow("lib/./net10.0/RichLibrary.dll")]
+    [DataRow("lib//net10.0//RichLibrary.dll")]
+    [DataRow(@"lib\net10.0\RichLibrary.dll")]
+    [DataRow("lib/ünicode/RichLibrary.dll")]
+    [DataRow("lib/..name/RichLibrary.dll")]
+    [DataRow("lib/version.2.5.1/RichLibrary.dll")]
+    public void OpenDll_SafePortablePath_OpensRealAssembly(string entryName)
+    {
+        var packagePath = CreatePackage((entryName, ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            var entry = Assert.ContainsSingle(package.DllFiles);
+            using var analyzer = package.OpenDll(entry);
+
+            Assert.IsTrue(analyzer.HasMetadata);
+            Assert.AreEqual("RichLibrary", analyzer.AssemblyName);
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a value-equal copy of a package entry is rejected because it is not the exact
+    /// object returned by the analyzer.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_ValueEqualEntryCopy_ThrowsArgumentException()
+    {
+        var packagePath = CreatePackage(("lib/RichLibrary.dll", ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            var entry = Assert.ContainsSingle(package.DllFiles);
+            var copy = entry with { };
+            Assert.AreEqual(entry, copy);
+
+            Assert.ThrowsExactly<ArgumentException>(() => package.OpenDll(copy));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a caller-constructed entry is rejected before its hostile path can create a
+    /// directory outside the extraction root.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_ForgedEntry_ThrowsBeforeFilesystemAccess()
+    {
+        var outsideDirectoryName = "dotsider-nupkg-forged-" + Guid.NewGuid().ToString("N");
+        var outsideDirectory = Path.Combine(Path.GetTempPath(), outsideDirectoryName);
+        var packagePath = CreatePackage(("lib/RichLibrary.dll", ReadSampleAssembly()));
+        var forged = new NuGetFileEntry(
+            "RichLibrary.dll",
+            $"../{outsideDirectoryName}/RichLibrary.dll",
+            "..",
+            1,
+            1,
+            true);
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            Assert.IsNull(package.ExtractionDirectory);
+
+            Assert.ThrowsExactly<ArgumentException>(() => package.OpenDll(forged));
+            Assert.IsFalse(Directory.Exists(outsideDirectory));
+            Assert.IsNull(package.ExtractionDirectory);
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+            DeleteDirectory(outsideDirectory);
+        }
+    }
+
+    /// <summary>
+    /// Verifies an entry returned by a different analyzer instance is rejected.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_EntryFromAnotherAnalyzer_ThrowsArgumentException()
+    {
+        var firstPackagePath = CreatePackage(("lib/RichLibrary.dll", ReadSampleAssembly()));
+        var secondPackagePath = CreatePackage(("lib/RichLibrary.dll", ReadSampleAssembly()));
+
+        try
+        {
+            using var firstPackage = new NuGetPackageAnalyzer(firstPackagePath);
+            using var secondPackage = new NuGetPackageAnalyzer(secondPackagePath);
+            var foreignEntry = Assert.ContainsSingle(secondPackage.DllFiles);
+
+            Assert.ThrowsExactly<ArgumentException>(() => firstPackage.OpenDll(foreignEntry));
+        }
+        finally
+        {
+            DeletePackage(firstPackagePath);
+            DeletePackage(secondPackagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies an exact package-owned entry that is not a DLL cannot be passed to OpenDll.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_PackageOwnedNonDllEntry_ThrowsArgumentException()
+    {
+        var packagePath = CreatePackage(("content/readme.txt", "content"u8.ToArray()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            var entry = Assert.ContainsSingle(package.Files.Where(entry => entry.Name == "readme.txt"));
+
+            Assert.ThrowsExactly<ArgumentException>(() => package.OpenDll(entry));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a null entry is rejected with the public contract's specific exception.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_NullEntry_ThrowsArgumentNullException()
+    {
+        var packagePath = CreatePackage(("lib/RichLibrary.dll", ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+
+            Assert.ThrowsExactly<ArgumentNullException>(() => package.OpenDll(null!));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies listing a package and rejecting an unsafe owned entry do not create an extraction
+    /// directory.
+    /// </summary>
+    [TestMethod]
+    public void PackageListingAndUnsafeEntry_DoNotCreateExtractionDirectory()
+    {
+        var packagePath = CreatePackage(
+            ("../outside/RichLibrary.dll", ReadSampleAssembly()),
+            ("lib/RichLibrary.dll", ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            Assert.HasCount(2, package.DllFiles);
+            Assert.IsNull(package.ExtractionDirectory);
+            var unsafeEntry = Assert.ContainsSingle(
+                package.DllFiles.Where(entry => entry.FullPath.StartsWith("..", StringComparison.Ordinal)));
+
+            Assert.ThrowsExactly<UnsafePackageEntryException>(() => package.OpenDll(unsafeEntry));
+
+            Assert.IsNull(package.ExtractionDirectory);
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies duplicate archive names are all rejected rather than ambiguously selecting one
+    /// payload.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_DuplicateExactEntryNames_ThrowsForEveryEntry()
+    {
+        var packagePath = CreatePackage(
+            ("lib/RichLibrary.dll", ReadSampleAssembly()),
+            ("lib/RichLibrary.dll", ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            Assert.HasCount(2, package.DllFiles);
+
+            TestAssert.All(
+                package.DllFiles,
+                entry => Assert.ThrowsExactly<UnsafePackageEntryException>(() => package.OpenDll(entry)));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies different archive names that canonicalize to one destination are all rejected.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_CanonicalDestinationAliases_ThrowsForEveryEntry()
+    {
+        var packagePath = CreatePackage(
+            ("lib/RichLibrary.dll", ReadSampleAssembly()),
+            ("lib/./RichLibrary.dll", ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            Assert.HasCount(2, package.DllFiles);
+
+            TestAssert.All(
+                package.DllFiles,
+                entry => Assert.ThrowsExactly<UnsafePackageEntryException>(() => package.OpenDll(entry)));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a destination that is also another DLL's parent directory makes both entries
+    /// unsafe, independent of activation order.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_FileDirectoryTopologyConflict_ThrowsForEveryEntryInEitherOrder()
+    {
+        var packagePath = CreatePackage(
+            ("lib/A.dll", ReadSampleAssembly()),
+            ("lib/A.dll/B.dll", ReadSampleAssembly()));
+
+        try
+        {
+            foreach (var reverse in new[] { false, true })
+            {
+                using var package = new NuGetPackageAnalyzer(packagePath);
+                NuGetFileEntry[] entries = reverse
+                    ? [.. package.DllFiles.Reverse()]
+                    : [.. package.DllFiles];
+
+                TestAssert.All(
+                    entries,
+                    entry => Assert.ThrowsExactly<UnsafePackageEntryException>(
+                        () => package.OpenDll(entry)));
+
+                Assert.IsNotNull(package.ExtractionDirectory);
+                Assert.IsFalse(Directory.Exists(Path.Combine(package.ExtractionDirectory, "lib")));
+            }
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a non-descendant prefix sibling cannot hide a later file-versus-directory
+    /// conflict during destination planning.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_TopologyConflictSeparatedByPrefixSibling_RejectsOnlyConflictPair()
+    {
+        var packagePath = CreatePackage(
+            ("lib/A.dll", ReadSampleAssembly()),
+            ("lib/A.dll-other.dll", ReadSampleAssembly()),
+            ("lib/A.dll/B.dll", ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            var parent = package.DllFiles.Single(static entry => entry.FullPath == "lib/A.dll");
+            var sibling = package.DllFiles.Single(static entry =>
+                entry.FullPath == "lib/A.dll-other.dll");
+            var child = package.DllFiles.Single(static entry => entry.FullPath == "lib/A.dll/B.dll");
+
+            Assert.ThrowsExactly<UnsafePackageEntryException>(() => package.OpenDll(parent));
+            Assert.ThrowsExactly<UnsafePackageEntryException>(() => package.OpenDll(child));
+            using var analyzer = package.OpenDll(sibling);
+            Assert.AreEqual("RichLibrary", analyzer.AssemblyName);
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies planning a deeply segmented path uses allocation proportional to the archive
+    /// path instead of repeatedly allocating every progressively shorter parent path.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_DeepSegmentedPath_PlanningAllocationIsLinear()
+    {
+        const long AllocationLimit = 64L * 1024 * 1024;
+        var deepPath = string.Concat(Enumerable.Repeat("a/", 8_000)) + "Deep.dll";
+        var packagePath = CreatePackage(
+            (deepPath, [0x01]),
+            ("lib/RichLibrary.dll", ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            var entry = package.DllFiles.Single(static entry =>
+                entry.FullPath == "lib/RichLibrary.dll");
+            var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+
+            using var analyzer = package.OpenDll(entry);
+
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+            Assert.AreEqual("RichLibrary", analyzer.AssemblyName);
+            Assert.IsLessThan(AllocationLimit, allocated);
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a large duplicate group is classified once per entry without repeatedly feeding
+    /// the growing alias group through topology analysis.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_ManyDuplicateDestinations_RejectsEveryEntryWithBoundedAllocation()
+    {
+        const int DuplicateCount = 4_096;
+        const long AllocationLimit = 64L * 1024 * 1024;
+        byte[] content = [0x01];
+        var entries = Enumerable.Range(0, DuplicateCount)
+            .Select(_ => (EntryName: "lib/Duplicate.dll", Content: content))
+            .ToArray();
+        var packagePath = CreatePackage(entries);
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            Assert.HasCount(DuplicateCount, package.DllFiles);
+            var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+
+            Assert.ThrowsExactly<UnsafePackageEntryException>(() =>
+                package.OpenDll(package.DllFiles[0]));
+
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+            Assert.IsLessThan(AllocationLimit, allocated);
+            Assert.AreEqual(1, package.TopologyDestinationCount);
+            TestAssert.All(
+                package.DllFiles,
+                entry => Assert.ThrowsExactly<UnsafePackageEntryException>(() =>
+                    package.OpenDll(entry)));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies destination aliases that differ only by case are rejected on case-insensitive
+    /// platforms.
+    /// </summary>
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows | OperatingSystems.OSX)]
+    public void OpenDll_CaseInsensitivePlatformAliases_ThrowsForEveryEntry()
+    {
+        var packagePath = CreatePackage(
+            ("lib/RichLibrary.dll", ReadSampleAssembly()),
+            ("LIB/RICHLIBRARY.DLL", ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            Assert.HasCount(2, package.DllFiles);
+
+            TestAssert.All(
+                package.DllFiles,
+                entry => Assert.ThrowsExactly<UnsafePackageEntryException>(() => package.OpenDll(entry)));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies canonically equivalent Unicode names are rejected on macOS filesystems.
+    /// </summary>
+    [TestMethod]
+    [OSCondition(OperatingSystems.OSX)]
+    public void OpenDll_MacUnicodeNormalizationAliases_ThrowsForEveryEntry()
+    {
+        var packagePath = CreatePackage(
+            ("lib/caf\u00E9.dll", ReadSampleAssembly()),
+            ("lib/cafe\u0301.dll", ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            Assert.HasCount(2, package.DllFiles);
+
+            TestAssert.All(
+                package.DllFiles,
+                entry => Assert.ThrowsExactly<UnsafePackageEntryException>(() => package.OpenDll(entry)));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies case-distinct archive paths remain distinct on Linux filesystems.
+    /// </summary>
+    [TestMethod]
+    [OSCondition(OperatingSystems.Linux)]
+    public void OpenDll_LinuxCaseDistinctEntries_OpenIndependently()
+    {
+        var packagePath = CreatePackage(
+            ("lib/RichLibrary.dll", ReadSampleAssembly()),
+            ("LIB/RICHLIBRARY.DLL", ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            using var first = package.OpenDll(package.DllFiles[0]);
+            using var second = package.OpenDll(package.DllFiles[1]);
+
+            Assert.AreNotEqual(first.FilePath, second.FilePath);
+            Assert.AreEqual("RichLibrary", first.AssemblyName);
+            Assert.AreEqual("RichLibrary", second.AssemblyName);
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies repeatedly opening one entry reuses the successful immutable extraction.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_RepeatedOpen_ReusesExtractedFile()
+    {
+        var packagePath = CreatePackage(("lib/RichLibrary.dll", ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            var entry = Assert.ContainsSingle(package.DllFiles);
+            string firstPath;
+            using (var first = package.OpenDll(entry))
+            {
+                firstPath = first.FilePath;
+            }
+
+            using var second = package.OpenDll(entry);
+            Assert.AreEqual(firstPath, second.FilePath);
+            Assert.AreEqual("RichLibrary", second.AssemblyName);
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a failed analyzer construction removes its extracted file so the same failure is
+    /// reproduced on a second attempt instead of becoming a create-new collision.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_InvalidAssemblyTwice_ThrowsBadImageFormatBothTimes()
+    {
+        var packagePath = CreatePackage(("lib/invalid.dll", [0x01, 0x02, 0x03, 0x04]));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            var entry = Assert.ContainsSingle(package.DllFiles);
+
+            Assert.ThrowsExactly<BadImageFormatException>(() => package.OpenDll(entry));
+            Assert.IsNotNull(package.ExtractionDirectory);
+            var extractedPath = Path.Combine(package.ExtractionDirectory, "lib", "invalid.dll");
+            Assert.IsFalse(File.Exists(extractedPath));
+
+            Assert.ThrowsExactly<BadImageFormatException>(() => package.OpenDll(entry));
+            Assert.IsFalse(File.Exists(extractedPath));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies concurrent opens of one entry share the single successful contained extraction.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task OpenDll_ConcurrentSameEntry_AllOpenSuccessfully()
+    {
+        const int Concurrency = 8;
+        var cancellationToken = _testContext.CancellationToken;
+        var packagePath = CreatePackage(
+            ("lib/RichLibrary.dll", CreatePaddedAssembly(1024 * 1024)));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            var entry = Assert.ContainsSingle(package.DllFiles);
+            using var barrier = new Barrier(Concurrency);
+            var tasks = Enumerable.Range(0, Concurrency)
+                .Select(_ => Task.Factory.StartNew(
+                    () =>
+                    {
+                        if (!barrier.SignalAndWait(TimeSpan.FromSeconds(10), cancellationToken))
+                            throw new TimeoutException("Concurrent open barrier was not reached.");
+
+                        using var analyzer = package.OpenDll(entry);
+                        Assert.AreEqual("RichLibrary", analyzer.AssemblyName);
+                        return analyzer.FilePath;
+                    },
+                    cancellationToken,
+                    TaskCreationOptions.LongRunning,
+                    TaskScheduler.Default))
+                .ToArray();
+
+            var paths = await Task.WhenAll(tasks).WaitAsync(cancellationToken);
+            var extractedPaths = paths.Distinct(StringComparer.Ordinal).ToArray();
+            Assert.HasCount(1, extractedPaths);
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies racing an open with disposal produces only a complete analyzer or the documented
+    /// disposed outcome, never an archive or partial-copy failure.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task OpenDll_RacingDispose_ProducesOnlySerializedOutcomes()
+    {
+        var cancellationToken = _testContext.CancellationToken;
+        var packagePath = CreatePackage(
+            ("lib/RichLibrary.dll", CreatePaddedAssembly(4 * 1024 * 1024)));
+
+        try
+        {
+            for (var iteration = 0; iteration < 12; iteration++)
+            {
+                var package = new NuGetPackageAnalyzer(packagePath);
+                var entry = Assert.ContainsSingle(package.DllFiles);
+                using var barrier = new Barrier(2);
+
+                try
+                {
+                    var openTask = Task.Factory.StartNew(
+                        () =>
+                        {
+                            barrier.SignalAndWait(cancellationToken);
+                            try
+                            {
+                                using var analyzer = package.OpenDll(entry);
+                                Assert.AreEqual("RichLibrary", analyzer.AssemblyName);
+                            }
+                            catch (ObjectDisposedException)
+                            {
+                            }
+                        },
+                        cancellationToken,
+                        TaskCreationOptions.LongRunning,
+                        TaskScheduler.Default);
+                    var disposeTask = Task.Factory.StartNew(
+                        () =>
+                        {
+                            barrier.SignalAndWait(cancellationToken);
+                            package.Dispose();
+                        },
+                        cancellationToken,
+                        TaskCreationOptions.LongRunning,
+                        TaskScheduler.Default);
+
+                    await Task.WhenAll(openTask, disposeTask).WaitAsync(cancellationToken);
+                }
+                finally
+                {
+                    package.Dispose();
+
+                    if (package.ExtractionDirectory is { } extractionDirectory)
+                        DeleteDirectory(extractionDirectory);
+                }
+            }
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies distinct safe archive paths retain distinct extraction destinations.
+    /// </summary>
+    [TestMethod]
+    public void OpenDll_DistinctSafePaths_UseDistinctExtractedFiles()
+    {
+        var packagePath = CreatePackage(
+            ("lib/net9.0/RichLibrary.dll", ReadSampleAssembly()),
+            ("lib/net10.0/RichLibrary.dll", ReadSampleAssembly()));
+
+        try
+        {
+            using var package = new NuGetPackageAnalyzer(packagePath);
+            Assert.HasCount(2, package.DllFiles);
+            using var first = package.OpenDll(package.DllFiles[0]);
+            using var second = package.OpenDll(package.DllFiles[1]);
+
+            Assert.AreNotEqual(first.FilePath, second.FilePath);
+            Assert.AreEqual("RichLibrary", first.AssemblyName);
+            Assert.AreEqual("RichLibrary", second.AssemblyName);
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies disposal removes the complete private extraction root, is idempotent, and prevents
+    /// later extraction.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_AfterExtraction_RemovesRootAndPreventsOpen()
+    {
+        var packagePath = CreatePackage(("lib/RichLibrary.dll", ReadSampleAssembly()));
+
+        try
+        {
+            var package = new NuGetPackageAnalyzer(packagePath);
+            var entry = Assert.ContainsSingle(package.DllFiles);
+            string extractedPath;
+            using (var analyzer = package.OpenDll(entry))
+            {
+                extractedPath = analyzer.FilePath;
+            }
+
+            var extractedDirectory = Path.GetDirectoryName(extractedPath)!;
+            var extractionRoot = Directory.GetParent(extractedDirectory)!.FullName;
+            Assert.IsTrue(File.Exists(extractedPath));
+            Assert.IsTrue(Directory.Exists(extractionRoot));
+
+            package.Dispose();
+            package.Dispose();
+
+            Assert.IsFalse(Directory.Exists(extractionRoot));
+            Assert.ThrowsExactly<ObjectDisposedException>(() => package.OpenDll(entry));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a malformed manifest does not leave the package archive locked when construction
+    /// fails.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_MalformedNuspec_ReleasesArchiveHandle()
+    {
+        var packagePath = CreatePackageWithManifest(
+            "<package><metadata><id>Unclosed",
+            ("lib/RichLibrary.dll", ReadSampleAssembly()));
+
+        try
+        {
+            Assert.ThrowsExactly<XmlException>(() => new NuGetPackageAnalyzer(packagePath));
+
+            using (new FileStream(
+                packagePath,
+                FileMode.Open,
+                FileAccess.ReadWrite,
+                FileShare.None))
+            {
+            }
+
+            File.Delete(packagePath);
+            Assert.IsFalse(File.Exists(packagePath));
+        }
+        finally
+        {
+            DeletePackage(packagePath);
+        }
+    }
+
+    private static string CreatePackage(params (string EntryName, byte[] Content)[] entries) =>
+        CreatePackageWithManifest(ValidManifest, entries);
+
+    private static string CreatePackageWithManifest(
+        string manifest,
+        params (string EntryName, byte[] Content)[] entries)
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            "dotsider-nupkg-security-" + Guid.NewGuid().ToString("N"));
+        var packagePath = Path.Combine(directory, "SecurityTests.1.0.0.nupkg");
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            using var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create);
+            var manifestEntry = archive.CreateEntry("SecurityTests.nuspec", CompressionLevel.NoCompression);
+            using (var writer = new StreamWriter(manifestEntry.Open()))
+            {
+                writer.Write(manifest);
+            }
+
+            foreach (var (entryName, content) in entries)
+            {
+                var archiveEntry = archive.CreateEntry(entryName, CompressionLevel.NoCompression);
+                using var destination = archiveEntry.Open();
+                destination.Write(content);
+            }
+
+            return packagePath;
+        }
+        catch
+        {
+            DeleteDirectory(directory);
+            throw;
+        }
+    }
+
+    private static void DeletePackage(string packagePath) =>
+        DeleteDirectory(Path.GetDirectoryName(packagePath)!);
+
+    private static void DeleteDirectory(string directory)
+    {
+        if (Directory.Exists(directory))
+            Directory.Delete(directory, recursive: true);
+    }
+
+    private static byte[] ReadSampleAssembly() => File.ReadAllBytes(Samples.RichLibraryDll);
+
+    private static byte[] CreatePaddedAssembly(int minimumLength)
+    {
+        var assembly = ReadSampleAssembly();
+        if (assembly.Length >= minimumLength)
+            return assembly;
+
+        Array.Resize(ref assembly, minimumLength);
+        return assembly;
+    }
+}

--- a/tests/Dotsider.Tests/NuGetUnsafeEntryIntegrationTests.cs
+++ b/tests/Dotsider.Tests/NuGetUnsafeEntryIntegrationTests.cs
@@ -1,0 +1,495 @@
+using Hex1b;
+using Hex1b.Automation;
+using Hex1b.Input;
+using Hex1b.Widgets;
+using System.IO.Compression;
+using System.Text;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Verifies that NuGet mode reports unsafe package entries without leaving the package browser.
+/// </summary>
+/// <param name="testContext">The current test context.</param>
+[TestClass]
+public sealed class NuGetUnsafeEntryIntegrationTests(TestContext testContext)
+{
+    private const string ExtractionFailedError = "Cannot open DLL: extraction failed";
+    private const string InvalidAssemblyError = "Cannot open DLL: invalid .NET assembly";
+    private const string UnsafeEntryError = "Cannot open DLL: unsafe package entry path";
+
+    private static SampleAssemblyFixture Samples => SampleAssemblyHost.Instance;
+
+    private readonly TestContext _testContext = testContext;
+
+    /// <summary>
+    /// Verifies that activating an unsafe DLL reports a sanitized error and a subsequent safe DLL opens.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task UnsafeDllActivation_RejectsEntryThenSafeDllOpens()
+    {
+        var cancellationToken = _testContext.CancellationToken;
+        var uniqueName = "dotsider-nupkg-ui-" + Guid.NewGuid().ToString("N");
+        var packageDirectory = Directory.CreateTempSubdirectory("dotsider-nupkg-ui-test-").FullName;
+        var packagePath = Path.Combine(packageDirectory, "UnsafePackage.1.0.0.nupkg");
+        var outsideDirectory = Path.Combine(Path.GetTempPath(), uniqueName);
+        var sentinelPath = Path.Combine(outsideDirectory, "unsafe.dll");
+        var sentinelText = "outside sentinel must remain unchanged";
+        var unsafeEntryPath = $"../{uniqueName}/unsafe.dll";
+        const string safeEntryPath = "lib/net10.0/RichLibrary.dll";
+
+        try
+        {
+            Directory.CreateDirectory(outsideDirectory);
+            File.WriteAllText(sentinelPath, sentinelText);
+
+            var assemblyBytes = File.ReadAllBytes(Samples.RichLibraryDll);
+            CreatePackage(
+                packagePath,
+                (unsafeEntryPath, assemblyBytes),
+                (safeEntryPath, assemblyBytes));
+
+            var workload = new Hex1bAppWorkloadAdapter();
+            var terminal = Hex1bTerminal.CreateBuilder()
+                .WithWorkload(workload)
+                .WithHeadless()
+                .WithDimensions(120, 30)
+                .Build();
+            NuGetState? state = null;
+            NuGetApp? nuGetApp = null;
+            Hex1bApp? app = null;
+            app = new Hex1bApp(
+                context =>
+                {
+                    state ??= new NuGetState(app!, packagePath);
+                    nuGetApp ??= new NuGetApp(state);
+                    return Task.FromResult<Hex1bWidget>(nuGetApp.Build(context));
+                },
+                new Hex1bAppOptions
+                {
+                    EnableInputCoalescing = false,
+                    WorkloadAdapter = workload
+                });
+
+            var runTask = app.RunAsync(cancellationToken);
+            string? extractedPath = null;
+            string? extractionRoot = null;
+            string? observedOpenError = null;
+            var observedUnsafeState = false;
+            var unsafeRowRemainedVisible = false;
+            var rawHostilePathRendered = false;
+
+            try
+            {
+                await new Hex1bTerminalInputSequenceBuilder()
+                    .WaitUntil(snapshot => snapshot.InAlternateScreen, TimeSpan.FromSeconds(10))
+                    .WaitUntil(
+                        _ => string.Equals(
+                            state?.FileTreeFocusedKey as string,
+                            unsafeEntryPath,
+                            StringComparison.Ordinal),
+                        TimeSpan.FromSeconds(10))
+                    .Key(Hex1bKey.Enter)
+                    .WaitUntil(snapshot =>
+                    {
+                        observedOpenError = state?.OpenError;
+                        observedUnsafeState = state is
+                        {
+                            IsBrowsingPackage: true,
+                            OpenError: UnsafeEntryError,
+                            SelectedDllState: null
+                        };
+                        unsafeRowRemainedVisible = snapshot.ContainsText("unsafe.dll");
+                        rawHostilePathRendered = snapshot.ContainsText(unsafeEntryPath);
+                        return observedUnsafeState
+                            && unsafeRowRemainedVisible
+                            && snapshot.ContainsText(UnsafeEntryError);
+                    }, TimeSpan.FromSeconds(10))
+                    .Key(Hex1bKey.DownArrow)
+                    .WaitUntil(
+                        _ => string.Equals(
+                            state?.FileTreeFocusedKey as string,
+                            safeEntryPath,
+                            StringComparison.Ordinal),
+                        TimeSpan.FromSeconds(10))
+                    .Key(Hex1bKey.Enter)
+                    .WaitUntil(_ => state is
+                    {
+                        IsBrowsingPackage: false,
+                        OpenError: null,
+                        SelectedDllEntry.Name: "RichLibrary.dll",
+                        SelectedDllState: not null
+                    }, TimeSpan.FromSeconds(10))
+                    .WaitUntil(snapshot => snapshot.ContainsText("DLL Inspector"), TimeSpan.FromSeconds(10))
+                    .Build()
+                    .ApplyAsync(terminal, cancellationToken);
+
+                Assert.IsTrue(observedUnsafeState);
+                Assert.IsTrue(unsafeRowRemainedVisible);
+                Assert.AreEqual(UnsafeEntryError, observedOpenError);
+                Assert.IsFalse(rawHostilePathRendered);
+                Assert.IsNotNull(state);
+                Assert.IsFalse(state.IsBrowsingPackage);
+                Assert.IsNull(state.OpenError);
+                Assert.IsNotNull(state.SelectedDllState);
+                Assert.AreEqual("RichLibrary", state.SelectedDllState.Analyzer.AssemblyName);
+                Assert.AreEqual(safeEntryPath, state.SelectedDllEntry!.FullPath);
+                Assert.Contains(unsafeEntryPath, state.Package.DllFiles.Select(entry => entry.FullPath));
+
+                extractedPath = state.SelectedDllState.Analyzer.FilePath;
+                extractionRoot = GetExtractionRoot(extractedPath);
+                Assert.IsTrue(File.Exists(extractedPath));
+            }
+            finally
+            {
+                app.RequestStop();
+                try
+                {
+                    await runTask;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // The cooperative test timeout has already failed the test.
+                }
+                finally
+                {
+                    try
+                    {
+                        state?.Dispose();
+                        state?.Dispose();
+                    }
+                    finally
+                    {
+                        app.Dispose();
+                        terminal.Dispose();
+                        workload.Dispose();
+                    }
+                }
+            }
+
+            Assert.IsNotNull(extractedPath);
+            Assert.IsNotNull(extractionRoot);
+            Assert.IsFalse(File.Exists(extractedPath));
+            Assert.IsFalse(Directory.Exists(extractionRoot));
+            Assert.AreEqual(sentinelText, File.ReadAllText(sentinelPath));
+        }
+        finally
+        {
+            try
+            {
+                DeleteDirectory(packageDirectory);
+            }
+            finally
+            {
+                DeleteDirectory(outsideDirectory);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies terminal control sequences in an archive name are rendered visibly and cannot
+    /// execute an OSC clipboard operation while the package is merely being browsed.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task MaliciousControlText_IsEscapedBeforeTerminalRendering()
+    {
+        const string RawAuthors = "dotsider\u009B31mtests";
+        const string RawControlName =
+            "\x1b]52;c;cHduZWQ=\x07-\x1b[31mX\x1b[0m-\x1b]8;;x\x07L\x1b]8;;\x07.dll";
+        const string RawDescription = "security\u2028metadata";
+        const string RawPackageId = "Unsafe\u202EPackage";
+        const string RawPackageVersion = "1.0.0\u2066";
+        const string VisibleAuthors = "dotsider\\u009B31mtests";
+        const string VisibleControlPrefix = "␛]52;c;cHduZWQ=␇-␛[31mX␛[0m";
+        const string VisibleDescription = "security\\u2028metadata";
+        const string VisiblePackageId = "Unsafe\\u202EPackage";
+        const string VisiblePackageVersion = "1.0.0\\u2066";
+        var cancellationToken = _testContext.CancellationToken;
+        var packageDirectory = Directory.CreateTempSubdirectory("dotsider-nupkg-control-test-").FullName;
+        var rawPackageFileName = OperatingSystem.IsWindows()
+            ? "Control\u202EPackage.1.0.0.nupkg"
+            : "\x1b]52;c;cGFja2FnZQ==\x07-ControlPackage.1.0.0.nupkg";
+        var visiblePackageFileName = OperatingSystem.IsWindows()
+            ? "Control\\u202EPackage.1.0.0.nupkg"
+            : "␛]52;c;cGFja2FnZQ==␇-ControlPackage.1.0.0.nupkg";
+        var packagePath = Path.Combine(packageDirectory, rawPackageFileName);
+        var entryPath = "lib/" + RawControlName;
+
+        try
+        {
+            CreatePackageWithMetadata(
+                packagePath,
+                RawPackageId,
+                RawPackageVersion,
+                RawAuthors,
+                RawDescription,
+                (entryPath, []));
+
+            var workload = new Hex1bAppWorkloadAdapter();
+            var clipboard = new ClipboardCapturingWorkloadAdapter(workload);
+            var terminal = Hex1bTerminal.CreateBuilder()
+                .WithWorkload(workload)
+                .WithHeadless()
+                .WithDimensions(120, 30)
+                .Build();
+            NuGetState? state = null;
+            NuGetApp? nuGetApp = null;
+            Hex1bApp? app = null;
+            app = new Hex1bApp(
+                context =>
+                {
+                    state ??= new NuGetState(app!, packagePath);
+                    nuGetApp ??= new NuGetApp(state);
+                    return Task.FromResult<Hex1bWidget>(nuGetApp.Build(context));
+                },
+                new Hex1bAppOptions
+                {
+                    EnableInputCoalescing = false,
+                    WorkloadAdapter = clipboard
+                });
+
+            var runTask = app.RunAsync(cancellationToken);
+            var rawMetadataRendered = false;
+            try
+            {
+                await new Hex1bTerminalInputSequenceBuilder()
+                    .WaitUntil(snapshot => snapshot.InAlternateScreen, TimeSpan.FromSeconds(10))
+                    .WaitUntil(
+                        snapshot =>
+                        {
+                            rawMetadataRendered = snapshot.ContainsText(RawPackageId)
+                                || snapshot.ContainsText(RawPackageVersion)
+                                || snapshot.ContainsText(RawAuthors)
+                                || snapshot.ContainsText(RawDescription);
+                            return snapshot.ContainsText(VisibleControlPrefix)
+                                && snapshot.ContainsText(visiblePackageFileName)
+                                && snapshot.ContainsText(VisiblePackageId)
+                                && snapshot.ContainsText(VisiblePackageVersion)
+                                && snapshot.ContainsText(VisibleAuthors)
+                                && snapshot.ContainsText(VisibleDescription);
+                        },
+                        TimeSpan.FromSeconds(10))
+                    .Build()
+                    .ApplyAsync(terminal, cancellationToken);
+
+                Assert.IsNotNull(state);
+                Assert.AreEqual(rawPackageFileName, state.Package.FileName);
+                Assert.AreEqual(RawPackageId, state.Package.PackageId);
+                Assert.AreEqual(RawPackageVersion, state.Package.PackageVersion);
+                Assert.AreEqual(RawAuthors, state.Package.Authors);
+                Assert.AreEqual(RawDescription, state.Package.Description);
+                var entry = Assert.ContainsSingle(state.Package.DllFiles);
+                Assert.AreEqual(entryPath, entry.FullPath);
+                Assert.AreEqual(RawControlName, entry.Name);
+                Assert.IsFalse(rawMetadataRendered);
+                Assert.IsEmpty(clipboard.ClipboardWrites);
+                Assert.IsNull(state.Package.ExtractionDirectory);
+
+                await new Hex1bTerminalInputSequenceBuilder()
+                    .Type("y")
+                    .WaitUntil(_ => clipboard.ClipboardWrites.Count == 1, TimeSpan.FromSeconds(10))
+                    .WaitUntil(
+                        snapshot => snapshot.ContainsText("Yanked: lib/␛]52;c;"),
+                        TimeSpan.FromSeconds(10))
+                    .Build()
+                    .ApplyAsync(terminal, cancellationToken);
+
+                Assert.IsTrue(clipboard.ClipboardWrites.TryDequeue(out var clipboardText));
+                Assert.AreEqual(entryPath, clipboardText);
+                Assert.IsEmpty(clipboard.ClipboardWrites);
+                Assert.IsNotNull(state.YankNotification);
+                Assert.DoesNotContain("\x1b", state.YankNotification);
+            }
+            finally
+            {
+                app.RequestStop();
+                try
+                {
+                    await runTask;
+                }
+                finally
+                {
+                    try
+                    {
+                        state?.Dispose();
+                    }
+                    finally
+                    {
+                        app.Dispose();
+                        terminal.Dispose();
+                        clipboard.Dispose();
+                    }
+                }
+            }
+        }
+        finally
+        {
+            DeleteDirectory(packageDirectory);
+        }
+    }
+
+    /// <summary>
+    /// Verifies opening one safe DLL extracts only that DLL and a pre-existing destination is
+    /// never overwritten, while the selected analyzer remains active after the failed open.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void TryOpenDll_ExistingDestination_PreservesFileAndSelectedState()
+    {
+        const string FirstEntryPath = "lib/net10.0/First.dll";
+        const string SecondEntryPath = "lib/net10.0/Second.dll";
+        byte[] sentinel = [0x21, 0x09, 0x20, 0x99];
+        var packageDirectory = Directory.CreateTempSubdirectory("dotsider-nupkg-existing-test-").FullName;
+        var packagePath = Path.Combine(packageDirectory, "ExistingDestination.1.0.0.nupkg");
+
+        try
+        {
+            var assemblyBytes = File.ReadAllBytes(Samples.RichLibraryDll);
+            CreatePackage(
+                packagePath,
+                (FirstEntryPath, assemblyBytes),
+                (SecondEntryPath, assemblyBytes));
+
+            using var workload = new Hex1bAppWorkloadAdapter();
+            using var terminal = Hex1bTerminal.CreateBuilder()
+                .WithWorkload(workload)
+                .WithHeadless()
+                .WithDimensions(80, 24)
+                .Build();
+            using var app = new Hex1bApp(
+                _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+                new Hex1bAppOptions { WorkloadAdapter = workload });
+            using var state = new NuGetState(app, packagePath);
+            var firstEntry = state.Package.DllFiles.Single(static entry =>
+                entry.FullPath == FirstEntryPath);
+            var secondEntry = state.Package.DllFiles.Single(static entry =>
+                entry.FullPath == SecondEntryPath);
+
+            Assert.IsTrue(state.TryOpenDll(firstEntry));
+            var selectedState = state.SelectedDllState;
+            Assert.IsNotNull(selectedState);
+            Assert.AreSame(firstEntry, state.SelectedDllEntry);
+            var extractionDirectory = state.Package.ExtractionDirectory;
+            Assert.IsNotNull(extractionDirectory);
+            var secondDestination = Path.Combine(
+                extractionDirectory,
+                "lib",
+                "net10.0",
+                "Second.dll");
+            Assert.IsFalse(File.Exists(secondDestination));
+
+            File.WriteAllBytes(secondDestination, sentinel);
+
+            Assert.IsFalse(state.TryOpenDll(secondEntry));
+            Assert.AreEqual(ExtractionFailedError, state.OpenError);
+            Assert.AreSame(selectedState, state.SelectedDllState);
+            Assert.AreSame(firstEntry, state.SelectedDllEntry);
+            Assert.IsFalse(state.IsBrowsingPackage);
+            Assert.AreSequenceEqual(sentinel, File.ReadAllBytes(secondDestination));
+        }
+        finally
+        {
+            DeleteDirectory(packageDirectory);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a package-owned DLL containing invalid bytes produces a sanitized state error.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void TryOpenDll_InvalidAssembly_ShowsSanitizedError()
+    {
+        var packageDirectory = Directory.CreateTempSubdirectory("dotsider-nupkg-invalid-test-").FullName;
+        var packagePath = Path.Combine(packageDirectory, "InvalidPackage.1.0.0.nupkg");
+        const string invalidEntryPath = "lib/net10.0/raw-hostile-value.dll";
+
+        try
+        {
+            CreatePackage(packagePath, (invalidEntryPath, [0x01, 0x02, 0x03, 0x04]));
+
+            using var workload = new Hex1bAppWorkloadAdapter();
+            using var terminal = Hex1bTerminal.CreateBuilder()
+                .WithWorkload(workload)
+                .WithHeadless()
+                .WithDimensions(80, 24)
+                .Build();
+            using var app = new Hex1bApp(
+                _ => Task.FromResult<Hex1bWidget>(new TextBlockWidget("test")),
+                new Hex1bAppOptions { WorkloadAdapter = workload });
+            using var state = new NuGetState(app, packagePath);
+
+            var entry = Assert.ContainsSingle(state.Package.DllFiles);
+            var opened = state.TryOpenDll(entry);
+
+            Assert.IsFalse(opened);
+            Assert.IsTrue(state.IsBrowsingPackage);
+            Assert.IsNull(state.SelectedDllState);
+            Assert.AreEqual(InvalidAssemblyError, state.OpenError);
+            Assert.DoesNotContain(invalidEntryPath, state.OpenError!);
+
+            state.Dispose();
+            state.Dispose();
+        }
+        finally
+        {
+            DeleteDirectory(packageDirectory);
+        }
+    }
+
+    private static void CreatePackage(
+        string packagePath,
+        params (string EntryPath, byte[] Contents)[] files) =>
+        CreatePackageWithMetadata(
+            packagePath,
+            "UnsafePackage",
+            "1.0.0",
+            "dotsider tests",
+            "Security regression package",
+            files);
+
+    private static void CreatePackageWithMetadata(
+        string packagePath,
+        string packageId,
+        string packageVersion,
+        string authors,
+        string description,
+        params (string EntryPath, byte[] Contents)[] files)
+    {
+        using var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create);
+        WriteEntry(
+            archive,
+            "UnsafePackage.nuspec",
+            Encoding.UTF8.GetBytes(
+                $"<package><metadata><id>{packageId}</id><version>{packageVersion}</version>" +
+                $"<authors>{authors}</authors><description>{description}</description>" +
+                "</metadata></package>"));
+
+        foreach (var (entryPath, contents) in files)
+            WriteEntry(archive, entryPath, contents);
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        if (Directory.Exists(path))
+            Directory.Delete(path, recursive: true);
+    }
+
+    private static string GetExtractionRoot(string extractedPath)
+    {
+        var tempPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(Path.GetTempPath()));
+        var relativePath = Path.GetRelativePath(tempPath, extractedPath);
+        var firstSeparator = relativePath.IndexOfAny([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar]);
+        Assert.IsGreaterThan(0, firstSeparator, $"Extracted path was not inside a private temp directory: {extractedPath}");
+        return Path.Combine(tempPath, relativePath[..firstSeparator]);
+    }
+
+    private static void WriteEntry(ZipArchive archive, string entryPath, byte[] contents)
+    {
+        var entry = archive.CreateEntry(entryPath, CompressionLevel.NoCompression);
+        using var stream = entry.Open();
+        stream.Write(contents);
+    }
+}

--- a/tests/Dotsider.Tests/StandardModeViewTests.cs
+++ b/tests/Dotsider.Tests/StandardModeViewTests.cs
@@ -10,8 +10,9 @@ namespace Dotsider.Tests;
 /// <summary>
 /// Tests for Standard Mode View.
 /// </summary>
+/// <param name="testContext">The current test context.</param>
 [TestClass]
-public class StandardModeViewTests : IDisposable
+public class StandardModeViewTests(TestContext testContext) : IDisposable
 {
     private static SampleAssemblyFixture Samples => SampleAssemblyHost.Instance;
 
@@ -19,6 +20,8 @@ public class StandardModeViewTests : IDisposable
     private Hex1bTerminal? _terminal;
     private Hex1bApp? _hex1bApp;
     private DotsiderState? _state;
+
+    private readonly TestContext _testContext = testContext;
 
     private (Hex1bTerminal terminal, Hex1bApp app) CreateDotsiderApp(string dllPath, int? initialTab = null)
         => CreateDotsiderAppCore(dllPath, initialTab, enableMouse: false, enableInputCoalescing: false);
@@ -826,6 +829,55 @@ public class StandardModeViewTests : IDisposable
     }
 
     /// <summary>
+    /// A completed dependency-graph build failure replaces the transient build status with the
+    /// stable, generic error and does not disclose the underlying exception through the terminal.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task Tab6_GraphBuildFault_ShowsStableError()
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+            _testContext.CancellationToken);
+        var (terminal, app) = CreateDotsiderApp(Samples.RichLibraryDll);
+        var runTask = app.RunAsync(cts.Token);
+
+        try
+        {
+            await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
+                .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+                .Build()
+                .ApplyAsync(terminal, cts.Token);
+
+            Assert.IsNotNull(_state);
+            _state.GraphBuilder = (_, _) =>
+                throw new InvalidOperationException("sensitive graph-build details");
+
+            await new Hex1bTerminalInputSequenceBuilder()
+                .Key(Hex1bKey.D6)
+                .WaitUntil(_ => _state.GraphNavigationError is not null,
+                    TimeSpan.FromSeconds(10))
+                .WaitUntil(s => s.ContainsText("Cannot build dependency graph"),
+                    TimeSpan.FromSeconds(10))
+                .Build()
+                .ApplyAsync(terminal, cts.Token);
+
+            await _state.GraphBuildTask.WaitAsync(cts.Token);
+
+            using var snapshot = terminal.CreateSnapshot();
+            var screenText = snapshot.GetScreenText();
+            Assert.Contains("Cannot build dependency graph", screenText);
+            Assert.DoesNotContain("Building dependency graph...", screenText);
+            Assert.DoesNotContain("sensitive graph-build details", screenText);
+        }
+        finally
+        {
+            cts.Cancel();
+            await runTask;
+        }
+    }
+
+    /// <summary>
     /// Opening the AppLocalRollForward sample on the Dep Graph tab must not render the
     /// <c>! </c> IdentityMismatch marker for <c>Microsoft.Diagnostics.NETCore.Client</c>.
     /// The sample's transitive AssemblyRef from <c>Microsoft.Diagnostics.Tracing.TraceEvent</c>
@@ -837,15 +889,26 @@ public class StandardModeViewTests : IDisposable
     [Timeout(30_000, CooperativeCancellation = true)]
     public async Task Tab6_AppLocalRollForward_NoIdentityMismatchMarker()
     {
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken.None);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+            _testContext.CancellationToken);
         var (terminal, app) = CreateDotsiderApp(Samples.AppLocalRollForwardDll);
         var runTask = app.RunAsync(cts.Token);
-        await Task.Delay(100, cts.Token);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
             .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
             .Key(Hex1bKey.D6)
+            .WaitUntil(_ => _state is { GraphBuildInProgress: true } or { CachedGraph: not null },
+                TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, cts.Token);
+
+        Assert.IsNotNull(_state);
+        await _state.GraphBuildTask.WaitAsync(cts.Token);
+        Assert.IsNull(_state.GraphNavigationError);
+        Assert.IsNotNull(_state.CachedGraph);
+
+        await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.ContainsText("Microsoft.Diagnostics.NETCore.Client"),
                 TimeSpan.FromSeconds(10))
             .Build()
@@ -855,8 +918,9 @@ public class StandardModeViewTests : IDisposable
         Assert.IsFalse(snapshot.ContainsText("! Microsoft.Diagnostics.NETCore.Client"),
             "AppLocal roll-forward must suppress the IdentityMismatch marker on the Dep Graph tab.");
 
-        Assert.IsNotNull(_state!.CachedGraph);
-        var clientNodes = _state.CachedGraph!.Value.Nodes
+        var graph = _state!.CachedGraph;
+        Assert.IsNotNull(graph);
+        var clientNodes = graph.Value.Nodes
             .Where(n => n.Name == "Microsoft.Diagnostics.NETCore.Client")
             .ToList();
         var clientNode = Assert.ContainsSingle(clientNodes);
@@ -910,9 +974,10 @@ public class StandardModeViewTests : IDisposable
             .Build()
             .ApplyAsync(terminal, cts.Token);
 
-        Assert.IsNotNull(_state!.CachedGraph);
-        Assert.IsGreaterThan(0, _state.CachedGraph.Value.Nodes.Count);
-        Assert.IsGreaterThan(0, _state.CachedGraph.Value.Edges.Count);
+        var graph = _state!.CachedGraph;
+        Assert.IsNotNull(graph);
+        Assert.IsGreaterThan(0, graph.Value.Nodes.Count);
+        Assert.IsGreaterThan(0, graph.Value.Edges.Count);
 
         cts.Cancel();
         await runTask;
@@ -1231,10 +1296,15 @@ public class StandardModeViewTests : IDisposable
             .ApplyAsync(terminal, cts.Token);
 
         Assert.IsFalse(_state!.DepGraphHideFramework);
-        Assert.IsNotNull(_state.CachedGraph);
-        var rootId = _state.CachedGraph!.Value.Nodes.First(n => n.IsRoot).Id;
-        Assert.IsNotNull(_state.GraphNavigation);
-        Assert.Contains(n => _state.GraphNavigation!.TryGetValue(n.Id, out var c) && c.IsFrameworkAssembly, _state.CachedGraph.Value.Nodes);
+        var graph = _state.CachedGraph;
+        Assert.IsNotNull(graph);
+        var rootId = graph.Value.Nodes.First(n => n.IsRoot).Id;
+        var navigation = _state.GraphNavigation;
+        Assert.IsNotNull(navigation);
+        Assert.Contains(
+            n => navigation.TryGetValue(n.Id, out var context)
+                && context.IsFrameworkAssembly,
+            graph.Value.Nodes);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.F)
@@ -1245,7 +1315,7 @@ public class StandardModeViewTests : IDisposable
 
         Assert.IsTrue(_state.DepGraphHideFramework);
         // Root id is still in the cached graph after toggle (underlying graph not rebuilt).
-        Assert.Contains(n => n.Id == rootId && n.IsRoot, _state.CachedGraph.Value.Nodes);
+        Assert.Contains(n => n.Id == rootId && n.IsRoot, graph.Value.Nodes);
 
         cts.Cancel();
         await runTask;

--- a/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
@@ -1240,8 +1240,15 @@ public class StandardModeYankIntegrationTests : IDisposable
             .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
             .Key(Hex1bKey.Tab)
             .WaitUntil(_ => IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
+            .Key(Hex1bKey.RightArrow)
+            .Key(Hex1bKey.RightArrow)
+            .WaitUntil(_ => _state!.GeneralInfoEditorState!.Cursor.Position.Value == 2,
+                TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal, ct);
+
+        Assert.AreEqual('A', _state!.GeneralInfoEditorState!.Document.GetText()[
+            _state.GeneralInfoEditorState.Cursor.Position.Value]);
 
         // Press y — verify it arms WaitingForYMotion
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1262,14 +1269,17 @@ public class StandardModeYankIntegrationTests : IDisposable
         // Press w — selects + yanks
         await new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.W)
-            .WaitUntil(_ => _state!.YankNotification is not null, TimeSpan.FromSeconds(5))
+            .WaitUntil(snapshot => _clipboardAdapter!.ClipboardWrites.TryPeek(out _),
+                TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal, ct);
 
-        Assert.IsNotNull(_state!.YankNotification);
-        Assert.IsTrue(_clipboardAdapter!.ClipboardWrites.TryDequeue(out var clipboard));
-        Assert.IsFalse(string.IsNullOrEmpty(clipboard));
+        Assert.IsTrue(_clipboardAdapter!.ClipboardWrites.TryDequeue(out var clipboard),
+            "CopyToClipboard should have emitted an OSC 52 sequence");
+        Assert.AreEqual("Assembly", clipboard);
         Assert.AreEqual(VimMotionState.Idle, _state.VimPending);
+        Assert.IsFalse(_state.GeneralInfoEditorState.Cursor.HasSelection);
+        Assert.AreEqual(9, _state.GeneralInfoEditorState.Cursor.Position.Value);
 
         _cts!.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/Dotsider.Tests/UntrustedTerminalTextTests.cs
+++ b/tests/Dotsider.Tests/UntrustedTerminalTextTests.cs
@@ -1,0 +1,23 @@
+using Dotsider.Views;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests terminal-safe presentation of untrusted text.
+/// </summary>
+[TestClass]
+public sealed class UntrustedTerminalTextTests
+{
+    /// <summary>
+    /// Verifies truncation never leaves an unmatched surrogate at the preview boundary.
+    /// </summary>
+    [TestMethod]
+    public void TruncateWithEllipsis_SupplementaryRuneAtBoundary_PreservesValidUtf16()
+    {
+        var value = new string('a', 36) + "\U0001F600tail";
+
+        var result = UntrustedTerminalText.TruncateWithEllipsis(value, 40);
+
+        Assert.AreEqual(new string('a', 36) + "...", result);
+    }
+}


### PR DESCRIPTION
NuGet package entries are now bound to their originating archive records and validated against a canonical private extraction root before any filesystem write. Dotsider extracts only the selected DLL, rejects traversal, rooted paths, aliases, and file/directory collisions, and keeps unsafe rows visible with a sanitized error.

The NuGet UI escapes untrusted package text and closes analyzer state deterministically. Background graph construction is cancellation-safe when an inspected DLL is replaced or NuGet mode closes. Hand-built package regressions exercise real managed assemblies and platform path behavior, and the public API and usage docs describe the boundary.

Fixes: #209