### PR TITLE
Harden Webcil section validation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,5 +3,6 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 </Project>

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
@@ -42,6 +42,10 @@ manifest assembly.
 - `targetFrameworkOverride` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The manifest's target-framework context.
 - `preferredRuntimePackOverride` ([String](https://learn.microsoft.com/dotnet/api/system.string)): The manifest's preferred runtime pack.
 
+**Exceptions:**
+
+- [BadImageFormatException](https://learn.microsoft.com/dotnet/api/system.badimageformatexception): bytes contains a recognized managed PE or Webcil image that is malformed.
+
 ```csharp
 public AssemblyAnalyzer(byte[] bytes, string filePath, string? sourceBundlePath, string? displayName, string? targetFrameworkOverride, string? preferredRuntimePackOverride)
 ```
@@ -62,6 +66,10 @@ Used for assembly resolution context.
 when the entry assembly is extracted from a bundle). If null, defaults to the file name
 portion of filePath.
 
+**Exceptions:**
+
+- [BadImageFormatException](https://learn.microsoft.com/dotnet/api/system.badimageformatexception): bytes contains a recognized managed PE or Webcil image that is malformed.
+
 ```csharp
 public AssemblyAnalyzer(byte[] bytes, string filePath, string? sourceBundlePath = null, string? displayName = null)
 ```
@@ -77,6 +85,7 @@ Opens and analyzes the specified .NET assembly file.
 **Exceptions:**
 
 - [FileNotFoundException](https://learn.microsoft.com/dotnet/api/system.io.filenotfoundexception): The file does not exist.
+- [BadImageFormatException](https://learn.microsoft.com/dotnet/api/system.badimageformatexception): The file contains a recognized managed PE or Webcil image that is malformed.
 
 ```csharp
 public AssemblyAnalyzer(string filePath)
@@ -858,7 +867,13 @@ Returns null if the method has no IL body (abstract, extern, or native).
 
 **Returns:** [MethodBodyBlock](https://learn.microsoft.com/dotnet/api/system.reflection.metadata.methodbodyblock)
 
-The method body block, or null.
+The method body block, or null. The returned block references analyzer-owned storage and
+must not be used after this analyzer is disposed.
+
+**Exceptions:**
+
+- [BadImageFormatException](https://learn.microsoft.com/dotnet/api/system.badimageformatexception): The method RVA maps to a malformed or truncated method body.
+- [ObjectDisposedException](https://learn.microsoft.com/dotnet/api/system.objectdisposedexception): This analyzer has been disposed.
 
 ```csharp
 public MethodBodyBlock? GetMethodBody(MethodDefInfo method)

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-ResolvedModule.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-ResolvedModule.md
@@ -96,3 +96,4 @@ The manifest assembly's target-framework context.
 ```csharp
 public string? TargetFramework { get; init; }
 ```
+

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-UnsafePackageEntryException.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-UnsafePackageEntryException.md
@@ -61,3 +61,4 @@ specified error message.
 ```csharp
 public UnsafePackageEntryException(string? message)
 ```
+

--- a/docs/src/content/docs/usage/pe-metadata.md
+++ b/docs/src/content/docs/usage/pe-metadata.md
@@ -35,6 +35,8 @@ R2R Sections and AOT Types apply to Native AOT binaries. ILC strips ECMA-335 met
 
 Dotsider treats metadata and signature blobs as untrusted. When an image is otherwise readable, cyclic or excessively nested type relationships and malformed ECMA-335 or ReadyToRun signatures are contained: affected names use token or unknown fallbacks, navigation remains unresolved, and unreadable native mappings are omitted instead of being guessed or terminating the analysis.
 
+For Webcil images, section ranges are validated within the containing payload before metadata or IL is exposed. Recognized but corrupt Webcil images are rejected as malformed rather than interpreted as raw WebAssembly.
+
 Symbols reads whichever artifact the platform's publish produced — a native PDB on Windows, a `.dbg` ELF sidecar on Linux, a dSYM bundle on macOS, or `dotnet.native.js.symbols` beside `dotnet.native.wasm` — after validating or parsing the format-specific identity. ILC's mangled names are demangled by joining against the binary's own recovered metadata, so a managed name is marked exact only when the join is unambiguous. ReadyToRun symbols come from the runtime-function map and carry the owning MethodDef token. Wasm symbols come from the Wasm function/code sections, with names layered from the SDK symbol map, the Wasm name section, exports, then synthetic `func_N` fallbacks. Functions carry their declaring source file and line when the symbol file records them. Without a symbol file, unwind data (`.pdata`, `.eh_frame`, or `LC_FUNCTION_STARTS`) still recovers nameless function boundaries for native PE/ELF/Mach-O binaries — enough for counts and size histograms, though unwind data can miss leaf and thunk functions.
 
 ## Text selection and copy

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -80,6 +80,9 @@ public sealed class AssemblyAnalyzer : IDisposable
     /// </summary>
     /// <param name="filePath">Absolute path to the assembly file.</param>
     /// <exception cref="FileNotFoundException">The file does not exist.</exception>
+    /// <exception cref="BadImageFormatException">
+    /// The file contains a recognized managed PE or Webcil image that is malformed.
+    /// </exception>
     public AssemblyAnalyzer(string filePath)
     {
         FilePath = filePath;
@@ -95,8 +98,16 @@ public sealed class AssemblyAnalyzer : IDisposable
         IsReadOnly = fileInfo.IsReadOnly;
 
         _stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        if (TryInitializeWebcil(_rawBytes))
-            return;
+        try
+        {
+            if (TryInitializeWebcil(_rawBytes))
+                return;
+        }
+        catch
+        {
+            Dispose();
+            throw;
+        }
 
         try
         {
@@ -146,6 +157,9 @@ public sealed class AssemblyAnalyzer : IDisposable
     /// when the entry assembly is extracted from a bundle). If null, defaults to the file name
     /// portion of <paramref name="filePath"/>.
     /// </param>
+    /// <exception cref="BadImageFormatException">
+    /// <paramref name="bytes"/> contains a recognized managed PE or Webcil image that is malformed.
+    /// </exception>
     public AssemblyAnalyzer(byte[] bytes, string filePath, string? sourceBundlePath = null,
         string? displayName = null)
         : this(
@@ -168,6 +182,9 @@ public sealed class AssemblyAnalyzer : IDisposable
     /// <param name="displayName">The logical name of the analyzed module.</param>
     /// <param name="targetFrameworkOverride">The manifest's target-framework context.</param>
     /// <param name="preferredRuntimePackOverride">The manifest's preferred runtime pack.</param>
+    /// <exception cref="BadImageFormatException">
+    /// <paramref name="bytes"/> contains a recognized managed PE or Webcil image that is malformed.
+    /// </exception>
     public AssemblyAnalyzer(
         byte[] bytes,
         string filePath,
@@ -188,8 +205,16 @@ public sealed class AssemblyAnalyzer : IDisposable
         CreatedTime = DateTime.UtcNow;
 
         _stream = new MemoryStream(bytes, writable: false);
-        if (TryInitializeWebcil(_rawBytes))
-            return;
+        try
+        {
+            if (TryInitializeWebcil(_rawBytes))
+                return;
+        }
+        catch
+        {
+            Dispose();
+            throw;
+        }
 
         try
         {
@@ -1019,7 +1044,14 @@ public sealed class AssemblyAnalyzer : IDisposable
     /// Returns null if the method has no IL body (abstract, extern, or native).
     /// </summary>
     /// <param name="method">The method definition to get the body for.</param>
-    /// <returns>The method body block, or null.</returns>
+    /// <returns>
+    /// The method body block, or null. The returned block references analyzer-owned storage and
+    /// must not be used after this analyzer is disposed.
+    /// </returns>
+    /// <exception cref="BadImageFormatException">
+    /// The method RVA maps to a malformed or truncated method body.
+    /// </exception>
+    /// <exception cref="ObjectDisposedException">This analyzer has been disposed.</exception>
     public MethodBodyBlock? GetMethodBody(MethodDefInfo method)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -1421,7 +1453,8 @@ public sealed class AssemblyAnalyzer : IDisposable
 
     private bool TryInitializeWebcil(ReadOnlySpan<byte> bytes)
     {
-        if (!Wasm.WebcilImageReader.TryRead(bytes, out var webcil) || webcil is null)
+        Wasm.WebcilImageReader? webcil = Wasm.WebcilImageReader.Open(bytes);
+        if (webcil is null)
             return false;
 
         _peReader = null;

--- a/src/Dotsider.Core/Analysis/Wasm/WebcilHeader.cs
+++ b/src/Dotsider.Core/Analysis/Wasm/WebcilHeader.cs
@@ -1,0 +1,24 @@
+namespace Dotsider.Core.Analysis.Wasm;
+
+/// <summary>
+/// Represents the fixed fields in a version 0 or version 1 Webcil header.
+/// </summary>
+/// <param name="Id">The Webcil signature.</param>
+/// <param name="VersionMajor">The format major version.</param>
+/// <param name="VersionMinor">The format minor version.</param>
+/// <param name="CoffSections">The number of section table entries.</param>
+/// <param name="PeCliHeaderRva">The CLR header RVA.</param>
+/// <param name="PeCliHeaderSize">The CLR header size.</param>
+/// <param name="PeDebugRva">The debug directory RVA.</param>
+/// <param name="PeDebugSize">The debug directory size.</param>
+/// <param name="TableBase">The version 1 table base, or <see cref="uint.MaxValue"/> for version 0.</param>
+internal readonly record struct WebcilHeader(
+    uint Id,
+    int VersionMajor,
+    int VersionMinor,
+    int CoffSections,
+    uint PeCliHeaderRva,
+    uint PeCliHeaderSize,
+    uint PeDebugRva,
+    uint PeDebugSize,
+    uint TableBase);

--- a/src/Dotsider.Core/Analysis/Wasm/WebcilImageReader.cs
+++ b/src/Dotsider.Core/Analysis/Wasm/WebcilImageReader.cs
@@ -14,35 +14,37 @@ namespace Dotsider.Core.Analysis.Wasm;
 /// </summary>
 internal sealed class WebcilImageReader
 {
-    private const uint WebcilMagic = 0x4C496257;
-    private const uint WasmMagic = 0x6D736100;
-    private const uint WasmVersion = 1;
-    private const int HeaderV0Size = 28;
-    private const int HeaderV1Size = 32;
-    private const int SectionHeaderSize = 16;
+    private const int ClrHeaderSize = 72;
     private const int DebugDirectoryEntrySize = 28;
     private const uint EmbeddedPortablePdbSignature = 0x4244504D;
+    private const int HeaderV0Size = 28;
+    private const int HeaderV1Size = 32;
+    private const int MaxSections = 16;
+    private const int SectionHeaderSize = 16;
+    private const uint WasmMagic = 0x6D736100;
+    private const uint WasmVersion = 1;
+    private const uint WebcilMagic = 0x4C496257;
 
-    private readonly byte[] _image;
-    private readonly List<WebcilSection> _sections;
     private readonly List<WebcilDebugEntry> _debugEntries;
-    private readonly WebcilHeader _header;
+    private readonly byte[] _image;
     private readonly byte[] _metadataBytes;
+    private readonly List<WebcilSection> _sections;
 
     private WebcilImageReader(
         byte[] image,
-        long payloadOffset,
+        int payloadOffset,
         WebcilHeader header,
         List<WebcilSection> sections,
+        ClrHeader clrHeader,
         byte[] metadataBytes,
         List<WebcilDebugEntry> debugEntries)
     {
-        _image = image;
-        PayloadOffset = payloadOffset;
-        _header = header;
-        _sections = sections;
-        _metadataBytes = metadataBytes;
         _debugEntries = debugEntries;
+        _image = image;
+        _metadataBytes = metadataBytes;
+        _sections = sections;
+        PayloadOffset = payloadOffset;
+        ClrHeader = clrHeader;
         Info = new WebcilInfo(
             header.VersionMajor,
             header.VersionMinor,
@@ -50,8 +52,9 @@ internal sealed class WebcilImageReader
             payloadOffset,
             sections.Count,
             metadataBytes.Length,
-            checked((int)header.PeDebugSize));
-        ClrHeader = ReadClrHeader(header, sections, image, payloadOffset);
+            header.PeDebugRva == 0 || header.PeDebugSize == 0
+                ? 0
+                : checked((int)header.PeDebugSize));
     }
 
     /// <summary>
@@ -65,39 +68,36 @@ internal sealed class WebcilImageReader
     public ClrHeader ClrHeader { get; }
 
     /// <summary>
-    /// Attempts to read a Webcil image from raw bytes.
+    /// Opens a bare or WebAssembly-wrapped Webcil image.
     /// </summary>
     /// <param name="bytes">The candidate file bytes.</param>
-    /// <param name="reader">The parsed Webcil reader when the bytes contain Webcil.</param>
-    /// <returns>True when a bare or Wasm-wrapped Webcil payload was found and parsed.</returns>
-    public static bool TryRead(ReadOnlySpan<byte> bytes, out WebcilImageReader? reader)
+    /// <returns>The parsed reader, or <see langword="null"/> when no Webcil payload exists.</returns>
+    /// <exception cref="BadImageFormatException">
+    /// A Webcil payload was recognized, but its headers, sections, or managed directories are malformed.
+    /// </exception>
+    public static WebcilImageReader? Open(ReadOnlySpan<byte> bytes)
     {
-        reader = null;
-        if (!TryFindPayload(bytes, out var payloadOffset))
-            return false;
+        if (!TryFindPayload(bytes, out int payloadOffset, out int payloadLength))
+            return null;
 
-        try
-        {
-            if (!TryReadHeader(bytes, payloadOffset, out var header))
-                return false;
+        ReadOnlySpan<byte> payload = bytes.Slice(payloadOffset, payloadLength);
+        WebcilHeader header = ReadHeader(payload);
+        List<WebcilSection> sections = ReadSectionTable(payload, header);
+        ClrHeader clrHeader = ReadClrHeader(header, sections, payload);
+        ValidateClrDirectories(clrHeader, sections, payload.Length);
+        byte[] metadataBytes = ReadMetadata(payload, clrHeader, sections);
+        List<WebcilDebugEntry> debugEntries = ReadDebugEntries(payload, header, sections);
+        byte[] image = GC.AllocateUninitializedArray<byte>(payloadLength, pinned: true);
+        payload.CopyTo(image);
 
-            var sections = ReadSections(bytes, payloadOffset, header);
-            var metadataBytes = ReadMetadata(bytes, payloadOffset, header, sections);
-            var debugEntries = ReadDebugEntries(bytes, payloadOffset, header, sections);
-            reader = new WebcilImageReader(
-                bytes.ToArray(),
-                payloadOffset,
-                header,
-                sections,
-                metadataBytes,
-                debugEntries);
-            return true;
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException or OverflowException)
-        {
-            reader = null;
-            return false;
-        }
+        return new WebcilImageReader(
+            image,
+            payloadOffset,
+            header,
+            sections,
+            clrHeader,
+            metadataBytes,
+            debugEntries);
     }
 
     /// <summary>
@@ -114,12 +114,12 @@ internal sealed class WebcilImageReader
     /// <returns>The method body block, or null when the RVA does not map to Webcil bytes.</returns>
     public unsafe MethodBodyBlock? GetMethodBody(int rva)
     {
-        if (rva == 0 || !TryTranslateRva((uint)rva, out var offset, out var available) || available <= 0)
+        if (rva <= 0 || !TryTranslateRva((uint)rva, out int offset, out int available) || available == 0)
             return null;
 
-        fixed (byte* ptr = &_image[(int)offset])
+        fixed (byte* image = _image)
         {
-            var blob = new BlobReader(ptr, checked((int)available));
+            BlobReader blob = new(image + offset, available);
             return MethodBodyBlock.Create(blob);
         }
     }
@@ -129,12 +129,12 @@ internal sealed class WebcilImageReader
     /// </summary>
     /// <returns>Generic section rows with Webcil-adjusted raw data offsets.</returns>
     public IReadOnlyList<SectionInfo> ReadSections() =>
-        [.. _sections.Select((s, i) => new SectionInfo(
-            Name: $"webcil-section-{i}",
-            VirtualAddress: checked((int)s.VirtualAddress),
-            VirtualSize: checked((int)s.VirtualSize),
-            RawDataOffset: checked((int)(PayloadOffset + s.PointerToRawData)),
-            RawDataSize: checked((int)s.SizeOfRawData),
+        [.. _sections.Select((section, index) => new SectionInfo(
+            Name: $"webcil-section-{index}",
+            VirtualAddress: unchecked((int)section.VirtualAddress),
+            VirtualSize: unchecked((int)section.VirtualSize),
+            RawDataOffset: checked(PayloadOffset + (int)section.PointerToRawData),
+            RawDataSize: (int)section.SizeOfRawData,
             Characteristics: 0))];
 
     /// <summary>
@@ -142,15 +142,15 @@ internal sealed class WebcilImageReader
     /// </summary>
     /// <returns>Debug directory rows with formatted Webcil payload details.</returns>
     public IReadOnlyList<DebugDirectoryInfo> ReadDebugDirectory() =>
-        [.. _debugEntries.Select(e => new DebugDirectoryInfo(
-            Type: e.Type,
-            Stamp: e.Stamp,
-            MajorVersion: e.MajorVersion,
-            MinorVersion: e.MinorVersion,
-            DataSize: e.DataSize,
-            AddressOfRawData: e.DataRva,
-            PointerToRawData: checked((int)(PayloadOffset + e.DataPointer)),
-            Payload: FormatPayload(e)))];
+        [.. _debugEntries.Select(entry => new DebugDirectoryInfo(
+            Type: entry.Type,
+            Stamp: entry.Stamp,
+            MajorVersion: entry.MajorVersion,
+            MinorVersion: entry.MinorVersion,
+            DataSize: entry.DataSize,
+            AddressOfRawData: entry.DataRva,
+            PointerToRawData: checked(PayloadOffset + entry.DataPointer),
+            Payload: FormatPayload(entry)))];
 
     /// <summary>
     /// Opens an embedded portable PDB from a Webcil debug directory entry.
@@ -159,14 +159,14 @@ internal sealed class WebcilImageReader
     /// <returns>A metadata provider over the decompressed portable PDB image.</returns>
     public MetadataReaderProvider ReadEmbeddedPortablePdb(WebcilDebugEntry entry)
     {
-        var payload = ReadEntryPayload(entry);
+        ReadOnlySpan<byte> payload = ReadEntryPayload(entry);
         if (payload.Length < 8 || BinaryPrimitives.ReadUInt32LittleEndian(payload) != EmbeddedPortablePdbSignature)
             throw new BadImageFormatException("Unexpected embedded portable PDB signature.");
 
-        var decompressedSize = BinaryPrimitives.ReadInt32LittleEndian(payload[4..]);
-        using var compressed = new MemoryStream(payload[8..].ToArray(), writable: false);
-        using var deflate = new DeflateStream(compressed, CompressionMode.Decompress);
-        var decompressed = new byte[decompressedSize];
+        int decompressedSize = BinaryPrimitives.ReadInt32LittleEndian(payload[4..]);
+        using MemoryStream compressed = new(payload[8..].ToArray(), writable: false);
+        using DeflateStream deflate = new(compressed, CompressionMode.Decompress);
+        byte[] decompressed = new byte[decompressedSize];
         deflate.ReadExactly(decompressed);
         return MetadataReaderProvider.FromPortablePdbImage(ImmutableArray.Create(decompressed));
     }
@@ -192,7 +192,7 @@ internal sealed class WebcilImageReader
     /// <returns>The portable PDB identity and build-time path.</returns>
     public WebcilCodeViewData ReadCodeView(WebcilDebugEntry entry)
     {
-        var payload = ReadEntryPayload(entry);
+        ReadOnlySpan<byte> payload = ReadEntryPayload(entry);
         if (payload.Length < 24
             || payload[0] != (byte)'R'
             || payload[1] != (byte)'S'
@@ -202,9 +202,9 @@ internal sealed class WebcilImageReader
             throw new BadImageFormatException("Unexpected CodeView payload signature.");
         }
 
-        var guid = new Guid(payload[4..20]);
-        var age = BinaryPrimitives.ReadInt32LittleEndian(payload[20..]);
-        var path = ReadUtf8NullTerminated(payload[24..]);
+        Guid guid = new(payload[4..20]);
+        int age = BinaryPrimitives.ReadInt32LittleEndian(payload[20..]);
+        string path = ReadUtf8NullTerminated(payload[24..]);
         return new WebcilCodeViewData(guid, age, path);
     }
 
@@ -218,218 +218,138 @@ internal sealed class WebcilImageReader
     public bool TryReadInt32AtRva(int rva, int relativeOffset, out int value)
     {
         value = 0;
-        if (!TryTranslateRva((uint)rva, out var offset, out var available)
+        if (rva == 0
             || relativeOffset < 0
-            || relativeOffset + 4 > available)
+            || !TryTranslateRva((uint)rva, out int offset, out int available)
+            || available < sizeof(int)
+            || relativeOffset > available - sizeof(int))
         {
             return false;
         }
 
-        value = BinaryPrimitives.ReadInt32LittleEndian(_image.AsSpan((int)offset + relativeOffset, 4));
+        value = BinaryPrimitives.ReadInt32LittleEndian(_image.AsSpan(offset + relativeOffset, sizeof(int)));
         return true;
     }
 
-    private long PayloadOffset { get; }
+    private int PayloadOffset { get; }
 
-    private static bool TryFindPayload(ReadOnlySpan<byte> bytes, out long payloadOffset)
+    private static WebcilHeader ReadHeader(ReadOnlySpan<byte> payload)
     {
-        payloadOffset = 0;
-        if (bytes.Length < 4)
-            return false;
+        if (payload.Length < HeaderV0Size)
+            throw new BadImageFormatException("The Webcil header is truncated.");
 
-        if (BinaryPrimitives.ReadUInt32LittleEndian(bytes) == WebcilMagic)
-            return true;
+        uint id = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+        ushort versionMajor = BinaryPrimitives.ReadUInt16LittleEndian(payload[4..]);
+        ushort versionMinor = BinaryPrimitives.ReadUInt16LittleEndian(payload[6..]);
+        ushort coffSections = BinaryPrimitives.ReadUInt16LittleEndian(payload[8..]);
 
-        if (bytes.Length < 8
-            || BinaryPrimitives.ReadUInt32LittleEndian(bytes) != WasmMagic
-            || BinaryPrimitives.ReadUInt32LittleEndian(bytes[4..]) != WasmVersion)
-        {
-            return false;
-        }
+        if (id != WebcilMagic)
+            throw new BadImageFormatException("The Webcil signature is invalid.");
+        if (versionMajor is not (0 or 1) || versionMinor != 0)
+            throw new BadImageFormatException("The Webcil version is unsupported.");
+        if (coffSections is 0 or > MaxSections)
+            throw new BadImageFormatException("The Webcil section count is invalid.");
 
-        var pos = 8;
-        while (pos < bytes.Length)
-        {
-            var sectionId = ReadByte(bytes, ref pos);
-            var sectionSize = checked((int)ReadUleb(bytes, ref pos));
-            var sectionEnd = checked(pos + sectionSize);
-            if (sectionEnd > bytes.Length)
-                return false;
+        int headerSize = versionMajor == 0 ? HeaderV0Size : HeaderV1Size;
+        int sectionTableSize = coffSections * SectionHeaderSize;
+        if (payload.Length < headerSize || sectionTableSize > payload.Length - headerSize)
+            throw new BadImageFormatException("The Webcil section table is truncated.");
 
-            if (sectionId != 11)
-            {
-                pos = sectionEnd;
-                continue;
-            }
-
-            var segmentCount = checked((int)ReadUleb(bytes, ref pos));
-            for (var i = 0; i < segmentCount && pos < sectionEnd; i++)
-            {
-                var mode = ReadByte(bytes, ref pos);
-                if (mode == 0)
-                    SkipConstExpr(bytes, ref pos, sectionEnd);
-                else if (mode == 2)
-                {
-                    _ = ReadUleb(bytes, ref pos);
-                    SkipConstExpr(bytes, ref pos, sectionEnd);
-                }
-                else if (mode != 1)
-                {
-                    return false;
-                }
-
-                var size = checked((int)ReadUleb(bytes, ref pos));
-                if (pos + size > sectionEnd)
-                    return false;
-
-                var segment = bytes[pos..(pos + size)];
-                if (segment.Length >= 4
-                    && BinaryPrimitives.ReadUInt32LittleEndian(segment) == WebcilMagic
-                    && TryReadHeader(bytes, pos, out _))
-                {
-                    payloadOffset = pos;
-                    return true;
-                }
-
-                pos += size;
-            }
-
-            return false;
-        }
-
-        return false;
+        return new WebcilHeader(
+            Id: id,
+            VersionMajor: versionMajor,
+            VersionMinor: versionMinor,
+            CoffSections: coffSections,
+            PeCliHeaderRva: BinaryPrimitives.ReadUInt32LittleEndian(payload[12..]),
+            PeCliHeaderSize: BinaryPrimitives.ReadUInt32LittleEndian(payload[16..]),
+            PeDebugRva: BinaryPrimitives.ReadUInt32LittleEndian(payload[20..]),
+            PeDebugSize: BinaryPrimitives.ReadUInt32LittleEndian(payload[24..]),
+            TableBase: versionMajor == 0
+                ? uint.MaxValue
+                : BinaryPrimitives.ReadUInt32LittleEndian(payload[HeaderV0Size..]));
     }
 
-    private static bool TryReadHeader(ReadOnlySpan<byte> bytes, long offset, out WebcilHeader header)
+    private static List<WebcilSection> ReadSectionTable(ReadOnlySpan<byte> payload, WebcilHeader header)
     {
-        header = default;
-        if (offset < 0 || offset + HeaderV0Size > bytes.Length)
-            return false;
-
-        var span = bytes[(int)offset..];
-        header = new WebcilHeader(
-            Id: BinaryPrimitives.ReadUInt32LittleEndian(span),
-            VersionMajor: BinaryPrimitives.ReadUInt16LittleEndian(span[4..]),
-            VersionMinor: BinaryPrimitives.ReadUInt16LittleEndian(span[6..]),
-            CoffSections: BinaryPrimitives.ReadUInt16LittleEndian(span[8..]),
-            PeCliHeaderRva: BinaryPrimitives.ReadUInt32LittleEndian(span[12..]),
-            PeCliHeaderSize: BinaryPrimitives.ReadUInt32LittleEndian(span[16..]),
-            PeDebugRva: BinaryPrimitives.ReadUInt32LittleEndian(span[20..]),
-            PeDebugSize: BinaryPrimitives.ReadUInt32LittleEndian(span[24..]),
-            TableBase: uint.MaxValue);
-
-        if (header.Id != WebcilMagic
-            || header.VersionMajor is not (0 or 1)
-            || header.VersionMinor != 0)
+        int sectionOffset = header.VersionMajor == 0 ? HeaderV0Size : HeaderV1Size;
+        List<WebcilSection> sections = new(header.CoffSections);
+        for (int index = 0; index < header.CoffSections; index++)
         {
-            return false;
-        }
-
-        if (header.VersionMajor >= 1)
-        {
-            if (offset + HeaderV1Size > bytes.Length)
-                return false;
-            header = header with { TableBase = BinaryPrimitives.ReadUInt32LittleEndian(span[HeaderV0Size..]) };
-        }
-
-        return true;
-    }
-
-    private static List<WebcilSection> ReadSections(ReadOnlySpan<byte> bytes, long payloadOffset, WebcilHeader header)
-    {
-        var sectionOffset = checked(payloadOffset + (header.VersionMajor >= 1 ? HeaderV1Size : HeaderV0Size));
-        var result = new List<WebcilSection>(header.CoffSections);
-        for (var i = 0; i < header.CoffSections; i++)
-        {
-            var offset = checked(sectionOffset + i * SectionHeaderSize);
-            if (offset + SectionHeaderSize > bytes.Length)
-                throw new BadImageFormatException("The Webcil section table is truncated.");
-
-            var span = bytes[(int)offset..];
-            result.Add(new WebcilSection(
+            int offset = sectionOffset + index * SectionHeaderSize;
+            ReadOnlySpan<byte> span = payload.Slice(offset, SectionHeaderSize);
+            WebcilSection section = new(
                 VirtualSize: BinaryPrimitives.ReadUInt32LittleEndian(span),
                 VirtualAddress: BinaryPrimitives.ReadUInt32LittleEndian(span[4..]),
                 SizeOfRawData: BinaryPrimitives.ReadUInt32LittleEndian(span[8..]),
-                PointerToRawData: BinaryPrimitives.ReadUInt32LittleEndian(span[12..])));
+                PointerToRawData: BinaryPrimitives.ReadUInt32LittleEndian(span[12..]));
+
+            ValidateSection(section, payload.Length);
+            foreach (WebcilSection previous in sections)
+            {
+                uint sectionEnd = section.VirtualAddress + section.VirtualSize;
+                uint previousEnd = previous.VirtualAddress + previous.VirtualSize;
+                if (sectionEnd > previous.VirtualAddress && previousEnd > section.VirtualAddress)
+                    throw new BadImageFormatException("Webcil sections overlap in virtual address space.");
+            }
+
+            sections.Add(section);
         }
 
-        return result;
+        return sections;
     }
 
-    private static byte[] ReadMetadata(
-        ReadOnlySpan<byte> bytes,
-        long payloadOffset,
-        WebcilHeader header,
-        IReadOnlyList<WebcilSection> sections)
+    private static void ValidateSection(WebcilSection section, int payloadLength)
     {
-        var clr = ReadClrHeader(header, sections, bytes, payloadOffset);
-        if (!TryTranslateRva(sections, payloadOffset, (uint)clr.MetadataRva, out var offset, out var available)
-            || clr.MetadataSize <= 0
-            || clr.MetadataSize > available)
+        if (section.PointerToRawData > (uint)payloadLength
+            || section.SizeOfRawData > (uint)payloadLength - section.PointerToRawData)
         {
-            throw new BadImageFormatException("The Webcil metadata directory does not map to file bytes.");
+            throw new BadImageFormatException("A Webcil section extends past the end of its payload.");
         }
 
-        return bytes.Slice((int)offset, clr.MetadataSize).ToArray();
-    }
-
-    private static List<WebcilDebugEntry> ReadDebugEntries(
-        ReadOnlySpan<byte> bytes,
-        long payloadOffset,
-        WebcilHeader header,
-        IReadOnlyList<WebcilSection> sections)
-    {
-        if (header.PeDebugRva == 0 || header.PeDebugSize == 0)
-            return [];
-
-        if (!TryTranslateRva(sections, payloadOffset, header.PeDebugRva, out var offset, out var available)
-            || header.PeDebugSize > available
-            || header.PeDebugSize % DebugDirectoryEntrySize != 0)
-        {
-            return [];
-        }
-
-        var count = checked((int)header.PeDebugSize / DebugDirectoryEntrySize);
-        var result = new List<WebcilDebugEntry>(count);
-        for (var i = 0; i < count; i++)
-        {
-            var span = bytes.Slice((int)offset + i * DebugDirectoryEntrySize, DebugDirectoryEntrySize);
-            var characteristics = BinaryPrimitives.ReadUInt32LittleEndian(span);
-            if (characteristics != 0)
-                continue;
-
-            result.Add(new WebcilDebugEntry(
-                Stamp: BinaryPrimitives.ReadUInt32LittleEndian(span[4..]),
-                MajorVersion: BinaryPrimitives.ReadUInt16LittleEndian(span[8..]),
-                MinorVersion: BinaryPrimitives.ReadUInt16LittleEndian(span[10..]),
-                Type: (DebugDirectoryEntryType)BinaryPrimitives.ReadInt32LittleEndian(span[12..]),
-                DataSize: BinaryPrimitives.ReadInt32LittleEndian(span[16..]),
-                DataRva: BinaryPrimitives.ReadInt32LittleEndian(span[20..]),
-                DataPointer: BinaryPrimitives.ReadInt32LittleEndian(span[24..])));
-        }
-
-        return result;
+        if (section.VirtualSize > uint.MaxValue - section.VirtualAddress)
+            throw new BadImageFormatException("A Webcil section's virtual address range overflows.");
     }
 
     private static ClrHeader ReadClrHeader(
         WebcilHeader header,
         IReadOnlyList<WebcilSection> sections,
-        ReadOnlySpan<byte> bytes,
-        long payloadOffset)
+        ReadOnlySpan<byte> payload)
     {
-        if (!TryTranslateRva(sections, payloadOffset, header.PeCliHeaderRva, out var offset, out var available)
-            || available < 72)
+        if (header.PeCliHeaderRva == 0
+            || header.PeCliHeaderSize < ClrHeaderSize
+            || !TryTranslateRva(
+                sections,
+                payload.Length,
+                header.PeCliHeaderRva,
+                out int offset,
+                out int available)
+            || available < ClrHeaderSize)
         {
             throw new BadImageFormatException("The Webcil CLR header does not map to file bytes.");
         }
 
-        var span = bytes[(int)offset..];
+        ReadOnlySpan<byte> span = payload.Slice(offset, ClrHeaderSize);
+        uint clrHeaderSize = BinaryPrimitives.ReadUInt32LittleEndian(span);
+        if (clrHeaderSize < ClrHeaderSize)
+            throw new BadImageFormatException("The Webcil CLR header is truncated.");
+
+        ushort majorRuntimeVersion = BinaryPrimitives.ReadUInt16LittleEndian(span[4..]);
+        CorFlags flags = (CorFlags)BinaryPrimitives.ReadUInt32LittleEndian(span[16..]);
+        if (majorRuntimeVersion is <= 1 or > 2)
+            throw new BadImageFormatException("The Webcil CLR runtime version is unsupported.");
+        if ((flags & CorFlags.NativeEntryPoint) != 0)
+            throw new BadImageFormatException("Webcil does not support native entry points.");
+        if (BinaryPrimitives.ReadUInt32LittleEndian(span[52..]) != 0)
+            throw new BadImageFormatException("Webcil does not support CLR vtable fixups.");
+        if (BinaryPrimitives.ReadUInt32LittleEndian(span[60..]) != 0)
+            throw new BadImageFormatException("Webcil does not support export address table jumps.");
+
         return new ClrHeader(
-            MajorRuntimeVersion: BinaryPrimitives.ReadUInt16LittleEndian(span[4..]),
+            MajorRuntimeVersion: majorRuntimeVersion,
             MinorRuntimeVersion: BinaryPrimitives.ReadUInt16LittleEndian(span[6..]),
             MetadataRva: BinaryPrimitives.ReadInt32LittleEndian(span[8..]),
             MetadataSize: BinaryPrimitives.ReadInt32LittleEndian(span[12..]),
-            Flags: (CorFlags)BinaryPrimitives.ReadUInt32LittleEndian(span[16..]),
+            Flags: flags,
             EntryPointToken: BinaryPrimitives.ReadInt32LittleEndian(span[20..]),
             ResourcesRva: BinaryPrimitives.ReadInt32LittleEndian(span[24..]),
             ResourcesSize: BinaryPrimitives.ReadInt32LittleEndian(span[28..]),
@@ -438,6 +358,144 @@ internal sealed class WebcilImageReader
             ManagedNativeHeader: new DirectoryEntry(
                 BinaryPrimitives.ReadInt32LittleEndian(span[64..]),
                 BinaryPrimitives.ReadInt32LittleEndian(span[68..])));
+    }
+
+    private static void ValidateClrDirectories(
+        ClrHeader clrHeader,
+        IReadOnlyList<WebcilSection> sections,
+        int payloadLength)
+    {
+        ValidateDirectory(
+            sections,
+            payloadLength,
+            clrHeader.MetadataRva,
+            clrHeader.MetadataSize,
+            required: true,
+            "metadata");
+        ValidateDirectory(
+            sections,
+            payloadLength,
+            clrHeader.ResourcesRva,
+            clrHeader.ResourcesSize,
+            required: false,
+            "resources");
+        ValidateDirectory(
+            sections,
+            payloadLength,
+            clrHeader.StrongNameSignatureRva,
+            clrHeader.StrongNameSignatureSize,
+            required: false,
+            "strong-name signature");
+        ValidateDirectory(
+            sections,
+            payloadLength,
+            clrHeader.ManagedNativeHeader.RelativeVirtualAddress,
+            clrHeader.ManagedNativeHeader.Size,
+            required: false,
+            "managed native header");
+
+        if ((clrHeader.Flags & CorFlags.StrongNameSigned) != 0
+            && clrHeader.StrongNameSignatureRva == 0)
+        {
+            throw new BadImageFormatException(
+                "The Webcil CLR header marks the image as strong-name signed without a signature.");
+        }
+    }
+
+    private static void ValidateDirectory(
+        IReadOnlyList<WebcilSection> sections,
+        int payloadLength,
+        int rva,
+        int size,
+        bool required,
+        string name)
+    {
+        if (rva == 0)
+        {
+            if (required)
+                throw new BadImageFormatException($"The Webcil {name} directory is invalid.");
+            return;
+        }
+
+        if (size < 0
+            || !TryTranslateRva(sections, payloadLength, (uint)rva, out _, out int available)
+            || size > available)
+        {
+            throw new BadImageFormatException($"The Webcil {name} directory does not map to file bytes.");
+        }
+    }
+
+    private static byte[] ReadMetadata(
+        ReadOnlySpan<byte> payload,
+        ClrHeader clrHeader,
+        IReadOnlyList<WebcilSection> sections)
+    {
+        if (!TryTranslateRva(
+                sections,
+                payload.Length,
+                (uint)clrHeader.MetadataRva,
+                out int offset,
+                out int available)
+            || clrHeader.MetadataSize <= 0
+            || clrHeader.MetadataSize > available)
+        {
+            throw new BadImageFormatException("The Webcil metadata directory does not map to file bytes.");
+        }
+
+        return payload.Slice(offset, clrHeader.MetadataSize).ToArray();
+    }
+
+    private static List<WebcilDebugEntry> ReadDebugEntries(
+        ReadOnlySpan<byte> payload,
+        WebcilHeader header,
+        IReadOnlyList<WebcilSection> sections)
+    {
+        if (header.PeDebugRva == 0 || header.PeDebugSize == 0)
+            return [];
+
+        if (header.PeDebugSize % DebugDirectoryEntrySize != 0
+            || !TryTranslateRva(
+                sections,
+                payload.Length,
+                header.PeDebugRva,
+                out int offset,
+                out int available)
+            || header.PeDebugSize > (uint)available)
+        {
+            throw new BadImageFormatException("The Webcil debug directory does not map to file bytes.");
+        }
+
+        int debugSize = (int)header.PeDebugSize;
+        int count = debugSize / DebugDirectoryEntrySize;
+        List<WebcilDebugEntry> result = new(count);
+        for (int index = 0; index < count; index++)
+        {
+            ReadOnlySpan<byte> span = payload.Slice(
+                offset + index * DebugDirectoryEntrySize,
+                DebugDirectoryEntrySize);
+            if (BinaryPrimitives.ReadUInt32LittleEndian(span) != 0)
+                throw new BadImageFormatException("Webcil debug-directory characteristics must be zero.");
+
+            uint dataSize = BinaryPrimitives.ReadUInt32LittleEndian(span[16..]);
+            uint dataRva = BinaryPrimitives.ReadUInt32LittleEndian(span[20..]);
+            uint dataPointer = BinaryPrimitives.ReadUInt32LittleEndian(span[24..]);
+            ValidatePayloadRange(
+                dataPointer,
+                dataSize,
+                payload.Length,
+                "The Webcil debug payload is out of range.");
+
+            result.Add(new WebcilDebugEntry(
+                Stamp: BinaryPrimitives.ReadUInt32LittleEndian(span[4..]),
+                MajorVersion: BinaryPrimitives.ReadUInt16LittleEndian(span[8..]),
+                MinorVersion: BinaryPrimitives.ReadUInt16LittleEndian(span[10..]),
+                Type: (DebugDirectoryEntryType)BinaryPrimitives.ReadInt32LittleEndian(span[12..]),
+                DataSize: (int)dataSize,
+                DataRva: unchecked((int)dataRva),
+                DataPointer: (int)dataPointer));
+        }
+
+        return result;
     }
 
     private string FormatPayload(WebcilDebugEntry entry)
@@ -461,25 +519,25 @@ internal sealed class WebcilImageReader
 
     private string FormatCodeViewPayload(WebcilDebugEntry entry)
     {
-        var data = ReadCodeView(entry);
+        WebcilCodeViewData data = ReadCodeView(entry);
         return $"Portable PDB; PDB GUID: {data.Guid}; age: {data.Age}; path: {data.Path}";
     }
 
     private string FormatPdbChecksumPayload(WebcilDebugEntry entry)
     {
-        var payload = ReadEntryPayload(entry);
-        var nul = payload.IndexOf((byte)0);
+        ReadOnlySpan<byte> payload = ReadEntryPayload(entry);
+        int nul = payload.IndexOf((byte)0);
         if (nul < 0)
             return "";
 
-        var algorithm = System.Text.Encoding.UTF8.GetString(payload[..nul]);
-        var checksum = payload[(nul + 1)..];
+        string algorithm = System.Text.Encoding.UTF8.GetString(payload[..nul]);
+        ReadOnlySpan<byte> checksum = payload[(nul + 1)..];
         return $"Algorithm: {algorithm}; checksum: {Convert.ToHexString(checksum)}";
     }
 
     private string FormatEmbeddedPortablePdbPayload(WebcilDebugEntry entry)
     {
-        var payload = ReadEntryPayload(entry);
+        ReadOnlySpan<byte> payload = ReadEntryPayload(entry);
         return payload.Length >= 8
             ? $"present; uncompressed size: {BinaryPrimitives.ReadInt32LittleEndian(payload[4..])} bytes"
             : "present";
@@ -487,18 +545,20 @@ internal sealed class WebcilImageReader
 
     private ReadOnlySpan<byte> ReadEntryPayload(WebcilDebugEntry entry)
     {
-        var offset = checked(PayloadOffset + entry.DataPointer);
-        if (entry.DataSize < 0 || offset < 0 || offset + entry.DataSize > _image.Length)
-            throw new BadImageFormatException("The Webcil debug entry payload is out of range.");
-        return _image.AsSpan((int)offset, entry.DataSize);
+        ValidatePayloadRange(
+            entry.DataPointer,
+            entry.DataSize,
+            _image.Length,
+            "The Webcil debug entry payload is out of range.");
+        return _image.AsSpan(entry.DataPointer, entry.DataSize);
     }
 
-    private bool TryTranslateRva(uint rva, out long offset, out long available) =>
-        TryTranslateRva(_sections, PayloadOffset, rva, out offset, out available);
+    private bool TryTranslateRva(uint rva, out int offset, out int available) =>
+        TryTranslateRva(_sections, _image.Length, rva, out offset, out available);
 
     private WebcilDebugEntry? FindDebugEntry(DebugDirectoryEntryType type)
     {
-        foreach (var entry in _debugEntries)
+        foreach (WebcilDebugEntry entry in _debugEntries)
             if (entry.Type == type)
                 return entry;
 
@@ -507,96 +567,231 @@ internal sealed class WebcilImageReader
 
     private static bool TryTranslateRva(
         IReadOnlyList<WebcilSection> sections,
-        long payloadOffset,
+        int payloadLength,
         uint rva,
-        out long offset,
-        out long available)
+        out int offset,
+        out int available)
     {
         offset = 0;
         available = 0;
-        foreach (var section in sections)
+        foreach (WebcilSection section in sections)
         {
-            if (rva < section.VirtualAddress || rva >= section.VirtualAddress + section.VirtualSize)
+            if (rva < section.VirtualAddress)
                 continue;
 
-            var delta = rva - section.VirtualAddress;
-            if (delta >= section.SizeOfRawData)
+            uint delta = rva - section.VirtualAddress;
+            if (delta >= section.VirtualSize || delta >= section.SizeOfRawData)
+                continue;
+
+            uint rawOffset = section.PointerToRawData + delta;
+            if (rawOffset > (uint)payloadLength)
                 return false;
 
-            offset = checked(payloadOffset + section.PointerToRawData + delta);
-            available = section.SizeOfRawData - delta;
+            uint virtualAvailable = section.VirtualSize - delta;
+            uint rawAvailable = section.SizeOfRawData - delta;
+            uint payloadAvailable = (uint)payloadLength - rawOffset;
+            offset = (int)rawOffset;
+            available = (int)Math.Min(virtualAvailable, Math.Min(rawAvailable, payloadAvailable));
             return true;
         }
 
         return false;
     }
 
-    private static byte ReadByte(ReadOnlySpan<byte> bytes, ref int pos)
+    private static bool TryFindPayload(
+        ReadOnlySpan<byte> bytes,
+        out int payloadOffset,
+        out int payloadLength)
     {
-        if ((uint)pos >= (uint)bytes.Length)
-            throw new BadImageFormatException("Unexpected end of WebAssembly data.");
-        return bytes[pos++];
-    }
+        payloadOffset = 0;
+        payloadLength = 0;
+        if (bytes.Length < sizeof(uint))
+            return false;
 
-    private static uint ReadUleb(ReadOnlySpan<byte> bytes, ref int pos)
-    {
-        uint result = 0;
-        var shift = 0;
-        while (true)
+        if (BinaryPrimitives.ReadUInt32LittleEndian(bytes) == WebcilMagic)
         {
-            var b = ReadByte(bytes, ref pos);
-            result |= (uint)(b & 0x7F) << shift;
-            if ((b & 0x80) == 0)
-                return result;
-            shift += 7;
-            if (shift >= 35)
-                throw new BadImageFormatException("WebAssembly ULEB128 value is too large.");
+            payloadLength = bytes.Length;
+            return true;
         }
+
+        if (bytes.Length < 8
+            || BinaryPrimitives.ReadUInt32LittleEndian(bytes) != WasmMagic
+            || BinaryPrimitives.ReadUInt32LittleEndian(bytes[4..]) != WasmVersion)
+        {
+            return false;
+        }
+
+        bool recognized = false;
+        try
+        {
+            int position = 8;
+            while (position < bytes.Length)
+            {
+                byte sectionId = ReadByte(bytes, ref position, bytes.Length);
+                uint sectionSize = ReadUleb32(bytes, ref position, bytes.Length);
+                bool sectionTruncated = sectionSize > (uint)(bytes.Length - position);
+                int sectionEnd = sectionTruncated ? bytes.Length : position + (int)sectionSize;
+                if (sectionId != 11)
+                {
+                    if (sectionTruncated)
+                        return false;
+                    position = sectionEnd;
+                    continue;
+                }
+
+                uint segmentCount = ReadUleb32(bytes, ref position, sectionEnd);
+                for (uint index = 0; index < segmentCount; index++)
+                {
+                    uint mode = ReadUleb32(bytes, ref position, sectionEnd);
+                    if (mode == 0)
+                    {
+                        SkipConstExpr(bytes, ref position, sectionEnd);
+                    }
+                    else if (mode == 2)
+                    {
+                        _ = ReadUleb32(bytes, ref position, sectionEnd);
+                        SkipConstExpr(bytes, ref position, sectionEnd);
+                    }
+                    else if (mode != 1)
+                    {
+                        return false;
+                    }
+
+                    uint size = ReadUleb32(bytes, ref position, sectionEnd);
+                    recognized = size >= sizeof(uint)
+                        && position <= sectionEnd - sizeof(uint)
+                        && BinaryPrimitives.ReadUInt32LittleEndian(bytes[position..]) == WebcilMagic;
+                    if (recognized && sectionTruncated)
+                    {
+                        throw new BadImageFormatException(
+                            "The WebAssembly data section containing Webcil extends past the file.");
+                    }
+                    if (size > (uint)(sectionEnd - position))
+                    {
+                        if (recognized)
+                            throw new BadImageFormatException(
+                                "The wrapped Webcil payload extends past its data segment.");
+                        return false;
+                    }
+
+                    if (recognized)
+                    {
+                        payloadOffset = position;
+                        payloadLength = (int)size;
+                        return true;
+                    }
+
+                    position += (int)size;
+                }
+
+                return false;
+            }
+        }
+        catch (Exception ex) when (
+            !recognized
+            && ex is BadImageFormatException or OverflowException or ArgumentOutOfRangeException)
+        {
+            return false;
+        }
+        catch (Exception ex) when (
+            recognized
+            && ex is OverflowException or ArgumentOutOfRangeException)
+        {
+            throw new BadImageFormatException("The wrapped Webcil payload is malformed.", ex);
+        }
+
+        return false;
     }
 
-    private static void SkipConstExpr(ReadOnlySpan<byte> bytes, ref int pos, int end)
+    private static uint ReadUleb32(ReadOnlySpan<byte> bytes, ref int position, int end)
     {
-        while (pos < end)
+        uint value = 0;
+        for (int index = 0; index < 5; index++)
         {
-            var opcode = ReadByte(bytes, ref pos);
+            byte current = ReadByte(bytes, ref position, end);
+            if (index == 4 && (current & 0xF0) != 0)
+                throw new BadImageFormatException("A WebAssembly ULEB128 value is too large.");
+
+            value |= (uint)(current & 0x7F) << (index * 7);
+            if ((current & 0x80) == 0)
+                return value;
+        }
+
+        throw new BadImageFormatException("A WebAssembly ULEB128 value is too large.");
+    }
+
+    private static byte ReadByte(ReadOnlySpan<byte> bytes, ref int position, int end)
+    {
+        if ((uint)position >= (uint)end || (uint)position >= (uint)bytes.Length)
+            throw new BadImageFormatException("Unexpected end of WebAssembly data.");
+        return bytes[position++];
+    }
+
+    private static void SkipConstExpr(ReadOnlySpan<byte> bytes, ref int position, int end)
+    {
+        while (position < end)
+        {
+            byte opcode = ReadByte(bytes, ref position, end);
             switch (opcode)
             {
                 case 0x0B:
                     return;
                 case 0x41:
+                    SkipLeb128(bytes, ref position, end, 5);
+                    break;
                 case 0x42:
-                    _ = ReadUleb(bytes, ref pos);
+                    SkipLeb128(bytes, ref position, end, 10);
+                    break;
+                case 0x43:
+                    SkipBytes(ref position, end, sizeof(float));
+                    break;
+                case 0x44:
+                    SkipBytes(ref position, end, sizeof(double));
                     break;
                 case 0x23:
-                    _ = ReadUleb(bytes, ref pos);
+                case 0xD2:
+                    _ = ReadUleb32(bytes, ref position, end);
                     break;
-                default:
+                case 0xD0:
+                    SkipLeb128(bytes, ref position, end, 5);
                     break;
             }
         }
+
+        throw new BadImageFormatException("A WebAssembly constant expression is unterminated.");
+    }
+
+    private static void SkipLeb128(ReadOnlySpan<byte> bytes, ref int position, int end, int maximumBytes)
+    {
+        for (int index = 0; index < maximumBytes; index++)
+            if ((ReadByte(bytes, ref position, end) & 0x80) == 0)
+                return;
+
+        throw new BadImageFormatException("A WebAssembly LEB128 value is too large.");
+    }
+
+    private static void SkipBytes(ref int position, int end, int count)
+    {
+        if (position > end - count)
+            throw new BadImageFormatException("Unexpected end of WebAssembly data.");
+        position += count;
+    }
+
+    private static void ValidatePayloadRange(int offset, int size, int payloadLength, string message)
+    {
+        if (offset < 0 || size < 0 || offset > payloadLength || size > payloadLength - offset)
+            throw new BadImageFormatException(message);
+    }
+
+    private static void ValidatePayloadRange(uint offset, uint size, int payloadLength, string message)
+    {
+        if (offset > (uint)payloadLength || size > (uint)payloadLength - offset)
+            throw new BadImageFormatException(message);
     }
 
     private static string ReadUtf8NullTerminated(ReadOnlySpan<byte> bytes)
     {
-        var nul = bytes.IndexOf((byte)0);
+        int nul = bytes.IndexOf((byte)0);
         return System.Text.Encoding.UTF8.GetString(nul >= 0 ? bytes[..nul] : bytes);
     }
-
-    private readonly record struct WebcilHeader(
-        uint Id,
-        int VersionMajor,
-        int VersionMinor,
-        int CoffSections,
-        uint PeCliHeaderRva,
-        uint PeCliHeaderSize,
-        uint PeDebugRva,
-        uint PeDebugSize,
-        uint TableBase);
-
-    private readonly record struct WebcilSection(
-        uint VirtualSize,
-        uint VirtualAddress,
-        uint SizeOfRawData,
-        uint PointerToRawData);
-
 }

--- a/src/Dotsider.Core/Analysis/Wasm/WebcilSection.cs
+++ b/src/Dotsider.Core/Analysis/Wasm/WebcilSection.cs
@@ -1,0 +1,14 @@
+namespace Dotsider.Core.Analysis.Wasm;
+
+/// <summary>
+/// Represents one entry in a Webcil section table.
+/// </summary>
+/// <param name="VirtualSize">The section's virtual size.</param>
+/// <param name="VirtualAddress">The section's starting RVA.</param>
+/// <param name="SizeOfRawData">The number of file-backed bytes.</param>
+/// <param name="PointerToRawData">The payload-relative offset of the file-backed bytes.</param>
+internal readonly record struct WebcilSection(
+    uint VirtualSize,
+    uint VirtualAddress,
+    uint SizeOfRawData,
+    uint PointerToRawData);

--- a/src/Dotsider/DiffApp.cs
+++ b/src/Dotsider/DiffApp.cs
@@ -149,11 +149,6 @@ public sealed class DiffApp(DiffState state)
                 // Universal yank
                 bindings.Key(Hex1bKey.Y).Global().Action(ctx =>
                 {
-                    // Timeout check
-                    if (_state.VimPending != VimMotionState.Idle
-                        && (DateTime.UtcNow - _state.VimPendingTimestamp).TotalSeconds > 1.0)
-                        _state.VimPending = VimMotionState.Idle;
-
                     // yy: second y while already armed → yank entire line
                     if (_state.VimPending == VimMotionState.WaitingForYMotion
                         && ctx.FocusedNode is EditorNode { State: var yyState } yyEditor

--- a/src/Dotsider/DiffState.cs
+++ b/src/Dotsider/DiffState.cs
@@ -91,7 +91,7 @@ public sealed class DiffState : IDisposable
     /// <summary>Cursor position when the text-object sequence was armed, for cursor affinity.</summary>
     public int VimPendingCursorOffset { get; set; }
 
-    /// <summary>Timestamp when the text-object sequence was armed, for 1-second timeout.</summary>
+    /// <summary>Timestamp of the latest text-object state transition.</summary>
     public DateTime VimPendingTimestamp { get; set; }
 
     /// <summary>Delegate to perform a neovim-style editor yank, set by the host app (DiffApp).</summary>

--- a/src/Dotsider/DotsiderApp.cs
+++ b/src/Dotsider/DotsiderApp.cs
@@ -182,11 +182,6 @@ public sealed class DotsiderApp(DotsiderState state)
                 // Universal yank — works on all tabs with neovim-style behavior
                 bindings.Key(Hex1bKey.Y).Global().Action(ctx =>
                 {
-                    // Timeout check — reset stale vim pending state
-                    if (_state.VimPending != VimMotionState.Idle
-                        && (DateTime.UtcNow - _state.VimPendingTimestamp).TotalSeconds > 1.0)
-                        _state.VimPending = VimMotionState.Idle;
-
                     // 1. yy: second y while already armed → yank entire line
                     if (_state.VimPending == VimMotionState.WaitingForYMotion
                         && ctx.FocusedNode is EditorNode { State: var yyState } yyEditor

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -480,7 +480,7 @@ public sealed class DotsiderState : IDisposable
     /// <summary>Cursor position when the text-object sequence was armed, for cursor affinity.</summary>
     public int VimPendingCursorOffset { get; set; }
 
-    /// <summary>Timestamp when the text-object sequence was armed, for 1-second timeout.</summary>
+    /// <summary>Timestamp of the latest text-object state transition.</summary>
     public DateTime VimPendingTimestamp { get; set; }
 
     /// <summary>Delegate to perform a neovim-style editor yank, set by the host app (DotsiderApp/NuGetApp).</summary>

--- a/src/Dotsider/NuGetApp.cs
+++ b/src/Dotsider/NuGetApp.cs
@@ -236,7 +236,7 @@ public sealed class NuGetApp(NuGetState state)
                                 _state.App.Invalidate();
                                 return;
                             }
-                            
+
                             if (dllState.StringsDetailContent is not null)
                             {
                                 dllState.StringsDetailContent = null;
@@ -309,14 +309,6 @@ public sealed class NuGetApp(NuGetState state)
                 // Universal yank — same behavior as DotsiderApp
                 bindings.Key(Hex1bKey.Y).Global().Action(ctx =>
                 {
-                    // Timeout check — reset stale state on both stores
-                    if (_state.VimPending != VimMotionState.Idle
-                        && (DateTime.UtcNow - _state.VimPendingTimestamp).TotalSeconds > 1.0)
-                        _state.VimPending = VimMotionState.Idle;
-                    if (_state.SelectedDllState is { VimPending: not VimMotionState.Idle } dllTimeout
-                        && (DateTime.UtcNow - dllTimeout.VimPendingTimestamp).TotalSeconds > 1.0)
-                        dllTimeout.VimPending = VimMotionState.Idle;
-
                     // 1. yy: second y while already armed → yank entire line
                     // Check both state stores (browser vs DLL inspector)
                     if (ctx.FocusedNode is EditorNode { State: var yyState } yyEditor)
@@ -355,7 +347,7 @@ public sealed class NuGetApp(NuGetState state)
                     {
                         // Don't arm on hex dump normal mode (I conflicts with Insert)
                         var isHexNormal = _state.SelectedDllState is
-                            { CurrentTab: TabId.HexDump, HexMode: HexEditMode.Normal };
+                        { CurrentTab: TabId.HexDump, HexMode: HexEditMode.Normal };
                         if (isHexNormal)
                         {
                             _state.VimPending = VimMotionState.Idle;

--- a/src/Dotsider/NuGetState.cs
+++ b/src/Dotsider/NuGetState.cs
@@ -79,7 +79,7 @@ public sealed class NuGetState(Hex1bApp app, string nupkgPath) : IDisposable
     /// <summary>Cursor position when the text-object sequence was armed, for cursor affinity.</summary>
     public int VimPendingCursorOffset { get; set; }
 
-    /// <summary>Timestamp when the text-object sequence was armed, for 1-second timeout.</summary>
+    /// <summary>Timestamp of the latest text-object state transition.</summary>
     public DateTime VimPendingTimestamp { get; set; }
 
     /// <summary>Delegate to perform a neovim-style editor yank, set by the host app (NuGetApp).</summary>

--- a/src/Dotsider/SizeDiffApp.cs
+++ b/src/Dotsider/SizeDiffApp.cs
@@ -113,10 +113,6 @@ public sealed class SizeDiffApp(SizeDiffState state)
                 // Yank: editors only — the treemap has no row model to yank.
                 bindings.Key(Hex1bKey.Y).Global().Action(ctx =>
                 {
-                    if (_state.VimPending != VimMotionState.Idle
-                        && (DateTime.UtcNow - _state.VimPendingTimestamp).TotalSeconds > 1.0)
-                        _state.VimPending = VimMotionState.Idle;
-
                     if (_state.VimPending == VimMotionState.WaitingForYMotion
                         && ctx.FocusedNode is EditorNode { State: var yyState } yyEditor
                         && yyState == _state.VimPendingEditor

--- a/src/Dotsider/SizeDiffState.cs
+++ b/src/Dotsider/SizeDiffState.cs
@@ -132,7 +132,7 @@ public sealed class SizeDiffState(Hex1bApp app, MstatSource left, MstatSource ri
     /// <summary>Cursor position when the text-object sequence was armed, for cursor affinity.</summary>
     public int VimPendingCursorOffset { get; set; }
 
-    /// <summary>Timestamp when the text-object sequence was armed, for 1-second timeout.</summary>
+    /// <summary>Timestamp of the latest text-object state transition.</summary>
     public DateTime VimPendingTimestamp { get; set; }
 
     /// <summary>Delegate to perform a neovim-style editor yank, set by the host app.</summary>

--- a/src/Dotsider/Views/TextObjectHelper.cs
+++ b/src/Dotsider/Views/TextObjectHelper.cs
@@ -112,7 +112,10 @@ public static class TextObjectHelper
     /// <param name="getVimPending">Returns the current <see cref="VimMotionState"/>.</param>
     /// <param name="getVimPendingEditor">Returns the editor that started the sequence.</param>
     /// <param name="getVimPendingCursorOffset">Returns the cursor offset when the sequence was armed.</param>
-    /// <param name="getVimPendingTimestamp">Returns the timestamp when the sequence was armed.</param>
+    /// <param name="getVimPendingTimestamp">
+    /// Returns the timestamp of the latest pending-state transition. The timestamp is retained for API compatibility;
+    /// operator-pending input is cancelled by input rather than elapsed wall-clock time.
+    /// </param>
     /// <param name="setVimState">Sets <see cref="VimMotionState"/>, pending editor, and cursor offset.</param>
     /// <param name="performYank">Called for <c>yiw</c>/<c>yiW</c> to yank the selection.</param>
     /// <param name="invalidate">Requests a UI refresh.</param>
@@ -127,19 +130,15 @@ public static class TextObjectHelper
         Action<InputBindingActionContext, EditorNode>? performYank,
         Action invalidate)
     {
+        // Retain the timestamp delegate in the public contract without making valid operator-pending
+        // input depend on wall-clock scheduling.
+        _ = getVimPendingTimestamp;
+
         void ResetToIdle() => setVimState(VimMotionState.Idle, null, 0);
 
         // --- I binding (always registered — starts text object from Idle) ---
         bindings.Key(Hex1bKey.I).Action(ctx =>
         {
-            // Timeout check — reset stale state, then fall through to process
-            // this i as a fresh sequence start (don't discard the keypress)
-            if (getVimPending() != VimMotionState.Idle
-                && (DateTime.UtcNow - getVimPendingTimestamp()).TotalSeconds > 1.0)
-            {
-                ResetToIdle();
-            }
-
             var pending = getVimPending();
             switch (pending)
             {
@@ -210,7 +209,7 @@ public static class TextObjectHelper
         bindings.Key(Hex1bKey.W).Action(ctx =>
         {
             CompleteTextObject(ctx, thisEditorState, getVimPending, getVimPendingEditor,
-                getVimPendingCursorOffset, getVimPendingTimestamp, setVimState,
+                getVimPendingCursorOffset, setVimState,
                 performYank, invalidate, isWord: true);
         }, "");
 
@@ -218,7 +217,7 @@ public static class TextObjectHelper
         bindings.Shift().Key(Hex1bKey.W).Action(ctx =>
         {
             CompleteTextObject(ctx, thisEditorState, getVimPending, getVimPendingEditor,
-                getVimPendingCursorOffset, getVimPendingTimestamp, setVimState,
+                getVimPendingCursorOffset, setVimState,
                 performYank, invalidate, isWord: false);
         }, "");
 
@@ -292,21 +291,12 @@ public static class TextObjectHelper
         Func<VimMotionState> getVimPending,
         Func<EditorState?> getVimPendingEditor,
         Func<int> getVimPendingCursorOffset,
-        Func<DateTime> getVimPendingTimestamp,
         Action<VimMotionState, EditorState?, int> setVimState,
         Action<InputBindingActionContext, EditorNode>? performYank,
         Action invalidate,
         bool isWord)
     {
         void ResetToIdle() => setVimState(VimMotionState.Idle, null, 0);
-
-        // Timeout check
-        if (getVimPending() != VimMotionState.Idle
-            && (DateTime.UtcNow - getVimPendingTimestamp()).TotalSeconds > 1.0)
-        {
-            ResetToIdle();
-            return;
-        }
 
         var pending = getVimPending();
 

--- a/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
@@ -1259,12 +1259,20 @@ public class StandardModeYankIntegrationTests : IDisposable
 
         Assert.AreEqual(VimMotionState.WaitingForYMotion, _state!.VimPending);
 
+        await Task.Delay(TimeSpan.FromMilliseconds(1_100), ct);
+        Assert.AreEqual(VimMotionState.WaitingForYMotion, _state.VimPending);
+
         // Press i — advances to WaitingForYTextObject
         await new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.I)
             .WaitUntil(_ => _state!.VimPending == VimMotionState.WaitingForYTextObject, TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal, ct);
+
+        // Operator-pending input follows Vim semantics: it remains armed until completion or
+        // an actual cancelling input, independent of UI scheduling delays.
+        await Task.Delay(TimeSpan.FromMilliseconds(1_100), ct);
+        Assert.AreEqual(VimMotionState.WaitingForYTextObject, _state.VimPending);
 
         // Press w — selects + yanks
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1590,11 +1598,22 @@ public class StandardModeYankIntegrationTests : IDisposable
             .Build()
             .ApplyAsync(terminal, ct);
 
-        // yy to yank the current line
+        // yy to yank the current line. Operator-pending y must not expire while the user pauses
+        // or the UI thread is delayed by other work.
         await new Hex1bTerminalInputSequenceBuilder()
             .Type("y")
+            .WaitUntil(_ => _state.VimPending == VimMotionState.WaitingForYMotion,
+                TimeSpan.FromSeconds(5))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        await Task.Delay(TimeSpan.FromMilliseconds(1_100), ct);
+        Assert.AreEqual(VimMotionState.WaitingForYMotion, _state.VimPending);
+
+        await new Hex1bTerminalInputSequenceBuilder()
             .Type("y")
-            .WaitUntil(s => s.ContainsText("Yanked"), TimeSpan.FromSeconds(5))
+            .WaitUntil(snapshot => _clipboardAdapter!.ClipboardWrites.TryPeek(out _),
+                TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal, ct);
 

--- a/tests/Dotsider.Tests/SyntheticWebcilBuilder.cs
+++ b/tests/Dotsider.Tests/SyntheticWebcilBuilder.cs
@@ -1,0 +1,328 @@
+using System.Buffers.Binary;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Produces deterministic Webcil images from real ECMA-335 metadata and IL.
+/// </summary>
+internal static class SyntheticWebcilBuilder
+{
+    private const int DebugDirectoryEntrySize = 28;
+    private const int SectionHeaderSize = 16;
+    private const uint WebcilMagic = 0x4C496257;
+
+    internal static SyntheticWebcilImage Create(
+        int version = 1,
+        bool wrapped = false,
+        int sectionCount = 1,
+        int wrapperSuffixLength = 0,
+        int additionalSectionSize = 4)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(version, 0);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(version, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(sectionCount, 1);
+        ArgumentOutOfRangeException.ThrowIfNegative(wrapperSuffixLength);
+        ArgumentOutOfRangeException.ThrowIfLessThan(additionalSectionSize, 1);
+
+        byte[] peBytes = CreatePortableExecutable();
+        using PEReader peReader = new(new MemoryStream(peBytes, writable: false));
+        PEHeaders headers = peReader.PEHeaders;
+        PEHeader peHeader = headers.PEHeader
+            ?? throw new InvalidOperationException("The synthetic PE has no optional header.");
+        int corHeaderRva = peHeader.CorHeaderTableDirectory.RelativeVirtualAddress;
+        SectionHeader sourceSection = headers.SectionHeaders.Single(section =>
+            corHeaderRva >= section.VirtualAddress
+            && corHeaderRva - section.VirtualAddress < section.VirtualSize);
+        MetadataReader metadataReader = peReader.GetMetadataReader();
+        int methodRva = metadataReader.GetMethodDefinition(
+            MetadataTokens.MethodDefinitionHandle(1)).RelativeVirtualAddress;
+        int metadataRva = headers.CorHeader?.MetadataDirectory.RelativeVirtualAddress
+            ?? throw new InvalidOperationException("The synthetic PE has no CLR header.");
+
+        int headerSize = version == 0 ? 28 : 32;
+        int rawStart = Align(headerSize + sectionCount * SectionHeaderSize, 16);
+        int sourceRawSize = sourceSection.SizeOfRawData;
+        int payloadLength = checked(
+            rawStart + sourceRawSize + (sectionCount - 1) * additionalSectionSize);
+        byte[] payload = new byte[payloadLength];
+
+        BinaryPrimitives.WriteUInt32LittleEndian(payload, WebcilMagic);
+        BinaryPrimitives.WriteUInt16LittleEndian(payload.AsSpan(4), checked((ushort)version));
+        BinaryPrimitives.WriteUInt16LittleEndian(payload.AsSpan(8), checked((ushort)sectionCount));
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(12), checked((uint)corHeaderRva));
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            payload.AsSpan(16),
+            checked((uint)peHeader.CorHeaderTableDirectory.Size));
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            payload.AsSpan(20),
+            checked((uint)peHeader.DebugTableDirectory.RelativeVirtualAddress));
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            payload.AsSpan(24),
+            checked((uint)peHeader.DebugTableDirectory.Size));
+        if (version == 1)
+            BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(28), uint.MaxValue);
+
+        WriteSection(
+            payload,
+            headerSize,
+            checked((uint)sourceSection.VirtualSize),
+            checked((uint)sourceSection.VirtualAddress),
+            checked((uint)sourceRawSize),
+            checked((uint)rawStart));
+        peBytes.AsSpan(sourceSection.PointerToRawData, sourceRawSize).CopyTo(payload.AsSpan(rawStart));
+        int methodRvaOffset = checked(
+            rawStart
+            + metadataRva
+            - sourceSection.VirtualAddress
+            + metadataReader.GetTableMetadataOffset(TableIndex.MethodDef));
+        int clrHeaderOffset = checked(rawStart + corHeaderRva - sourceSection.VirtualAddress);
+
+        int nextRaw = rawStart + sourceRawSize;
+        uint nextVirtual = checked((uint)(sourceSection.VirtualAddress + sourceSection.VirtualSize));
+        for (int index = 1; index < sectionCount; index++)
+        {
+            WriteSection(
+                payload,
+                headerSize + index * SectionHeaderSize,
+                virtualSize: checked((uint)additionalSectionSize),
+                virtualAddress: nextVirtual,
+                rawSize: checked((uint)additionalSectionSize),
+                rawPointer: checked((uint)nextRaw));
+            payload[nextRaw] = 0x02;
+            nextRaw += additionalSectionSize;
+            nextVirtual += checked((uint)additionalSectionSize);
+        }
+
+        if (!wrapped)
+            return new SyntheticWebcilImage(
+                payload,
+                clrHeaderOffset,
+                methodRva,
+                methodRvaOffset,
+                payload.Length,
+                payloadOffset: 0,
+                sectionCount);
+
+        byte[] wrappedBytes = Wrap(payload, wrapperSuffixLength, out int payloadOffset);
+        return new SyntheticWebcilImage(
+            wrappedBytes,
+            clrHeaderOffset,
+            methodRva,
+            methodRvaOffset,
+            payload.Length,
+            payloadOffset,
+            sectionCount);
+    }
+
+    internal static SyntheticWebcilImage CreateWithDebugDirectory(
+        int version = 1,
+        bool wrapped = false)
+    {
+        SyntheticWebcilImage image = Create(
+            version,
+            wrapped,
+            sectionCount: 2,
+            additionalSectionSize: 64);
+        uint directoryRva = image.GetSectionVirtualAddress(1);
+        uint directoryPointer = image.GetSectionPointer(1);
+        uint dataRva = checked(directoryRva + DebugDirectoryEntrySize);
+        uint dataPointer = checked(directoryPointer + DebugDirectoryEntrySize);
+        image.SetPeDebugRva(directoryRva);
+        image.SetPeDebugSize(DebugDirectoryEntrySize);
+
+        Span<byte> entry = image.Bytes.AsSpan(
+            image.GetSectionDataOffset(1),
+            DebugDirectoryEntrySize);
+        entry.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(entry[4..], 0x12345678);
+        BinaryPrimitives.WriteUInt16LittleEndian(entry[8..], 1);
+        BinaryPrimitives.WriteUInt16LittleEndian(entry[10..], 2);
+        BinaryPrimitives.WriteInt32LittleEndian(entry[12..], (int)DebugDirectoryEntryType.Reproducible);
+        BinaryPrimitives.WriteUInt32LittleEndian(entry[16..], 4);
+        BinaryPrimitives.WriteUInt32LittleEndian(entry[20..], dataRva);
+        BinaryPrimitives.WriteUInt32LittleEndian(entry[24..], dataPointer);
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            image.Bytes.AsSpan(checked(image.PayloadOffset + (int)dataPointer)),
+            0xA5A5A5A5);
+        return image;
+    }
+
+    internal static SyntheticWebcilImage CreateWithOversizedWasmDataSection(int version = 1)
+    {
+        SyntheticWebcilImage bare = Create(version);
+        byte[] wrappedBytes = Wrap(
+            bare.Bytes,
+            suffixLength: 0,
+            out int payloadOffset,
+            declaredSizeAdjustment: 1);
+        return new SyntheticWebcilImage(
+            wrappedBytes,
+            bare.ClrHeaderOffset,
+            bare.MethodRva,
+            bare.MethodRvaOffset,
+            bare.PayloadLength,
+            payloadOffset,
+            bare.SectionCount);
+    }
+
+    internal static byte[] CreateWithTruncatedSectionTable(int version, bool wrapped)
+    {
+        SyntheticWebcilImage image = Create(version);
+        int headerSize = version == 0 ? 28 : 32;
+        byte[] truncatedPayload = image.Bytes.AsSpan(0, headerSize + SectionHeaderSize - 1).ToArray();
+        return wrapped
+            ? Wrap(truncatedPayload, suffixLength: 0, out _)
+            : truncatedPayload;
+    }
+
+    private static int Align(int value, int alignment) =>
+        checked((value + alignment - 1) & ~(alignment - 1));
+
+    private static byte[] CreatePortableExecutable()
+    {
+        MetadataBuilder metadata = new();
+        metadata.AddAssembly(
+            metadata.GetOrAddString("SyntheticWebcil"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            0,
+            AssemblyHashAlgorithm.None);
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("SyntheticWebcil.dll"),
+            metadata.GetOrAddGuid(new Guid("497F4CE9-AB71-4A8B-9E5B-3753807F4A56")),
+            default,
+            default);
+
+        metadata.AddTypeDefinition(
+            TypeAttributes.NotPublic,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        AssemblyName coreLibraryName = typeof(object).Assembly.GetName();
+        byte[]? publicKeyToken = coreLibraryName.GetPublicKeyToken();
+        BlobHandle publicKeyTokenHandle = publicKeyToken is { Length: > 0 }
+            ? metadata.GetOrAddBlob(publicKeyToken)
+            : default;
+        AssemblyReferenceHandle coreLibrary = metadata.AddAssemblyReference(
+            metadata.GetOrAddString(coreLibraryName.Name!),
+            coreLibraryName.Version ?? new Version(0, 0, 0, 0),
+            default,
+            publicKeyTokenHandle,
+            0,
+            default);
+        TypeReferenceHandle objectType = metadata.AddTypeReference(
+            coreLibrary,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed,
+            metadata.GetOrAddString("Synthetic"),
+            metadata.GetOrAddString("Calculator"),
+            baseType: objectType,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        BlobBuilder ilStream = new();
+        BlobBuilder code = new();
+        InstructionEncoder encoder = new(code);
+        encoder.LoadConstantI4(42);
+        encoder.OpCode(ILOpCode.Ret);
+        int bodyOffset = new MethodBodyStreamEncoder(ilStream).AddMethodBody(encoder, maxStack: 1);
+        byte[] methodSignature = [0x00, 0x00, 0x08];
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL | MethodImplAttributes.Managed,
+            metadata.GetOrAddString("Answer"),
+            metadata.GetOrAddBlob(methodSignature),
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+
+        BlobBuilder managedResources = new();
+        managedResources.WriteInt32(4);
+        byte[] resourceBytes = [0x10, 0x20, 0x30, 0x40];
+        managedResources.WriteBytes(resourceBytes);
+        metadata.AddManifestResource(
+            ManifestResourceAttributes.Public,
+            metadata.GetOrAddString("SyntheticResource"),
+            implementation: default,
+            offset: 0);
+
+        ManagedPEBuilder peBuilder = new(
+            new PEHeaderBuilder(imageCharacteristics: Characteristics.Dll),
+            new MetadataRootBuilder(metadata),
+            ilStream,
+            managedResources: managedResources);
+        BlobBuilder image = new();
+        peBuilder.Serialize(image);
+        return image.ToArray();
+    }
+
+    private static void WriteSection(
+        Span<byte> payload,
+        int offset,
+        uint virtualSize,
+        uint virtualAddress,
+        uint rawSize,
+        uint rawPointer)
+    {
+        BinaryPrimitives.WriteUInt32LittleEndian(payload[offset..], virtualSize);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload[(offset + 4)..], virtualAddress);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload[(offset + 8)..], rawSize);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload[(offset + 12)..], rawPointer);
+    }
+
+    private static byte[] Wrap(
+        byte[] payload,
+        int suffixLength,
+        out int payloadOffset,
+        int declaredSizeAdjustment = 0)
+    {
+        using MemoryStream stream = new();
+        stream.Write([0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00]);
+        stream.WriteByte(11);
+
+        using MemoryStream dataSection = new();
+        WriteUleb(dataSection, 1);
+        dataSection.WriteByte(1);
+        WriteUleb(dataSection, checked((uint)payload.Length));
+        int dataHeaderLength = checked((int)dataSection.Length);
+        dataSection.Write(payload);
+        WriteUleb(stream, checked((uint)(dataSection.Length + declaredSizeAdjustment)));
+        payloadOffset = checked((int)stream.Length + dataHeaderLength);
+        dataSection.Position = 0;
+        dataSection.CopyTo(stream);
+
+        if (suffixLength > 0)
+        {
+            stream.WriteByte(0);
+            WriteUleb(stream, checked((uint)suffixLength + 1));
+            WriteUleb(stream, 0);
+            stream.Write(new byte[suffixLength]);
+        }
+
+        return stream.ToArray();
+    }
+
+    private static void WriteUleb(Stream stream, uint value)
+    {
+        do
+        {
+            byte next = (byte)(value & 0x7F);
+            value >>= 7;
+            if (value != 0)
+                next |= 0x80;
+            stream.WriteByte(next);
+        }
+        while (value != 0);
+    }
+}

--- a/tests/Dotsider.Tests/SyntheticWebcilImage.cs
+++ b/tests/Dotsider.Tests/SyntheticWebcilImage.cs
@@ -1,0 +1,156 @@
+using System.Buffers.Binary;
+using System.Reflection.PortableExecutable;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Describes a mutable synthetic Webcil image and the offsets needed by boundary tests.
+/// </summary>
+internal sealed class SyntheticWebcilImage
+{
+    internal SyntheticWebcilImage(
+        byte[] bytes,
+        int clrHeaderOffset,
+        int methodRva,
+        int methodRvaOffset,
+        int payloadLength,
+        int payloadOffset,
+        int sectionCount)
+    {
+        Bytes = bytes;
+        ClrHeaderOffset = clrHeaderOffset;
+        MethodRva = methodRva;
+        MethodRvaOffset = methodRvaOffset;
+        PayloadLength = payloadLength;
+        PayloadOffset = payloadOffset;
+        SectionCount = sectionCount;
+    }
+
+    internal byte[] Bytes { get; }
+
+    internal int ClrHeaderOffset { get; }
+
+    internal int MethodRva { get; }
+
+    internal int MethodRvaOffset { get; }
+
+    internal int PayloadLength { get; }
+
+    internal int PayloadOffset { get; }
+
+    internal int SectionCount { get; }
+
+    internal uint GetSectionPointer(int index) => ReadSectionValue(index, 12);
+
+    internal int GetSectionDataOffset(int index) =>
+        checked(PayloadOffset + (int)GetSectionPointer(index));
+
+    internal uint GetSectionVirtualAddress(int index) => ReadSectionValue(index, 4);
+
+    internal uint GetSectionVirtualSize(int index) => ReadSectionValue(index, 0);
+
+    internal uint GetClrMetadataRva() => ReadClrHeaderUInt32(8);
+
+    internal uint GetClrMetadataSize() => ReadClrHeaderUInt32(12);
+
+    internal void SetSectionCount(ushort value) =>
+        BinaryPrimitives.WriteUInt16LittleEndian(Bytes.AsSpan(PayloadOffset + 8, sizeof(ushort)), value);
+
+    internal void SetClrExportAddressTableJumpsSize(uint value) =>
+        WriteClrHeaderUInt32(60, value);
+
+    internal void SetClrHeaderSize(uint value) =>
+        WriteClrHeaderUInt32(0, value);
+
+    internal void SetClrFlags(CorFlags value) =>
+        WriteClrHeaderUInt32(16, (uint)value);
+
+    internal void SetClrMajorRuntimeVersion(ushort value) =>
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            Bytes.AsSpan(PayloadOffset + ClrHeaderOffset + 4, sizeof(ushort)),
+            value);
+
+    internal void SetClrManagedNativeHeaderRva(uint value) =>
+        WriteClrHeaderUInt32(64, value);
+
+    internal void SetClrManagedNativeHeaderSize(uint value) =>
+        WriteClrHeaderUInt32(68, value);
+
+    internal void SetClrMetadataRva(uint value) =>
+        WriteClrHeaderUInt32(8, value);
+
+    internal void SetClrMetadataSize(uint value) =>
+        WriteClrHeaderUInt32(12, value);
+
+    internal void SetClrResourcesRva(uint value) =>
+        WriteClrHeaderUInt32(24, value);
+
+    internal void SetClrResourcesSize(uint value) =>
+        WriteClrHeaderUInt32(28, value);
+
+    internal void SetClrStrongNameSignatureRva(uint value) =>
+        WriteClrHeaderUInt32(32, value);
+
+    internal void SetClrStrongNameSignatureSize(uint value) =>
+        WriteClrHeaderUInt32(36, value);
+
+    internal void SetClrVTableFixupsSize(uint value) =>
+        WriteClrHeaderUInt32(52, value);
+
+    internal void SetMethodRva(int value) =>
+        BinaryPrimitives.WriteInt32LittleEndian(Bytes.AsSpan(PayloadOffset + MethodRvaOffset, sizeof(int)), value);
+
+    internal void SetPeCliHeaderRva(uint value) =>
+        BinaryPrimitives.WriteUInt32LittleEndian(Bytes.AsSpan(PayloadOffset + 12, sizeof(uint)), value);
+
+    internal void SetPeCliHeaderSize(uint value) =>
+        BinaryPrimitives.WriteUInt32LittleEndian(Bytes.AsSpan(PayloadOffset + 16, sizeof(uint)), value);
+
+    internal void SetPeDebugRva(uint value) =>
+        BinaryPrimitives.WriteUInt32LittleEndian(Bytes.AsSpan(PayloadOffset + 20, sizeof(uint)), value);
+
+    internal void SetPeDebugSize(uint value) =>
+        BinaryPrimitives.WriteUInt32LittleEndian(Bytes.AsSpan(PayloadOffset + 24, sizeof(uint)), value);
+
+    internal void SetSectionPointer(int index, uint value) => WriteSectionValue(index, 12, value);
+
+    internal void SetSectionRawSize(int index, uint value) => WriteSectionValue(index, 8, value);
+
+    internal void SetSectionVirtualAddress(int index, uint value) => WriteSectionValue(index, 4, value);
+
+    internal void SetSectionVirtualSize(int index, uint value) => WriteSectionValue(index, 0, value);
+
+    internal void SetVersionMajor(ushort value) =>
+        BinaryPrimitives.WriteUInt16LittleEndian(Bytes.AsSpan(PayloadOffset + 4, sizeof(ushort)), value);
+
+    internal void SetVersionMinor(ushort value) =>
+        BinaryPrimitives.WriteUInt16LittleEndian(Bytes.AsSpan(PayloadOffset + 6, sizeof(ushort)), value);
+
+    private int GetSectionOffset(int index)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, SectionCount);
+        int headerSize = BinaryPrimitives.ReadUInt16LittleEndian(
+            Bytes.AsSpan(PayloadOffset + 4, sizeof(ushort))) >= 1
+            ? 32
+            : 28;
+        return PayloadOffset + headerSize + index * 16;
+    }
+
+    private uint ReadSectionValue(int index, int fieldOffset) =>
+        BinaryPrimitives.ReadUInt32LittleEndian(Bytes.AsSpan(GetSectionOffset(index) + fieldOffset, sizeof(uint)));
+
+    private uint ReadClrHeaderUInt32(int fieldOffset) =>
+        BinaryPrimitives.ReadUInt32LittleEndian(
+            Bytes.AsSpan(PayloadOffset + ClrHeaderOffset + fieldOffset, sizeof(uint)));
+
+    private void WriteClrHeaderUInt32(int fieldOffset, uint value) =>
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            Bytes.AsSpan(PayloadOffset + ClrHeaderOffset + fieldOffset, sizeof(uint)),
+            value);
+
+    private void WriteSectionValue(int index, int fieldOffset, uint value) =>
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            Bytes.AsSpan(GetSectionOffset(index) + fieldOffset, sizeof(uint)),
+            value);
+}

--- a/tests/Dotsider.Tests/WasmSdkModuleDecoderTests.cs
+++ b/tests/Dotsider.Tests/WasmSdkModuleDecoderTests.cs
@@ -1,6 +1,7 @@
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Disasm;
 using Dotsider.Core.Analysis.Models;
+using System.Buffers.Binary;
 
 namespace Dotsider.Tests;
 
@@ -113,6 +114,56 @@ public sealed class WasmSdkModuleDecoderTests
         Assert.IsNotNull(il);
         Assert.Contains("IL_", il.Value.Text);
         Assert.Contains("ldarg", il.Value.Text);
+    }
+
+    /// <summary>
+    /// A real SDK Webcil wrapper is rejected when its final section crosses the containing data
+    /// segment even though the claimed bytes remain present in the outer WebAssembly module.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void BrowserWasmWebcilAssembly_SectionCrossesPayloadBoundary_ThrowsBadImageFormatException()
+    {
+        TestSkip.When(
+            Samples.WasmConsoleWebcilWasm is null,
+            "browser-wasm publish did not produce the Webcil app assembly on this leg.");
+        string path = Samples.WasmConsoleWebcilWasm!;
+        byte[] bytes = File.ReadAllBytes(path);
+        (int payloadOffset, int payloadLength) = FindWebcilPayload(bytes);
+        int payloadEnd = checked(payloadOffset + payloadLength);
+        Assert.IsGreaterThan(
+            payloadEnd,
+            bytes.Length,
+            "The SDK wrapper must contain suffix bytes after its Webcil data segment.");
+
+        ushort version = BinaryPrimitives.ReadUInt16LittleEndian(bytes.AsSpan(payloadOffset + 4));
+        ushort sectionCount = BinaryPrimitives.ReadUInt16LittleEndian(bytes.AsSpan(payloadOffset + 8));
+        Assert.IsInRange((ushort)1, (ushort)16, sectionCount);
+        int sectionTableOffset = checked(payloadOffset + (version == 0 ? 28 : 32));
+        int finalSectionOffset = sectionTableOffset;
+        uint finalRawEnd = 0;
+        uint rawPointer = 0;
+        for (int index = 0; index < sectionCount; index++)
+        {
+            int candidateOffset = checked(sectionTableOffset + index * 16);
+            uint candidateSize = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(candidateOffset + 8));
+            uint candidatePointer = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(candidateOffset + 12));
+            uint candidateEnd = checked(candidatePointer + candidateSize);
+            if (candidateEnd <= finalRawEnd)
+                continue;
+
+            finalSectionOffset = candidateOffset;
+            finalRawEnd = candidateEnd;
+            rawPointer = candidatePointer;
+        }
+
+        Assert.AreEqual(checked((uint)payloadLength), finalRawEnd);
+        Assert.IsLessThan(checked((uint)payloadLength), rawPointer);
+        uint crossingSize = checked((uint)payloadLength - rawPointer + 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(finalSectionOffset + 8), crossingSize);
+
+        Assert.ThrowsExactly<BadImageFormatException>(() =>
+            new AssemblyAnalyzer(bytes, path));
     }
 
     /// <summary>
@@ -281,5 +332,98 @@ public sealed class WasmSdkModuleDecoderTests
 
         TestAssert.All(values, index =>
             Assert.IsGreaterThanOrEqualTo(importCount, index, $"{label} index {index} should account for {importCount} imports."));
+    }
+
+    private static (int Offset, int Length) FindWebcilPayload(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < 8
+            || BinaryPrimitives.ReadUInt32LittleEndian(bytes) != 0x6D736100
+            || BinaryPrimitives.ReadUInt32LittleEndian(bytes[4..]) != 1)
+        {
+            throw new InvalidDataException("The SDK fixture is not a WebAssembly module.");
+        }
+
+        int position = 8;
+        while (position < bytes.Length)
+        {
+            byte sectionId = ReadByte(bytes, ref position, bytes.Length);
+            int sectionSize = checked((int)ReadUleb(bytes, ref position, bytes.Length));
+            int sectionEnd = checked(position + sectionSize);
+            if (sectionEnd > bytes.Length)
+                throw new InvalidDataException("The SDK fixture contains a truncated WebAssembly section.");
+
+            if (sectionId != 11)
+            {
+                position = sectionEnd;
+                continue;
+            }
+
+            int segmentCount = checked((int)ReadUleb(bytes, ref position, sectionEnd));
+            for (int index = 0; index < segmentCount; index++)
+            {
+                uint mode = ReadUleb(bytes, ref position, sectionEnd);
+                if (mode == 0)
+                {
+                    SkipInitializer(bytes, ref position, sectionEnd);
+                }
+                else if (mode == 2)
+                {
+                    _ = ReadUleb(bytes, ref position, sectionEnd);
+                    SkipInitializer(bytes, ref position, sectionEnd);
+                }
+                else if (mode != 1)
+                {
+                    throw new InvalidDataException($"Unsupported WebAssembly data-segment mode {mode}.");
+                }
+
+                int length = checked((int)ReadUleb(bytes, ref position, sectionEnd));
+                if (length > sectionEnd - position)
+                    throw new InvalidDataException("The SDK fixture contains a truncated data segment.");
+                if (length >= sizeof(uint)
+                    && BinaryPrimitives.ReadUInt32LittleEndian(bytes[position..]) == 0x4C496257)
+                {
+                    return (position, length);
+                }
+
+                position += length;
+            }
+
+            break;
+        }
+
+        throw new InvalidDataException("The SDK fixture does not contain a Webcil data segment.");
+    }
+
+    private static byte ReadByte(ReadOnlySpan<byte> bytes, ref int position, int end)
+    {
+        if ((uint)position >= (uint)end)
+            throw new InvalidDataException("Unexpected end of WebAssembly data.");
+        return bytes[position++];
+    }
+
+    private static uint ReadUleb(ReadOnlySpan<byte> bytes, ref int position, int end)
+    {
+        uint result = 0;
+        for (int shift = 0; shift < 35; shift += 7)
+        {
+            byte value = ReadByte(bytes, ref position, end);
+            result |= (uint)(value & 0x7F) << shift;
+            if ((value & 0x80) == 0)
+                return result;
+        }
+
+        throw new InvalidDataException("The SDK fixture contains an oversized ULEB128 value.");
+    }
+
+    private static void SkipInitializer(ReadOnlySpan<byte> bytes, ref int position, int end)
+    {
+        while (true)
+        {
+            byte opcode = ReadByte(bytes, ref position, end);
+            if (opcode == 0x0B)
+                return;
+            if (opcode is 0x41 or 0x42 or 0x23)
+                _ = ReadUleb(bytes, ref position, end);
+        }
     }
 }

--- a/tests/Dotsider.Tests/WebcilImageReaderTests.cs
+++ b/tests/Dotsider.Tests/WebcilImageReaderTests.cs
@@ -1,0 +1,991 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+using Dotsider.Core.Analysis.Wasm;
+using System.Buffers.Binary;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Verifies that Webcil payloads, sections, and method bodies remain inside their validated bounds.
+/// </summary>
+[TestClass]
+public sealed class WebcilImageReaderTests
+{
+    /// <summary>
+    /// Both Webcil revisions open in bare and minimally wrapped form.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, false)]
+    [DataRow(0, true)]
+    [DataRow(1, false)]
+    [DataRow(1, true)]
+    public void Open_ValidImage_ExposesMetadataAndIl(int version, bool wrapped)
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(version, wrapped);
+
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+
+        Assert.IsNotNull(reader);
+        Assert.AreEqual(version, reader.Info.VersionMajor);
+        Assert.AreEqual(wrapped, reader.Info.IsWasmWrapped);
+        Assert.AreEqual(image.PayloadOffset, reader.Info.PayloadOffset);
+        IReadOnlyList<SectionInfo> sections = reader.ReadSections();
+        Assert.HasCount(image.SectionCount, sections);
+        for (int index = 0; index < sections.Count; index++)
+        {
+            Assert.AreEqual(
+                checked(image.PayloadOffset + (int)image.GetSectionPointer(index)),
+                sections[index].RawDataOffset);
+        }
+
+        using MetadataReaderProvider provider = reader.CreateMetadataReaderProvider();
+        Assert.AreEqual("SyntheticWebcil", provider.GetMetadataReader().GetString(
+            provider.GetMetadataReader().GetAssemblyDefinition().Name));
+        MethodBodyBlock? body = reader.GetMethodBody(image.MethodRva);
+        Assert.IsNotNull(body);
+        byte[] expectedIl = [0x1F, 0x2A, 0x2A];
+        Assert.AreSequenceEqual(expectedIl, body.GetILBytes());
+    }
+
+    /// <summary>
+    /// Unsupported major and minor Webcil versions fail closed through the public facade.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_UnsupportedWebcilVersion_ThrowsBadImageFormatException(bool wrapped)
+    {
+        SyntheticWebcilImage unsupportedMajor = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        unsupportedMajor.SetVersionMajor(2);
+        AssertMalformedImage(unsupportedMajor);
+
+        SyntheticWebcilImage unsupportedMinor = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        unsupportedMinor.SetVersionMinor(1);
+        AssertMalformedImage(unsupportedMinor);
+    }
+
+    /// <summary>
+    /// The runtime-supported section-count boundaries are accepted and values outside them fail closed.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, false)]
+    [DataRow(1, true)]
+    [DataRow(16, true)]
+    [DataRow(17, false)]
+    public void Open_SectionCountBoundary_MatchesRuntimeLimit(int sectionCount, bool valid)
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(sectionCount: Math.Max(sectionCount, 1));
+        image.SetSectionCount(checked((ushort)sectionCount));
+
+        if (valid)
+        {
+            Assert.IsNotNull(WebcilImageReader.Open(image.Bytes));
+            return;
+        }
+
+        Assert.ThrowsExactly<BadImageFormatException>(() => WebcilImageReader.Open(image.Bytes));
+    }
+
+    /// <summary>
+    /// Recognized bare and wrapped payloads fail closed when either revision's section table is truncated.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, false)]
+    [DataRow(0, true)]
+    [DataRow(1, false)]
+    [DataRow(1, true)]
+    public void Open_TruncatedSectionTable_ThrowsBadImageFormatException(int version, bool wrapped)
+    {
+        byte[] bytes = SyntheticWebcilBuilder.CreateWithTruncatedSectionTable(version, wrapped);
+
+        Assert.ThrowsExactly<BadImageFormatException>(() => WebcilImageReader.Open(bytes));
+    }
+
+    /// <summary>
+    /// A zero-length raw range may begin at the payload end, but never beyond it.
+    /// </summary>
+    [TestMethod]
+    public void Open_ZeroLengthRawRange_RequiresPointerInsideOrAtPayloadEnd()
+    {
+        SyntheticWebcilImage exactEnd = SyntheticWebcilBuilder.Create(sectionCount: 2);
+        exactEnd.SetSectionPointer(1, checked((uint)exactEnd.PayloadLength));
+        exactEnd.SetSectionRawSize(1, 0);
+        Assert.IsNotNull(WebcilImageReader.Open(exactEnd.Bytes));
+
+        SyntheticWebcilImage pastEnd = SyntheticWebcilBuilder.Create(sectionCount: 2);
+        pastEnd.SetSectionPointer(1, checked((uint)pastEnd.PayloadLength + 1));
+        pastEnd.SetSectionRawSize(1, 0);
+        Assert.ThrowsExactly<BadImageFormatException>(() => WebcilImageReader.Open(pastEnd.Bytes));
+    }
+
+    /// <summary>
+    /// Raw ranges ending after the payload or overflowing unsigned arithmetic fail closed.
+    /// </summary>
+    [TestMethod]
+    public void Open_InvalidRawRange_ThrowsBadImageFormatException()
+    {
+        SyntheticWebcilImage crossingEnd = SyntheticWebcilBuilder.Create(sectionCount: 2);
+        crossingEnd.SetSectionPointer(1, checked((uint)crossingEnd.PayloadLength));
+        crossingEnd.SetSectionRawSize(1, 1);
+        Assert.ThrowsExactly<BadImageFormatException>(() => WebcilImageReader.Open(crossingEnd.Bytes));
+
+        SyntheticWebcilImage overflowing = SyntheticWebcilBuilder.Create(sectionCount: 2);
+        overflowing.SetSectionPointer(1, uint.MaxValue);
+        overflowing.SetSectionRawSize(1, 2);
+        Assert.ThrowsExactly<BadImageFormatException>(() => WebcilImageReader.Open(overflowing.Bytes));
+    }
+
+    /// <summary>
+    /// A section cannot overflow the 32-bit virtual address space or overlap another virtual section.
+    /// </summary>
+    [TestMethod]
+    public void Open_InvalidVirtualRange_ThrowsBadImageFormatException()
+    {
+        SyntheticWebcilImage overflowing = SyntheticWebcilBuilder.Create(sectionCount: 2);
+        overflowing.SetSectionVirtualAddress(1, uint.MaxValue);
+        overflowing.SetSectionVirtualSize(1, 2);
+        Assert.ThrowsExactly<BadImageFormatException>(() => WebcilImageReader.Open(overflowing.Bytes));
+
+        SyntheticWebcilImage overlapping = SyntheticWebcilBuilder.Create(sectionCount: 2);
+        overlapping.SetSectionVirtualAddress(1, overlapping.GetSectionVirtualAddress(0));
+        overlapping.SetSectionVirtualSize(1, 1);
+        Assert.ThrowsExactly<BadImageFormatException>(() => WebcilImageReader.Open(overlapping.Bytes));
+    }
+
+    /// <summary>
+    /// Adjacent virtual ranges are legal and do not require an artificial gap.
+    /// </summary>
+    [TestMethod]
+    public void Open_AdjacentVirtualRanges_AreAccepted()
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(sectionCount: 2);
+        uint expectedStart = checked(image.GetSectionVirtualAddress(0) + image.GetSectionVirtualSize(0));
+
+        Assert.AreEqual(expectedStart, image.GetSectionVirtualAddress(1));
+        Assert.IsNotNull(WebcilImageReader.Open(image.Bytes));
+    }
+
+    /// <summary>
+    /// Webcil raw ranges do not acquire a file-alignment rule that the runtime does not impose.
+    /// </summary>
+    [TestMethod]
+    public void Open_UnalignedRawRange_IsAccepted()
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(sectionCount: 2);
+        image.SetSectionPointer(1, checked(image.GetSectionPointer(1) + 1));
+        image.SetSectionRawSize(1, 1);
+
+        Assert.IsNotNull(WebcilImageReader.Open(image.Bytes));
+    }
+
+    /// <summary>
+    /// Wrapped Webcil raw ranges are limited to the data-segment payload, not the outer Wasm file.
+    /// </summary>
+    [TestMethod]
+    public void Open_WrappedRawRangeEscapesPayloadButNotOuterFile_ThrowsBadImageFormatException()
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(
+            wrapped: true,
+            sectionCount: 2,
+            wrapperSuffixLength: 32);
+        image.SetSectionPointer(1, checked((uint)image.PayloadLength));
+        image.SetSectionRawSize(1, 1);
+
+        int payloadEnd = image.PayloadOffset + image.PayloadLength;
+        Assert.IsGreaterThan(
+            payloadEnd,
+            image.Bytes.Length,
+            "The test needs outer Wasm bytes after the Webcil data-segment payload.");
+        Assert.ThrowsExactly<BadImageFormatException>(() => WebcilImageReader.Open(image.Bytes));
+    }
+
+    /// <summary>
+    /// A recognizable payload inside a truncated Wasm data section cannot downgrade to raw Wasm.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    public void Open_WebcilInTruncatedWasmDataSection_ThrowsBadImageFormatException(int version)
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.CreateWithOversizedWasmDataSection(version);
+
+        Assert.ThrowsExactly<BadImageFormatException>(() => WebcilImageReader.Open(image.Bytes));
+        Assert.ThrowsExactly<BadImageFormatException>(() =>
+            new AssemblyAnalyzer(image.Bytes, "truncated-data-section.wasm"));
+    }
+
+    /// <summary>
+    /// Webcil accepts non-overflowing unsigned virtual ranges and projects their bit patterns to int models.
+    /// </summary>
+    [TestMethod]
+    public void Open_HighBitVirtualAddress_IsAccepted()
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(sectionCount: 2);
+        image.SetSectionVirtualAddress(1, 0x80000000);
+        image.SetSectionVirtualSize(1, 4);
+        image.SetClrResourcesRva(0x80000000);
+        image.SetClrResourcesSize(4);
+        int resourceOffset = checked(image.PayloadOffset + (int)image.GetSectionPointer(1));
+        BinaryPrimitives.WriteInt32LittleEndian(image.Bytes.AsSpan(resourceOffset), 0x12345678);
+
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+
+        Assert.IsNotNull(reader);
+        SectionInfo section = reader.ReadSections()[1];
+        Assert.AreEqual(int.MinValue, section.VirtualAddress);
+        Assert.AreEqual(4, section.VirtualSize);
+        Assert.AreEqual(int.MinValue, reader.ClrHeader.ResourcesRva);
+        Assert.AreEqual(4, reader.ClrHeader.ResourcesSize);
+        Assert.IsTrue(reader.TryReadInt32AtRva(reader.ClrHeader.ResourcesRva, 0, out int value));
+        Assert.AreEqual(0x12345678, value);
+
+        using AssemblyAnalyzer analyzer = new(image.Bytes, "high-bit-resource.webcil");
+        ResourceInfo resource = Assert.ContainsSingle(analyzer.Resources);
+        Assert.AreEqual("SyntheticResource", resource.Name);
+        Assert.AreEqual(0x12345678, resource.Size);
+    }
+
+    /// <summary>
+    /// CLR runtime versions outside the range supported by the runtime fail closed.
+    /// </summary>
+    [TestMethod]
+    [DataRow((ushort)1, false)]
+    [DataRow((ushort)1, true)]
+    [DataRow((ushort)3, false)]
+    [DataRow((ushort)3, true)]
+    public void Open_UnsupportedClrRuntimeVersion_ThrowsBadImageFormatException(
+        ushort majorRuntimeVersion,
+        bool wrapped)
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        image.SetClrMajorRuntimeVersion(majorRuntimeVersion);
+
+        AssertMalformedImage(image);
+    }
+
+    /// <summary>
+    /// CLR features forbidden by the runtime's Webcil decoder fail closed through the public facade.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_UnsupportedClrHeaderFeatures_ThrowBadImageFormatException(bool wrapped)
+    {
+        SyntheticWebcilImage nativeEntryPoint = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        nativeEntryPoint.SetClrFlags(CorFlags.ILOnly | CorFlags.NativeEntryPoint);
+        AssertMalformedImage(nativeEntryPoint);
+
+        SyntheticWebcilImage vtableFixups = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        vtableFixups.SetClrVTableFixupsSize(1);
+        AssertMalformedImage(vtableFixups);
+
+        SyntheticWebcilImage exportAddressTableJumps = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        exportAddressTableJumps.SetClrExportAddressTableJumpsSize(1);
+        AssertMalformedImage(exportAddressTableJumps);
+
+        SyntheticWebcilImage missingStrongNameSignature = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        missingStrongNameSignature.SetClrStrongNameSignatureRva(0);
+        missingStrongNameSignature.SetClrFlags(CorFlags.ILOnly | CorFlags.StrongNameSigned);
+        AssertMalformedImage(missingStrongNameSignature);
+    }
+
+    /// <summary>
+    /// The runtime-required CLR header bytes must map, and both size declarations must meet its minimum.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_InvalidClrHeaderRange_ThrowsBadImageFormatException(bool wrapped)
+    {
+        SyntheticWebcilImage unmappedRva = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        unmappedRva.SetPeCliHeaderRva(uint.MaxValue);
+        AssertMalformedImage(unmappedRva);
+
+        SyntheticWebcilImage shortDirectory = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        shortDirectory.SetPeCliHeaderSize(71);
+        AssertMalformedImage(shortDirectory);
+
+        SyntheticWebcilImage shortInternalSize = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        shortInternalSize.SetClrHeaderSize(71);
+        AssertMalformedImage(shortInternalSize);
+    }
+
+    /// <summary>
+    /// The runtime-required 72-byte CLR header may end at the final mapped byte of a section.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_ClrHeaderEndingAtSectionBoundary_IsAccepted(bool wrapped)
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(
+            wrapped: wrapped,
+            sectionCount: 2,
+            additionalSectionSize: 72);
+        byte[] clrHeader = image.Bytes.AsSpan(
+            image.PayloadOffset + image.ClrHeaderOffset,
+            72).ToArray();
+        clrHeader.CopyTo(image.Bytes.AsSpan(image.GetSectionDataOffset(1), 72));
+        image.SetPeCliHeaderRva(image.GetSectionVirtualAddress(1));
+        image.SetPeCliHeaderSize(72);
+
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+
+        Assert.IsNotNull(reader);
+        using AssemblyAnalyzer analyzer = new(
+            image.Bytes,
+            wrapped ? "clr-boundary.wasm" : "clr-boundary.webcil");
+        Assert.AreEqual("SyntheticWebcil", analyzer.AssemblyName);
+    }
+
+    /// <summary>
+    /// Future-extended CLR header declarations remain compatible when the runtime-required bytes map.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_ExtendedClrHeaderDeclarations_AreAccepted(bool wrapped)
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        image.SetPeCliHeaderSize(uint.MaxValue);
+        image.SetClrHeaderSize(uint.MaxValue);
+
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+
+        Assert.IsNotNull(reader);
+        using AssemblyAnalyzer analyzer = new(
+            image.Bytes,
+            wrapped ? "extended-header.wasm" : "extended-header.webcil");
+        Assert.IsTrue(analyzer.HasMetadata);
+    }
+
+    /// <summary>
+    /// CLR directories ending exactly at a mapped section boundary are accepted.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_OptionalClrDirectoriesEndingAtSectionBoundary_AreAccepted(bool wrapped)
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(wrapped: wrapped, sectionCount: 2);
+        uint rva = image.GetSectionVirtualAddress(1);
+        uint size = image.GetSectionVirtualSize(1);
+        image.SetClrResourcesRva(rva);
+        image.SetClrResourcesSize(size);
+        image.SetClrStrongNameSignatureRva(rva);
+        image.SetClrStrongNameSignatureSize(size);
+        image.SetClrManagedNativeHeaderRva(rva);
+        image.SetClrManagedNativeHeaderSize(size);
+
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+
+        Assert.IsNotNull(reader);
+        Assert.AreEqual(unchecked((int)rva), reader.ClrHeader.ResourcesRva);
+        Assert.AreEqual(unchecked((int)rva), reader.ClrHeader.ManagedNativeHeader.RelativeVirtualAddress);
+        using AssemblyAnalyzer analyzer = new(
+            image.Bytes,
+            wrapped ? "directories.wasm" : "directories.webcil");
+        Assert.IsTrue(analyzer.HasMetadata);
+    }
+
+    /// <summary>
+    /// Required metadata may end at the final mapped byte of its section.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_MetadataEndingAtSectionBoundary_IsAccepted(bool wrapped)
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(
+            wrapped: wrapped,
+            sectionCount: 2,
+            additionalSectionSize: 4_096);
+        uint metadataRva = image.GetClrMetadataRva();
+        uint metadataSize = image.GetClrMetadataSize();
+        Assert.IsLessThanOrEqualTo(image.GetSectionVirtualSize(1), metadataSize);
+        int sourceOffset = checked(
+            image.GetSectionDataOffset(0)
+            + (int)(metadataRva - image.GetSectionVirtualAddress(0)));
+        byte[] metadata = image.Bytes.AsSpan(sourceOffset, checked((int)metadataSize)).ToArray();
+        metadata.CopyTo(image.Bytes.AsSpan(image.GetSectionDataOffset(1), metadata.Length));
+        image.SetSectionVirtualSize(1, metadataSize);
+        image.SetSectionRawSize(1, metadataSize);
+        image.SetClrMetadataRva(image.GetSectionVirtualAddress(1));
+
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+
+        Assert.IsNotNull(reader);
+        using AssemblyAnalyzer analyzer = new(
+            image.Bytes,
+            wrapped ? "metadata-boundary.wasm" : "metadata-boundary.webcil");
+        Assert.AreEqual("SyntheticWebcil", analyzer.AssemblyName);
+    }
+
+    /// <summary>
+    /// Required metadata cannot be empty, and nonempty CLR directory extents cannot cross mapped bytes.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_InvalidClrDirectoryRange_ThrowsBadImageFormatException(bool wrapped)
+    {
+        SyntheticWebcilImage metadataZeroSize = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        metadataZeroSize.SetClrMetadataSize(0);
+        AssertMalformedImage(metadataZeroSize);
+
+        SyntheticWebcilImage metadataNegativeSize = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        metadataNegativeSize.SetClrMetadataSize(uint.MaxValue);
+        AssertMalformedImage(metadataNegativeSize);
+
+        SyntheticWebcilImage metadataPastBoundary = SyntheticWebcilBuilder.Create(
+            wrapped: wrapped,
+            sectionCount: 2);
+        metadataPastBoundary.SetClrMetadataRva(metadataPastBoundary.GetSectionVirtualAddress(1));
+        metadataPastBoundary.SetClrMetadataSize(
+            checked(metadataPastBoundary.GetSectionVirtualSize(1) + 1));
+        AssertMalformedImage(metadataPastBoundary);
+
+        SyntheticWebcilImage resourcesPastBoundary = SyntheticWebcilBuilder.Create(
+            wrapped: wrapped,
+            sectionCount: 2);
+        resourcesPastBoundary.SetClrResourcesRva(resourcesPastBoundary.GetSectionVirtualAddress(1));
+        resourcesPastBoundary.SetClrResourcesSize(
+            checked(resourcesPastBoundary.GetSectionVirtualSize(1) + 1));
+        AssertMalformedImage(resourcesPastBoundary);
+
+        SyntheticWebcilImage strongNamePastBoundary = SyntheticWebcilBuilder.Create(
+            wrapped: wrapped,
+            sectionCount: 2);
+        strongNamePastBoundary.SetClrStrongNameSignatureRva(
+            strongNamePastBoundary.GetSectionVirtualAddress(1));
+        strongNamePastBoundary.SetClrStrongNameSignatureSize(
+            checked(strongNamePastBoundary.GetSectionVirtualSize(1) + 1));
+        AssertMalformedImage(strongNamePastBoundary);
+
+        SyntheticWebcilImage managedNativePastBoundary = SyntheticWebcilBuilder.Create(
+            wrapped: wrapped,
+            sectionCount: 2);
+        managedNativePastBoundary.SetClrManagedNativeHeaderRva(
+            managedNativePastBoundary.GetSectionVirtualAddress(1));
+        managedNativePastBoundary.SetClrManagedNativeHeaderSize(
+            checked(managedNativePastBoundary.GetSectionVirtualSize(1) + 1));
+        AssertMalformedImage(managedNativePastBoundary);
+    }
+
+    /// <summary>
+    /// Optional CLR directories preserve the runtime's zero-RVA and mapped-zero-size compatibility.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_OptionalClrDirectoryZeroEncodings_AreAccepted(bool wrapped)
+    {
+        SyntheticWebcilImage zeroRvas = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        zeroRvas.SetClrResourcesRva(0);
+        zeroRvas.SetClrResourcesSize(1);
+        zeroRvas.SetClrStrongNameSignatureRva(0);
+        zeroRvas.SetClrStrongNameSignatureSize(1);
+        zeroRvas.SetClrManagedNativeHeaderRva(0);
+        zeroRvas.SetClrManagedNativeHeaderSize(1);
+        Assert.IsNotNull(WebcilImageReader.Open(zeroRvas.Bytes));
+
+        SyntheticWebcilImage zeroSizes = SyntheticWebcilBuilder.Create(
+            wrapped: wrapped,
+            sectionCount: 2);
+        uint mappedRva = zeroSizes.GetSectionVirtualAddress(1);
+        zeroSizes.SetClrResourcesRva(mappedRva);
+        zeroSizes.SetClrResourcesSize(0);
+        zeroSizes.SetClrStrongNameSignatureRva(mappedRva);
+        zeroSizes.SetClrStrongNameSignatureSize(0);
+        zeroSizes.SetClrManagedNativeHeaderRva(mappedRva);
+        zeroSizes.SetClrManagedNativeHeaderSize(0);
+        Assert.IsNotNull(WebcilImageReader.Open(zeroSizes.Bytes));
+    }
+
+    /// <summary>
+    /// Wrapped section and debug-entry offsets retain their exact outer-file provenance.
+    /// </summary>
+    [TestMethod]
+    public void Open_WrappedDebugDirectory_ReportsExactOuterOffsets()
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.CreateWithDebugDirectory(wrapped: true);
+
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+
+        Assert.IsNotNull(reader);
+        Assert.AreEqual(image.PayloadOffset, reader.Info.PayloadOffset);
+        Assert.AreEqual(
+            checked(image.PayloadOffset + (int)image.GetSectionPointer(1)),
+            reader.ReadSections()[1].RawDataOffset);
+        DebugDirectoryInfo entry = Assert.ContainsSingle(reader.ReadDebugDirectory());
+        Assert.AreEqual(DebugDirectoryEntryType.Reproducible, entry.Type);
+        Assert.AreEqual(0x12345678u, entry.Stamp);
+        Assert.AreEqual(1, entry.MajorVersion);
+        Assert.AreEqual(2, entry.MinorVersion);
+        Assert.AreEqual(4, entry.DataSize);
+        Assert.AreEqual(
+            checked((int)image.GetSectionVirtualAddress(1) + 28),
+            entry.AddressOfRawData);
+        Assert.AreEqual(
+            checked(image.PayloadOffset + (int)image.GetSectionPointer(1) + 28),
+            entry.PointerToRawData);
+
+        using AssemblyAnalyzer analyzer = new(image.Bytes, "debug-provenance.wasm");
+        Assert.AreEqual(
+            checked(image.PayloadOffset + (int)image.GetSectionPointer(1)),
+            analyzer.Sections[1].RawDataOffset);
+        DebugDirectoryInfo publicEntry = Assert.ContainsSingle(analyzer.DebugDirectory);
+        Assert.AreEqual(entry.Type, publicEntry.Type);
+        Assert.AreEqual(entry.Stamp, publicEntry.Stamp);
+        Assert.AreEqual(entry.MajorVersion, publicEntry.MajorVersion);
+        Assert.AreEqual(entry.MinorVersion, publicEntry.MinorVersion);
+        Assert.AreEqual(entry.DataSize, publicEntry.DataSize);
+        Assert.AreEqual(entry.AddressOfRawData, publicEntry.AddressOfRawData);
+        Assert.AreEqual(entry.PointerToRawData, publicEntry.PointerToRawData);
+    }
+
+    /// <summary>
+    /// Reserved debug characteristics are malformed rather than an entry that can be silently ignored.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_NonzeroDebugCharacteristics_ThrowsBadImageFormatException(bool wrapped)
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.CreateWithDebugDirectory(wrapped: wrapped);
+        SetDebugEntryUInt32(image, fieldOffset: 0, value: 1);
+
+        AssertMalformedImage(image);
+    }
+
+    /// <summary>
+    /// A zero-length debug payload may begin exactly at the Webcil payload end, but not beyond it.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_ZeroLengthDebugPayload_RequiresPointerInsideOrAtPayloadEnd(bool wrapped)
+    {
+        SyntheticWebcilImage exactEnd = SyntheticWebcilBuilder.CreateWithDebugDirectory(wrapped: wrapped);
+        SetDebugEntryUInt32(exactEnd, fieldOffset: 16, value: 0);
+        SetDebugEntryUInt32(
+            exactEnd,
+            fieldOffset: 24,
+            value: checked((uint)exactEnd.PayloadLength));
+        Assert.IsNotNull(WebcilImageReader.Open(exactEnd.Bytes));
+
+        SyntheticWebcilImage pastEnd = SyntheticWebcilBuilder.CreateWithDebugDirectory(wrapped: wrapped);
+        SetDebugEntryUInt32(pastEnd, fieldOffset: 16, value: 0);
+        SetDebugEntryUInt32(
+            pastEnd,
+            fieldOffset: 24,
+            value: checked((uint)pastEnd.PayloadLength + 1));
+        AssertMalformedImage(pastEnd);
+    }
+
+    /// <summary>
+    /// A complete debug-directory row may end at the final mapped byte of its section.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_DebugDirectoryEndingAtSectionBoundary_IsAccepted(bool wrapped)
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.CreateWithDebugDirectory(wrapped: wrapped);
+        image.SetSectionVirtualSize(1, 28);
+        image.SetSectionRawSize(1, 28);
+        SetDebugEntryUInt32(image, fieldOffset: 16, value: 0);
+        SetDebugEntryUInt32(
+            image,
+            fieldOffset: 24,
+            value: checked((uint)image.PayloadLength));
+
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+
+        Assert.IsNotNull(reader);
+        DebugDirectoryInfo entry = Assert.ContainsSingle(reader.ReadDebugDirectory());
+        Assert.AreEqual(DebugDirectoryEntryType.Reproducible, entry.Type);
+        Assert.AreEqual(0, entry.DataSize);
+        Assert.AreEqual(checked(image.PayloadOffset + image.PayloadLength), entry.PointerToRawData);
+    }
+
+    /// <summary>
+    /// Either zero debug-directory field represents an absent directory, matching the runtime.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_AbsentDebugDirectoryEncoding_ReportsNoEntries(bool wrapped)
+    {
+        SyntheticWebcilImage zeroRva = SyntheticWebcilBuilder.CreateWithDebugDirectory(wrapped: wrapped);
+        zeroRva.SetPeDebugRva(0);
+        zeroRva.SetPeDebugSize(uint.MaxValue);
+        WebcilImageReader? zeroRvaReader = WebcilImageReader.Open(zeroRva.Bytes);
+        Assert.IsNotNull(zeroRvaReader);
+        Assert.AreEqual(0, zeroRvaReader.Info.DebugDirectorySize);
+        Assert.IsEmpty(zeroRvaReader.ReadDebugDirectory());
+        using AssemblyAnalyzer zeroRvaAnalyzer = new(
+            zeroRva.Bytes,
+            wrapped ? "zero-debug-rva.wasm" : "zero-debug-rva.webcil");
+        Assert.IsNotNull(zeroRvaAnalyzer.WebcilInfo);
+        Assert.AreEqual(0, zeroRvaAnalyzer.WebcilInfo.DebugDirectorySize);
+        Assert.IsEmpty(zeroRvaAnalyzer.DebugDirectory);
+
+        SyntheticWebcilImage zeroSize = SyntheticWebcilBuilder.CreateWithDebugDirectory(wrapped: wrapped);
+        zeroSize.SetPeDebugSize(0);
+        WebcilImageReader? zeroSizeReader = WebcilImageReader.Open(zeroSize.Bytes);
+        Assert.IsNotNull(zeroSizeReader);
+        Assert.AreEqual(0, zeroSizeReader.Info.DebugDirectorySize);
+        Assert.IsEmpty(zeroSizeReader.ReadDebugDirectory());
+        using AssemblyAnalyzer zeroSizeAnalyzer = new(
+            zeroSize.Bytes,
+            wrapped ? "zero-debug-size.wasm" : "zero-debug-size.webcil");
+        Assert.IsNotNull(zeroSizeAnalyzer.WebcilInfo);
+        Assert.AreEqual(0, zeroSizeAnalyzer.WebcilInfo.DebugDirectorySize);
+        Assert.IsEmpty(zeroSizeAnalyzer.DebugDirectory);
+    }
+
+    /// <summary>
+    /// Debug directory rows and their payloads cannot cross the Webcil payload or mapped section bytes.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Open_InvalidDebugDirectoryRange_ThrowsBadImageFormatException(bool wrapped)
+    {
+        SyntheticWebcilImage partialEntry = SyntheticWebcilBuilder.CreateWithDebugDirectory(wrapped: wrapped);
+        partialEntry.SetPeDebugSize(27);
+        AssertMalformedImage(partialEntry);
+
+        SyntheticWebcilImage unmappedDirectory = SyntheticWebcilBuilder.CreateWithDebugDirectory(wrapped: wrapped);
+        unmappedDirectory.SetPeDebugRva(checked(
+            unmappedDirectory.GetSectionVirtualAddress(1)
+            + unmappedDirectory.GetSectionVirtualSize(1)));
+        AssertMalformedImage(unmappedDirectory);
+
+        SyntheticWebcilImage oversizedDirectory = SyntheticWebcilBuilder.CreateWithDebugDirectory(wrapped: wrapped);
+        oversizedDirectory.SetPeDebugSize(84);
+        AssertMalformedImage(oversizedDirectory);
+
+        SyntheticWebcilImage payloadPastEnd = SyntheticWebcilBuilder.CreateWithDebugDirectory(wrapped: wrapped);
+        SetDebugEntryUInt32(payloadPastEnd, fieldOffset: 16, value: 1);
+        SetDebugEntryUInt32(
+            payloadPastEnd,
+            fieldOffset: 24,
+            checked((uint)payloadPastEnd.PayloadLength));
+        AssertMalformedImage(payloadPastEnd);
+
+        SyntheticWebcilImage payloadOverflow = SyntheticWebcilBuilder.CreateWithDebugDirectory(wrapped: wrapped);
+        SetDebugEntryUInt32(payloadOverflow, fieldOffset: 16, value: 2);
+        SetDebugEntryUInt32(payloadOverflow, fieldOffset: 24, uint.MaxValue);
+        AssertMalformedImage(payloadOverflow);
+
+        SyntheticWebcilImage negativePayloadSize = SyntheticWebcilBuilder.CreateWithDebugDirectory(wrapped: wrapped);
+        SetDebugEntryUInt32(negativePayloadSize, fieldOffset: 16, uint.MaxValue);
+        AssertMalformedImage(negativePayloadSize);
+    }
+
+    /// <summary>
+    /// Zero, negative, unmapped, virtual-tail, and raw-padding RVAs do not produce method bodies.
+    /// </summary>
+    [TestMethod]
+    public void GetMethodBody_UnmappedRva_ReturnsNull()
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(sectionCount: 3);
+        image.SetSectionVirtualSize(1, 8);
+        image.SetSectionRawSize(1, 4);
+        image.SetSectionVirtualAddress(2, checked(image.GetSectionVirtualAddress(1) + 8));
+        image.SetSectionVirtualSize(2, 4);
+        image.SetSectionPointer(2, image.GetSectionPointer(1));
+        image.SetSectionRawSize(2, 8);
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+        Assert.IsNotNull(reader);
+
+        Assert.IsNull(reader.GetMethodBody(0));
+        Assert.IsNull(reader.GetMethodBody(-1));
+        Assert.IsNull(reader.GetMethodBody(int.MaxValue));
+        Assert.IsNull(reader.GetMethodBody(checked((int)image.GetSectionVirtualAddress(1) + 4)));
+        Assert.IsNull(reader.GetMethodBody(checked((int)image.GetSectionVirtualAddress(2) + 4)));
+    }
+
+    /// <summary>
+    /// Zero and negative signed method RVAs remain invalid even when their unsigned bit patterns map.
+    /// </summary>
+    [TestMethod]
+    public void GetMethodBody_MappedZeroAndNegativeRvas_ReturnNull()
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(sectionCount: 3);
+        image.SetSectionVirtualAddress(1, 0);
+        image.SetSectionVirtualSize(1, 2);
+        image.SetSectionRawSize(1, 2);
+        image.SetSectionVirtualAddress(2, 0x80000000);
+        image.SetSectionVirtualSize(2, 2);
+        image.SetSectionRawSize(2, 2);
+        image.Bytes[image.GetSectionDataOffset(1)] = 0x06;
+        image.Bytes[image.GetSectionDataOffset(1) + 1] = 0x2A;
+        image.Bytes[image.GetSectionDataOffset(2)] = 0x06;
+        image.Bytes[image.GetSectionDataOffset(2) + 1] = 0x2A;
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+        Assert.IsNotNull(reader);
+
+        Assert.IsNull(reader.GetMethodBody(0));
+        Assert.IsNull(reader.GetMethodBody(int.MinValue));
+    }
+
+    /// <summary>
+    /// A complete tiny body ending at the final mapped byte remains byte-exact across compacting collections.
+    /// </summary>
+    [TestMethod]
+    public void AssemblyAnalyzer_TinyBodyEndingAtFinalMappedByte_SurvivesCompactingCollections()
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(sectionCount: 2);
+        image.SetSectionVirtualSize(1, 2);
+        image.SetSectionRawSize(1, 2);
+        int bodyOffset = checked(image.PayloadOffset + (int)image.GetSectionPointer(1));
+        image.Bytes[bodyOffset] = 0x06;
+        image.Bytes[bodyOffset + 1] = 0x2A;
+        image.SetMethodRva(checked((int)image.GetSectionVirtualAddress(1)));
+        using AssemblyAnalyzer analyzer = new(image.Bytes, "boundary.webcil");
+        MethodDefInfo method = Assert.ContainsSingle(
+            static method => method.Name == "Answer",
+            analyzer.MethodDefs);
+
+        MethodBodyBlock? body = analyzer.GetMethodBody(method);
+        Assert.IsNotNull(body);
+        byte[] expected = [0x2A];
+        Assert.AreSequenceEqual(expected, body.GetILBytes());
+
+        CompactManagedHeap();
+
+        Assert.AreSequenceEqual(expected, body.GetILBytes());
+        GC.KeepAlive(analyzer);
+    }
+
+    /// <summary>
+    /// A method body cannot consume bytes from a following virtual section even when raw ranges overlap.
+    /// </summary>
+    [TestMethod]
+    public void GetMethodBody_TruncatedAtVirtualSectionBoundary_ThrowsBadImageFormatException()
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(sectionCount: 3);
+        image.SetSectionVirtualSize(1, 1);
+        image.SetSectionRawSize(1, 5);
+        image.SetSectionVirtualAddress(2, checked(image.GetSectionVirtualAddress(1) + 1));
+        image.SetSectionPointer(2, checked(image.GetSectionPointer(1) + 1));
+        image.Bytes[checked(image.PayloadOffset + (int)image.GetSectionPointer(1))] = 0x06;
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+        Assert.IsNotNull(reader);
+
+        Assert.ThrowsExactly<BadImageFormatException>(() =>
+            reader.GetMethodBody(checked((int)image.GetSectionVirtualAddress(1))));
+    }
+
+    /// <summary>
+    /// An RVA at one section's exclusive end resolves to an adjacent section beginning at that RVA.
+    /// </summary>
+    [TestMethod]
+    public void GetMethodBody_AdjacentSectionStart_ReadsSecondSection()
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(sectionCount: 3);
+        image.SetSectionVirtualSize(1, 1);
+        image.SetSectionRawSize(1, 5);
+        image.SetSectionVirtualAddress(2, checked(image.GetSectionVirtualAddress(1) + 1));
+        image.SetSectionVirtualSize(2, 2);
+        image.SetSectionPointer(2, checked(image.GetSectionPointer(1) + 1));
+        image.SetSectionRawSize(2, 2);
+        image.Bytes[image.GetSectionDataOffset(2)] = 0x06;
+        image.Bytes[image.GetSectionDataOffset(2) + 1] = 0x2A;
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+        Assert.IsNotNull(reader);
+
+        MethodBodyBlock? body = reader.GetMethodBody(
+            checked((int)image.GetSectionVirtualAddress(2)));
+
+        Assert.IsNotNull(body);
+        byte[] expected = [0x2A];
+        Assert.AreSequenceEqual(expected, body.GetILBytes());
+    }
+
+    /// <summary>
+    /// Large relative offsets are rejected without signed overflow.
+    /// </summary>
+    [TestMethod]
+    public void TryReadInt32AtRva_IntMaxRelativeOffset_ReturnsFalse()
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create();
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+        Assert.IsNotNull(reader);
+
+        Assert.IsFalse(reader.TryReadInt32AtRva(image.MethodRva, int.MaxValue, out _));
+    }
+
+    /// <summary>
+    /// Method-body storage remains stable across compacting collections for the reader lifetime.
+    /// </summary>
+    [TestMethod]
+    public void GetMethodBody_CompactingCollections_PreservesIlBytes()
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create();
+        WebcilImageReader? reader = WebcilImageReader.Open(image.Bytes);
+        Assert.IsNotNull(reader);
+        MethodBodyBlock? body = reader.GetMethodBody(image.MethodRva);
+        Assert.IsNotNull(body);
+        byte[]? ilBytes = body.GetILBytes();
+        Assert.IsNotNull(ilBytes);
+        byte[] expected = [.. ilBytes];
+
+        CompactManagedHeap();
+
+        Assert.AreSequenceEqual(expected, body.GetILBytes());
+        GC.KeepAlive(reader);
+    }
+
+    /// <summary>
+    /// The public analyzer and disassembler expose valid synthetic Webcil metadata and IL.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void AssemblyAnalyzer_ValidWebcil_DisassemblesMethod(bool wrapped)
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        using AssemblyAnalyzer analyzer = new(
+            image.Bytes,
+            wrapped ? "synthetic.wasm" : "synthetic.webcil");
+
+        Assert.IsTrue(analyzer.HasMetadata);
+        Assert.AreEqual(BinaryKind.Managed, analyzer.BinaryKind);
+        Assert.IsNotNull(analyzer.WebcilInfo);
+        MethodDefInfo method = Assert.ContainsSingle(
+            static method => method.Name == "Answer",
+            analyzer.MethodDefs);
+        (string Text, IReadOnlyList<IlInstruction> Instructions, int HeaderLineCount)? disassembly =
+            new IlDisassembler(analyzer).DisassembleWithText(method);
+        Assert.IsNotNull(disassembly);
+        Assert.Contains("ldc.i4.s 42", disassembly.Value.Text);
+        Assert.Contains("ret", disassembly.Value.Text);
+    }
+
+    /// <summary>
+    /// Public IL disassembly reports a mapped body truncated at its section boundary as malformed.
+    /// </summary>
+    [TestMethod]
+    public void IlDisassembler_MethodBodyCrossesSectionBoundary_ThrowsBadImageFormatException()
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(sectionCount: 3);
+        image.SetSectionVirtualSize(1, 1);
+        image.SetSectionRawSize(1, 5);
+        image.SetSectionVirtualAddress(2, checked(image.GetSectionVirtualAddress(1) + 1));
+        image.SetSectionPointer(2, checked(image.GetSectionPointer(1) + 1));
+        image.Bytes[checked(image.PayloadOffset + (int)image.GetSectionPointer(1))] = 0x06;
+        image.SetMethodRva(checked((int)image.GetSectionVirtualAddress(1)));
+        using AssemblyAnalyzer analyzer = new(image.Bytes, "truncated.webcil");
+        MethodDefInfo method = Assert.ContainsSingle(
+            static method => method.Name == "Answer",
+            analyzer.MethodDefs);
+
+        Assert.ThrowsExactly<BadImageFormatException>(() =>
+            new IlDisassembler(analyzer).Disassemble(method));
+    }
+
+    /// <summary>
+    /// Recognized corrupt bare and wrapped Webcil images fail closed at the public analyzer boundary.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void AssemblyAnalyzer_RecognizedCorruptWebcil_ThrowsBadImageFormatException(bool wrapped)
+    {
+        SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(wrapped: wrapped);
+        image.SetSectionCount(0);
+
+        Assert.ThrowsExactly<BadImageFormatException>(() =>
+            new AssemblyAnalyzer(image.Bytes, wrapped ? "corrupt.wasm" : "corrupt.webcil"));
+    }
+
+    /// <summary>
+    /// A failed file-path construction releases its stream so the corrupt file is immediately deletable.
+    /// </summary>
+    [TestMethod]
+    public void AssemblyAnalyzer_CorruptWrappedFile_ReleasesFileHandle()
+    {
+        TestSkip.Unless(
+            OperatingSystem.IsWindows(),
+            "Exclusive file-handle release is observable through deletion only on Windows.");
+        string path = Path.Combine(Path.GetTempPath(), $"dotsider-webcil-{Guid.NewGuid():N}.wasm");
+        try
+        {
+            SyntheticWebcilImage image = SyntheticWebcilBuilder.Create(wrapped: true);
+            image.SetSectionCount(0);
+            File.WriteAllBytes(path, image.Bytes);
+
+            Assert.ThrowsExactly<BadImageFormatException>(() => new AssemblyAnalyzer(path));
+            File.Delete(path);
+
+            Assert.IsFalse(File.Exists(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// Genuine non-Webcil Wasm remains on the raw WebAssembly analysis path.
+    /// </summary>
+    [TestMethod]
+    public void AssemblyAnalyzer_NonWebcilWasm_RemainsRawWasm()
+    {
+        byte[] wasm = [0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00];
+
+        using AssemblyAnalyzer analyzer = new(wasm, "empty.wasm");
+
+        Assert.IsFalse(analyzer.HasMetadata);
+        Assert.AreEqual(BinaryKind.Wasm, analyzer.BinaryKind);
+        Assert.IsNull(analyzer.WebcilInfo);
+        Assert.IsNotNull(analyzer.WasmModuleInfo);
+    }
+
+    /// <summary>
+    /// A sub-four-byte data segment cannot borrow following bytes to resemble a Webcil signature.
+    /// </summary>
+    [TestMethod]
+    public void Open_ShortDataSegmentFollowedByWebcilMagicBytes_ReturnsNull()
+    {
+        byte[] wasm =
+        [
+            0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+            0x0B, 0x07,
+            0x01,
+            0x01, 0x01, (byte)'W', (byte)'b', (byte)'I', (byte)'L',
+        ];
+
+        Assert.IsNull(WebcilImageReader.Open(wasm));
+    }
+
+    private static void CompactManagedHeap()
+    {
+        for (int iteration = 0; iteration < 5; iteration++)
+        {
+            _ = Enumerable.Range(0, 2_048).Select(static _ => new byte[256]).ToArray();
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        }
+    }
+
+    private static void AssertMalformedImage(SyntheticWebcilImage image)
+    {
+        Assert.ThrowsExactly<BadImageFormatException>(() => WebcilImageReader.Open(image.Bytes));
+        Assert.ThrowsExactly<BadImageFormatException>(() =>
+            new AssemblyAnalyzer(image.Bytes, image.PayloadOffset == 0 ? "invalid.webcil" : "invalid.wasm"));
+    }
+
+    private static void SetDebugEntryUInt32(
+        SyntheticWebcilImage image,
+        int fieldOffset,
+        uint value) =>
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            image.Bytes.AsSpan(image.GetSectionDataOffset(1) + fieldOffset, sizeof(uint)),
+            value);
+}


### PR DESCRIPTION
Webcil parsing now validates sections and RVAs against the containing payload before exposing metadata or IL, and keeps method-body storage valid for the lifetime of the analyzer. Malformed wrapped payloads are rejected instead of falling through to raw Wasm. Regression coverage exercises synthetic boundaries, the SDK fixture, and the public analysis paths.

Fixes: #208