### PR TITLE
Harden IL operand bounds

### DIFF
--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-IlDisassembler.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-IlDisassembler.md
@@ -39,7 +39,8 @@ public IlDisassembler(AssemblyAnalyzer analyzer)
 ### Disassemble(MethodDefInfo)
 
 Disassembles a method's IL body into a sequence of instructions.
-Returns an empty list if the method has no IL body.
+Returns an empty list if the method has no IL body. A body ending inside an opcode or operand
+returns its valid prefix followed by one [IsMalformed](/api/dotsider.core.analysis.models.ilinstruction.ismalformed/) marker.
 
 **Parameters:**
 
@@ -55,7 +56,8 @@ public IReadOnlyList<IlInstruction> Disassemble(MethodDefInfo method)
 
 ### DisassembleWithText(MethodDefInfo)
 
-Disassembles a method and returns the text, instruction list, and header line count.
+Disassembles a method and returns the text, instruction list, and header line count. A
+malformed terminal opcode or operand is represented by one [IsMalformed](/api/dotsider.core.analysis.models.ilinstruction.ismalformed/) marker.
 
 **Parameters:**
 
@@ -71,7 +73,8 @@ public (string Text, IReadOnlyList<IlInstruction> Instructions, int HeaderLineCo
 
 ### FormatDisassembly(MethodDefInfo)
 
-Formats a complete disassembly listing for a method, including header information.
+Formats a complete disassembly listing for a method, including header information and any
+terminal malformed-IL marker.
 
 **Parameters:**
 

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-IlInstruction.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-IlInstruction.md
@@ -74,6 +74,16 @@ Whether the sequence point document has embedded source.
 public bool HasEmbeddedSource { get; init; }
 ```
 
+### IsMalformed
+
+Gets or initializes a value indicating whether this is the terminal marker for malformed IL.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool IsMalformed { get; init; }
+```
+
 ### LocalName
 
 The active PDB local variable name for LocalSlot, or null.

--- a/src/Dotsider.Core/Analysis/AssemblyDiffer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyDiffer.cs
@@ -318,34 +318,21 @@ public static class AssemblyDiffer
 
         while (leftOffset < leftIl.Length && rightOffset < rightIl.Length)
         {
-            // Read opcodes
-            var leftOpByte = leftIl[leftOffset++];
-            var rightOpByte = rightIl[rightOffset++];
-
-            ILOpCode leftOp, rightOp;
-            if (leftOpByte == 0xFE)
+            if (!IlOperandReader.TryReadOpCode(leftIl, ref leftOffset, out ILOpCode leftOp)
+                || !IlOperandReader.TryReadOpCode(rightIl, ref rightOffset, out ILOpCode rightOp))
             {
-                if (leftOffset >= leftIl.Length) return true;
-                leftOp = (ILOpCode)(0xFE00 | leftIl[leftOffset++]);
-            }
-            else
-            {
-                leftOp = (ILOpCode)leftOpByte;
-            }
-
-            if (rightOpByte == 0xFE)
-            {
-                if (rightOffset >= rightIl.Length) return true;
-                rightOp = (ILOpCode)(0xFE00 | rightIl[rightOffset++]);
-            }
-            else
-            {
-                rightOp = (ILOpCode)rightOpByte;
+                return true;
             }
 
             if (leftOp != rightOp) return true;
 
             var operandKind = IlDisassembler.GetOperandType(leftOp);
+            if (!IlOperandReader.TryGetOperandLength(leftIl, leftOffset, operandKind, out int leftLength)
+                || !IlOperandReader.TryGetOperandLength(rightIl, rightOffset, operandKind, out int rightLength))
+            {
+                return true;
+            }
+
             switch (operandKind)
             {
                 case OperandKind.None:
@@ -354,34 +341,17 @@ public static class AssemblyDiffer
                 case OperandKind.ShortBranchTarget:
                 case OperandKind.ShortInlineI:
                 case OperandKind.ShortInlineVar:
-                    if (leftIl[leftOffset] != rightIl[rightOffset]) return true;
-                    leftOffset++;
-                    rightOffset++;
-                    break;
-
                 case OperandKind.InlineVar:
-                    if (leftIl[leftOffset] != rightIl[rightOffset]
-                        || leftIl[leftOffset + 1] != rightIl[rightOffset + 1])
-                        return true;
-                    leftOffset += 2;
-                    rightOffset += 2;
-                    break;
-
                 case OperandKind.BranchTarget:
                 case OperandKind.InlineI:
                 case OperandKind.ShortInlineR:
-                    if (!leftIl.AsSpan(leftOffset, 4).SequenceEqual(rightIl.AsSpan(rightOffset, 4)))
-                        return true;
-                    leftOffset += 4;
-                    rightOffset += 4;
-                    break;
-
                 case OperandKind.InlineI8:
                 case OperandKind.InlineR:
-                    if (!leftIl.AsSpan(leftOffset, 8).SequenceEqual(rightIl.AsSpan(rightOffset, 8)))
+                case OperandKind.InlineSwitch:
+                    if (leftLength != rightLength
+                        || !leftIl.AsSpan(leftOffset, leftLength)
+                            .SequenceEqual(rightIl.AsSpan(rightOffset, rightLength)))
                         return true;
-                    leftOffset += 8;
-                    rightOffset += 8;
                     break;
 
                 case OperandKind.InlineMethod:
@@ -389,8 +359,8 @@ public static class AssemblyDiffer
                 case OperandKind.InlineType:
                 case OperandKind.InlineTok:
                     {
-                        var leftToken = IlDisassembler.ReadInt32(leftIl, ref leftOffset);
-                        var rightToken = IlDisassembler.ReadInt32(rightIl, ref rightOffset);
+                        var leftToken = IlOperandReader.ReadInt32(leftIl, leftOffset);
+                        var rightToken = IlOperandReader.ReadInt32(rightIl, rightOffset);
                         var leftResolved = leftAnalyzer.ResolveTokenForComparison(leftToken);
                         var rightResolved = rightAnalyzer.ResolveTokenForComparison(rightToken);
                         if (leftResolved != rightResolved) return true;
@@ -399,8 +369,8 @@ public static class AssemblyDiffer
 
                 case OperandKind.InlineString:
                     {
-                        var leftToken = IlDisassembler.ReadInt32(leftIl, ref leftOffset);
-                        var rightToken = IlDisassembler.ReadInt32(rightIl, ref rightOffset);
+                        var leftToken = IlOperandReader.ReadInt32(leftIl, leftOffset);
+                        var rightToken = IlOperandReader.ReadInt32(rightIl, rightOffset);
                         var leftReader = leftAnalyzer.GetMetadataReader();
                         var rightReader = rightAnalyzer.GetMetadataReader();
                         if (leftReader is null || rightReader is null) return leftToken != rightToken;
@@ -421,31 +391,20 @@ public static class AssemblyDiffer
 
                 case OperandKind.InlineSig:
                     {
-                        var leftToken = IlDisassembler.ReadInt32(leftIl, ref leftOffset);
-                        var rightToken = IlDisassembler.ReadInt32(rightIl, ref rightOffset);
+                        var leftToken = IlOperandReader.ReadInt32(leftIl, leftOffset);
+                        var rightToken = IlOperandReader.ReadInt32(rightIl, rightOffset);
                         var leftResolved = leftAnalyzer.ResolveTokenForComparison(leftToken);
                         var rightResolved = rightAnalyzer.ResolveTokenForComparison(rightToken);
                         if (leftResolved != rightResolved) return true;
                         break;
                     }
 
-                case OperandKind.InlineSwitch:
-                    {
-                        var leftCount = IlDisassembler.ReadInt32(leftIl, ref leftOffset);
-                        var rightCount = IlDisassembler.ReadInt32(rightIl, ref rightOffset);
-                        if (leftCount != rightCount) return true;
-                        var targetBytes = leftCount * 4;
-                        if (!leftIl.AsSpan(leftOffset, targetBytes)
-                            .SequenceEqual(rightIl.AsSpan(rightOffset, targetBytes)))
-                            return true;
-                        leftOffset += targetBytes;
-                        rightOffset += targetBytes;
-                        break;
-                    }
-
                 default:
                     break;
             }
+
+            leftOffset += leftLength;
+            rightOffset += rightLength;
         }
 
         return leftOffset != leftIl.Length || rightOffset != rightIl.Length;

--- a/src/Dotsider.Core/Analysis/IlDisassembler.cs
+++ b/src/Dotsider.Core/Analysis/IlDisassembler.cs
@@ -16,7 +16,8 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
 
     /// <summary>
     /// Disassembles a method's IL body into a sequence of instructions.
-    /// Returns an empty list if the method has no IL body.
+    /// Returns an empty list if the method has no IL body. A body ending inside an opcode or operand
+    /// returns its valid prefix followed by one <see cref="IlInstruction.IsMalformed"/> marker.
     /// </summary>
     /// <param name="method">The method to disassemble.</param>
     /// <returns>The list of decoded IL instructions.</returns>
@@ -37,22 +38,26 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
         while (offset < ilBytes.Length)
         {
             var instructionOffset = offset;
-            var opCodeByte = ilBytes[offset++];
-
-            ILOpCode opCode;
-            if (opCodeByte == 0xFE)
+            if (!IlOperandReader.TryReadOpCode(ilBytes, ref offset, out ILOpCode opCode))
             {
-                if (offset >= ilBytes.Length) break;
-                var secondByte = ilBytes[offset++];
-                opCode = (ILOpCode)(0xFE00 | secondByte);
-            }
-            else
-            {
-                opCode = (ILOpCode)opCodeByte;
+                instructions.Add(CreateMalformedInstruction(
+                    instructionOffset,
+                    ".invalid",
+                    "<truncated opcode>"));
+                break;
             }
 
             var operandStart = offset;
-            var operand = DecodeOperand(ilBytes, ref offset, opCode);
+            if (!TryDecodeOperand(ilBytes, operandStart, opCode, out string operand, out int operandLength))
+            {
+                instructions.Add(CreateMalformedInstruction(
+                    instructionOffset,
+                    FormatOpCode(opCode),
+                    "<truncated operand>"));
+                break;
+            }
+
+            offset = operandStart + operandLength;
             var localSlot = TryGetLocalSlot(opCode, ilBytes, operandStart);
             var localName = localSlot is null
                 ? null
@@ -64,9 +69,9 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
             var operandKind = GetOperandType(opCode);
             if (operandKind is OperandKind.InlineMethod or OperandKind.InlineField
                 or OperandKind.InlineType or OperandKind.InlineTok
-                && operandStart + 4 <= ilBytes.Length)
+                && operandLength == sizeof(int))
             {
-                metadataToken = BitConverter.ToInt32(ilBytes, operandStart);
+                metadataToken = IlOperandReader.ReadInt32(ilBytes, operandStart);
             }
 
             sequencePointsByOffset.TryGetValue(instructionOffset, out var sequencePoint);
@@ -91,7 +96,8 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
     }
 
     /// <summary>
-    /// Formats a complete disassembly listing for a method, including header information.
+    /// Formats a complete disassembly listing for a method, including header information and any
+    /// terminal malformed-IL marker.
     /// </summary>
     /// <param name="method">The method to disassemble.</param>
     /// <returns>A multi-line string with the full disassembly listing.</returns>
@@ -102,7 +108,8 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
     }
 
     /// <summary>
-    /// Disassembles a method and returns the text, instruction list, and header line count.
+    /// Disassembles a method and returns the text, instruction list, and header line count. A
+    /// malformed terminal opcode or operand is represented by one <see cref="IlInstruction.IsMalformed"/> marker.
     /// </summary>
     /// <param name="method">The method to disassemble.</param>
     /// <returns>Tuple of (text, instructions, headerLineCount), or null if no IL body.</returns>
@@ -271,27 +278,44 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
         };
     }
 
-    private string DecodeOperand(byte[] ilBytes, ref int offset, ILOpCode opCode)
+    private bool TryDecodeOperand(
+        byte[] ilBytes,
+        int operandStart,
+        ILOpCode opCode,
+        out string operand,
+        out int operandLength)
     {
-        return GetOperandType(opCode) switch
+        var operandKind = GetOperandType(opCode);
+        if (!IlOperandReader.TryGetOperandLength(ilBytes, operandStart, operandKind, out operandLength))
+        {
+            operand = string.Empty;
+            return false;
+        }
+
+        var operandEnd = operandStart + operandLength;
+        operand = operandKind switch
         {
             OperandKind.None => "",
-            OperandKind.ShortBranchTarget => FormatBranchTarget(offset + 1 + ReadSByte(ilBytes, ref offset)),
-            OperandKind.BranchTarget => FormatBranchTarget(offset + 4 + ReadInt32(ilBytes, ref offset)),
-            OperandKind.ShortInlineI => ReadSByte(ilBytes, ref offset).ToString(),
-            OperandKind.InlineI => ReadInt32(ilBytes, ref offset).ToString(),
-            OperandKind.InlineI8 => ReadInt64(ilBytes, ref offset).ToString(),
-            OperandKind.ShortInlineR => ReadSingle(ilBytes, ref offset).ToString("G"),
-            OperandKind.InlineR => ReadDouble(ilBytes, ref offset).ToString("G"),
-            OperandKind.ShortInlineVar => ReadByte(ilBytes, ref offset).ToString(),
-            OperandKind.InlineVar => ReadUInt16(ilBytes, ref offset).ToString(),
-            OperandKind.InlineString => ResolveStringToken(ReadInt32(ilBytes, ref offset)),
+            OperandKind.ShortBranchTarget => FormatBranchTarget(
+                (long)operandEnd + IlOperandReader.ReadSByte(ilBytes, operandStart)),
+            OperandKind.BranchTarget => FormatBranchTarget(
+                (long)operandEnd + IlOperandReader.ReadInt32(ilBytes, operandStart)),
+            OperandKind.ShortInlineI => IlOperandReader.ReadSByte(ilBytes, operandStart).ToString(),
+            OperandKind.InlineI => IlOperandReader.ReadInt32(ilBytes, operandStart).ToString(),
+            OperandKind.InlineI8 => IlOperandReader.ReadInt64(ilBytes, operandStart).ToString(),
+            OperandKind.ShortInlineR => IlOperandReader.ReadSingle(ilBytes, operandStart).ToString("G"),
+            OperandKind.InlineR => IlOperandReader.ReadDouble(ilBytes, operandStart).ToString("G"),
+            OperandKind.ShortInlineVar => IlOperandReader.ReadByte(ilBytes, operandStart).ToString(),
+            OperandKind.InlineVar => IlOperandReader.ReadUInt16(ilBytes, operandStart).ToString(),
+            OperandKind.InlineString => ResolveStringToken(IlOperandReader.ReadInt32(ilBytes, operandStart)),
             OperandKind.InlineMethod or OperandKind.InlineField or OperandKind.InlineType or OperandKind.InlineTok
-                => analyzer.ResolveToken(ReadInt32(ilBytes, ref offset)),
-            OperandKind.InlineSig => $"StandaloneSig(0x{ReadInt32(ilBytes, ref offset):X8})",
-            OperandKind.InlineSwitch => DecodeSwitch(ilBytes, ref offset),
+                => analyzer.ResolveToken(IlOperandReader.ReadInt32(ilBytes, operandStart)),
+            OperandKind.InlineSig => $"StandaloneSig(0x{IlOperandReader.ReadInt32(ilBytes, operandStart):X8})",
+            OperandKind.InlineSwitch => DecodeSwitch(ilBytes, operandStart, operandLength),
             _ => ""
         };
+
+        return true;
     }
 
     private string ResolveStringToken(int token)
@@ -308,62 +332,32 @@ public sealed class IlDisassembler(AssemblyAnalyzer analyzer)
         }
     }
 
-    private static string DecodeSwitch(byte[] ilBytes, ref int offset)
+    private static string DecodeSwitch(byte[] ilBytes, int operandStart, int operandLength)
     {
-        var count = ReadInt32(ilBytes, ref offset);
-        if (count <= 0 || count > 1000) return $"({count} targets)";
+        var count = IlOperandReader.ReadInt32(ilBytes, operandStart);
+        if (count == 0) return "(0 targets)";
 
-        var baseOffset = offset + count * 4;
-        var targets = new List<string>();
+        var targetsOffset = operandStart + sizeof(int);
+        var baseOffset = operandStart + operandLength;
+        var targets = new List<string>(Math.Min(count, 10));
         for (var i = 0; i < count && i < 10; i++)
         {
-            var target = baseOffset + ReadInt32(ilBytes, ref offset);
+            var target = (long)baseOffset
+                + IlOperandReader.ReadInt32(ilBytes, targetsOffset + (i * sizeof(int)));
             targets.Add(FormatBranchTarget(target));
         }
-        // Skip remaining targets if more than 10
         if (count > 10)
         {
-            offset += (count - 10) * 4;
             targets.Add($"... ({count - 10} more)");
         }
         return $"({string.Join(", ", targets)})";
     }
 
-    private static string FormatBranchTarget(int target) => $"IL_{target:X4}";
-    private static string FormatOpCode(ILOpCode opCode) => opCode.ToString().ToLowerInvariant().Replace('_', '.');
+    private static IlInstruction CreateMalformedInstruction(int offset, string opCode, string operand) =>
+        new IlInstruction(offset, opCode, operand) { IsMalformed = true };
 
-    internal static sbyte ReadSByte(byte[] il, ref int offset) => (sbyte)il[offset++];
-    internal static byte ReadByte(byte[] il, ref int offset) => il[offset++];
-    internal static ushort ReadUInt16(byte[] il, ref int offset)
-    {
-        var v = BitConverter.ToUInt16(il, offset);
-        offset += 2;
-        return v;
-    }
-    internal static int ReadInt32(byte[] il, ref int offset)
-    {
-        var v = BitConverter.ToInt32(il, offset);
-        offset += 4;
-        return v;
-    }
-    internal static long ReadInt64(byte[] il, ref int offset)
-    {
-        var v = BitConverter.ToInt64(il, offset);
-        offset += 8;
-        return v;
-    }
-    internal static float ReadSingle(byte[] il, ref int offset)
-    {
-        var v = BitConverter.ToSingle(il, offset);
-        offset += 4;
-        return v;
-    }
-    internal static double ReadDouble(byte[] il, ref int offset)
-    {
-        var v = BitConverter.ToDouble(il, offset);
-        offset += 8;
-        return v;
-    }
+    private static string FormatBranchTarget(long target) => $"IL_{target:X4}";
+    private static string FormatOpCode(ILOpCode opCode) => opCode.ToString().ToLowerInvariant().Replace('_', '.');
 
     internal static OperandKind GetOperandType(ILOpCode opCode) => opCode switch
     {

--- a/src/Dotsider.Core/Analysis/IlOperandReader.cs
+++ b/src/Dotsider.Core/Analysis/IlOperandReader.cs
@@ -1,0 +1,175 @@
+using System.Buffers.Binary;
+using System.Reflection.Metadata;
+
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Performs bounds-checked reads of ECMA-335 IL opcodes and operands.
+/// </summary>
+internal static class IlOperandReader
+{
+    /// <summary>
+    /// Reads one complete one-byte or two-byte IL opcode.
+    /// </summary>
+    /// <param name="il">The method IL bytes.</param>
+    /// <param name="offset">The current byte offset, advanced only for bytes that are present.</param>
+    /// <param name="opCode">The decoded opcode when the read succeeds.</param>
+    /// <returns><see langword="true"/> when a complete opcode was read; otherwise, <see langword="false"/>.</returns>
+    internal static bool TryReadOpCode(ReadOnlySpan<byte> il, ref int offset, out ILOpCode opCode)
+    {
+        opCode = default;
+        if (offset >= il.Length)
+        {
+            return false;
+        }
+
+        byte first = il[offset++];
+        if (first != 0xFE)
+        {
+            opCode = (ILOpCode)first;
+            return true;
+        }
+
+        if (offset >= il.Length)
+        {
+            return false;
+        }
+
+        opCode = (ILOpCode)(0xFE00 | il[offset++]);
+        return true;
+    }
+
+    /// <summary>
+    /// Gets the complete encoded length of an operand without reading beyond the IL buffer.
+    /// </summary>
+    /// <param name="il">The method IL bytes.</param>
+    /// <param name="offset">The byte offset where the operand begins.</param>
+    /// <param name="operandKind">The operand encoding to validate.</param>
+    /// <param name="length">The validated operand length when the method succeeds.</param>
+    /// <returns><see langword="true"/> when the complete operand is present; otherwise, <see langword="false"/>.</returns>
+    internal static bool TryGetOperandLength(
+        ReadOnlySpan<byte> il,
+        int offset,
+        OperandKind operandKind,
+        out int length)
+    {
+        return operandKind switch
+        {
+            OperandKind.None => TryGetFixedLength(il, offset, 0, out length),
+            OperandKind.ShortBranchTarget or OperandKind.ShortInlineI or OperandKind.ShortInlineVar
+                => TryGetFixedLength(il, offset, 1, out length),
+            OperandKind.InlineVar => TryGetFixedLength(il, offset, 2, out length),
+            OperandKind.BranchTarget or OperandKind.InlineI or OperandKind.ShortInlineR
+                or OperandKind.InlineString or OperandKind.InlineMethod or OperandKind.InlineField
+                or OperandKind.InlineType or OperandKind.InlineTok or OperandKind.InlineSig
+                => TryGetFixedLength(il, offset, 4, out length),
+            OperandKind.InlineI8 or OperandKind.InlineR => TryGetFixedLength(il, offset, 8, out length),
+            OperandKind.InlineSwitch => TryGetSwitchLength(il, offset, out length),
+            _ => Fail(out length)
+        };
+    }
+
+    /// <summary>
+    /// Reads a signed byte from a previously validated operand.
+    /// </summary>
+    /// <param name="il">The method IL bytes.</param>
+    /// <param name="offset">The byte offset to read.</param>
+    /// <returns>The signed byte value.</returns>
+    internal static sbyte ReadSByte(ReadOnlySpan<byte> il, int offset) => unchecked((sbyte)il[offset]);
+
+    /// <summary>
+    /// Reads an unsigned byte from a previously validated operand.
+    /// </summary>
+    /// <param name="il">The method IL bytes.</param>
+    /// <param name="offset">The byte offset to read.</param>
+    /// <returns>The unsigned byte value.</returns>
+    internal static byte ReadByte(ReadOnlySpan<byte> il, int offset) => il[offset];
+
+    /// <summary>
+    /// Reads a little-endian unsigned 16-bit integer from a previously validated operand.
+    /// </summary>
+    /// <param name="il">The method IL bytes.</param>
+    /// <param name="offset">The byte offset to read.</param>
+    /// <returns>The unsigned 16-bit value.</returns>
+    internal static ushort ReadUInt16(ReadOnlySpan<byte> il, int offset) =>
+        BinaryPrimitives.ReadUInt16LittleEndian(il[offset..]);
+
+    /// <summary>
+    /// Reads a little-endian signed 32-bit integer from a previously validated operand.
+    /// </summary>
+    /// <param name="il">The method IL bytes.</param>
+    /// <param name="offset">The byte offset to read.</param>
+    /// <returns>The signed 32-bit value.</returns>
+    internal static int ReadInt32(ReadOnlySpan<byte> il, int offset) =>
+        BinaryPrimitives.ReadInt32LittleEndian(il[offset..]);
+
+    /// <summary>
+    /// Reads a little-endian signed 64-bit integer from a previously validated operand.
+    /// </summary>
+    /// <param name="il">The method IL bytes.</param>
+    /// <param name="offset">The byte offset to read.</param>
+    /// <returns>The signed 64-bit value.</returns>
+    internal static long ReadInt64(ReadOnlySpan<byte> il, int offset) =>
+        BinaryPrimitives.ReadInt64LittleEndian(il[offset..]);
+
+    /// <summary>
+    /// Reads a little-endian single-precision floating-point value from a previously validated operand.
+    /// </summary>
+    /// <param name="il">The method IL bytes.</param>
+    /// <param name="offset">The byte offset to read.</param>
+    /// <returns>The single-precision floating-point value.</returns>
+    internal static float ReadSingle(ReadOnlySpan<byte> il, int offset) =>
+        BitConverter.Int32BitsToSingle(ReadInt32(il, offset));
+
+    /// <summary>
+    /// Reads a little-endian double-precision floating-point value from a previously validated operand.
+    /// </summary>
+    /// <param name="il">The method IL bytes.</param>
+    /// <param name="offset">The byte offset to read.</param>
+    /// <returns>The double-precision floating-point value.</returns>
+    internal static double ReadDouble(ReadOnlySpan<byte> il, int offset) =>
+        BitConverter.Int64BitsToDouble(ReadInt64(il, offset));
+
+    private static bool TryGetFixedLength(ReadOnlySpan<byte> il, int offset, int length, out int operandLength)
+    {
+        operandLength = 0;
+        if (offset < 0 || offset > il.Length || length > il.Length - offset)
+        {
+            return false;
+        }
+
+        operandLength = length;
+        return true;
+    }
+
+    private static bool TryGetSwitchLength(ReadOnlySpan<byte> il, int offset, out int length)
+    {
+        length = 0;
+        if (!TryGetFixedLength(il, offset, sizeof(int), out _))
+        {
+            return false;
+        }
+
+        int count = ReadInt32(il, offset);
+        if (count < 0)
+        {
+            return false;
+        }
+
+        int targetsOffset = offset + sizeof(int);
+        int remaining = il.Length - targetsOffset;
+        if (count > remaining / sizeof(int))
+        {
+            return false;
+        }
+
+        length = sizeof(int) + (count * sizeof(int));
+        return true;
+    }
+
+    private static bool Fail(out int length)
+    {
+        length = 0;
+        return false;
+    }
+}

--- a/src/Dotsider.Core/Analysis/Models/IlInstruction.cs
+++ b/src/Dotsider.Core/Analysis/Models/IlInstruction.cs
@@ -33,4 +33,14 @@ public sealed record IlInstruction(
     bool HasEmbeddedSource = false,
     int? LocalSlot = null,
     string? LocalName = null,
-    int? DisplayLine = null);
+    int? DisplayLine = null)
+{
+    /// <summary>
+    /// Gets or initializes a value indicating whether this is the terminal marker for malformed IL.
+    /// </summary>
+    /// <remarks>
+    /// A malformed instruction is emitted only after every valid instruction that precedes it. It
+    /// has no metadata token and must not be treated as navigable.
+    /// </remarks>
+    public bool IsMalformed { get; init; }
+}

--- a/src/Dotsider/Views/DynamicAnalysisView.cs
+++ b/src/Dotsider/Views/DynamicAnalysisView.cs
@@ -225,7 +225,7 @@ public static class DynamicAnalysisView
             // Tab cycles focus through editors and subtab strip on Counters/Summary
             if (state.DynamicSubTab == DynamicSubTabId.Counters)
             {
-                bindings.Key(Hex1bKey.Tab).Global().Action(_ =>
+                bindings.Key(Hex1bKey.Tab).Global().Action(context =>
                 {
                     state.VimPending = VimMotionState.Idle;
                     var next = state.App.FocusedNode is EditorNode { State: var es } ? es switch
@@ -237,23 +237,23 @@ public static class DynamicAnalysisView
                     } : state.DynamicCpuEditorState; // subtab strip → CPU
 
                     if (next is not null)
-                        state.App.RequestFocus(node => node is EditorNode e && e.State == next);
+                        context.FocusWhere(node => node is EditorNode e && ReferenceEquals(e.State, next));
                     else
-                        state.App.RequestFocus(node =>
+                        context.FocusWhere(node =>
                             node is TabPanelNode { MetricName: "dynamic-subtabs" });
                     state.App.Invalidate();
                 }, "Cycle focus");
             }
             else if (state.DynamicSubTab == DynamicSubTabId.Summary)
             {
-                bindings.Key(Hex1bKey.Tab).Global().Action(_ =>
+                bindings.Key(Hex1bKey.Tab).Global().Action(context =>
                 {
                     state.VimPending = VimMotionState.Idle;
                     if (state.App.FocusedNode is EditorNode)
-                        state.App.RequestFocus(node =>
+                        context.FocusWhere(node =>
                             node is TabPanelNode { MetricName: "dynamic-subtabs" });
                     else
-                        state.App.RequestFocus(node => node is EditorNode);
+                        context.FocusWhere(node => node is EditorNode);
                     state.App.Invalidate();
                 }, "Toggle focus");
             }

--- a/tests/Dotsider.Tests/AssemblyDifferTests.cs
+++ b/tests/Dotsider.Tests/AssemblyDifferTests.cs
@@ -1,5 +1,6 @@
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Buffers.Binary;
 
 namespace Dotsider.Tests;
 
@@ -315,6 +316,92 @@ public class AssemblyDifferTests
     }
 
     /// <summary>
+    /// Verifies every truncated fixed-width operand fails closed as a changed method body.
+    /// </summary>
+    /// <param name="name">The operand shape under test.</param>
+    /// <param name="expectedOpcode">The corresponding disassembly mnemonic.</param>
+    /// <param name="il">The malformed method body.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DynamicData(nameof(IlDisassemblerTests.TruncatedOperandCases), typeof(IlDisassemblerTests))]
+    public void Compare_IdenticalTruncatedFixedWidthOperands_AreDifferent(
+        string name,
+        string expectedOpcode,
+        byte[] il)
+    {
+        byte[] leftImage = SyntheticIlAssembly.Create(il);
+        byte[] rightImage = SyntheticIlAssembly.Create(il);
+        using var left = new AssemblyAnalyzer(leftImage, $"left-{name}.dll");
+        using var right = new AssemblyAnalyzer(rightImage, $"right-{name}.dll");
+
+        var result = AssemblyDiffer.Compare(left, right);
+
+        DiffEntry<MethodDefInfo> method = Assert.ContainsSingle(result.MethodDiffs);
+        Assert.AreEqual("Method", method.Left!.Name);
+        Assert.AreEqual(expectedOpcode, new IlDisassembler(left).Disassemble(method.Left)[1].OpCode);
+        Assert.AreEqual(DiffKind.Changed, method.Kind);
+    }
+
+    /// <summary>
+    /// Verifies malformed switch encodings fail closed as changed method bodies.
+    /// </summary>
+    /// <param name="name">The malformed switch shape.</param>
+    /// <param name="il">The malformed method body.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DynamicData(nameof(IlDisassemblerTests.TruncatedSwitchCases), typeof(IlDisassemblerTests))]
+    public void Compare_IdenticalMalformedSwitches_AreDifferent(string name, byte[] il)
+    {
+        byte[] leftImage = SyntheticIlAssembly.Create(il);
+        byte[] rightImage = SyntheticIlAssembly.Create(il);
+        using var left = new AssemblyAnalyzer(leftImage, $"left-switch-{name}.dll");
+        using var right = new AssemblyAnalyzer(rightImage, $"right-switch-{name}.dll");
+
+        var result = AssemblyDiffer.Compare(left, right);
+
+        DiffEntry<MethodDefInfo> method = Assert.ContainsSingle(result.MethodDiffs);
+        Assert.AreEqual(DiffKind.Changed, method.Kind);
+    }
+
+    /// <summary>
+    /// Verifies an orphaned extended-opcode prefix fails closed as a changed method body.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Compare_IdenticalTruncatedExtendedOpcodes_AreDifferent()
+    {
+        byte[] il = [0x00, 0xFE];
+        byte[] leftImage = SyntheticIlAssembly.Create(il);
+        byte[] rightImage = SyntheticIlAssembly.Create(il);
+        using var left = new AssemblyAnalyzer(leftImage, "left-truncated-opcode.dll");
+        using var right = new AssemblyAnalyzer(rightImage, "right-truncated-opcode.dll");
+
+        var result = AssemblyDiffer.Compare(left, right);
+
+        DiffEntry<MethodDefInfo> method = Assert.ContainsSingle(result.MethodDiffs);
+        Assert.AreEqual(DiffKind.Changed, method.Kind);
+    }
+
+    /// <summary>
+    /// Verifies a complete large switch table remains equal and does not desynchronize the body walk.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Compare_EquivalentLargeSwitchBodies_AreUnchanged()
+    {
+        byte[] il = CreateLargeValidSwitch();
+        byte[] leftImage = SyntheticIlAssembly.Create(il);
+        byte[] rightImage = SyntheticIlAssembly.Create(il);
+        using var left = new AssemblyAnalyzer(leftImage, "left-large-switch.dll");
+        using var right = new AssemblyAnalyzer(rightImage, "right-large-switch.dll");
+
+        var result = AssemblyDiffer.Compare(left, right);
+
+        DiffEntry<MethodDefInfo> method = Assert.ContainsSingle(result.MethodDiffs);
+        Assert.AreEqual(DiffKind.Unchanged, method.Kind);
+    }
+
+    /// <summary>
     /// Verifies comparing an assembly against itself produces no body changes.
     /// </summary>
     [TestMethod]
@@ -404,5 +491,16 @@ public class AssemblyDifferTests
         Assert.IsNotNull(hasCallback);
         Assert.AreEqual(DiffKind.Changed, hasCallback.Kind);
         Assert.Contains("body", hasCallback.ChangeDescription!);
+    }
+
+    private static byte[] CreateLargeValidSwitch()
+    {
+        const int count = 1001;
+        var il = new byte[1 + 1 + sizeof(int) + (count * sizeof(int)) + 1];
+        il[0] = 0x00;
+        il[1] = 0x45;
+        BinaryPrimitives.WriteInt32LittleEndian(il.AsSpan(2), count);
+        il[^1] = 0x2A;
+        return il;
     }
 }

--- a/tests/Dotsider.Tests/DynamicYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/DynamicYankIntegrationTests.cs
@@ -96,12 +96,16 @@ public class DynamicYankIntegrationTests : IDisposable
             .WaitUntil(_ => IsFocusedOnEditor(_state!.DynamicCpuEditorState), TimeSpan.FromSeconds(5))
             .Key(Hex1bKey.Tab)
             .WaitUntil(_ => IsFocusedOnEditor(_state!.DynamicMemoryEditorState), TimeSpan.FromSeconds(5))
+            .WaitUntil(_ => _state!.DynamicSubTab == DynamicSubTabId.Counters, TimeSpan.FromSeconds(5))
             .Key(Hex1bKey.Tab)
             .WaitUntil(_ => IsFocusedOnEditor(_state!.DynamicGcEditorState), TimeSpan.FromSeconds(5))
+            .WaitUntil(_ => _state!.DynamicSubTab == DynamicSubTabId.Counters, TimeSpan.FromSeconds(5))
             .Key(Hex1bKey.Tab)
             .WaitUntil(_ => IsFocusedOnEditor(_state!.DynamicThreadingEditorState), TimeSpan.FromSeconds(5))
+            .WaitUntil(_ => _state!.DynamicSubTab == DynamicSubTabId.Counters, TimeSpan.FromSeconds(5))
             .Key(Hex1bKey.Tab)
             .WaitUntil(_ => !IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
+            .WaitUntil(_ => _state!.DynamicSubTab == DynamicSubTabId.Counters, TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal, ct);
     }

--- a/tests/Dotsider.Tests/IlDisassemblerTests.cs
+++ b/tests/Dotsider.Tests/IlDisassemblerTests.cs
@@ -1,5 +1,8 @@
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Buffers.Binary;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 
 namespace Dotsider.Tests;
 
@@ -10,6 +13,43 @@ namespace Dotsider.Tests;
 public class IlDisassemblerTests
 {
     private static SampleAssemblyFixture Samples => SampleAssemblyHost.Instance;
+
+    /// <summary>
+    /// Supplies one truncated body for every fixed-width IL operand encoding.
+    /// </summary>
+    /// <returns>The display name, expected opcode, and malformed IL body for each case.</returns>
+    public static IEnumerable<object[]> TruncatedOperandCases()
+    {
+        yield return ["short branch", "br.s", CreateTruncatedOperand(ILOpCode.Br_s, 1)];
+        yield return ["branch", "br", CreateTruncatedOperand(ILOpCode.Br, 4)];
+        yield return ["short integer", "ldc.i4.s", CreateTruncatedOperand(ILOpCode.Ldc_i4_s, 1)];
+        yield return ["integer", "ldc.i4", CreateTruncatedOperand(ILOpCode.Ldc_i4, 4)];
+        yield return ["long integer", "ldc.i8", CreateTruncatedOperand(ILOpCode.Ldc_i8, 8)];
+        yield return ["single", "ldc.r4", CreateTruncatedOperand(ILOpCode.Ldc_r4, 4)];
+        yield return ["double", "ldc.r8", CreateTruncatedOperand(ILOpCode.Ldc_r8, 8)];
+        yield return ["short variable", "ldarg.s", CreateTruncatedOperand(ILOpCode.Ldarg_s, 1)];
+        yield return ["variable", "ldarg", CreateTruncatedOperand(ILOpCode.Ldarg, 2)];
+        yield return ["string token", "ldstr", CreateTruncatedOperand(ILOpCode.Ldstr, 4)];
+        yield return ["method token", "call", CreateTruncatedOperand(ILOpCode.Call, 4)];
+        yield return ["field token", "ldfld", CreateTruncatedOperand(ILOpCode.Ldfld, 4)];
+        yield return ["type token", "box", CreateTruncatedOperand(ILOpCode.Box, 4)];
+        yield return ["member token", "ldtoken", CreateTruncatedOperand(ILOpCode.Ldtoken, 4)];
+        yield return ["signature token", "calli", CreateTruncatedOperand(ILOpCode.Calli, 4)];
+    }
+
+    /// <summary>
+    /// Supplies malformed <c>switch</c> encodings that must not read past the method body.
+    /// </summary>
+    /// <returns>The display name and malformed IL body for each switch case.</returns>
+    public static IEnumerable<object[]> TruncatedSwitchCases()
+    {
+        yield return ["missing count", new byte[] { 0x00, 0x45 }];
+        yield return ["partial count", new byte[] { 0x00, 0x45, 0x01, 0x00, 0x00 }];
+        yield return ["negative count", new byte[] { 0x00, 0x45, 0xFF, 0xFF, 0xFF, 0xFF }];
+        yield return ["missing target", new byte[] { 0x00, 0x45, 0x01, 0x00, 0x00, 0x00 }];
+        yield return ["partial target", new byte[] { 0x00, 0x45, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }];
+        yield return ["overflowing count", new byte[] { 0x00, 0x45, 0xFF, 0xFF, 0xFF, 0x7F }];
+    }
 
     /// <summary>
     /// Verifies hello world main method contains call and ret.
@@ -400,6 +440,136 @@ public class IlDisassemblerTests
         }
     }
 
+    /// <summary>
+    /// Verifies every fixed-width operand that ends early yields one explicit, non-navigable marker.
+    /// </summary>
+    /// <param name="name">The operand shape under test.</param>
+    /// <param name="expectedOpcode">The expected rendered opcode.</param>
+    /// <param name="il">The malformed method body.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DynamicData(nameof(TruncatedOperandCases))]
+    public void Disassemble_TruncatedFixedWidthOperand_EmitsTerminalMalformedMarker(
+        string name,
+        string expectedOpcode,
+        byte[] il)
+    {
+        byte[] image = SyntheticIlAssembly.Create(il);
+        using var analyzer = new AssemblyAnalyzer(image, $"{name}.dll");
+        MethodDefInfo method = Assert.ContainsSingle(analyzer.MethodDefs);
+
+        var disassembler = new IlDisassembler(analyzer);
+        IReadOnlyList<IlInstruction> instructions = disassembler.Disassemble(method);
+
+        Assert.HasCount(2, instructions);
+        Assert.AreEqual("nop", instructions[0].OpCode);
+        IlInstruction malformed = instructions[1];
+        Assert.AreEqual(expectedOpcode, malformed.OpCode);
+        Assert.AreEqual("<truncated operand>", malformed.Operand);
+        Assert.IsTrue(malformed.IsMalformed);
+        Assert.IsNull(malformed.MetadataToken);
+        Assert.Contains("<truncated operand>", disassembler.FormatDisassembly(method));
+    }
+
+    /// <summary>
+    /// Verifies malformed switch counts and target tables yield one terminal marker without throwing.
+    /// </summary>
+    /// <param name="name">The malformed switch shape.</param>
+    /// <param name="il">The malformed method body.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DynamicData(nameof(TruncatedSwitchCases))]
+    public void Disassemble_MalformedSwitch_EmitsTerminalMalformedMarker(string name, byte[] il)
+    {
+        byte[] image = SyntheticIlAssembly.Create(il);
+        using var analyzer = new AssemblyAnalyzer(image, $"switch-{name}.dll");
+        MethodDefInfo method = Assert.ContainsSingle(analyzer.MethodDefs);
+
+        IReadOnlyList<IlInstruction> instructions = new IlDisassembler(analyzer).Disassemble(method);
+
+        Assert.HasCount(2, instructions);
+        IlInstruction malformed = instructions[1];
+        Assert.AreEqual("switch", malformed.OpCode);
+        Assert.AreEqual("<truncated operand>", malformed.Operand);
+        Assert.IsTrue(malformed.IsMalformed);
+    }
+
+    /// <summary>
+    /// Verifies an orphaned extended-opcode prefix is retained as an explicit terminal marker.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Disassemble_TruncatedExtendedOpcode_EmitsTerminalMalformedMarker()
+    {
+        byte[] image = SyntheticIlAssembly.Create([0x00, 0xFE]);
+        using var analyzer = new AssemblyAnalyzer(image, "truncated-opcode.dll");
+        MethodDefInfo method = Assert.ContainsSingle(analyzer.MethodDefs);
+
+        IReadOnlyList<IlInstruction> instructions = new IlDisassembler(analyzer).Disassemble(method);
+
+        Assert.HasCount(2, instructions);
+        IlInstruction malformed = instructions[1];
+        Assert.AreEqual(".invalid", malformed.OpCode);
+        Assert.AreEqual("<truncated opcode>", malformed.Operand);
+        Assert.IsTrue(malformed.IsMalformed);
+    }
+
+    /// <summary>
+    /// Verifies a large valid switch advances over every target and preserves the following opcode.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Disassemble_LargeValidSwitch_PreservesInstructionAfterTargetTable()
+    {
+        byte[] image = SyntheticIlAssembly.Create(CreateLargeValidSwitch());
+        using var analyzer = new AssemblyAnalyzer(image, "large-switch.dll");
+        MethodDefInfo method = Assert.ContainsSingle(analyzer.MethodDefs);
+
+        IReadOnlyList<IlInstruction> instructions = new IlDisassembler(analyzer).Disassemble(method);
+
+        Assert.HasCount(3, instructions);
+        Assert.AreEqual("switch", instructions[1].OpCode);
+        Assert.Contains("... (991 more)", instructions[1].Operand);
+        Assert.AreEqual("ret", instructions[2].OpCode);
+        Assert.DoesNotContain(static instruction => instruction.IsMalformed, instructions);
+    }
+
+    /// <summary>
+    /// Verifies a real compiled method shortened inside a call operand degrades through disassembly
+    /// and comparison without throwing.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void RealSample_MethodEndingInsideCallOperand_DegradesWithoutThrowing()
+    {
+        byte[] original = File.ReadAllBytes(Samples.HelloWorldDll);
+        byte[] patched = (byte[])original.Clone();
+        (int Token, int Rva, int CallOffset) target = FindCallToTruncate(original);
+        TruncateMethodBodyAtCallOperand(patched, target.Rva, target.CallOffset);
+
+        using var intactAnalyzer = new AssemblyAnalyzer(original, "HelloWorld.dll");
+        using var malformedAnalyzer = new AssemblyAnalyzer(patched, "HelloWorld-truncated.dll");
+        MethodDefInfo malformedMethod = Assert.ContainsSingle(
+            method => method.Token == target.Token,
+            malformedAnalyzer.MethodDefs);
+
+        IReadOnlyList<IlInstruction> instructions = new IlDisassembler(malformedAnalyzer)
+            .Disassemble(malformedMethod);
+
+        IlInstruction malformed = Assert.ContainsSingle(
+            static instruction => instruction.IsMalformed,
+            instructions);
+        Assert.AreEqual("call", malformed.OpCode);
+        Assert.AreEqual("<truncated operand>", malformed.Operand);
+        Assert.IsNull(malformed.MetadataToken);
+
+        var diff = AssemblyDiffer.Compare(intactAnalyzer, malformedAnalyzer);
+        DiffEntry<MethodDefInfo> changed = Assert.ContainsSingle(
+            entry => entry.Left?.Token == target.Token,
+            diff.MethodDiffs);
+        Assert.AreEqual(DiffKind.Changed, changed.Kind);
+    }
+
     private static MethodDefInfo FindMethod(AssemblyAnalyzer analyzer, string typeName, string methodName)
     {
         var method = analyzer.MethodDefs.FirstOrDefault(m =>
@@ -408,5 +578,105 @@ public class IlDisassemblerTests
 
         Assert.IsNotNull(method);
         return method;
+    }
+
+    private static (int Token, int Rva, int CallOffset) FindCallToTruncate(byte[] image)
+    {
+        using var analyzer = new AssemblyAnalyzer(image, "HelloWorld.dll");
+        var disassembler = new IlDisassembler(analyzer);
+        foreach (MethodDefInfo method in analyzer.MethodDefs.Where(static method => method.Rva != 0))
+        {
+            MethodBodyBlock? body = analyzer.GetMethodBody(method);
+            byte[]? il = body?.GetILBytes();
+            if (il is null)
+            {
+                continue;
+            }
+
+            IlInstruction? call = disassembler.Disassemble(method).FirstOrDefault(
+                static instruction => instruction.OpCode == "call");
+            if (call is not null && call.Offset <= il.Length - 5)
+            {
+                return (method.Token, method.Rva, call.Offset);
+            }
+        }
+
+        throw new InvalidOperationException("The HelloWorld fixture has no complete call instruction.");
+    }
+
+    private static void TruncateMethodBodyAtCallOperand(byte[] image, int rva, int callOffset)
+    {
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        MethodBodyBlock body = peReader.GetMethodBody(rva);
+        byte[] il = body.GetILBytes()
+            ?? throw new InvalidOperationException("The selected method body has no IL bytes.");
+        if (callOffset < 0 || callOffset > il.Length - 5 || il[callOffset] != 0x28)
+        {
+            throw new InvalidOperationException("The selected call no longer fits in the method body.");
+        }
+
+        int codeSize = callOffset + 2;
+        int fileOffset = RvaToFileOffset(peReader.PEHeaders, rva);
+        byte format = image[fileOffset];
+
+        if ((format & 0x3) == 0x2)
+        {
+            if (codeSize > 63)
+            {
+                throw new InvalidOperationException("The tiny method body cannot encode the requested code size.");
+            }
+
+            image[fileOffset] = (byte)((codeSize << 2) | 0x2);
+            return;
+        }
+
+        if ((format & 0x3) != 0x3)
+        {
+            throw new InvalidOperationException("The selected method has an unrecognized method-body header.");
+        }
+
+        BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(fileOffset + 4), codeSize);
+    }
+
+    private static int RvaToFileOffset(PEHeaders headers, int rva)
+    {
+        foreach (SectionHeader section in headers.SectionHeaders)
+        {
+            int sectionSize = Math.Max(section.VirtualSize, section.SizeOfRawData);
+            if (rva >= section.VirtualAddress && rva - section.VirtualAddress < sectionSize)
+            {
+                return checked(section.PointerToRawData + (rva - section.VirtualAddress));
+            }
+        }
+
+        throw new InvalidOperationException("The selected method RVA does not map to a PE section.");
+    }
+
+    private static byte[] CreateLargeValidSwitch()
+    {
+        const int count = 1001;
+        var il = new byte[1 + 1 + sizeof(int) + (count * sizeof(int)) + 1];
+        il[0] = 0x00;
+        il[1] = 0x45;
+        BinaryPrimitives.WriteInt32LittleEndian(il.AsSpan(2), count);
+        il[^1] = 0x2A;
+        return il;
+    }
+
+    private static byte[] CreateTruncatedOperand(ILOpCode opCode, int operandLength)
+    {
+        var il = new List<byte> { 0x00 };
+        ushort value = (ushort)opCode;
+        if (value > byte.MaxValue)
+        {
+            il.Add(0xFE);
+        }
+        il.Add((byte)value);
+        for (var i = 1; i < operandLength; i++)
+        {
+            il.Add(0);
+        }
+        return [.. il];
     }
 }

--- a/tests/Dotsider.Tests/SyntheticIlAssembly.cs
+++ b/tests/Dotsider.Tests/SyntheticIlAssembly.cs
@@ -1,0 +1,71 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Builds a minimal in-memory managed assembly with one method containing caller-supplied IL bytes.
+/// </summary>
+internal static class SyntheticIlAssembly
+{
+    /// <summary>
+    /// Creates an assembly with one public static method containing the supplied IL bytes.
+    /// </summary>
+    /// <param name="il">The exact IL bytes to write into the method body.</param>
+    /// <returns>The serialized managed PE image.</returns>
+    internal static byte[] Create(ReadOnlySpan<byte> il)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddAssembly(
+            metadata.GetOrAddString("SyntheticIl"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            0,
+            AssemblyHashAlgorithm.None);
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("SyntheticIl.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("Synthetic"),
+            metadata.GetOrAddString("Owner"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var ilStream = new BlobBuilder();
+        var code = new BlobBuilder();
+        code.WriteBytes(il.ToArray());
+        var instructions = new InstructionEncoder(code);
+        int bodyOffset = new MethodBodyStreamEncoder(ilStream).AddMethodBody(instructions, maxStack: 8);
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Method"),
+            metadata.GetOrAddBlob(new byte[] { 0x00, 0x00, 0x01 }),
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        var peBuilder = new ManagedPEBuilder(
+            new PEHeaderBuilder(imageCharacteristics: Characteristics.Dll),
+            new MetadataRootBuilder(metadata),
+            ilStream);
+        var blob = new BlobBuilder();
+        peBuilder.Serialize(blob);
+
+        return blob.ToArray();
+    }
+}


### PR DESCRIPTION
Validate opcode and operand extents before decoding IL so a method body that ends mid-instruction retains its valid prefix and gets a malformed terminal marker rather than reading past the buffer. Diffing now treats malformed IL as changed, including malformed switch tables. The Dynamic view’s Tab traversal also resolves against the active focus ring, preventing a concurrent render from replacing the requested focus.

Fixes: #223