### PR TITLE
Resolve MethodSpec tokens in IL output

### DIFF
--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
@@ -1040,7 +1040,8 @@ Resolves a metadata token to a human-readable name.
 
 **Returns:** [String](https://learn.microsoft.com/dotnet/api/system.string)
 
-A display string for the token.
+A display string for the token. Constructed generic methods include their decoded type
+arguments; malformed or unsupported metadata is returned as the original hexadecimal token.
 
 ```csharp
 public string ResolveToken(int token)

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -1153,7 +1153,10 @@ public sealed class AssemblyAnalyzer : IDisposable
     /// Resolves a metadata token to a human-readable name.
     /// </summary>
     /// <param name="token">The metadata token to resolve.</param>
-    /// <returns>A display string for the token.</returns>
+    /// <returns>
+    /// A display string for the token. Constructed generic methods include their decoded type
+    /// arguments; malformed or unsupported metadata is returned as the original hexadecimal token.
+    /// </returns>
     public string ResolveToken(int token)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -1168,6 +1171,7 @@ public sealed class AssemblyAnalyzer : IDisposable
                 HandleKind.TypeDefinition => GetTypeDefName((TypeDefinitionHandle)handle),
                 HandleKind.MethodDefinition => GetMethodDefName((MethodDefinitionHandle)handle),
                 HandleKind.MemberReference => GetMemberRefName((MemberReferenceHandle)handle),
+                HandleKind.MethodSpecification => GetMethodSpecName((MethodSpecificationHandle)handle),
                 HandleKind.FieldDefinition => GetFieldDefName((FieldDefinitionHandle)handle),
                 HandleKind.StandaloneSignature => $"StandaloneSig(0x{token:X8})",
                 HandleKind.UserString => GetUserString(MetadataTokens.UserStringHandle(token & 0x00FFFFFF)),
@@ -2510,6 +2514,78 @@ public sealed class AssemblyAnalyzer : IDisposable
             _ => "?"
         };
         return $"{parent}::{name}";
+    }
+
+    private string GetMethodSpecName(MethodSpecificationHandle handle)
+    {
+        var token = MetadataTokens.GetToken(handle);
+        if (_metadataReader is null) return $"0x{token:X8}";
+
+        try
+        {
+            var provider = new AssemblySignatureTypeProvider(failOnInvalidMetadata: true);
+            var specification = _metadataReader.GetMethodSpecification(handle);
+            var typeArguments = SafeSignatureDecoder.DecodeMethodSpecificationSignature(
+                _metadataReader, handle, provider, genericContext: default);
+
+            string declaringType;
+            string methodName;
+            MethodSignature<string> methodSignature;
+
+            switch (specification.Method.Kind)
+            {
+                case HandleKind.MethodDefinition:
+                {
+                    var methodHandle = (MethodDefinitionHandle)specification.Method;
+                    var method = _metadataReader.GetMethodDefinition(methodHandle);
+                    declaringType = provider.GetTypeFromDefinition(
+                        _metadataReader, method.GetDeclaringType(), rawTypeKind: 0);
+                    methodName = _metadataReader.GetString(method.Name);
+                    methodSignature = SafeSignatureDecoder.DecodeMethodSignature(
+                        _metadataReader, methodHandle, provider, genericContext: default);
+                    break;
+                }
+                case HandleKind.MemberReference:
+                {
+                    var memberHandle = (MemberReferenceHandle)specification.Method;
+                    var member = _metadataReader.GetMemberReference(memberHandle);
+                    declaringType = member.Parent.Kind switch
+                    {
+                        HandleKind.TypeDefinition => provider.GetTypeFromDefinition(
+                            _metadataReader, (TypeDefinitionHandle)member.Parent, rawTypeKind: 0),
+                        HandleKind.TypeReference => provider.GetTypeFromReference(
+                            _metadataReader, (TypeReferenceHandle)member.Parent, rawTypeKind: 0),
+                        HandleKind.TypeSpecification => SafeSignatureDecoder.DecodeType(
+                            _metadataReader,
+                            (TypeSpecificationHandle)member.Parent,
+                            provider,
+                            genericContext: default),
+                        _ => throw new BadImageFormatException(
+                            $"MethodSpec 0x{token:X8} has an unsupported MemberRef parent."),
+                    };
+                    methodName = _metadataReader.GetString(member.Name);
+                    methodSignature = SafeSignatureDecoder.DecodeMemberReferenceMethodSignature(
+                        _metadataReader, memberHandle, provider, genericContext: default);
+                    break;
+                }
+                default:
+                    throw new BadImageFormatException(
+                        $"MethodSpec 0x{token:X8} does not reference a method definition or member reference.");
+            }
+
+            if (methodSignature.GenericParameterCount == 0
+                || methodSignature.GenericParameterCount != typeArguments.Length)
+            {
+                throw new BadImageFormatException(
+                    $"MethodSpec 0x{token:X8} has a generic argument count that does not match its method.");
+            }
+
+            return $"{declaringType}::{methodName}<{string.Join(", ", typeArguments)}>";
+        }
+        catch (Exception ex) when (ex is ArgumentException or BadImageFormatException or InvalidOperationException)
+        {
+            return $"0x{token:X8}";
+        }
     }
 
     private string GetFieldDefName(FieldDefinitionHandle handle)

--- a/src/Dotsider.DocGenerator/Dotsider.DocGenerator.csproj
+++ b/src/Dotsider.DocGenerator/Dotsider.DocGenerator.csproj
@@ -17,8 +17,8 @@
     <!-- Must match the Roslyn version Docfx.App was built against -->
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
-    <!-- Temporary direct reference to resolve vulnerability in System.Security.Cryptography.Xml < 9.0.15 -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.15" />
+    <!-- Temporary direct reference to resolve vulnerability in System.Security.Cryptography.Xml < 9.0.18 -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.18" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 

--- a/tests/Dotsider.Mcp.Tests/IlToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/IlToolsTests.cs
@@ -40,6 +40,39 @@ public class IlToolsTests : McpServerTestBase
     }
 
     /// <summary>
+    /// disassemble_method renders compiler-produced MethodSpec operands as constructed generic methods.
+    /// </summary>
+    [TestMethod]
+    public async Task DisassembleMethod_MethodSpecs_ReturnConstructedGenericOperands()
+    {
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+
+        var result = await client.CallToolAsync(
+            "disassemble_method",
+            new Dictionary<string, object?>
+            {
+                ["assemblyPath"] = typeof(MethodSpecReproFixture).Assembly.Location,
+                ["typeName"] = MethodSpecReproFixture.TypeName,
+                ["methodName"] = MethodSpecReproFixture.MethodName
+            },
+            cancellationToken: TestCancellationToken);
+
+        var text = GetTextContent(result);
+        Assert.IsNotNull(text);
+        var json = JsonSerializer.Deserialize<JsonElement>(text);
+        var methodSpecOperands = json.GetProperty("instructions")
+            .EnumerateArray()
+            .Where(instruction => instruction.TryGetProperty("metadataToken", out var token)
+                && token.ValueKind == JsonValueKind.Number
+                && (uint)token.GetInt32() >> 24 == 0x2B)
+            .Select(instruction => instruction.GetProperty("operand").GetString()!)
+            .ToArray();
+
+        Assert.AreSequenceEqual(MethodSpecReproFixture.ExpectedDisplays, methodSpecOperands);
+    }
+
+    /// <summary>
     /// disassemble_method can include portable PDB debug information when requested.
     /// </summary>
     [TestMethod]

--- a/tests/Dotsider.Mcp.Tests/MetadataToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/MetadataToolsTests.cs
@@ -1,3 +1,6 @@
+using Dotsider.Core.Analysis;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Text.Json;
 
 namespace Dotsider.Mcp.Tests;
@@ -196,5 +199,50 @@ public class MetadataToolsTests : McpServerTestBase
         var json = JsonSerializer.Deserialize<JsonElement>(text);
         Assert.IsTrue(json.TryGetProperty("resolved", out var resolved));
         Assert.IsFalse(string.IsNullOrEmpty(resolved.GetString()));
+    }
+
+    /// <summary>
+    /// resolve_token decodes a compiler-produced MethodSpec into its constructed generic method.
+    /// </summary>
+    [TestMethod]
+    public async Task ResolveToken_MethodSpecs_ReturnConstructedGenericMethods()
+    {
+        var assemblyPath = typeof(MethodSpecReproFixture).Assembly.Location;
+        int[] methodSpecTokens;
+        using (var analyzer = new AssemblyAnalyzer(assemblyPath))
+        {
+            var method = Assert.ContainsSingle(analyzer.MethodDefs.Where(candidate =>
+                candidate.DeclaringType == MethodSpecReproFixture.TypeName
+                && candidate.Name == MethodSpecReproFixture.MethodName));
+            methodSpecTokens = [.. new IlDisassembler(analyzer)
+                .Disassemble(method)
+                .Where(candidate => candidate.OpCode == "call"
+                    && candidate.MetadataToken is { } token
+                    && MetadataTokens.EntityHandle(token).Kind == HandleKind.MethodSpecification)
+                .Select(instruction => instruction.MetadataToken!.Value)];
+        }
+
+        Assert.HasCount(MethodSpecReproFixture.ExpectedDisplays.Count, methodSpecTokens);
+        await StartServerAsync();
+        await using var client = await CreateClientAsync();
+        var resolvedNames = new List<string>();
+        foreach (var methodSpecToken in methodSpecTokens)
+        {
+            var result = await client.CallToolAsync(
+                "resolve_token",
+                new Dictionary<string, object?>
+                {
+                    ["assemblyPath"] = assemblyPath,
+                    ["token"] = methodSpecToken
+                },
+                cancellationToken: TestCancellationToken);
+
+            var text = GetTextContent(result);
+            Assert.IsNotNull(text);
+            var json = JsonSerializer.Deserialize<JsonElement>(text);
+            resolvedNames.Add(json.GetProperty("resolved").GetString()!);
+        }
+
+        Assert.AreSequenceEqual(MethodSpecReproFixture.ExpectedDisplays, resolvedNames);
     }
 }

--- a/tests/Dotsider.Tests/AssemblyAnalyzerTests.cs
+++ b/tests/Dotsider.Tests/AssemblyAnalyzerTests.cs
@@ -1,5 +1,7 @@
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
 namespace Dotsider.Tests;
@@ -769,6 +771,110 @@ public class AssemblyAnalyzerTests
     }
 
     /// <summary>
+    /// Verifies MethodSpecs backed by ordinary MemberRefs expose their constructed LINQ names.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ResolveToken_MethodSpecMemberRef_FormatsConstructedMethod()
+    {
+        using var analyzer = new AssemblyAnalyzer(typeof(MethodSpecReproFixture).Assembly.Location);
+        var tokens = GetMethodSpecificationTokens(
+            analyzer,
+            MethodSpecReproFixture.MethodName,
+            expectedCount: MethodSpecReproFixture.ExpectedDisplays.Count);
+        var reader = analyzer.GetMetadataReader()!;
+
+        TestAssert.All(tokens, token => Assert.AreEqual(
+            HandleKind.MemberReference,
+            reader.GetMethodSpecification((MethodSpecificationHandle)MetadataTokens.EntityHandle(token))
+                .Method.Kind));
+        Assert.AreSequenceEqual(
+            MethodSpecReproFixture.ExpectedDisplays,
+            tokens.Select(analyzer.ResolveToken));
+    }
+
+    /// <summary>
+    /// Verifies a MethodSpec may target a MethodDef and may itself contain a constructed generic
+    /// type argument.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ResolveToken_MethodSpecMethodDef_FormatsConstructedTypeArgument()
+    {
+        using var analyzer = new AssemblyAnalyzer(typeof(MethodSpecReproFixture).Assembly.Location);
+        var token = Assert.ContainsSingle(GetMethodSpecificationTokens(
+            analyzer,
+            MethodSpecReproFixture.MethodDefCallerName,
+            expectedCount: 1));
+        var specification = analyzer.GetMetadataReader()!.GetMethodSpecification(
+            (MethodSpecificationHandle)MetadataTokens.EntityHandle(token));
+
+        Assert.AreEqual(HandleKind.MethodDefinition, specification.Method.Kind);
+        Assert.AreEqual(MethodSpecReproFixture.MethodDefExpectedDisplay, analyzer.ResolveToken(token));
+    }
+
+    /// <summary>
+    /// Verifies a MethodSpec MemberRef can be owned by a TypeSpec and retains the constructed
+    /// declaring type in its display.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ResolveToken_MethodSpecMemberRefWithTypeSpecParent_FormatsConstructedOwner()
+    {
+        using var analyzer = new AssemblyAnalyzer(typeof(MethodSpecReproFixture).Assembly.Location);
+        var token = Assert.ContainsSingle(GetMethodSpecificationTokens(
+            analyzer,
+            MethodSpecReproFixture.TypeSpecParentCallerName,
+            expectedCount: 1));
+        var reader = analyzer.GetMetadataReader()!;
+        var specification = reader.GetMethodSpecification(
+            (MethodSpecificationHandle)MetadataTokens.EntityHandle(token));
+        var memberReference = reader.GetMemberReference((MemberReferenceHandle)specification.Method);
+
+        Assert.AreEqual(HandleKind.MemberReference, specification.Method.Kind);
+        Assert.AreEqual(HandleKind.TypeSpecification, memberReference.Parent.Kind);
+        Assert.AreEqual(MethodSpecReproFixture.TypeSpecParentExpectedDisplay, analyzer.ResolveToken(token));
+    }
+
+    /// <summary>
+    /// Verifies invalid MethodSpec metadata fails closed to the complete original token.
+    /// </summary>
+    /// <param name="name">The malformed metadata shape.</param>
+    /// <param name="memberReferenceMethod">The underlying MemberRef signature.</param>
+    /// <param name="methodSpecification">The MethodSpec signature.</param>
+    /// <param name="targetsField">Whether the MethodSpec targets the field MemberRef.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DynamicData(nameof(InvalidMethodSpecificationCases))]
+    public void ResolveToken_InvalidMethodSpec_ReturnsExactRawToken(
+        string name,
+        byte[] memberReferenceMethod,
+        byte[] methodSpecification,
+        bool targetsField)
+    {
+        _ = name;
+        using var scope = FacadeSignatureMetadataScope.Create(
+            memberReferenceMethod: memberReferenceMethod,
+            methodSpecification: methodSpecification,
+            methodSpecificationTargetsField: targetsField);
+        using var analyzer = new AssemblyAnalyzer(scope.Image, "InvalidMethodSpec.dll");
+        var token = MetadataTokens.GetToken(scope.MethodSpecification);
+
+        Assert.AreEqual($"0x{token:X8}", analyzer.ResolveToken(token));
+    }
+
+    /// <summary>Verifies an out-of-range MethodSpec row retains the exact original token.</summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ResolveToken_OutOfRangeMethodSpec_ReturnsExactRawToken()
+    {
+        using var analyzer = new AssemblyAnalyzer(typeof(MethodSpecReproFixture).Assembly.Location);
+        const int token = 0x2BFFFFFF;
+
+        Assert.AreEqual("0x2BFFFFFF", analyzer.ResolveToken(token));
+    }
+
+    /// <summary>
     /// Verifies resolve token invalid token returns hex string.
     /// </summary>
     [TestMethod]
@@ -778,6 +884,59 @@ public class AssemblyAnalyzerTests
         using var a = new AssemblyAnalyzer(Samples.RichLibraryDll);
         var result = a.ResolveToken(0x7F000001);
         Assert.Contains("0x", result);
+    }
+
+    /// <summary>Supplies malformed or inconsistent MethodSpec metadata.</summary>
+    /// <returns>The case name, underlying method signature, MethodSpec signature, and field flag.</returns>
+    public static IEnumerable<object[]> InvalidMethodSpecificationCases()
+    {
+        // Generic method with one type parameter, no parameters, and an int return type.
+        byte[] genericArityOne = [0x10, 0x01, 0x00, 0x08];
+        byte[] validIntInstantiation = [0x0A, 0x01, 0x08];
+
+        yield return [
+            "truncated instantiation signature",
+            genericArityOne,
+            new byte[] { 0x0A, 0x01 },
+            false
+        ];
+        yield return [
+            "non-generic underlying method",
+            new byte[] { 0x00, 0x00, 0x08 },
+            validIntInstantiation,
+            false
+        ];
+        yield return [
+            "generic arity mismatch",
+            new byte[] { 0x10, 0x02, 0x00, 0x08 },
+            validIntInstantiation,
+            false
+        ];
+        yield return [
+            "field MemberRef",
+            genericArityOne,
+            validIntInstantiation,
+            true
+        ];
+    }
+
+    private static int[] GetMethodSpecificationTokens(
+        AssemblyAnalyzer analyzer,
+        string methodName,
+        int expectedCount)
+    {
+        var method = Assert.ContainsSingle(analyzer.MethodDefs.Where(candidate =>
+            candidate.DeclaringType == MethodSpecReproFixture.TypeName
+            && candidate.Name == methodName));
+        var tokens = new IlDisassembler(analyzer)
+            .Disassemble(method)
+            .Where(candidate => candidate.MetadataToken is { } token
+                && MetadataTokens.EntityHandle(token).Kind == HandleKind.MethodSpecification)
+            .Select(candidate => candidate.MetadataToken!.Value)
+            .ToArray();
+
+        Assert.HasCount(expectedCount, tokens);
+        return tokens;
     }
 
     /// <summary>

--- a/tests/Dotsider.Tests/CliTests.cs
+++ b/tests/Dotsider.Tests/CliTests.cs
@@ -79,6 +79,25 @@ public class CliTests
     }
 
     /// <summary>
+    /// Verifies <c>analyze --il</c> renders a generic method instantiation instead of its raw
+    /// MethodSpec metadata token.
+    /// </summary>
+    [TestMethod]
+    public async Task Analyze_Il_MethodSpec_PrintsConstructedGenericMethod()
+    {
+        var (exitCode, stdout, _) = await RunDotsiderAsync(
+            "analyze",
+            typeof(MethodSpecReproFixture).Assembly.Location,
+            "--il",
+            $"{MethodSpecReproFixture.TypeName}.{MethodSpecReproFixture.MethodName}");
+
+        Assert.AreEqual(0, exitCode);
+        foreach (var expectedDisplay in MethodSpecReproFixture.ExpectedDisplays)
+            Assert.Contains($"call {expectedDisplay}", stdout);
+        Assert.DoesNotContain("call 0x2B", stdout);
+    }
+
+    /// <summary>
     /// Verifies analyze embedded source prints source text from an embedded portable PDB.
     /// </summary>
     [TestMethod]

--- a/tests/Dotsider.Tests/FacadeSignatureMetadataScope.cs
+++ b/tests/Dotsider.Tests/FacadeSignatureMetadataScope.cs
@@ -87,6 +87,7 @@ internal sealed class FacadeSignatureMetadataScope : IDisposable
     /// <param name="methodSpecification">The MethodSpec instantiation signature.</param>
     /// <param name="typeSpecifications">The TypeSpec signatures.</param>
     /// <param name="emitMethodBody">Whether the MethodDef should have a body referencing the local signature.</param>
+    /// <param name="methodSpecificationTargetsField">Whether the MethodSpec should target the field MemberRef.</param>
     /// <returns>A disposable metadata scope.</returns>
     public static FacadeSignatureMetadataScope Create(
         byte[]? method = null,
@@ -98,7 +99,8 @@ internal sealed class FacadeSignatureMetadataScope : IDisposable
         byte[]? memberReferenceField = null,
         byte[]? methodSpecification = null,
         IReadOnlyList<byte[]>? typeSpecifications = null,
-        bool emitMethodBody = false)
+        bool emitMethodBody = false,
+        bool methodSpecificationTargetsField = false)
     {
         var metadata = new MetadataBuilder();
         metadata.AddAssembly(
@@ -178,7 +180,9 @@ internal sealed class FacadeSignatureMetadataScope : IDisposable
             metadata.GetOrAddString("ReferencedField"),
             metadata.GetOrAddBlob(memberReferenceField ?? [0x06, 0x08]));
         var methodSpecificationHandle = metadata.AddMethodSpecification(
-            memberReferenceMethodHandle,
+            methodSpecificationTargetsField
+                ? memberReferenceFieldHandle
+                : memberReferenceMethodHandle,
             metadata.GetOrAddBlob(methodSpecification ?? [0x0A, 0x01, 0x08]));
 
         var typeSpecificationHandles = new List<TypeSpecificationHandle>(typeSpecifications?.Count ?? 0);

--- a/tests/Dotsider.Tests/IlDisassemblerTests.cs
+++ b/tests/Dotsider.Tests/IlDisassemblerTests.cs
@@ -2,6 +2,7 @@ using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
 using System.Buffers.Binary;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
 namespace Dotsider.Tests;
@@ -438,6 +439,35 @@ public class IlDisassemblerTests
                 return;
             }
         }
+    }
+
+    /// <summary>
+    /// Verifies compiler-produced MethodSpec operands are decoded in IL instead of falling back to
+    /// their 0x2B metadata tokens.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void LinqMethodSpecs_ResolveForDisassembly()
+    {
+        using var analyzer = new AssemblyAnalyzer(typeof(MethodSpecReproFixture).Assembly.Location);
+        var method = Assert.ContainsSingle(analyzer.MethodDefs.Where(candidate =>
+            candidate.DeclaringType == MethodSpecReproFixture.TypeName
+            && candidate.Name == MethodSpecReproFixture.MethodName));
+        var instructions = new IlDisassembler(analyzer)
+            .Disassemble(method)
+            .Where(candidate => candidate.OpCode == "call"
+                && candidate.MetadataToken is { } token
+                && MetadataTokens.EntityHandle(token).Kind == HandleKind.MethodSpecification)
+            .ToArray();
+
+        Assert.HasCount(MethodSpecReproFixture.ExpectedDisplays.Count, instructions);
+        TestAssert.All(instructions, instruction =>
+            Assert.AreEqual(0x2B000000,
+                instruction.MetadataToken!.Value & unchecked((int)0xFF000000)));
+        Assert.AreSequenceEqual(
+            MethodSpecReproFixture.ExpectedDisplays,
+            instructions.Select(instruction => instruction.Operand));
+        TestAssert.All(instructions, instruction => Assert.DoesNotContain("0x2B", instruction.Operand));
     }
 
     /// <summary>

--- a/tests/Dotsider.Tests/IlInspectorViewTests.cs
+++ b/tests/Dotsider.Tests/IlInspectorViewTests.cs
@@ -45,6 +45,56 @@ public class IlInspectorViewTests : IDisposable
     }
 
     /// <summary>
+    /// The IL Inspector renders a constructed generic method name instead of exposing the raw
+    /// MethodSpec token in its editor document.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task Tab3_MethodSpec_RendersConstructedGenericMethod()
+    {
+        var (terminal, app, ct) = CreateDotsiderApp(
+            typeof(MethodSpecReproFixture).Assembly.Location);
+        var runTask = app.RunAsync(ct);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(screen => screen.InAlternateScreen, TimeSpan.FromSeconds(10))
+            .WaitUntil(screen => screen.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
+            .Key(Hex1bKey.D3)
+            .WaitUntil(screen => screen.ContainsText("▶") || screen.ContainsText("▼"),
+                TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var method = _state!.Analyzer.MethodDefs.Single(candidate =>
+            candidate.DeclaringType == MethodSpecReproFixture.TypeName
+            && candidate.Name == MethodSpecReproFixture.MethodName);
+        _state.PendingMutations.Enqueue(state =>
+        {
+            state.IlTreeExpansionState["ns:(global)"] = true;
+            state.IlTreeExpansionState[$"type:{method.DeclaringType}"] = true;
+            state.IlSelectedMethod = method;
+            state.IlSelectedMethodOwner = null;
+            state.SetIlFocusedTreeKey($"method:{method.Token}");
+        });
+        _state.RequestExtraFrame();
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(_ => _state.IlEditorMethod?.Token == method.Token
+                && _state.IlEditorState?.Document.GetText().Contains("IL_", StringComparison.Ordinal) == true,
+                TimeSpan.FromSeconds(10))
+            .Build()
+            .ApplyAsync(terminal, ct);
+
+        var documentText = _state.IlEditorState!.Document.GetText();
+        foreach (var expectedDisplay in MethodSpecReproFixture.ExpectedDisplays)
+            Assert.Contains($"call {expectedDisplay}", documentText);
+        Assert.DoesNotContain("call 0x2B", documentText);
+
+        _cts!.Cancel();
+        await runTask;
+    }
+
+    /// <summary>
     /// After clicking in the IL editor and switching tabs, returning to IL
     /// must focus the tree table so arrow keys navigate methods, not the editor cursor.
     /// </summary>

--- a/tests/Dotsider.Tests/SessionBundleTests.cs
+++ b/tests/Dotsider.Tests/SessionBundleTests.cs
@@ -468,6 +468,59 @@ public class SessionBundleTests : IAsyncDisposable
         Assert.IsGreaterThan(depthBefore, _state!.NavigationStack.Count);
     }
 
+    /// <summary>
+    /// Verifies that disassemble and resolve-token render MethodSpec tokens consistently
+    /// through the production diagnostics socket.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task MethodSpecs_ThroughDiagnosticsSession_ReturnConstructedGenericMethods()
+    {
+        var ct = CancellationToken.None;
+        var (_, socketPath) = await StartTuiWithDiagnosticsAsync(
+            typeof(MethodSpecReproFixture).Assembly.Location, ct);
+
+        var disassembleResponse = await DotsiderClient.SendAsync(socketPath,
+            new DotsiderRequest
+            {
+                Method = "disassemble",
+                TypeName = MethodSpecReproFixture.TypeName,
+                MethodName = MethodSpecReproFixture.MethodName
+            }, ct);
+        Assert.IsTrue(disassembleResponse.Success);
+
+        var instructions = ((disassembleResponse.Data as JsonElement?)!.Value)
+            .GetProperty("instructions");
+        var methodSpecs = instructions.EnumerateArray()
+            .Where(instruction => instruction.TryGetProperty("metadataToken", out var token)
+                && token.ValueKind == JsonValueKind.Number
+                && (uint)token.GetInt32() >> 24 == 0x2B)
+            .Select(instruction => new
+            {
+                Token = instruction.GetProperty("metadataToken").GetInt32(),
+                Operand = instruction.GetProperty("operand").GetString()!
+            })
+            .ToArray();
+
+        Assert.AreSequenceEqual(
+            MethodSpecReproFixture.ExpectedDisplays,
+            methodSpecs.Select(methodSpec => methodSpec.Operand));
+
+        var resolvedNames = new List<string>();
+        foreach (var methodSpec in methodSpecs)
+        {
+            var resolveResponse = await DotsiderClient.SendAsync(socketPath,
+                new DotsiderRequest { Method = "resolve-token", Token = methodSpec.Token }, ct);
+            Assert.IsTrue(resolveResponse.Success);
+
+            var resolved = (resolveResponse.Data as JsonElement?)!.Value;
+            Assert.AreEqual(methodSpec.Token, resolved.GetProperty("token").GetInt32());
+            resolvedNames.Add(resolved.GetProperty("resolved").GetString()!);
+        }
+
+        Assert.AreSequenceEqual(MethodSpecReproFixture.ExpectedDisplays, resolvedNames);
+    }
+
     // --- navigate-back ---
 
     /// <summary>

--- a/tests/Shared/MethodSpecReproFixture.cs
+++ b/tests/Shared/MethodSpecReproFixture.cs
@@ -1,0 +1,54 @@
+/// <summary>
+/// Provides a compiler-produced LINQ call whose operand is a MethodSpec metadata token.
+/// </summary>
+internal static class MethodSpecReproFixture
+{
+    /// <summary>The fixture type name as it appears in assembly metadata.</summary>
+    internal const string TypeName = nameof(MethodSpecReproFixture);
+
+    /// <summary>The fixture method name as it appears in assembly metadata.</summary>
+    internal const string MethodName = nameof(FilterLetters);
+
+    /// <summary>The caller that instantiates a generic method defined in this assembly.</summary>
+    internal const string MethodDefCallerName = nameof(CallLocalGeneric);
+
+    /// <summary>The caller that instantiates a generic method on a constructed generic type.</summary>
+    internal const string TypeSpecParentCallerName = nameof(ConvertAll);
+
+    /// <summary>The expected human-readable displays for the method's three generic LINQ calls.</summary>
+    internal static IReadOnlyList<string> ExpectedDisplays { get; } =
+    [
+        "System.Linq.Enumerable::Where<char>",
+        "System.Linq.Enumerable::Select<char, char>",
+        "System.Linq.Enumerable::OrderBy<char, char>"
+    ];
+
+    /// <summary>The expected display for the MethodDef-backed instantiation.</summary>
+    internal const string MethodDefExpectedDisplay =
+        "MethodSpecReproFixture::Identity<System.Collections.Generic.List`1<int>>";
+
+    /// <summary>The expected display for the MemberRef whose parent is a TypeSpec.</summary>
+    internal const string TypeSpecParentExpectedDisplay =
+        "System.Collections.Generic.List`1<int>::ConvertAll<string>";
+
+    /// <summary>Produces three real LINQ MethodSpec calls beginning with <c>Where&lt;char&gt;</c>.</summary>
+    /// <param name="input">Characters to filter.</param>
+    /// <returns>Normalized letter characters from <paramref name="input"/> in sorted order.</returns>
+    internal static IEnumerable<char> FilterLetters(string input) => input
+        .Where(char.IsLetter)
+        .Select(static value => char.ToUpperInvariant(value))
+        .OrderBy(static value => value);
+
+    /// <summary>Instantiates a local generic method with a constructed generic argument.</summary>
+    /// <param name="input">The value passed through the generic method.</param>
+    /// <returns><paramref name="input"/> unchanged.</returns>
+    internal static List<int> CallLocalGeneric(List<int> input) => Identity(input);
+
+    /// <summary>Instantiates a generic method whose declaring type is <c>List&lt;int&gt;</c>.</summary>
+    /// <param name="input">Values to convert.</param>
+    /// <returns>The decimal representation of each input value.</returns>
+    internal static List<string> ConvertAll(List<int> input) =>
+        input.ConvertAll(static value => value.ToString());
+
+    private static T Identity<T>(T value) => value;
+}


### PR DESCRIPTION
MethodSpec operands now resolve their underlying MethodDef or MemberRef and decode the constructed generic arguments, so LINQ calls render as `System.Linq.Enumerable::Where<char>` across IL output, the CLI, TUI, MCP, and diagnostics sessions. Invalid metadata still falls back to the original token.

Regression coverage exercises MethodDef, MemberRef, TypeSpec, malformed signatures, and each affected surface. The DocGenerator now references System.Security.Cryptography.Xml 9.0.18 so its normal restore clears the vulnerability audit, and the API docs were regenerated.

Validated with the full solution build, all three test projects, and the DocGenerator.

Fixes: #236
