### PR TITLE
Harden embedded source editor launch

### DIFF
--- a/docs/src/content/docs/usage/il-inspector.md
+++ b/docs/src/content/docs/usage/il-inspector.md
@@ -32,6 +32,32 @@ Press `Esc` to go back. The previous IL bytecode, cursor position, tree expansio
 - Press `o` on a selected method to open embedded source when the PDB carries it.
 - Press `Esc` to return to where you came from.
 
+### Opening embedded source
+
+Embedded source is copied to a private, uniquely named directory under the system
+temporary directory for the dotsider session. Generated names contain only ASCII
+letters, digits, `_`, and `-`. Known non-script source extensions are retained for
+configured editors; unknown, script, and executable extensions are saved as `.txt`.
+Temporary copies are removed during normal teardown when the platform permits it.
+
+`VISUAL` takes precedence over `EDITOR`. Native executables and executable Unix
+scripts are launched directly without a shell. Unquoted whitespace separates
+arguments; single and double quotes group text, adjacent segments join, and empty
+quoted arguments are preserved. A backslash escapes whitespace, a matching quote,
+or another backslash and otherwise remains literal. Variable, command, and wildcard
+expansion, pipes, redirects, and command chaining are unsupported. On Windows, a
+resolved local `.cmd` or `.bat` editor shim such as VS Code's `code.cmd` is invoked
+through the system `cmd.exe`; the embedded-source path is carried as data rather
+than inserted as raw command text. A literal double quote inside an argument is
+rejected for batch shims because `cmd.exe` cannot represent that value
+unambiguously; quote characters used for grouping are unaffected.
+
+If neither configured editor resolves, dotsider attempts to open a `.txt` copy with
+the platform's default application. A graphical opener might not be available in a
+headless Linux environment; dotsider then displays the safe temporary path instead.
+Private copies left by a hard process termination remain subject to the operating
+system's normal temporary-file cleanup.
+
 ## Copy
 
 Select text in the disassembly pane with click-drag or `Shift` + arrow keys, then press `y` to yank it to the clipboard. The cursor collapses to the end of the selection and a brief flash confirms the copied range — matching neovim's yank behavior.

--- a/samples/EmbeddedSourceLib/EmbeddedSourceLib.csproj
+++ b/samples/EmbeddedSourceLib/EmbeddedSourceLib.csproj
@@ -8,4 +8,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Payload.cmd" />
+  </ItemGroup>
 </Project>

--- a/samples/EmbeddedSourceLib/Evil & Payload !.cs
+++ b/samples/EmbeddedSourceLib/Evil & Payload !.cs
@@ -1,0 +1,13 @@
+namespace EmbeddedSourceLib;
+
+/// <summary>
+/// Provides embedded source whose document name contains shell metacharacters.
+/// </summary>
+public static class HostileNameFixture
+{
+    /// <summary>
+    /// Returns a stable value used to locate this method in embedded-source tests.
+    /// </summary>
+    /// <returns>The value 43.</returns>
+    public static int Run() => 43;
+}

--- a/samples/EmbeddedSourceLib/Payload.cmd
+++ b/samples/EmbeddedSourceLib/Payload.cmd
@@ -1,0 +1,13 @@
+namespace EmbeddedSourceLib;
+
+/// <summary>
+/// Provides embedded source whose document carries a command-script extension.
+/// </summary>
+public static class HostileExtensionFixture
+{
+    /// <summary>
+    /// Returns a stable value used to locate this method in embedded-source tests.
+    /// </summary>
+    /// <returns>The value 42.</returns>
+    public static int Run() => 42;
+}

--- a/src/Dotsider/DotsiderState.cs
+++ b/src/Dotsider/DotsiderState.cs
@@ -20,6 +20,8 @@ public sealed class DotsiderState : IDisposable
     private readonly CancellationTokenSource _lifetimeCancellation = new();
     private readonly List<Task> _renderNudgerTasks = [];
     private DependencyGraphSnapshot? _dependencyGraphSnapshot;
+    private readonly Lazy<EmbeddedSourceTempFileStore> _embeddedSourceTempFiles =
+        new(static () => new EmbeddedSourceTempFileStore());
     private CancellationTokenSource? _graphBuildCancellation;
     private Task _graphBuildTask = Task.CompletedTask;
     private int _graphBuildGeneration;
@@ -95,6 +97,18 @@ public sealed class DotsiderState : IDisposable
 
     /// <summary>The Hex1b application instance.</summary>
     public Hex1bApp App { get; }
+
+    /// <summary>
+    /// Gets the private temporary store used for PDB-embedded source documents.
+    /// </summary>
+    internal EmbeddedSourceTempFileStore EmbeddedSourceTempFiles
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _embeddedSourceTempFiles.Value;
+        }
+    }
 
     /// <summary>
     /// Queue of mutations to apply on the UI thread, drained at the top of each render frame.
@@ -2434,6 +2448,8 @@ public sealed class DotsiderState : IDisposable
 
         CancelAndDrainGraphBuild();
         CancelAndDrainRenderNudgers();
+        if (_embeddedSourceTempFiles.IsValueCreated)
+            _embeddedSourceTempFiles.Value.Dispose();
         _lifetimeCancellation.Dispose();
         Tracer?.Dispose();
         foreach (var analyzer in NavigationStack)

--- a/src/Dotsider/Program.cs
+++ b/src/Dotsider/Program.cs
@@ -282,7 +282,14 @@ static async Task<int> RunTui(string[] args, string filePath)
         try
         {
             CursorColorHelper.ResetCursorColor();
-            hex1bApp.Dispose();
+            try
+            {
+                capturedState?.Dispose();
+            }
+            finally
+            {
+                hex1bApp.Dispose();
+            }
         }
         catch (Exception ex)
         {

--- a/src/Dotsider/Views/EditorCommand.cs
+++ b/src/Dotsider/Views/EditorCommand.cs
@@ -1,0 +1,147 @@
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// Represents a configured editor command parsed without shell evaluation.
+/// </summary>
+internal sealed class EditorCommand
+{
+    private static readonly SearchValues<char> ForbiddenControlCharacters =
+        SearchValues.Create(['\0', '\r', '\n']);
+
+    private static readonly SearchValues<char> UnsupportedShellOperators =
+        SearchValues.Create(['&', ';', '<', '>', '`', '|']);
+
+    private EditorCommand(string executable, IReadOnlyList<string> arguments)
+    {
+        Executable = executable;
+        Arguments = arguments;
+    }
+
+    /// <summary>
+    /// Gets the configured executable token.
+    /// </summary>
+    internal string Executable { get; }
+
+    /// <summary>
+    /// Gets the configured literal arguments.
+    /// </summary>
+    internal IReadOnlyList<string> Arguments { get; }
+
+    /// <summary>
+    /// Parses a shell-free editor command using documented quote and escape rules.
+    /// </summary>
+    /// <param name="value">The configured editor command.</param>
+    /// <param name="command">The parsed command when successful.</param>
+    /// <returns><see langword="true"/> when the command is well-formed.</returns>
+    internal static bool TryParse(
+        string? value,
+        [NotNullWhen(true)] out EditorCommand? command)
+    {
+        command = null;
+        if (string.IsNullOrWhiteSpace(value)
+            || value.AsSpan().ContainsAny(ForbiddenControlCharacters))
+        {
+            return false;
+        }
+
+        var tokens = new List<string>();
+        var builder = new StringBuilder();
+        var quote = '\0';
+        var tokenStarted = false;
+
+        for (var index = 0; index < value.Length; index++)
+        {
+            var character = value[index];
+            if (quote == '\0' && char.IsWhiteSpace(character))
+            {
+                AddToken(tokens, builder, ref tokenStarted);
+                continue;
+            }
+
+            if (character is '\'' or '"')
+            {
+                if (quote == '\0')
+                {
+                    quote = character;
+                    tokenStarted = true;
+                    continue;
+                }
+
+                if (quote == character)
+                {
+                    quote = '\0';
+                    continue;
+                }
+            }
+
+            if (character == '\\')
+            {
+                if (++index >= value.Length)
+                    return false;
+
+                var escaped = value[index];
+                var escapesQuote = quote == '\0'
+                    ? escaped is '\'' or '"'
+                    : escaped == quote;
+                if (char.IsWhiteSpace(escaped)
+                    || escaped == '\\'
+                    || escapesQuote)
+                {
+                    builder.Append(escaped);
+                }
+                else
+                {
+                    builder.Append('\\');
+                    builder.Append(escaped);
+                }
+
+                tokenStarted = true;
+                continue;
+            }
+
+            if (quote == '\0' && UnsupportedShellOperators.Contains(character))
+                return false;
+            if (quote == '\0'
+                && character == '$'
+                && index + 1 < value.Length
+                && value[index + 1] is '(' or '{')
+            {
+                return false;
+            }
+
+            builder.Append(character);
+            tokenStarted = true;
+        }
+
+        if (quote != '\0')
+            return false;
+
+        AddToken(tokens, builder, ref tokenStarted);
+        if (tokens.Count == 0 || string.IsNullOrWhiteSpace(tokens[0]))
+            return false;
+
+        var arguments = new string[tokens.Count - 1];
+        for (var index = 1; index < tokens.Count; index++)
+            arguments[index - 1] = tokens[index];
+
+        command = new EditorCommand(tokens[0], Array.AsReadOnly(arguments));
+        return true;
+    }
+
+    private static void AddToken(
+        List<string> tokens,
+        StringBuilder builder,
+        ref bool tokenStarted)
+    {
+        if (!tokenStarted)
+            return;
+
+        tokens.Add(builder.ToString());
+        builder.Clear();
+        tokenStarted = false;
+    }
+}

--- a/src/Dotsider/Views/EditorExecutableResolver.cs
+++ b/src/Dotsider/Views/EditorExecutableResolver.cs
@@ -1,0 +1,241 @@
+namespace Dotsider.Views;
+
+/// <summary>
+/// Resolves configured editor executables without searching an untrusted current directory.
+/// </summary>
+internal static class EditorExecutableResolver
+{
+    private const string DefaultPathExtensions = ".COM;.EXE;.BAT;.CMD";
+
+    /// <summary>
+    /// Resolves an editor command using the current platform and process environment.
+    /// </summary>
+    /// <param name="command">The parsed editor command.</param>
+    /// <param name="resolvedPath">The absolute executable path when found.</param>
+    /// <returns><see langword="true"/> when an eligible executable was found.</returns>
+    internal static bool TryResolve(EditorCommand command, out string resolvedPath)
+    {
+        var pathEntries = SplitPathEntries(Environment.GetEnvironmentVariable("PATH"));
+        return OperatingSystem.IsWindows()
+            ? TryResolveWindows(
+                command.Executable,
+                pathEntries,
+                SplitPathExtensions(Environment.GetEnvironmentVariable("PATHEXT")),
+                out resolvedPath)
+            : TryResolveUnix(command.Executable, pathEntries, out resolvedPath);
+    }
+
+    /// <summary>
+    /// Resolves a Windows editor through explicit paths or rooted PATH entries and PATHEXT.
+    /// </summary>
+    /// <param name="token">The configured executable token.</param>
+    /// <param name="pathEntries">The PATH entries to search.</param>
+    /// <param name="pathExtensions">The PATHEXT entries to apply.</param>
+    /// <param name="resolvedPath">The absolute executable path when found.</param>
+    /// <returns><see langword="true"/> when an eligible executable was found.</returns>
+    internal static bool TryResolveWindows(
+        string token,
+        IReadOnlyList<string> pathEntries,
+        IReadOnlyList<string> pathExtensions,
+        out string resolvedPath)
+    {
+        resolvedPath = "";
+        if (ContainsWindowsDirectorySeparator(token))
+        {
+            string explicitPath;
+            try
+            {
+                explicitPath = Path.GetFullPath(token);
+            }
+            catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
+            {
+                return false;
+            }
+
+            return TryWindowsCandidate(explicitPath, pathExtensions, out resolvedPath);
+        }
+
+        foreach (var entry in pathEntries)
+        {
+            if (!TryNormalizeRootedPathEntry(entry, out var directory))
+                continue;
+
+            if (TryWindowsCandidate(Path.Combine(directory, token), pathExtensions, out resolvedPath))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves a Unix editor through an explicit path or rooted PATH entries.
+    /// </summary>
+    /// <param name="token">The configured executable token.</param>
+    /// <param name="pathEntries">The PATH entries to search.</param>
+    /// <param name="resolvedPath">The absolute executable path when found.</param>
+    /// <returns><see langword="true"/> when an executable regular file was found.</returns>
+    internal static bool TryResolveUnix(
+        string token,
+        IReadOnlyList<string> pathEntries,
+        out string resolvedPath)
+    {
+        resolvedPath = "";
+        if (token.Contains('/', StringComparison.Ordinal))
+        {
+            string explicitPath;
+            try
+            {
+                explicitPath = Path.GetFullPath(token);
+            }
+            catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
+            {
+                return false;
+            }
+
+            if (IsUnixExecutable(explicitPath))
+            {
+                resolvedPath = explicitPath;
+                return true;
+            }
+
+            return false;
+        }
+
+        foreach (var entry in pathEntries)
+        {
+            if (!TryNormalizeRootedPathEntry(entry, out var directory))
+                continue;
+
+            var candidate = Path.Combine(directory, token);
+            if (!IsUnixExecutable(candidate))
+                continue;
+
+            resolvedPath = Path.GetFullPath(candidate);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Splits PATH into entries without treating an empty entry as the current directory.
+    /// </summary>
+    /// <param name="value">The PATH value.</param>
+    /// <returns>The nonempty PATH entries in their original order.</returns>
+    internal static IReadOnlyList<string> SplitPathEntries(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return [];
+
+        return value.Split(
+            Path.PathSeparator,
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    /// <summary>
+    /// Splits and normalizes PATHEXT while retaining only supported editor target types.
+    /// </summary>
+    /// <param name="value">The PATHEXT value, or null to use the Windows default.</param>
+    /// <returns>The normalized supported extensions in search order.</returns>
+    internal static IReadOnlyList<string> SplitPathExtensions(string? value)
+    {
+        var source = string.IsNullOrWhiteSpace(value) ? DefaultPathExtensions : value;
+        var extensions = new List<string>();
+        foreach (var item in source.Split(
+                     ';',
+                     StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var extension = item.StartsWith('.') ? item : $".{item}";
+            if (!IsSupportedWindowsExtension(extension)
+                || extensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            extensions.Add(extension.ToUpperInvariant());
+        }
+
+        return extensions;
+    }
+
+    private static bool ContainsWindowsDirectorySeparator(string value) =>
+        value.Contains('\\', StringComparison.Ordinal)
+        || value.Contains('/', StringComparison.Ordinal);
+
+    private static bool IsSupportedWindowsExtension(string extension) =>
+        extension.Equals(".bat", StringComparison.OrdinalIgnoreCase)
+        || extension.Equals(".cmd", StringComparison.OrdinalIgnoreCase)
+        || extension.Equals(".com", StringComparison.OrdinalIgnoreCase)
+        || extension.Equals(".exe", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsUnixExecutable(string path)
+    {
+        if (!File.Exists(path) || OperatingSystem.IsWindows())
+            return false;
+
+        try
+        {
+            var mode = File.GetUnixFileMode(path);
+            const UnixFileMode executeModes =
+                UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
+            return (mode & executeModes) != 0;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryNormalizeRootedPathEntry(string value, out string directory)
+    {
+        directory = value.Trim();
+        if (directory.Length >= 2
+            && directory[0] == '"'
+            && directory[^1] == '"')
+        {
+            directory = directory[1..^1];
+        }
+
+        if (directory.Length == 0 || !Path.IsPathFullyQualified(directory))
+            return false;
+
+        try
+        {
+            directory = Path.GetFullPath(directory);
+            return true;
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
+        {
+            directory = "";
+            return false;
+        }
+    }
+
+    private static bool TryWindowsCandidate(
+        string candidate,
+        IReadOnlyList<string> pathExtensions,
+        out string resolvedPath)
+    {
+        resolvedPath = "";
+        if (Path.HasExtension(candidate))
+            return TryExistingWindowsFile(candidate, out resolvedPath);
+
+        foreach (var extension in pathExtensions)
+        {
+            if (TryExistingWindowsFile(candidate + extension, out resolvedPath))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryExistingWindowsFile(string candidate, out string resolvedPath)
+    {
+        resolvedPath = "";
+        if (!IsSupportedWindowsExtension(Path.GetExtension(candidate)) || !File.Exists(candidate))
+            return false;
+
+        resolvedPath = Path.GetFullPath(candidate);
+        return true;
+    }
+}

--- a/src/Dotsider/Views/EditorLaunchStatus.cs
+++ b/src/Dotsider/Views/EditorLaunchStatus.cs
@@ -1,0 +1,22 @@
+namespace Dotsider.Views;
+
+/// <summary>
+/// Describes the result of resolving and starting an embedded-source editor.
+/// </summary>
+internal enum EditorLaunchStatus
+{
+    /// <summary>
+    /// No eligible configured editor was found.
+    /// </summary>
+    NotFound,
+
+    /// <summary>
+    /// An editor or platform association handler was started.
+    /// </summary>
+    Started,
+
+    /// <summary>
+    /// The configuration was malformed or an eligible target failed to start.
+    /// </summary>
+    Failed
+}

--- a/src/Dotsider/Views/EditorLauncher.cs
+++ b/src/Dotsider/Views/EditorLauncher.cs
@@ -1,0 +1,269 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// Resolves configured editors and starts them without exposing source paths to shell parsing.
+/// </summary>
+internal static class EditorLauncher
+{
+    private const string BatchArgumentPrefix = "DOTSIDER_EDITOR_ARGUMENT_";
+    private const string BatchScriptVariable = "DOTSIDER_EDITOR_SCRIPT";
+    private const string BatchSourceVariable = "DOTSIDER_EDITOR_SOURCE";
+
+    /// <summary>
+    /// Launches an editor using the process environment and production process starter.
+    /// </summary>
+    /// <param name="store">The store that owns the source path.</param>
+    /// <param name="sourcePath">The source path to open.</param>
+    /// <param name="openedPath">The exact path selected for the launch attempt.</param>
+    /// <returns>The editor launch status.</returns>
+    internal static EditorLaunchStatus Launch(
+        EmbeddedSourceTempFileStore store,
+        string sourcePath,
+        out string openedPath)
+    {
+        var pathEntries = EditorExecutableResolver.SplitPathEntries(
+            Environment.GetEnvironmentVariable("PATH"));
+        var pathExtensions = OperatingSystem.IsWindows()
+            ? EditorExecutableResolver.SplitPathExtensions(
+                Environment.GetEnvironmentVariable("PATHEXT"))
+            : [];
+
+        return Launch(
+            store,
+            sourcePath,
+            Environment.GetEnvironmentVariable("VISUAL"),
+            Environment.GetEnvironmentVariable("EDITOR"),
+            pathEntries,
+            pathExtensions,
+            StartProcess,
+            out openedPath);
+    }
+
+    /// <summary>
+    /// Launches an editor using explicit configuration and a caller-provided process starter.
+    /// </summary>
+    /// <param name="store">The store that owns the source path.</param>
+    /// <param name="sourcePath">The source path to open.</param>
+    /// <param name="visual">The configured VISUAL value.</param>
+    /// <param name="editor">The configured EDITOR value.</param>
+    /// <param name="pathEntries">The PATH entries available for resolution.</param>
+    /// <param name="pathExtensions">The PATHEXT entries available on Windows.</param>
+    /// <param name="startProcess">The process-start operation.</param>
+    /// <param name="openedPath">The exact path selected for the launch attempt.</param>
+    /// <returns>The editor launch status.</returns>
+    internal static EditorLaunchStatus Launch(
+        EmbeddedSourceTempFileStore store,
+        string sourcePath,
+        string? visual,
+        string? editor,
+        IReadOnlyList<string> pathEntries,
+        IReadOnlyList<string> pathExtensions,
+        Func<ProcessStartInfo, IDisposable?> startProcess,
+        out string openedPath)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourcePath);
+        ArgumentNullException.ThrowIfNull(pathEntries);
+        ArgumentNullException.ThrowIfNull(pathExtensions);
+        ArgumentNullException.ThrowIfNull(startProcess);
+
+        openedPath = sourcePath;
+        var status = TryConfiguredEditor(
+            visual,
+            sourcePath,
+            pathEntries,
+            pathExtensions,
+            startProcess);
+        if (status is EditorLaunchStatus.Started or EditorLaunchStatus.Failed)
+            return status;
+
+        status = TryConfiguredEditor(
+            editor,
+            sourcePath,
+            pathEntries,
+            pathExtensions,
+            startProcess);
+        if (status is EditorLaunchStatus.Started or EditorLaunchStatus.Failed)
+            return status;
+
+        try
+        {
+            openedPath = store.PrepareAssociationPath(sourcePath);
+            return TryStart(CreateAssociationStartInfo(openedPath), startProcess);
+        }
+        catch (Exception ex) when (IsExpectedLaunchException(ex))
+        {
+            return EditorLaunchStatus.Failed;
+        }
+    }
+
+    /// <summary>
+    /// Creates start information for a directly executable configured editor.
+    /// </summary>
+    /// <param name="executable">The resolved absolute editor path.</param>
+    /// <param name="arguments">The configured literal editor arguments.</param>
+    /// <param name="sourcePath">The absolute source path.</param>
+    /// <returns>Shell-free process start information.</returns>
+    internal static ProcessStartInfo CreateDirectStartInfo(
+        string executable,
+        IReadOnlyList<string> arguments,
+        string sourcePath)
+    {
+        var startInfo = new ProcessStartInfo(executable)
+        {
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(executable) ?? ""
+        };
+
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+        startInfo.ArgumentList.Add(sourcePath);
+        return startInfo;
+    }
+
+    /// <summary>
+    /// Creates start information for a resolved Windows batch editor shim.
+    /// </summary>
+    /// <param name="resolvedScript">The resolved absolute batch script path.</param>
+    /// <param name="arguments">The configured literal editor arguments.</param>
+    /// <param name="sourcePath">The absolute source path.</param>
+    /// <returns>Start information using the fully qualified system command interpreter.</returns>
+    internal static ProcessStartInfo CreateWindowsBatchStartInfo(
+        string resolvedScript,
+        IReadOnlyList<string> arguments,
+        string sourcePath)
+    {
+        if (arguments.Any(argument => argument.Contains('"')))
+        {
+            throw new ArgumentException(
+                "Windows batch editor arguments cannot contain literal double quotes.",
+                nameof(arguments));
+        }
+
+        var startInfo = new ProcessStartInfo(
+            Path.Combine(Environment.SystemDirectory, "cmd.exe"))
+        {
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(resolvedScript) ?? ""
+        };
+
+        startInfo.Environment[BatchScriptVariable] = $".{resolvedScript}";
+        startInfo.Environment[BatchSourceVariable] = $".{sourcePath}";
+
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            var variable = $"{BatchArgumentPrefix}{index:D4}";
+            startInfo.Environment[variable] = $".{arguments[index]}";
+        }
+
+        startInfo.Arguments = BuildBatchArguments(arguments.Count);
+        return startInfo;
+    }
+
+    /// <summary>
+    /// Creates platform-association start information for an inert text source path.
+    /// </summary>
+    /// <param name="sourcePath">The absolute <c>.txt</c> source path.</param>
+    /// <returns>Association-based process start information.</returns>
+    internal static ProcessStartInfo CreateAssociationStartInfo(string sourcePath)
+    {
+        if (!string.Equals(Path.GetExtension(sourcePath), ".txt", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException("Association fallback requires a .txt source path.", nameof(sourcePath));
+
+        return new ProcessStartInfo(sourcePath)
+        {
+            UseShellExecute = true,
+            WorkingDirectory = Path.GetDirectoryName(sourcePath) ?? ""
+        };
+    }
+
+    private static bool IsExpectedLaunchException(Exception exception) =>
+        exception is Win32Exception
+            or InvalidOperationException
+            or IOException
+            or UnauthorizedAccessException;
+
+    private static string BuildBatchArguments(int argumentCount)
+    {
+        var command = new StringBuilder($"\"\"%{BatchScriptVariable}:~1%\"");
+        for (var index = 0; index < argumentCount; index++)
+        {
+            command.Append(" \"%");
+            command.Append($"{BatchArgumentPrefix}{index:D4}");
+            command.Append(":~1%\"");
+        }
+
+        command.Append(" \"%");
+        command.Append(BatchSourceVariable);
+        command.Append(":~1%\"\"");
+        return $"/d /s /v:off /c {command}";
+    }
+
+    private static bool IsWindowsBatchFile(string path)
+    {
+        var extension = Path.GetExtension(path);
+        return extension.Equals(".bat", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".cmd", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IDisposable? StartProcess(ProcessStartInfo startInfo) =>
+        Process.Start(startInfo);
+
+    private static EditorLaunchStatus TryConfiguredEditor(
+        string? configuredValue,
+        string sourcePath,
+        IReadOnlyList<string> pathEntries,
+        IReadOnlyList<string> pathExtensions,
+        Func<ProcessStartInfo, IDisposable?> startProcess)
+    {
+        if (string.IsNullOrWhiteSpace(configuredValue))
+            return EditorLaunchStatus.NotFound;
+
+        if (!EditorCommand.TryParse(configuredValue, out var command))
+            return EditorLaunchStatus.Failed;
+
+        var resolved = OperatingSystem.IsWindows()
+            ? EditorExecutableResolver.TryResolveWindows(
+                command.Executable,
+                pathEntries,
+                pathExtensions,
+                out string resolvedPath)
+            : EditorExecutableResolver.TryResolveUnix(
+                command.Executable,
+                pathEntries,
+                out resolvedPath);
+        if (!resolved)
+            return EditorLaunchStatus.NotFound;
+
+        var startInfo = OperatingSystem.IsWindows() && IsWindowsBatchFile(resolvedPath)
+            ? command.Arguments.Any(argument => argument.Contains('"'))
+                ? null
+                : CreateWindowsBatchStartInfo(resolvedPath, command.Arguments, sourcePath)
+            : CreateDirectStartInfo(resolvedPath, command.Arguments, sourcePath);
+        if (startInfo is null)
+            return EditorLaunchStatus.Failed;
+
+        return TryStart(startInfo, startProcess);
+    }
+
+    private static EditorLaunchStatus TryStart(
+        ProcessStartInfo startInfo,
+        Func<ProcessStartInfo, IDisposable?> startProcess)
+    {
+        try
+        {
+            using var process = startProcess(startInfo);
+            return process is null
+                ? EditorLaunchStatus.Failed
+                : EditorLaunchStatus.Started;
+        }
+        catch (Exception ex) when (IsExpectedLaunchException(ex))
+        {
+            return EditorLaunchStatus.Failed;
+        }
+    }
+}

--- a/src/Dotsider/Views/EmbeddedSourceTempFileStore.cs
+++ b/src/Dotsider/Views/EmbeddedSourceTempFileStore.cs
@@ -1,0 +1,353 @@
+using System.Runtime.Versioning;
+
+namespace Dotsider.Views;
+
+/// <summary>
+/// Materializes untrusted embedded source in a private session directory using inert,
+/// collision-resistant file names.
+/// </summary>
+internal sealed class EmbeddedSourceTempFileStore : IDisposable
+{
+    private const int MaximumNameLength = 64;
+    private const int MaximumWriteAttempts = 10;
+    private const string TempDirectoryPrefix = "dotsider-embedded-source-";
+
+    private static readonly UnixFileMode PrivateDirectoryMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+
+    private static readonly UnixFileMode PrivateFileMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+    private readonly Lock _gate = new();
+    private string? _directoryPath;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a store and registers best-effort process-exit cleanup.
+    /// </summary>
+    internal EmbeddedSourceTempFileStore()
+    {
+        AppDomain.CurrentDomain.ProcessExit += HandleProcessExit;
+    }
+
+    /// <summary>
+    /// Gets the private session directory after it has been created.
+    /// </summary>
+    internal string? SessionDirectory
+    {
+        get
+        {
+            lock (_gate)
+                return _directoryPath;
+        }
+    }
+
+    /// <summary>
+    /// Builds an inert temporary filename for an untrusted metadata document name.
+    /// </summary>
+    /// <param name="methodName">The method name used when the document has no usable name.</param>
+    /// <param name="documentPath">The untrusted portable PDB document path.</param>
+    /// <returns>A bounded filename containing a GUID and a safe extension.</returns>
+    internal static string BuildFileName(string methodName, string documentPath) =>
+        BuildFileName(methodName, documentPath, Guid.NewGuid());
+
+    /// <summary>
+    /// Builds an inert temporary filename using a caller-supplied uniqueness value.
+    /// </summary>
+    /// <param name="methodName">The method name used when the document has no usable name.</param>
+    /// <param name="documentPath">The untrusted portable PDB document path.</param>
+    /// <param name="uniqueId">The uniqueness value to include in the filename.</param>
+    /// <returns>A bounded filename containing the supplied GUID and a safe extension.</returns>
+    internal static string BuildFileName(string methodName, string documentPath, Guid uniqueId)
+    {
+        var segment = GetDocumentSegment(documentPath);
+        var dotIndex = segment.LastIndexOf('.');
+        var name = dotIndex >= 0 ? segment[..dotIndex] : segment;
+
+        if (!TrySanitizeNamePart(name, out var sanitizedName)
+            && !TrySanitizeNamePart(methodName.AsSpan(), out sanitizedName))
+        {
+            sanitizedName = "source";
+        }
+
+        return $"{sanitizedName}-{uniqueId:N}{SanitizeExtension(segment, dotIndex)}";
+    }
+
+    /// <summary>
+    /// Replaces characters outside the filename allowlist and bounds the result length.
+    /// </summary>
+    /// <param name="value">The untrusted name component.</param>
+    /// <returns>An ASCII-only filename component no longer than 64 characters.</returns>
+    internal static string SanitizeNamePart(string value) => SanitizeNamePart(value.AsSpan());
+
+    /// <summary>
+    /// Returns the canonical safe extension for an untrusted document path.
+    /// </summary>
+    /// <param name="documentPath">The untrusted portable PDB document path.</param>
+    /// <returns>An allowlisted lowercase extension, or <c>.txt</c>.</returns>
+    internal static string SanitizeExtension(string documentPath)
+    {
+        var segment = GetDocumentSegment(documentPath);
+        return SanitizeExtension(segment, segment.LastIndexOf('.'));
+    }
+
+    /// <summary>
+    /// Writes embedded source bytes to a new file inside the private session directory.
+    /// </summary>
+    /// <param name="methodName">The method name used when the document has no usable name.</param>
+    /// <param name="documentPath">The untrusted portable PDB document path.</param>
+    /// <param name="bytes">The embedded source bytes.</param>
+    /// <returns>The absolute path of the newly created source file.</returns>
+    internal string Write(string methodName, string documentPath, byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(methodName);
+        ArgumentNullException.ThrowIfNull(documentPath);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        var directory = GetOrCreateDirectory();
+        for (var attempt = 0; attempt < MaximumWriteAttempts; attempt++)
+        {
+            var path = Path.Combine(directory, BuildFileName(methodName, documentPath));
+            try
+            {
+                using var stream = new FileStream(path, CreateFileOptions());
+                stream.Write(bytes);
+                return path;
+            }
+            catch (IOException) when (File.Exists(path))
+            {
+                // An extraordinarily unlikely GUID collision. Generate another name.
+            }
+        }
+
+        throw new IOException("Could not create a unique embedded-source temporary file.");
+    }
+
+    /// <summary>
+    /// Moves an owned source file to a <c>.txt</c> path for system-association dispatch.
+    /// </summary>
+    /// <param name="path">The source path created by this store.</param>
+    /// <returns>The original path when already text, otherwise the new text path.</returns>
+    internal string PrepareAssociationPath(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var directory = GetOrCreateDirectory();
+        var fullPath = Path.GetFullPath(path);
+        var pathDirectory = Path.GetDirectoryName(fullPath);
+        if (!string.Equals(
+                directory,
+                pathDirectory,
+                OperatingSystem.IsWindows()
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal))
+        {
+            throw new IOException("The embedded-source path is outside the private session directory.");
+        }
+
+        if (string.Equals(Path.GetExtension(fullPath), ".txt", StringComparison.OrdinalIgnoreCase))
+            return fullPath;
+
+        var textPath = Path.ChangeExtension(fullPath, ".txt");
+        File.Move(fullPath, textPath);
+        return textPath;
+    }
+
+    /// <summary>
+    /// Deletes this store's private session directory when possible.
+    /// </summary>
+    public void Dispose()
+    {
+        string? directory;
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            directory = _directoryPath;
+            _directoryPath = null;
+        }
+
+        AppDomain.CurrentDomain.ProcessExit -= HandleProcessExit;
+        DeleteDirectory(directory);
+    }
+
+    private static FileStreamOptions CreateFileOptions()
+    {
+        var options = new FileStreamOptions
+        {
+            Access = FileAccess.Write,
+            Mode = FileMode.CreateNew,
+            Share = FileShare.Read
+        };
+
+        if (!OperatingSystem.IsWindows())
+            SetUnixCreateMode(options);
+
+        return options;
+    }
+
+    private static void DeleteDirectory(string? directory)
+    {
+        if (directory is null)
+            return;
+
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (DirectoryNotFoundException)
+        {
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static ReadOnlySpan<char> GetDocumentSegment(string documentPath)
+    {
+        var path = documentPath.AsSpan();
+        var slash = path.LastIndexOf('/');
+        var backslash = path.LastIndexOf('\\');
+        var separator = Math.Max(slash, backslash);
+        return separator >= 0 ? path[(separator + 1)..] : path;
+    }
+
+    private static bool IsAllowedNameCharacter(char value) =>
+        value is >= 'A' and <= 'Z'
+            or >= 'a' and <= 'z'
+            or >= '0' and <= '9'
+            or '_'
+            or '-';
+
+    private static string SanitizeExtension(ReadOnlySpan<char> segment, int dotIndex)
+    {
+        if (dotIndex < 0)
+            return ".txt";
+
+        var extension = segment[dotIndex..];
+        if (extension.Equals(".cs", StringComparison.OrdinalIgnoreCase))
+            return ".cs";
+        if (extension.Equals(".cshtml", StringComparison.OrdinalIgnoreCase))
+            return ".cshtml";
+        if (extension.Equals(".fs", StringComparison.OrdinalIgnoreCase))
+            return ".fs";
+        if (extension.Equals(".fsi", StringComparison.OrdinalIgnoreCase))
+            return ".fsi";
+        if (extension.Equals(".il", StringComparison.OrdinalIgnoreCase))
+            return ".il";
+        if (extension.Equals(".json", StringComparison.OrdinalIgnoreCase))
+            return ".json";
+        if (extension.Equals(".md", StringComparison.OrdinalIgnoreCase))
+            return ".md";
+        if (extension.Equals(".razor", StringComparison.OrdinalIgnoreCase))
+            return ".razor";
+        if (extension.Equals(".resx", StringComparison.OrdinalIgnoreCase))
+            return ".resx";
+        if (extension.Equals(".txt", StringComparison.OrdinalIgnoreCase))
+            return ".txt";
+        if (extension.Equals(".vb", StringComparison.OrdinalIgnoreCase))
+            return ".vb";
+        if (extension.Equals(".vbhtml", StringComparison.OrdinalIgnoreCase))
+            return ".vbhtml";
+        if (extension.Equals(".xaml", StringComparison.OrdinalIgnoreCase))
+            return ".xaml";
+        if (extension.Equals(".xml", StringComparison.OrdinalIgnoreCase))
+            return ".xml";
+
+        return ".txt";
+    }
+
+    private static string SanitizeNamePart(ReadOnlySpan<char> value)
+    {
+        var length = Math.Min(value.Length, MaximumNameLength);
+        Span<char> buffer = stackalloc char[length];
+        _ = FillSanitizedName(value, buffer);
+
+        return new string(buffer);
+    }
+
+    private static bool TrySanitizeNamePart(
+        ReadOnlySpan<char> value,
+        out string sanitizedName)
+    {
+        var length = Math.Min(value.Length, MaximumNameLength);
+        Span<char> buffer = stackalloc char[length];
+        if (!FillSanitizedName(value, buffer))
+        {
+            sanitizedName = "";
+            return false;
+        }
+
+        sanitizedName = new string(buffer);
+        return true;
+    }
+
+    private static bool FillSanitizedName(
+        ReadOnlySpan<char> value,
+        Span<char> destination)
+    {
+        var containsAllowedCharacter = false;
+        for (var index = 0; index < destination.Length; index++)
+        {
+            var character = value[index];
+            if (IsAllowedNameCharacter(character))
+            {
+                destination[index] = character;
+                containsAllowedCharacter = true;
+            }
+            else
+            {
+                destination[index] = '_';
+            }
+        }
+
+        return containsAllowedCharacter;
+    }
+
+    [UnsupportedOSPlatform("windows")]
+    private static void SetUnixCreateMode(FileStreamOptions options) =>
+        options.UnixCreateMode = PrivateFileMode;
+
+    private string GetOrCreateDirectory()
+    {
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_directoryPath is not null)
+                return _directoryPath;
+
+            var directory = Directory.CreateTempSubdirectory(TempDirectoryPrefix).FullName;
+            try
+            {
+                if (!OperatingSystem.IsWindows())
+                    SetUnixDirectoryMode(directory);
+            }
+            catch
+            {
+                DeleteDirectory(directory);
+                throw;
+            }
+
+            _directoryPath = directory;
+            return directory;
+        }
+    }
+
+    [UnsupportedOSPlatform("windows")]
+    private static void SetUnixDirectoryMode(string directory) =>
+        File.SetUnixFileMode(directory, PrivateDirectoryMode);
+
+    private void HandleProcessExit(object? sender, EventArgs eventArgs)
+    {
+        string? directory;
+        lock (_gate)
+            directory = _directoryPath;
+
+        DeleteDirectory(directory);
+    }
+}

--- a/src/Dotsider/Views/IlEditorHost.cs
+++ b/src/Dotsider/Views/IlEditorHost.cs
@@ -4,7 +4,6 @@ using Hex1b.Documents;
 using Hex1b.Input;
 using Hex1b.Theming;
 using Hex1b.Widgets;
-using System.Diagnostics;
 
 namespace Dotsider.Views;
 
@@ -212,98 +211,30 @@ internal static class IlEditorHost
             return;
         }
 
-        var tempPath = WriteEmbeddedSourceToTemp(state.IlSelectedMethod.Name, source.Document, source.Bytes);
-        if (TryLaunchEditor(tempPath))
+        string tempPath;
+        try
         {
-            state.ShowTransientNotice($"Opened embedded source: {Path.GetFileName(tempPath)}");
+            tempPath = state.EmbeddedSourceTempFiles.Write(
+                state.IlSelectedMethod.Name,
+                source.Document,
+                source.Bytes);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            state.ShowTransientNotice("Could not write embedded source");
             return;
         }
 
-        state.ShowTransientNotice($"Embedded source: {tempPath}");
-    }
-
-    private static string WriteEmbeddedSourceToTemp(string methodName, string documentPath, byte[] bytes)
-    {
-        var directory = Path.Combine(Path.GetTempPath(), "dotsider", "embedded-source");
-        Directory.CreateDirectory(directory);
-
-        var extension = Path.GetExtension(documentPath);
-        if (string.IsNullOrEmpty(extension))
-            extension = ".txt";
-
-        var documentName = Path.GetFileNameWithoutExtension(documentPath);
-        if (string.IsNullOrWhiteSpace(documentName))
-            documentName = methodName;
-
-        var fileName = $"{SanitizeFileName(documentName)}-{Guid.NewGuid():N}{extension}";
-        var tempPath = Path.Combine(directory, fileName);
-        File.WriteAllBytes(tempPath, bytes);
-        return tempPath;
-    }
-
-    private static bool TryLaunchEditor(string path)
-    {
-        var editor = Environment.GetEnvironmentVariable("VISUAL");
-        if (string.IsNullOrWhiteSpace(editor))
-            editor = Environment.GetEnvironmentVariable("EDITOR");
-
-        if (!string.IsNullOrWhiteSpace(editor) && TryStartEditorCommand(editor, path))
-            return true;
-
-        try
+        var status = EditorLauncher.Launch(
+            state.EmbeddedSourceTempFiles,
+            tempPath,
+            out var openedPath);
+        if (status == EditorLaunchStatus.Started)
         {
-            Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
-    private static bool TryStartEditorCommand(string editor, string path)
-    {
-        try
-        {
-            using var process = Process.Start(CreateEditorStartInfo(editor, path));
-            process?.WaitForExit();
-            return process is not null && process.ExitCode == 0;
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
-    private static ProcessStartInfo CreateEditorStartInfo(string editor, string path)
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            var startInfo = new ProcessStartInfo("cmd.exe")
-            {
-                UseShellExecute = false
-            };
-            startInfo.ArgumentList.Add("/d");
-            startInfo.ArgumentList.Add("/s");
-            startInfo.ArgumentList.Add("/c");
-            startInfo.ArgumentList.Add($"{editor} \"{path}\"");
-            return startInfo;
+            state.ShowTransientNotice($"Opened embedded source: {openedPath}");
+            return;
         }
 
-        var shellInfo = new ProcessStartInfo("/bin/sh")
-        {
-            UseShellExecute = false
-        };
-        shellInfo.ArgumentList.Add("-c");
-        shellInfo.ArgumentList.Add($"{editor} \"$1\"");
-        shellInfo.ArgumentList.Add("dotsider-editor");
-        shellInfo.ArgumentList.Add(path);
-        return shellInfo;
-    }
-
-    private static string SanitizeFileName(string value)
-    {
-        var invalid = Path.GetInvalidFileNameChars();
-        return new string([.. value.Select(ch => invalid.Contains(ch) ? '_' : ch)]);
+        state.ShowTransientNotice($"Could not open embedded source: {openedPath}");
     }
 }

--- a/tests/Dotsider.Tests/EditorCommandTests.cs
+++ b/tests/Dotsider.Tests/EditorCommandTests.cs
@@ -1,0 +1,105 @@
+using Dotsider.Views;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests shell-free parsing of configured editor commands.
+/// </summary>
+[TestClass]
+public sealed class EditorCommandTests
+{
+    /// <summary>
+    /// Verifies common configured editor commands preserve their executable and arguments.
+    /// </summary>
+    /// <param name="value">The configured command.</param>
+    /// <param name="expectedExecutable">The expected executable token.</param>
+    /// <param name="expectedArguments">The expected arguments joined with a separator.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DataRow("code --wait", "code", "--wait")]
+    [DataRow(
+        "\"C:\\Program Files\\Microsoft VS Code\\Code.exe\" --wait",
+        @"C:\Program Files\Microsoft VS Code\Code.exe",
+        "--wait")]
+    [DataRow(
+        "open -a \"Visual Studio Code\"",
+        "open",
+        "-a\u001fVisual Studio Code")]
+    [DataRow(
+        "editor pre\"joined value\"post",
+        "editor",
+        "prejoined valuepost")]
+    [DataRow(
+        "editor 'single quoted' \"double quoted\"",
+        "editor",
+        "single quoted\u001fdouble quoted")]
+    [DataRow("editor \"\" tail", "editor", "\u001ftail")]
+    [DataRow(@"editor escaped\ value", "editor", "escaped value")]
+    [DataRow("editor \"escaped\\\"quote\"", "editor", "escaped\"quote")]
+    [DataRow("editor 'escaped\\'quote'", "editor", "escaped'quote")]
+    [DataRow(@"editor two\\slashes", "editor", @"two\slashes")]
+    [DataRow("editor 'double\\\"quote'", "editor", "double\\\"quote")]
+    public void TryParse_ValidCommand_PreservesLiteralTokens(
+        string value,
+        string expectedExecutable,
+        string expectedArguments)
+    {
+        var parsed = EditorCommand.TryParse(value, out var command);
+
+        Assert.IsTrue(parsed);
+        Assert.IsNotNull(command);
+        Assert.AreEqual(expectedExecutable, command.Executable);
+        Assert.AreEqual(expectedArguments, string.Join('\u001f', command.Arguments));
+        Assert.ThrowsExactly<NotSupportedException>(() =>
+            ((IList<string>)command.Arguments)[0] = "changed");
+    }
+
+    /// <summary>
+    /// Verifies malformed commands and unsupported shell operators fail closed.
+    /// </summary>
+    /// <param name="value">The malformed or shell-dependent command.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow("editor \"unterminated")]
+    [DataRow("editor trailing\\")]
+    [DataRow("editor\0argument")]
+    [DataRow("editor\rargument")]
+    [DataRow("editor\nargument")]
+    [DataRow("editor | pager")]
+    [DataRow("editor && other")]
+    [DataRow("editor ; other")]
+    [DataRow("editor > output")]
+    [DataRow("editor < input")]
+    [DataRow("editor || other")]
+    [DataRow("editor $(other)")]
+    [DataRow("editor ${OTHER}")]
+    [DataRow("editor `other`")]
+    public void TryParse_MalformedOrShellDependentCommand_ReturnsFalse(string value)
+    {
+        var parsed = EditorCommand.TryParse(value, out var command);
+
+        Assert.IsFalse(parsed);
+        Assert.IsNull(command);
+    }
+
+    /// <summary>
+    /// Verifies variable-like text remains literal and is never expanded by the parser.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void TryParse_VariableText_PreservesLiteralValue()
+    {
+        var parsed = EditorCommand.TryParse(
+            "editor \"%PATH%\" '$HOME' !VALUE! *.cs",
+            out var command);
+
+        Assert.IsTrue(parsed);
+        Assert.IsNotNull(command);
+        Assert.AreEqual("%PATH%", command.Arguments[0]);
+        Assert.AreEqual("$HOME", command.Arguments[1]);
+        Assert.AreEqual("!VALUE!", command.Arguments[2]);
+        Assert.AreEqual("*.cs", command.Arguments[3]);
+    }
+}

--- a/tests/Dotsider.Tests/EditorExecutableResolverTests.cs
+++ b/tests/Dotsider.Tests/EditorExecutableResolverTests.cs
@@ -1,0 +1,459 @@
+using Dotsider.Views;
+using System.Runtime.Versioning;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests deterministic cross-platform editor executable resolution.
+/// </summary>
+[TestClass]
+public sealed class EditorExecutableResolverTests
+{
+    private static readonly string[] ExpectedPathExtensions = [".CMD", ".EXE", ".BAT"];
+
+    /// <summary>
+    /// Verifies a bare Windows editor name resolves a command shim through PATHEXT.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(OperatingSystems.Windows)]
+    public void TryResolveWindows_BareCodeName_ResolvesCmdFromPath()
+    {
+        var directory = Directory.CreateTempSubdirectory("dotsider-editor-resolver-");
+        try
+        {
+            var expected = Path.Combine(directory.FullName, "code.cmd");
+            File.WriteAllText(expected, "");
+
+            var resolved = EditorExecutableResolver.TryResolveWindows(
+                "code",
+                [directory.FullName],
+                [".EXE", ".CMD"],
+                out var actual);
+
+            Assert.IsTrue(resolved);
+            Assert.IsTrue(string.Equals(
+                Path.GetFullPath(expected),
+                actual,
+                StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies PATHEXT ordering selects the first eligible Windows editor target.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(OperatingSystems.Windows)]
+    public void TryResolveWindows_MultipleExtensions_UsesPathExtOrder()
+    {
+        var directory = Directory.CreateTempSubdirectory("dotsider-editor-order-");
+        try
+        {
+            var batch = Path.Combine(directory.FullName, "editor.cmd");
+            var executable = Path.Combine(directory.FullName, "editor.exe");
+            File.WriteAllText(batch, "");
+            File.WriteAllText(executable, "");
+
+            var resolved = EditorExecutableResolver.TryResolveWindows(
+                "editor",
+                [directory.FullName],
+                [".CMD", ".EXE"],
+                out var actual);
+
+            Assert.IsTrue(resolved);
+            Assert.IsTrue(string.Equals(
+                Path.GetFullPath(batch),
+                actual,
+                StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies Windows PATH directory ordering selects the first matching target.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(OperatingSystems.Windows)]
+    public void TryResolveWindows_MultipleSearchDirectories_UsesPathOrder()
+    {
+        var firstDirectory = Directory.CreateTempSubdirectory("dotsider-editor-first-");
+        var secondDirectory = Directory.CreateTempSubdirectory("dotsider-editor-second-");
+        try
+        {
+            var expected = Path.Combine(firstDirectory.FullName, "editor.exe");
+            File.WriteAllText(expected, "");
+            File.WriteAllText(Path.Combine(secondDirectory.FullName, "editor.exe"), "");
+
+            var resolved = EditorExecutableResolver.TryResolveWindows(
+                "editor",
+                [firstDirectory.FullName, secondDirectory.FullName],
+                [".EXE"],
+                out var actual);
+
+            Assert.IsTrue(resolved);
+            Assert.IsTrue(string.Equals(
+                Path.GetFullPath(expected),
+                actual,
+                StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            firstDirectory.Delete(recursive: true);
+            secondDirectory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies every supported Windows editor target extension resolves.
+    /// </summary>
+    /// <param name="extension">The supported target extension.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(OperatingSystems.Windows)]
+    [DataRow(".bat")]
+    [DataRow(".cmd")]
+    [DataRow(".com")]
+    [DataRow(".exe")]
+    public void TryResolveWindows_SupportedExtension_ReturnsTarget(string extension)
+    {
+        var directory = Directory.CreateTempSubdirectory("dotsider-editor-target-");
+        try
+        {
+            var expected = Path.Combine(directory.FullName, $"editor{extension}");
+            File.WriteAllText(expected, "");
+
+            var resolved = EditorExecutableResolver.TryResolveWindows(
+                $"editor{extension}",
+                [directory.FullName],
+                [".EXE"],
+                out var actual);
+
+            Assert.IsTrue(resolved);
+            Assert.IsTrue(string.Equals(
+                Path.GetFullPath(expected),
+                actual,
+                StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies explicit Windows editor paths do not search alternative PATH directories.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(OperatingSystems.Windows)]
+    public void TryResolveWindows_ExplicitPath_IgnoresSearchDirectories()
+    {
+        var explicitDirectory = Directory.CreateTempSubdirectory("dotsider-editor-explicit-");
+        var searchDirectory = Directory.CreateTempSubdirectory("dotsider-editor-search-");
+        try
+        {
+            var expected = Path.Combine(explicitDirectory.FullName, "editor.exe");
+            File.WriteAllText(expected, "");
+            File.WriteAllText(Path.Combine(searchDirectory.FullName, "editor.exe"), "");
+
+            var resolved = EditorExecutableResolver.TryResolveWindows(
+                expected,
+                [searchDirectory.FullName],
+                [".EXE"],
+                out var actual);
+
+            Assert.IsTrue(resolved);
+            Assert.AreEqual(Path.GetFullPath(expected), actual);
+        }
+        finally
+        {
+            explicitDirectory.Delete(recursive: true);
+            searchDirectory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies an explicitly configured relative Windows path resolves only that location.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(OperatingSystems.Windows)]
+    public void TryResolveWindows_ExplicitRelativePath_ResolvesAgainstCurrentDirectory()
+    {
+        var directory = Directory.CreateTempSubdirectory("dotsider-editor-relative-");
+        try
+        {
+            var expected = Path.Combine(directory.FullName, "editor.exe");
+            File.WriteAllText(expected, "");
+            var relative = Path.GetRelativePath(Environment.CurrentDirectory, expected);
+            Assert.IsTrue(relative.Contains(
+                Path.DirectorySeparatorChar,
+                StringComparison.Ordinal));
+
+            var resolved = EditorExecutableResolver.TryResolveWindows(
+                relative,
+                [],
+                [".EXE"],
+                out var actual);
+
+            Assert.IsTrue(resolved);
+            Assert.IsTrue(string.Equals(
+                Path.GetFullPath(expected),
+                actual,
+                StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies empty, relative, and unsupported Windows PATH candidates fail closed.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(OperatingSystems.Windows)]
+    public void TryResolveWindows_UnsafeSearchEntriesAndExtension_ReturnsFalse()
+    {
+        var resolved = EditorExecutableResolver.TryResolveWindows(
+            "editor",
+            ["", ".", "relative"],
+            [".PS1"],
+            out var actual);
+
+        Assert.IsFalse(resolved);
+        Assert.AreEqual("", actual);
+    }
+
+    /// <summary>
+    /// Verifies PATHEXT normalization retains only supported extensions without duplicates.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void SplitPathExtensions_MixedValue_ReturnsSupportedCanonicalOrder()
+    {
+        var actual = EditorExecutableResolver.SplitPathExtensions(
+            "cmd;.EXE;.ps1;.CMD;bat");
+
+        Assert.AreSequenceEqual(
+            ExpectedPathExtensions,
+            actual);
+    }
+
+    /// <summary>
+    /// Verifies a bare Unix editor resolves only from the supplied rooted PATH.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    [UnsupportedOSPlatform("windows")]
+    public void TryResolveUnix_BareExecutable_ResolvesFromRootedPath()
+    {
+        var directory = Directory.CreateTempSubdirectory("dotsider-editor-unix-");
+        try
+        {
+            var expected = Path.Combine(directory.FullName, "editor");
+            File.WriteAllText(expected, "#!/bin/sh\nexit 0\n");
+            MakeExecutable(expected);
+
+            var resolved = EditorExecutableResolver.TryResolveUnix(
+                "editor",
+                ["", ".", directory.FullName],
+                out var actual);
+
+            Assert.IsTrue(resolved);
+            Assert.AreEqual(Path.GetFullPath(expected), actual);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies Unix directories and files without execute permission do not resolve.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    public void TryResolveUnix_NonExecutableTargets_ReturnFalse()
+    {
+        var directory = Directory.CreateTempSubdirectory("dotsider-editor-nonexec-");
+        try
+        {
+            File.WriteAllText(Path.Combine(directory.FullName, "editor"), "#!/bin/sh\n");
+            Directory.CreateDirectory(Path.Combine(directory.FullName, "directory-editor"));
+
+            Assert.IsFalse(EditorExecutableResolver.TryResolveUnix(
+                "editor",
+                [directory.FullName],
+                out _));
+            Assert.IsFalse(EditorExecutableResolver.TryResolveUnix(
+                "directory-editor",
+                [directory.FullName],
+                out _));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies an explicitly configured Unix executable ignores other search directories.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    [UnsupportedOSPlatform("windows")]
+    public void TryResolveUnix_ExplicitPath_IgnoresSearchDirectories()
+    {
+        var explicitDirectory = Directory.CreateTempSubdirectory("dotsider-editor-unix-explicit-");
+        var searchDirectory = Directory.CreateTempSubdirectory("dotsider-editor-unix-search-");
+        try
+        {
+            var expected = Path.Combine(explicitDirectory.FullName, "editor");
+            File.WriteAllText(expected, "#!/bin/sh\nexit 0\n");
+            MakeExecutable(expected);
+            var poison = Path.Combine(searchDirectory.FullName, "editor");
+            File.WriteAllText(poison, "#!/bin/sh\nexit 1\n");
+            MakeExecutable(poison);
+
+            var resolved = EditorExecutableResolver.TryResolveUnix(
+                expected,
+                [searchDirectory.FullName],
+                out var actual);
+
+            Assert.IsTrue(resolved);
+            Assert.AreEqual(Path.GetFullPath(expected), actual);
+        }
+        finally
+        {
+            explicitDirectory.Delete(recursive: true);
+            searchDirectory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies an explicitly configured relative Unix path resolves against the current directory.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    [UnsupportedOSPlatform("windows")]
+    public void TryResolveUnix_ExplicitRelativePath_ResolvesAgainstCurrentDirectory()
+    {
+        var directory = Directory.CreateTempSubdirectory("dotsider-editor-unix-relative-");
+        try
+        {
+            var expected = Path.Combine(directory.FullName, "editor");
+            File.WriteAllText(expected, "#!/bin/sh\nexit 0\n");
+            MakeExecutable(expected);
+            var relative = Path.GetRelativePath(Environment.CurrentDirectory, expected);
+            Assert.Contains('/', relative);
+
+            var resolved = EditorExecutableResolver.TryResolveUnix(
+                relative,
+                [],
+                out var actual);
+
+            Assert.IsTrue(resolved);
+            Assert.AreEqual(Path.GetFullPath(expected), actual);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a Unix symlink whose target is executable resolves successfully.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    [UnsupportedOSPlatform("windows")]
+    public void TryResolveUnix_SymlinkToExecutable_ReturnsResolvedLink()
+    {
+        var directory = Directory.CreateTempSubdirectory("dotsider-editor-symlink-");
+        try
+        {
+            var target = Path.Combine(directory.FullName, "target");
+            var link = Path.Combine(directory.FullName, "editor");
+            File.WriteAllText(target, "#!/bin/sh\nexit 0\n");
+            MakeExecutable(target);
+            File.CreateSymbolicLink(link, target);
+
+            var resolved = EditorExecutableResolver.TryResolveUnix(
+                "editor",
+                [directory.FullName],
+                out var actual);
+
+            Assert.IsTrue(resolved);
+            Assert.AreEqual(Path.GetFullPath(link), actual);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies Unix resolution never gives the current or process directory implicit precedence.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    [UnsupportedOSPlatform("windows")]
+    public void TryResolveUnix_PoisonedImplicitDirectories_SearchesOnlySuppliedPath()
+    {
+        var fileName = $"dotsider-editor-poison-{Guid.NewGuid():N}";
+        var currentDirectoryPoison = Path.Combine(Environment.CurrentDirectory, fileName);
+        var searchDirectory = Directory.CreateTempSubdirectory("dotsider-editor-clean-");
+        try
+        {
+            File.WriteAllText(currentDirectoryPoison, "#!/bin/sh\nexit 1\n");
+            MakeExecutable(currentDirectoryPoison);
+            var expected = Path.Combine(searchDirectory.FullName, fileName);
+            File.WriteAllText(expected, "#!/bin/sh\nexit 0\n");
+            MakeExecutable(expected);
+
+            var resolved = EditorExecutableResolver.TryResolveUnix(
+                fileName,
+                [searchDirectory.FullName],
+                out var actual);
+
+            Assert.IsTrue(resolved);
+            Assert.AreEqual(Path.GetFullPath(expected), actual);
+
+            var processName = Path.GetFileName(Environment.ProcessPath);
+            Assert.IsNotNull(processName);
+            Assert.IsFalse(EditorExecutableResolver.TryResolveUnix(
+                processName,
+                [],
+                out _));
+        }
+        finally
+        {
+            File.Delete(currentDirectoryPoison);
+            searchDirectory.Delete(recursive: true);
+        }
+    }
+
+    [UnsupportedOSPlatform("windows")]
+    private static void MakeExecutable(string path)
+    {
+        var mode = File.GetUnixFileMode(path);
+        File.SetUnixFileMode(path, mode | UnixFileMode.UserExecute);
+    }
+}

--- a/tests/Dotsider.Tests/EditorLauncherTests.cs
+++ b/tests/Dotsider.Tests/EditorLauncherTests.cs
@@ -1,0 +1,716 @@
+using Dotsider.Views;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests editor process construction and production launch orchestration.
+/// </summary>
+/// <param name="testContext">The current test context.</param>
+[TestClass]
+public sealed class EditorLauncherTests(TestContext testContext)
+{
+    private readonly TestContext _testContext = testContext;
+
+    /// <summary>
+    /// Verifies direct launch information uses an absolute executable and discrete source argument.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void CreateDirectStartInfo_ConfiguredEditor_UsesDiscreteArguments()
+    {
+        var executable = Path.GetFullPath(
+            OperatingSystem.IsWindows() ? @"C:\Tools\editor.exe" : "/usr/bin/editor");
+        var sourcePath = Path.GetFullPath(
+            OperatingSystem.IsWindows() ? @"C:\Temp\source file.cs" : "/tmp/source file.cs");
+
+        var startInfo = EditorLauncher.CreateDirectStartInfo(
+            executable,
+            ["--wait", "profile name"],
+            sourcePath);
+
+        Assert.AreEqual(executable, startInfo.FileName);
+        Assert.IsFalse(startInfo.UseShellExecute);
+        Assert.AreEqual(Path.GetDirectoryName(executable), startInfo.WorkingDirectory);
+        string[] expectedArguments = ["--wait", "profile name", sourcePath];
+        Assert.AreSequenceEqual(
+            expectedArguments,
+            startInfo.ArgumentList);
+    }
+
+    /// <summary>
+    /// Verifies association start information accepts only an inert text path.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void CreateAssociationStartInfo_TxtPath_UsesPlatformAssociation()
+    {
+        var sourcePath = Path.GetFullPath(Path.Combine("temp", "Source.txt"));
+
+        var startInfo = EditorLauncher.CreateAssociationStartInfo(sourcePath);
+
+        Assert.AreEqual(sourcePath, startInfo.FileName);
+        Assert.IsTrue(startInfo.UseShellExecute);
+        Assert.AreEqual(Path.GetDirectoryName(sourcePath), startInfo.WorkingDirectory);
+        Assert.ThrowsExactly<ArgumentException>(() =>
+            EditorLauncher.CreateAssociationStartInfo(Path.ChangeExtension(sourcePath, ".cs")));
+    }
+
+    /// <summary>
+    /// Verifies the Windows batch route carries only fixed environment references in command text.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(OperatingSystems.Windows)]
+    public void CreateWindowsBatchStartInfo_ConfiguredShim_UsesFixedCommandTemplate()
+    {
+        var script = Path.GetFullPath(@"C:\Editor Tools\code.cmd");
+        var source = Path.GetFullPath(@"C:\Temp Folder\source.cs");
+
+        var startInfo = EditorLauncher.CreateWindowsBatchStartInfo(
+            script,
+            ["--wait", "profile name"],
+            source);
+
+        Assert.AreEqual(
+            Path.Combine(Environment.SystemDirectory, "cmd.exe"),
+            startInfo.FileName);
+        Assert.IsFalse(startInfo.UseShellExecute);
+        Assert.AreEqual(Path.GetDirectoryName(script), startInfo.WorkingDirectory);
+        Assert.AreEqual(
+            "/d /s /v:off /c \"\"%DOTSIDER_EDITOR_SCRIPT:~1%\" " +
+            "\"%DOTSIDER_EDITOR_ARGUMENT_0000:~1%\" " +
+            "\"%DOTSIDER_EDITOR_ARGUMENT_0001:~1%\" " +
+            "\"%DOTSIDER_EDITOR_SOURCE:~1%\"\"",
+            startInfo.Arguments);
+        Assert.IsEmpty(startInfo.ArgumentList);
+        Assert.DoesNotContain(script, startInfo.Arguments, StringComparison.Ordinal);
+        Assert.DoesNotContain(source, startInfo.Arguments, StringComparison.Ordinal);
+        Assert.AreEqual($".{script}", startInfo.Environment["DOTSIDER_EDITOR_SCRIPT"]);
+        Assert.AreEqual($".{source}", startInfo.Environment["DOTSIDER_EDITOR_SOURCE"]);
+    }
+
+    /// <summary>
+    /// Verifies an unrepresentable literal quote in a Windows batch argument fails closed.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(OperatingSystems.Windows)]
+    public void CreateWindowsBatchStartInfo_LiteralQuoteArgument_Throws()
+    {
+        var script = Path.GetFullPath(@"C:\Editor Tools\code.cmd");
+        var source = Path.GetFullPath(@"C:\Temp Folder\source.cs");
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+            EditorLauncher.CreateWindowsBatchStartInfo(
+                script,
+                ["quote\"value"],
+                source));
+    }
+
+    /// <summary>
+    /// Verifies a real Windows batch shim receives spaces and command metacharacters literally.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(OperatingSystems.Windows)]
+    public async Task WindowsBatchShim_HostileLiteralArguments_ReceivesExactCommandLine()
+    {
+        var directory = Directory.CreateTempSubdirectory(
+            "dotsider-editor & % ! ^ (-");
+        try
+        {
+            var script = Path.Combine(directory.FullName, "shim.cmd");
+            var capture = Path.Combine(directory.FullName, "captured.txt");
+            var source = Path.Combine(directory.FullName, "source file.cs");
+            File.WriteAllText(
+                script,
+                "@echo off\r\n" +
+                "set \"DOTSIDER_RECEIVED_0000=value:%~1\"\r\n" +
+                "set \"DOTSIDER_RECEIVED_0001=value:%~2\"\r\n" +
+                "set \"DOTSIDER_RECEIVED_0002=value:%~3\"\r\n" +
+                "set \"DOTSIDER_RECEIVED_0003=value:%~4\"\r\n" +
+                "set \"DOTSIDER_RECEIVED_0004=value:%~5\"\r\n" +
+                "set \"DOTSIDER_RECEIVED_0005=value:%~6\"\r\n" +
+                "set \"DOTSIDER_RECEIVED_0006=value:%~7\"\r\n" +
+                "set \"DOTSIDER_RECEIVED_0007=value:%~8\"\r\n" +
+                "set \"DOTSIDER_RECEIVED_SOURCE=value:%~9\"\r\n" +
+                "> captured.txt (\r\n" +
+                "set DOTSIDER_RECEIVED_0000\r\n" +
+                "set DOTSIDER_RECEIVED_0001\r\n" +
+                "set DOTSIDER_RECEIVED_0002\r\n" +
+                "set DOTSIDER_RECEIVED_0003\r\n" +
+                "set DOTSIDER_RECEIVED_0004\r\n" +
+                "set DOTSIDER_RECEIVED_0005\r\n" +
+                "set DOTSIDER_RECEIVED_0006\r\n" +
+                "set DOTSIDER_RECEIVED_0007\r\n" +
+                "set DOTSIDER_RECEIVED_SOURCE\r\n" +
+                ")\r\n");
+            File.WriteAllText(source, "");
+            var arguments = new[]
+            {
+                "value with spaces",
+                "%PATH%",
+                "!bang!",
+                "^caret",
+                "a&b|c(paren)",
+                "semi;colon",
+                @"back\slash",
+                ""
+            };
+            var startInfo = EditorLauncher.CreateWindowsBatchStartInfo(
+                script,
+                arguments,
+                source);
+
+            using var process = Process.Start(startInfo);
+            Assert.IsNotNull(process);
+            await process.WaitForExitAsync(_testContext.CancellationToken);
+
+            Assert.AreEqual(0, process.ExitCode);
+            var expected = arguments
+                .Select((value, index) =>
+                    $"DOTSIDER_RECEIVED_{index:D4}=value:{value}")
+                .Append($"DOTSIDER_RECEIVED_SOURCE=value:{source}");
+            Assert.AreSequenceEqual(expected, File.ReadAllLines(capture));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a real Unix executable editor receives exact argv without a shell.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    [UnsupportedOSPlatform("windows")]
+    public async Task DirectUnixShim_LiteralArguments_ReceivesExactArgv()
+    {
+        var directory = Directory.CreateTempSubdirectory("dotsider-editor-unix-shim-");
+        try
+        {
+            var script = Path.Combine(directory.FullName, "editor");
+            var capture = Path.Combine(directory.FullName, "captured.txt");
+            var source = Path.Combine(directory.FullName, "source file.cs");
+            File.WriteAllText(
+                script,
+                "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$DOTSIDER_CAPTURE\"\n");
+            File.SetUnixFileMode(
+                script,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            File.WriteAllText(source, "");
+            var arguments = new[] { "--wait", "value with spaces", "$HOME", "a&b", "" };
+            var startInfo = EditorLauncher.CreateDirectStartInfo(script, arguments, source);
+            startInfo.Environment["DOTSIDER_CAPTURE"] = capture;
+
+            using var process = Process.Start(startInfo);
+            Assert.IsNotNull(process);
+            await process.WaitForExitAsync(_testContext.CancellationToken);
+
+            Assert.AreEqual(0, process.ExitCode);
+            Assert.AreSequenceEqual(
+                arguments.Append(source),
+                File.ReadAllLines(capture));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies VISUAL is started before EDITOR and preserves the allowlisted source extension.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Launch_VisualResolves_StartsVisualOnly()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var source = store.Write("Method", "Source.cs", [0x2A]);
+        var editor = CreateResolvedEditorFile(out var directory);
+        try
+        {
+            var starts = new List<ProcessStartInfo>();
+
+            var status = EditorLauncher.Launch(
+                store,
+                source,
+                editor,
+                editor,
+                [],
+                [".EXE"],
+                startInfo =>
+                {
+                    starts.Add(startInfo);
+                    return new MemoryStream();
+                },
+                out var openedPath);
+
+            Assert.AreEqual(EditorLaunchStatus.Started, status);
+            Assert.HasCount(1, starts);
+            Assert.AreEqual(source, openedPath);
+            Assert.EndsWith(".cs", starts[0].ArgumentList[^1]);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies successful launch disposes the returned handle without waiting for process exit.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Launch_ProcessStarts_DisposesHandleAndReturnsWithoutWaiting()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var source = store.Write("Method", "Source.cs", [0x2A]);
+        var editor = CreateResolvedEditorFile(out var directory);
+        try
+        {
+            Process? process = null;
+
+            var status = EditorLauncher.Launch(
+                store,
+                source,
+                editor,
+                null,
+                [],
+                [".EXE"],
+                _ =>
+                {
+                    process = Process.GetCurrentProcess();
+                    return process;
+                },
+                out _);
+
+            Assert.AreEqual(EditorLaunchStatus.Started, status);
+            Assert.IsNotNull(process);
+            Assert.ThrowsExactly<InvalidOperationException>(() => _ = process.Handle);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a starter that creates no process is reported as a launch failure.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Launch_ProcessStarterReturnsNull_ReturnsFailed()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var source = store.Write("Method", "Source.cs", [0x2A]);
+        var editor = CreateResolvedEditorFile(out var directory);
+        try
+        {
+            var status = EditorLauncher.Launch(
+                store,
+                source,
+                editor,
+                null,
+                [],
+                [".EXE"],
+                _ => null,
+                out var openedPath);
+
+            Assert.AreEqual(EditorLaunchStatus.Failed, status);
+            Assert.AreEqual(source, openedPath);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a literal quote remains a discrete argument for directly executable editors.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Launch_DirectArgumentContainsLiteralQuote_PreservesExactArgument()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var source = store.Write("Method", "Source.cs", [0x2A]);
+        var editor = CreateResolvedEditorFile(out var directory);
+        try
+        {
+            ProcessStartInfo? captured = null;
+            var configured = $"\"{editor}\" \"quote\\\"value\"";
+
+            var status = EditorLauncher.Launch(
+                store,
+                source,
+                configured,
+                null,
+                [],
+                [".EXE"],
+                startInfo =>
+                {
+                    captured = startInfo;
+                    return new MemoryStream();
+                },
+                out var openedPath);
+
+            Assert.AreEqual(EditorLaunchStatus.Started, status);
+            Assert.IsNotNull(captured);
+            Assert.AreEqual("quote\"value", captured.ArgumentList[0]);
+            Assert.AreEqual(source, captured.ArgumentList[1]);
+            Assert.AreEqual(source, openedPath);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a missing VISUAL permits EDITOR to start.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Launch_VisualNotFound_StartsEditor()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var source = store.Write("Method", "Source.cs", [0x2A]);
+        var editor = CreateResolvedEditorFile(out var directory);
+        try
+        {
+            ProcessStartInfo? captured = null;
+
+            var status = EditorLauncher.Launch(
+                store,
+                source,
+                "missing-dotsider-editor",
+                editor,
+                [],
+                [".EXE"],
+                startInfo =>
+                {
+                    captured = startInfo;
+                    return new MemoryStream();
+                },
+                out _);
+
+            Assert.AreEqual(EditorLaunchStatus.Started, status);
+            Assert.IsNotNull(captured);
+            Assert.AreEqual(Path.GetFullPath(editor), captured.FileName);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies Windows native targets launch directly while batch targets use the system interpreter.
+    /// </summary>
+    /// <param name="extension">The configured editor target extension.</param>
+    /// <param name="usesSystemCommandInterpreter">
+    /// Whether the resolved target requires the system command interpreter.
+    /// </param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(OperatingSystems.Windows)]
+    [DataRow(".bat", true)]
+    [DataRow(".cmd", true)]
+    [DataRow(".com", false)]
+    [DataRow(".exe", false)]
+    public void Launch_WindowsTarget_UsesExpectedStartPath(
+        string extension,
+        bool usesSystemCommandInterpreter)
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var source = store.Write("Method", "Source.cs", [0x2A]);
+        var directory = Directory.CreateTempSubdirectory("dotsider-editor-kind-");
+        try
+        {
+            var editor = Path.Combine(directory.FullName, $"editor{extension}");
+            File.WriteAllText(editor, "");
+            ProcessStartInfo? captured = null;
+
+            var status = EditorLauncher.Launch(
+                store,
+                source,
+                editor,
+                null,
+                [],
+                [".EXE"],
+                startInfo =>
+                {
+                    captured = startInfo;
+                    return new MemoryStream();
+                },
+                out _);
+
+            Assert.AreEqual(EditorLaunchStatus.Started, status);
+            Assert.IsNotNull(captured);
+            Assert.AreEqual(
+                usesSystemCommandInterpreter
+                    ? Path.Combine(Environment.SystemDirectory, "cmd.exe")
+                    : Path.GetFullPath(editor),
+                captured.FileName,
+                ignoreCase: true);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a literal quote that cannot round-trip through a batch shim fails before launch.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(OperatingSystems.Windows)]
+    public void Launch_WindowsBatchArgumentContainsLiteralQuote_ReturnsFailed()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var source = store.Write("Method", "Source.cs", [0x2A]);
+        var directory = Directory.CreateTempSubdirectory("dotsider-editor-quote-");
+        try
+        {
+            var editor = Path.Combine(directory.FullName, "editor.cmd");
+            File.WriteAllText(editor, "");
+            var configured = $"\"{editor}\" \"quote\\\"value\"";
+            var startCount = 0;
+
+            var status = EditorLauncher.Launch(
+                store,
+                source,
+                configured,
+                null,
+                [],
+                [".CMD"],
+                _ =>
+                {
+                    startCount++;
+                    return new MemoryStream();
+                },
+                out var openedPath);
+
+            Assert.AreEqual(EditorLaunchStatus.Failed, status);
+            Assert.AreEqual(0, startCount);
+            Assert.AreEqual(source, openedPath);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies unresolved configured editors use only a text association path.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Launch_BothEditorsNotFound_UsesTxtAssociation()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var source = store.Write("Method", "Source.cs", [0x2A]);
+        ProcessStartInfo? captured = null;
+
+        var status = EditorLauncher.Launch(
+            store,
+            source,
+            "missing-visual",
+            "missing-editor",
+            [],
+            [".EXE"],
+            startInfo =>
+            {
+                captured = startInfo;
+                return new MemoryStream();
+            },
+            out var openedPath);
+
+        Assert.AreEqual(EditorLaunchStatus.Started, status);
+        Assert.IsNotNull(captured);
+        Assert.IsTrue(captured.UseShellExecute);
+        Assert.EndsWith(".txt", captured.FileName);
+        Assert.AreEqual(captured.FileName, openedPath);
+        Assert.IsFalse(File.Exists(source));
+        Assert.IsTrue(File.Exists(openedPath));
+    }
+
+    /// <summary>
+    /// Verifies malformed configured editor syntax stops without trying another application.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Launch_MalformedVisual_ReturnsFailedWithoutStartingProcess()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var source = store.Write("Method", "Source.cs", [0x2A]);
+        var editor = CreateResolvedEditorFile(out var directory);
+        try
+        {
+            var startCount = 0;
+
+            var status = EditorLauncher.Launch(
+                store,
+                source,
+                "editor && other",
+                editor,
+                [],
+                [".EXE"],
+                _ =>
+                {
+                    startCount++;
+                    return new MemoryStream();
+                },
+                out var openedPath);
+
+            Assert.AreEqual(EditorLaunchStatus.Failed, status);
+            Assert.AreEqual(0, startCount);
+            Assert.AreEqual(source, openedPath);
+            Assert.IsTrue(File.Exists(source));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a configured-editor launch failure does not fall through to another application.
+    /// </summary>
+    /// <param name="nativeErrorCode">The simulated native process-start error.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DataRow(5)]
+    [DataRow(193)]
+    public void Launch_ResolvedVisualFails_ReturnsFailedWithoutFallback(int nativeErrorCode)
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var source = store.Write("Method", "Source.cs", [0x2A]);
+        var editor = CreateResolvedEditorFile(out var directory);
+        try
+        {
+            var startCount = 0;
+
+            var status = EditorLauncher.Launch(
+                store,
+                source,
+                editor,
+                editor,
+                [],
+                [".EXE"],
+                _ =>
+                {
+                    startCount++;
+                    throw new Win32Exception(nativeErrorCode);
+                },
+                out var openedPath);
+
+            Assert.AreEqual(EditorLaunchStatus.Failed, status);
+            Assert.AreEqual(1, startCount);
+            Assert.AreEqual(source, openedPath);
+            Assert.IsTrue(File.Exists(source));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies other expected process-start failures stop without falling through.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Launch_ExpectedStartExceptions_ReturnFailedWithoutFallback()
+    {
+        Exception[] exceptions =
+        [
+            new InvalidOperationException("invalid start"),
+            new IOException("I/O failure"),
+            new UnauthorizedAccessException("access denied")
+        ];
+
+        foreach (var exception in exceptions)
+        {
+            using var store = new EmbeddedSourceTempFileStore();
+            var source = store.Write("Method", "Source.cs", [0x2A]);
+            var editor = CreateResolvedEditorFile(out var directory);
+            try
+            {
+                var startCount = 0;
+
+                var status = EditorLauncher.Launch(
+                    store,
+                    source,
+                    editor,
+                    editor,
+                    [],
+                    [".EXE"],
+                    _ =>
+                    {
+                        startCount++;
+                        throw exception;
+                    },
+                    out var openedPath);
+
+                Assert.AreEqual(EditorLaunchStatus.Failed, status);
+                Assert.AreEqual(1, startCount);
+                Assert.AreEqual(source, openedPath);
+            }
+            finally
+            {
+                directory.Delete(recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies association failure reports the already moved safe text path.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Launch_AssociationFails_ReturnsMovedTxtPath()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var source = store.Write("Method", "Source.cs", [0x2A]);
+
+        var status = EditorLauncher.Launch(
+            store,
+            source,
+            null,
+            null,
+            [],
+            [".EXE"],
+            _ => throw new Win32Exception(2),
+            out var openedPath);
+
+        Assert.AreEqual(EditorLaunchStatus.Failed, status);
+        Assert.EndsWith(".txt", openedPath);
+        Assert.IsTrue(File.Exists(openedPath));
+        Assert.IsFalse(File.Exists(source));
+    }
+
+    private static string CreateResolvedEditorFile(out DirectoryInfo directory)
+    {
+        directory = Directory.CreateTempSubdirectory("dotsider-editor-launch-");
+        var path = Path.Combine(
+            directory.FullName,
+            OperatingSystem.IsWindows() ? "editor.exe" : "editor");
+        File.WriteAllText(path, "");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        return path;
+    }
+}

--- a/tests/Dotsider.Tests/EmbeddedSourceOpenTests.cs
+++ b/tests/Dotsider.Tests/EmbeddedSourceOpenTests.cs
@@ -1,0 +1,270 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+using Dotsider.Views;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests real compiler-produced embedded source through secure materialization and launch.
+/// </summary>
+[TestClass]
+public sealed partial class EmbeddedSourceOpenTests
+{
+    private static SampleAssemblyFixture Samples => SampleAssemblyHost.Instance;
+
+    /// <summary>
+    /// Verifies ordinary embedded C# source reaches a configured editor unchanged.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Open_CompilerEmbeddedCsSource_RoundTripsToDirectEditor()
+    {
+        using var analyzer = new AssemblyAnalyzer(Samples.EmbeddedSourceLibDll);
+        var source = GetSource(
+            analyzer,
+            "EmbeddedSourceLib.EmbeddedSourceFixture",
+            "Compute");
+        using var store = new EmbeddedSourceTempFileStore();
+        var materializedPath = store.Write("Compute", source.Document, source.Bytes);
+        var editor = CreateResolvedEditorFile(out var editorDirectory);
+        try
+        {
+            ProcessStartInfo? captured = null;
+
+            var status = LaunchDirect(
+                store,
+                materializedPath,
+                editor,
+                startInfo =>
+                {
+                    captured = startInfo;
+                    return new MemoryStream();
+                },
+                out var openedPath);
+
+            Assert.AreEqual(EditorLaunchStatus.Started, status);
+            Assert.IsNotNull(captured);
+            Assert.IsFalse(captured.UseShellExecute);
+            Assert.EndsWith(".cs", openedPath);
+            Assert.AreEqual(openedPath, captured.ArgumentList[^1]);
+            Assert.AreSequenceEqual(source.Bytes, File.ReadAllBytes(openedPath));
+        }
+        finally
+        {
+            editorDirectory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a genuine command-extension PDB document is materialized only as plain text.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Open_CompilerEmbeddedCmdDocument_UsesInertTxtPath()
+    {
+        using var analyzer = new AssemblyAnalyzer(Samples.EmbeddedSourceLibDll);
+        var source = GetSource(
+            analyzer,
+            "EmbeddedSourceLib.HostileExtensionFixture",
+            "Run");
+        Assert.EndsWith("Payload.cmd", source.Document);
+        using var store = new EmbeddedSourceTempFileStore();
+        var materializedPath = store.Write("Run", source.Document, source.Bytes);
+        var editor = CreateResolvedEditorFile(out var editorDirectory);
+        try
+        {
+            ProcessStartInfo? captured = null;
+
+            var status = LaunchDirect(
+                store,
+                materializedPath,
+                editor,
+                startInfo =>
+                {
+                    captured = startInfo;
+                    return new MemoryStream();
+                },
+                out var openedPath);
+
+            Assert.AreEqual(EditorLaunchStatus.Started, status);
+            Assert.IsNotNull(captured);
+            Assert.IsFalse(captured.UseShellExecute);
+            Assert.EndsWith(".txt", openedPath);
+            Assert.AreEqual(openedPath, captured.ArgumentList[^1]);
+            Assert.AreSequenceEqual(source.Bytes, File.ReadAllBytes(openedPath));
+        }
+        finally
+        {
+            editorDirectory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies a genuine metacharacter-bearing PDB document produces an inert C# filename.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Open_CompilerEmbeddedHostileName_ProducesInertNameAndExactBytes()
+    {
+        using var analyzer = new AssemblyAnalyzer(Samples.EmbeddedSourceLibDll);
+        var source = GetSource(
+            analyzer,
+            "EmbeddedSourceLib.HostileNameFixture",
+            "Run");
+        Assert.EndsWith("Evil & Payload !.cs", source.Document);
+        using var store = new EmbeddedSourceTempFileStore();
+        var materializedPath = store.Write("Run", source.Document, source.Bytes);
+        var editor = CreateResolvedEditorFile(out var editorDirectory);
+        try
+        {
+            ProcessStartInfo? captured = null;
+
+            var status = LaunchDirect(
+                store,
+                materializedPath,
+                editor,
+                startInfo =>
+                {
+                    captured = startInfo;
+                    return new MemoryStream();
+                },
+                out var openedPath);
+
+            Assert.AreEqual(EditorLaunchStatus.Started, status);
+            Assert.IsNotNull(captured);
+            Assert.IsTrue(InertCsFileNameRegex().IsMatch(Path.GetFileName(openedPath)));
+            Assert.AreEqual(openedPath, captured.ArgumentList[^1]);
+            Assert.AreSequenceEqual(source.Bytes, File.ReadAllBytes(openedPath));
+        }
+        finally
+        {
+            editorDirectory.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the platform association boundary receives a text copy of real C# source.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Open_CompilerEmbeddedCsSourceWithoutEditor_AssociatesTxtOnly()
+    {
+        using var analyzer = new AssemblyAnalyzer(Samples.EmbeddedSourceLibDll);
+        var source = GetSource(
+            analyzer,
+            "EmbeddedSourceLib.EmbeddedSourceFixture",
+            "Compute");
+        using var store = new EmbeddedSourceTempFileStore();
+        var materializedPath = store.Write("Compute", source.Document, source.Bytes);
+        ProcessStartInfo? captured = null;
+
+        var status = EditorLauncher.Launch(
+            store,
+            materializedPath,
+            visual: null,
+            editor: null,
+            pathEntries: [],
+            pathExtensions: [".EXE"],
+            startProcess: startInfo =>
+            {
+                captured = startInfo;
+                return new MemoryStream();
+            },
+            out var openedPath);
+
+        Assert.AreEqual(EditorLaunchStatus.Started, status);
+        Assert.IsNotNull(captured);
+        Assert.IsTrue(captured.UseShellExecute);
+        Assert.EndsWith(".txt", openedPath);
+        Assert.AreEqual(openedPath, captured.FileName);
+        Assert.AreSequenceEqual(source.Bytes, File.ReadAllBytes(openedPath));
+        Assert.IsFalse(File.Exists(materializedPath));
+    }
+
+    /// <summary>
+    /// Verifies traversal metadata cannot move embedded bytes outside the private session directory.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Open_TraversalDocumentName_RemainsInsidePrivateSessionDirectory()
+    {
+        using var analyzer = new AssemblyAnalyzer(Samples.EmbeddedSourceLibDll);
+        var source = GetSource(
+            analyzer,
+            "EmbeddedSourceLib.EmbeddedSourceFixture",
+            "Compute");
+        using var store = new EmbeddedSourceTempFileStore();
+
+        var materializedPath = store.Write(
+            "Compute",
+            @"..\..\outside\Payload.cmd",
+            source.Bytes);
+
+        Assert.IsNotNull(store.SessionDirectory);
+        Assert.IsTrue(string.Equals(
+            store.SessionDirectory,
+            Path.GetDirectoryName(materializedPath),
+            OperatingSystem.IsWindows()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal));
+        Assert.EndsWith(".txt", materializedPath);
+        Assert.AreSequenceEqual(source.Bytes, File.ReadAllBytes(materializedPath));
+    }
+
+    private static string CreateResolvedEditorFile(out DirectoryInfo directory)
+    {
+        directory = Directory.CreateTempSubdirectory("dotsider-embedded-editor-");
+        var path = Path.Combine(
+            directory.FullName,
+            OperatingSystem.IsWindows() ? "editor.exe" : "editor");
+        File.WriteAllText(path, "");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        return path;
+    }
+
+    private static EmbeddedSourceInfo GetSource(
+        AssemblyAnalyzer analyzer,
+        string typeName,
+        string methodName)
+    {
+        var method = analyzer.MethodDefs.FirstOrDefault(candidate =>
+            candidate.DeclaringType == typeName
+            && candidate.Name == methodName);
+        Assert.IsNotNull(method);
+
+        var source = analyzer.GetEmbeddedSource(method);
+        Assert.IsNotNull(source);
+        return source;
+    }
+
+    private static EditorLaunchStatus LaunchDirect(
+        EmbeddedSourceTempFileStore store,
+        string sourcePath,
+        string editor,
+        Func<ProcessStartInfo, IDisposable?> startProcess,
+        out string openedPath)
+    {
+        return EditorLauncher.Launch(
+            store,
+            sourcePath,
+            visual: editor,
+            editor: null,
+            pathEntries: [],
+            pathExtensions: [".EXE"],
+            startProcess,
+            out openedPath);
+    }
+
+    [GeneratedRegex(
+        @"^[A-Za-z0-9_-]{1,64}-[0-9a-f]{32}\.cs$",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex InertCsFileNameRegex();
+}

--- a/tests/Dotsider.Tests/EmbeddedSourceTempFileStoreTests.cs
+++ b/tests/Dotsider.Tests/EmbeddedSourceTempFileStoreTests.cs
@@ -1,0 +1,411 @@
+using Dotsider.Views;
+using System.Runtime.Versioning;
+using System.Text.RegularExpressions;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Tests private embedded-source storage and inert filename generation.
+/// </summary>
+[TestClass]
+public sealed partial class EmbeddedSourceTempFileStoreTests
+{
+    private const string AllowedNameCharacters =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-";
+
+    /// <summary>
+    /// Verifies every approved source extension survives in canonical lowercase form.
+    /// </summary>
+    /// <param name="extension">The source extension to validate.</param>
+    /// <param name="expected">The expected canonical extension.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DataRow(".CS", ".cs")]
+    [DataRow(".cshtml", ".cshtml")]
+    [DataRow(".fs", ".fs")]
+    [DataRow(".fsi", ".fsi")]
+    [DataRow(".il", ".il")]
+    [DataRow(".json", ".json")]
+    [DataRow(".md", ".md")]
+    [DataRow(".razor", ".razor")]
+    [DataRow(".resx", ".resx")]
+    [DataRow(".txt", ".txt")]
+    [DataRow(".vb", ".vb")]
+    [DataRow(".vbhtml", ".vbhtml")]
+    [DataRow(".xaml", ".xaml")]
+    [DataRow(".xml", ".xml")]
+    public void SanitizeExtension_AllowedSourceExtension_ReturnsCanonicalValue(
+        string extension,
+        string expected)
+    {
+        var actual = EmbeddedSourceTempFileStore.SanitizeExtension($"source{extension}");
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies executable, script, and unknown source extensions become plain text.
+    /// </summary>
+    /// <param name="extension">The unsafe source extension.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DataRow(".appref-ms")]
+    [DataRow(".application")]
+    [DataRow(".bat")]
+    [DataRow(".cmd")]
+    [DataRow(".com")]
+    [DataRow(".csx")]
+    [DataRow(".exe")]
+    [DataRow(".fsscript")]
+    [DataRow(".fsx")]
+    [DataRow(".hta")]
+    [DataRow(".js")]
+    [DataRow(".jse")]
+    [DataRow(".lnk")]
+    [DataRow(".msi")]
+    [DataRow(".ps1")]
+    [DataRow(".reg")]
+    [DataRow(".scr")]
+    [DataRow(".unknown")]
+    [DataRow(".url")]
+    [DataRow(".vbs")]
+    [DataRow(".wsf")]
+    [DataRow(".wsh")]
+    [DataRow(".")]
+    [DataRow(".c$")]
+    [DataRow(".cs ")]
+    public void SanitizeExtension_ExecutableOrScriptExtension_ReturnsTxt(string extension)
+    {
+        var actual = EmbeddedSourceTempFileStore.SanitizeExtension($"source{extension}");
+
+        Assert.AreEqual(".txt", actual);
+    }
+
+    /// <summary>
+    /// Verifies hostile document names always produce a bounded inert filename.
+    /// </summary>
+    /// <param name="documentPath">The hostile document path.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DataRow("evil\".bat")]
+    [DataRow("a&b|c.cs")]
+    [DataRow("%PATH%.cs")]
+    [DataRow(@"..\..\traversal.cs")]
+    [DataRow("foo;bar,baz=qux.cs")]
+    [DataRow("x^y!z(w).cs")]
+    [DataRow("foo bar.cs")]
+    [DataRow("evil\u0001\u001b.cs")]
+    [DataRow("café.cs")]
+    [DataRow("名前.cs")]
+    [DataRow("\uD800.cs")]
+    [DataRow("foo.cs:stream")]
+    [DataRow(@"\\server\share\x.cs")]
+    public void BuildFileName_HostileDocumentPath_ProducesInertName(string documentPath)
+    {
+        var fileName = EmbeddedSourceTempFileStore.BuildFileName(
+            "Method",
+            documentPath,
+            Guid.Empty);
+
+        Assert.IsTrue(
+            InertFileNameRegex().IsMatch(fileName),
+            $"Generated filename was not inert: {fileName}");
+    }
+
+    /// <summary>
+    /// Verifies document filename extraction is independent of the host operating system.
+    /// </summary>
+    /// <param name="documentPath">The cross-platform metadata document path.</param>
+    /// <param name="expectedPrefix">The expected sanitized filename prefix.</param>
+    /// <param name="expectedExtension">The expected extension.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DataRow(@"C:\dir.with.dot\Source.cs", "Source", ".cs")]
+    [DataRow("/dir.with.dot/Source.cs", "Source", ".cs")]
+    [DataRow(@"C:\mixed/path\Source.fs", "Source", ".fs")]
+    [DataRow(@"\\server\share.with.dot\Source.vb", "Source", ".vb")]
+    [DataRow("/parent/source", "source", ".txt")]
+    public void BuildFileName_CrossHostDocumentPath_UsesFinalDocumentSegment(
+        string documentPath,
+        string expectedPrefix,
+        string expectedExtension)
+    {
+        var fileName = EmbeddedSourceTempFileStore.BuildFileName(
+            "Fallback",
+            documentPath,
+            Guid.Empty);
+
+        Assert.StartsWith($"{expectedPrefix}-", fileName);
+        Assert.EndsWith(expectedExtension, fileName);
+    }
+
+    /// <summary>
+    /// Verifies empty and extension-only documents fall back to the sanitized method name.
+    /// </summary>
+    /// <param name="documentPath">The document path without a usable name.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow(".cs")]
+    [DataRow("/")]
+    [DataRow(@"\")]
+    public void BuildFileName_DocumentWithoutName_UsesSanitizedMethodName(string documentPath)
+    {
+        var fileName = EmbeddedSourceTempFileStore.BuildFileName(
+            "<Main>$|x",
+            documentPath,
+            Guid.Empty);
+
+        Assert.StartsWith("_Main___x-", fileName);
+    }
+
+    /// <summary>
+    /// Verifies names without any allowlisted character use the documented fallback chain.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void BuildFileName_AllInvalidNames_UsesMethodThenSourceFallback()
+    {
+        var methodFallback = EmbeddedSourceTempFileStore.BuildFileName(
+            "Method",
+            "!!!.cs",
+            Guid.Empty);
+        var sourceFallback = EmbeddedSourceTempFileStore.BuildFileName(
+            "!!!",
+            "!!!.cs",
+            Guid.Empty);
+
+        Assert.StartsWith("Method-", methodFallback);
+        Assert.StartsWith("source-", sourceFallback);
+    }
+
+    /// <summary>
+    /// Verifies very long document names produce only the bounded filename prefix.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void BuildFileName_LongDocumentName_CapsNameLength()
+    {
+        var fileName = EmbeddedSourceTempFileStore.BuildFileName(
+            "Method",
+            $"{new string('a', 5_000)}.cs",
+            Guid.Empty);
+        var fallbackName = EmbeddedSourceTempFileStore.BuildFileName(
+            "Method",
+            $"{new string('!', 5_000)}a.cs",
+            Guid.Empty);
+        var prefixLength = fileName.IndexOf('-', StringComparison.Ordinal);
+
+        Assert.AreEqual(64, prefixLength);
+        Assert.StartsWith("Method-", fallbackName);
+    }
+
+    /// <summary>
+    /// Verifies every UTF-16 code unit is reduced to the filename allowlist.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void SanitizeNamePart_EveryUtf16CodeUnit_ProducesAllowedAscii()
+    {
+        for (var value = 0; value <= char.MaxValue; value++)
+        {
+            var actual = EmbeddedSourceTempFileStore.SanitizeNamePart(
+                new string((char)value, 1));
+
+            Assert.AreEqual(1, actual.Length);
+            if (!AllowedNameCharacters.Contains(actual[0]))
+            {
+                Assert.Fail(
+                    $"U+{value:X4} produced disallowed filename character U+{(int)actual[0]:X4}.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies concurrent writes are unique, contained, and preserve exact source bytes.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Write_ConcurrentCalls_CreateUniqueContainedFiles()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var bytes = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+        var paths = new string[64];
+
+        Parallel.For(
+            0,
+            paths.Length,
+            index => paths[index] = store.Write("Method", @"C:\src\file.cs", bytes));
+
+        Assert.HasCount(paths.Length, paths.Distinct());
+        Assert.IsNotNull(store.SessionDirectory);
+        foreach (var path in paths)
+        {
+            Assert.IsTrue(string.Equals(
+                store.SessionDirectory,
+                Path.GetDirectoryName(path),
+                OperatingSystem.IsWindows()
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal));
+            Assert.AreSequenceEqual(bytes, File.ReadAllBytes(path));
+        }
+    }
+
+    /// <summary>
+    /// Verifies association preparation changes an allowlisted source extension to text.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void PrepareAssociationPath_AllowedSource_MovesFileToTxt()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var sourcePath = store.Write("Method", "Source.cs", [0x2A]);
+
+        var associationPath = store.PrepareAssociationPath(sourcePath);
+
+        Assert.EndsWith(".txt", associationPath);
+        Assert.IsFalse(File.Exists(sourcePath));
+        Assert.IsTrue(File.Exists(associationPath));
+    }
+
+    /// <summary>
+    /// Verifies association preparation never overwrites an existing text file.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void PrepareAssociationPath_TextTargetExists_ThrowsWithoutOverwriting()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var sourcePath = store.Write("Method", "Source.cs", [0x2A]);
+        var associationPath = Path.ChangeExtension(sourcePath, ".txt");
+        File.WriteAllBytes(associationPath, [0x11]);
+
+        Assert.ThrowsExactly<IOException>(() => store.PrepareAssociationPath(sourcePath));
+        Assert.AreSequenceEqual(new byte[] { 0x11 }, File.ReadAllBytes(associationPath));
+        Assert.IsTrue(File.Exists(sourcePath));
+    }
+
+    /// <summary>
+    /// Verifies association preparation rejects paths outside the owned session directory.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void PrepareAssociationPath_ExternalPath_Throws()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        _ = store.Write("Method", "Source.cs", [0x2A]);
+        var externalPath = Path.Combine(Path.GetTempPath(), "outside.cs");
+
+        Assert.ThrowsExactly<IOException>(() => store.PrepareAssociationPath(externalPath));
+    }
+
+    /// <summary>
+    /// Verifies Unix source storage uses private directory and file modes.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    [UnsupportedOSPlatform("windows")]
+    public void Write_OnUnix_UsesPrivatePermissions()
+    {
+        using var store = new EmbeddedSourceTempFileStore();
+        var path = store.Write("Method", "Source.cs", [0x2A]);
+        Assert.IsNotNull(store.SessionDirectory);
+
+        var directoryMode = File.GetUnixFileMode(store.SessionDirectory);
+        var fileMode = File.GetUnixFileMode(path);
+
+        Assert.AreEqual(
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
+            directoryMode);
+        Assert.AreEqual(UnixFileMode.UserRead | UnixFileMode.UserWrite, fileMode);
+    }
+
+    /// <summary>
+    /// Verifies normal disposal removes only the store's unique session directory.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Dispose_AfterWrite_RemovesSessionDirectoryAndIsIdempotent()
+    {
+        var store = new EmbeddedSourceTempFileStore();
+        _ = store.Write("Method", "Source.cs", [0x2A]);
+        var directory = store.SessionDirectory;
+        Assert.IsNotNull(directory);
+        Assert.Contains(
+            "dotsider-embedded-source-",
+            Path.GetFileName(directory),
+            StringComparison.Ordinal);
+
+        store.Dispose();
+        store.Dispose();
+
+        Assert.IsFalse(Directory.Exists(directory));
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+            store.Write("Method", "Source.cs", [0x2A]));
+    }
+
+    /// <summary>
+    /// Verifies a predictable legacy temp path cannot affect session-directory selection.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Write_PredictableLegacyTempDirectoryExists_UsesUniquePrivateDirectory()
+    {
+        var predictablePath = Path.Combine(Path.GetTempPath(), "dotsider");
+        var created = false;
+        if (!Directory.Exists(predictablePath) && !File.Exists(predictablePath))
+        {
+            Directory.CreateDirectory(predictablePath);
+            created = true;
+        }
+
+        try
+        {
+            using var store = new EmbeddedSourceTempFileStore();
+            _ = store.Write("Method", "Source.cs", [0x2A]);
+            Assert.IsNotNull(store.SessionDirectory);
+
+            Assert.IsFalse(string.Equals(
+                Path.GetFullPath(predictablePath),
+                store.SessionDirectory,
+                OperatingSystem.IsWindows()
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal));
+            Assert.StartsWith(
+                "dotsider-embedded-source-",
+                Path.GetFileName(store.SessionDirectory));
+
+            if (created)
+            {
+                Directory.Delete(predictablePath);
+                File.WriteAllText(predictablePath, "legacy path poison");
+                using var filePoisonStore = new EmbeddedSourceTempFileStore();
+                _ = filePoisonStore.Write("Method", "Source.cs", [0x2A]);
+                Assert.IsNotNull(filePoisonStore.SessionDirectory);
+                Assert.IsFalse(string.Equals(
+                    Path.GetFullPath(predictablePath),
+                    filePoisonStore.SessionDirectory,
+                    OperatingSystem.IsWindows()
+                        ? StringComparison.OrdinalIgnoreCase
+                        : StringComparison.Ordinal));
+            }
+        }
+        finally
+        {
+            if (created)
+            {
+                if (Directory.Exists(predictablePath))
+                    Directory.Delete(predictablePath);
+                else
+                    File.Delete(predictablePath);
+            }
+        }
+    }
+
+    [GeneratedRegex(
+        @"^[A-Za-z0-9_-]{1,64}-[0-9a-f]{32}\.[a-z]{2,7}$",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex InertFileNameRegex();
+}


### PR DESCRIPTION
PDB-embedded source now uses a private session directory with inert filenames and safe extensions. Configured editors launch with discrete arguments, while Windows command shims and the default association keep source paths out of shell command text.

Fixes: #230