### PR TITLE
Harden single-file bundle manifest parsing

### DIFF
--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-SingleFileBundleReader.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-SingleFileBundleReader.md
@@ -35,8 +35,8 @@ for extensionless files, appends `.dll` to the full filename.
 
 **Returns:** [Nullable\<Byte[], String\>\>](https://learn.microsoft.com/dotnet/api/system.nullable-2)
 
-The entry assembly bytes and name, or `null` if the file is not a bundle
-or no entry assembly could be identified.
+The entry assembly bytes and name, or `null` if the file is not a bundle,
+the manifest is invalid, or no entry assembly could be identified.
 
 ```csharp
 public static (byte[] Bytes, string Name)? FindEntryAssembly(string bundlePath)
@@ -88,7 +88,7 @@ Finds and reads an assembly entry by assembly name (without extension).
 
 **Returns:** [Byte[]](https://learn.microsoft.com/dotnet/api/system.byte[])
 
-The assembly bytes, or `null` if not found in the bundle.
+The assembly bytes, or `null` if the entry is not found, is unsafe, or cannot be read.
 
 ```csharp
 public static byte[]? ReadAssembly(string filePath, BundleManifest manifest, string assemblyName)
@@ -106,7 +106,7 @@ Reads a specific entry's raw bytes from the bundle.
 
 **Returns:** [Byte[]](https://learn.microsoft.com/dotnet/api/system.byte[])
 
-The entry's bytes, or `null` if the entry was not found.
+The entry's bytes, or `null` if the entry was not found, is unsafe, or cannot be read.
 
 ```csharp
 public static byte[]? ReadEntry(string filePath, BundleManifest manifest, string entryRelativePath)
@@ -114,11 +114,11 @@ public static byte[]? ReadEntry(string filePath, BundleManifest manifest, string
 
 ### ReadManifest(Stream)
 
-Reads the bundle manifest from a stream positioned at the header.
+Reads the bundle manifest from a readable, seekable stream positioned at the header.
 
 **Parameters:**
 
-- `stream` ([Stream](https://learn.microsoft.com/dotnet/api/system.io.stream)): A readable stream positioned at the bundle header offset.
+- `stream` ([Stream](https://learn.microsoft.com/dotnet/api/system.io.stream)): A readable, seekable stream positioned at the bundle header offset.
 
 **Returns:** [BundleManifest](/api/dotsider.core.analysis.models.bundlemanifest/)
 
@@ -126,7 +126,7 @@ The parsed bundle manifest.
 
 **Exceptions:**
 
-- [InvalidDataException](https://learn.microsoft.com/dotnet/api/system.io.invaliddataexception): The bundle version is unsupported.
+- [InvalidDataException](https://learn.microsoft.com/dotnet/api/system.io.invaliddataexception): The stream is unsuitable, the manifest is malformed, or the bundle version is unsupported.
 
 ```csharp
 public static BundleManifest ReadManifest(Stream stream)
@@ -147,7 +147,7 @@ The parsed bundle manifest.
 
 **Exceptions:**
 
-- [InvalidDataException](https://learn.microsoft.com/dotnet/api/system.io.invaliddataexception): The bundle version is unsupported.
+- [InvalidDataException](https://learn.microsoft.com/dotnet/api/system.io.invaliddataexception): The header offset is invalid, the manifest is malformed, or the bundle version is unsupported.
 
 ```csharp
 public static BundleManifest ReadManifest(string filePath, long headerOffset)

--- a/samples/SelfContainedConsole/SelfContainedConsole.csproj
+++ b/samples/SelfContainedConsole/SelfContainedConsole.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 </Project>

--- a/src/Dotsider.Core/Analysis/BoundedReadStream.cs
+++ b/src/Dotsider.Core/Analysis/BoundedReadStream.cs
@@ -1,0 +1,222 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Exposes at most a fixed number of readable bytes from an underlying stream.
+/// </summary>
+internal sealed class BoundedReadStream : Stream
+{
+    private readonly bool leaveOpen;
+    private readonly long length;
+    private long remaining;
+    private readonly Stream source;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundedReadStream"/> class.
+    /// </summary>
+    /// <param name="source">The readable source stream.</param>
+    /// <param name="length">The maximum number of bytes that may be read.</param>
+    /// <param name="leaveOpen"><c>true</c> to leave <paramref name="source"/> open when this stream is disposed.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="length"/> is negative.</exception>
+    internal BoundedReadStream(Stream source, long length, bool leaveOpen)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (!source.CanRead)
+            throw new ArgumentException("The source stream must be readable.", nameof(source));
+        if (length < 0)
+            throw new ArgumentOutOfRangeException(nameof(length));
+
+        this.source = source;
+        this.length = length;
+        remaining = length;
+        this.leaveOpen = leaveOpen;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the stream supports reading.
+    /// </summary>
+    public override bool CanRead => source.CanRead;
+
+    /// <summary>
+    /// Gets a value indicating whether the stream supports seeking.
+    /// </summary>
+    public override bool CanSeek => false;
+
+    /// <summary>
+    /// Gets a value indicating whether the stream supports writing.
+    /// </summary>
+    public override bool CanWrite => false;
+
+    /// <summary>
+    /// Gets the maximum readable length of this stream.
+    /// </summary>
+    public override long Length => length;
+
+    /// <summary>
+    /// Gets the number of bytes already read from this stream.
+    /// </summary>
+    public override long Position
+    {
+        get => length - remaining;
+        set => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Flushes the underlying stream.
+    /// </summary>
+    public override void Flush()
+    {
+        source.Flush();
+    }
+
+    /// <summary>
+    /// Reads up to the remaining bounded bytes into <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">The buffer to receive bytes.</param>
+    /// <param name="offset">The offset at which to begin writing.</param>
+    /// <param name="count">The maximum number of bytes to read.</param>
+    /// <returns>The number of bytes read, or zero when the bounded range is exhausted.</returns>
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        ValidateBufferArguments(buffer, offset, count);
+
+        var bytesToRead = GetReadCount(count);
+        if (bytesToRead == 0)
+            return 0;
+
+        var bytesRead = source.Read(buffer, offset, bytesToRead);
+        remaining -= bytesRead;
+        return bytesRead;
+    }
+
+    /// <summary>
+    /// Reads up to the remaining bounded bytes into <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">The buffer to receive bytes.</param>
+    /// <returns>The number of bytes read, or zero when the bounded range is exhausted.</returns>
+    public override int Read(Span<byte> buffer)
+    {
+        var bytesToRead = GetReadCount(buffer.Length);
+        if (bytesToRead == 0)
+            return 0;
+
+        var bytesRead = source.Read(buffer[..bytesToRead]);
+        remaining -= bytesRead;
+        return bytesRead;
+    }
+
+    /// <summary>
+    /// Asynchronously reads up to the remaining bounded bytes into <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">The buffer to receive bytes.</param>
+    /// <param name="offset">The offset at which to begin writing.</param>
+    /// <param name="count">The maximum number of bytes to read.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous read operation.</returns>
+    public override Task<int> ReadAsync(
+        byte[] buffer,
+        int offset,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        ValidateBufferArguments(buffer, offset, count);
+
+        var bytesToRead = GetReadCount(count);
+        return bytesToRead == 0
+            ? Task.FromResult(0)
+            : ReadAsyncCore(buffer, offset, bytesToRead, cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously reads up to the remaining bounded bytes into <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">The buffer to receive bytes.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A value task that represents the asynchronous read operation.</returns>
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        var bytesToRead = GetReadCount(buffer.Length);
+        return bytesToRead == 0
+            ? ValueTask.FromResult(0)
+            : ReadAsyncCore(buffer[..bytesToRead], cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads the next byte from the bounded range.
+    /// </summary>
+    /// <returns>The next byte, or <c>-1</c> when the bounded range is exhausted.</returns>
+    public override int ReadByte()
+    {
+        if (remaining == 0)
+            return -1;
+
+        var value = source.ReadByte();
+        if (value >= 0)
+            remaining--;
+
+        return value;
+    }
+
+    /// <summary>
+    /// Sets the position within the stream.
+    /// </summary>
+    /// <param name="offset">The byte offset relative to <paramref name="origin"/>.</param>
+    /// <param name="origin">The reference point used to obtain the new position.</param>
+    /// <returns>Never returns because seeking is not supported.</returns>
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Sets the length of the stream.
+    /// </summary>
+    /// <param name="value">The requested length.</param>
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Writes bytes to the stream.
+    /// </summary>
+    /// <param name="buffer">The bytes to write.</param>
+    /// <param name="offset">The offset at which to begin reading from <paramref name="buffer"/>.</param>
+    /// <param name="count">The number of bytes to write.</param>
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Releases the stream and optionally the underlying source stream.
+    /// </summary>
+    /// <param name="disposing"><c>true</c> when called during disposal; otherwise <c>false</c>.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !leaveOpen)
+            source.Dispose();
+
+        base.Dispose(disposing);
+    }
+
+    private int GetReadCount(int requestedCount)
+    {
+        return (int)Math.Min(remaining, requestedCount);
+    }
+
+    private async Task<int> ReadAsyncCore(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        var bytesRead = await source.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+        remaining -= bytesRead;
+        return bytesRead;
+    }
+
+    private async ValueTask<int> ReadAsyncCore(Memory<byte> buffer, CancellationToken cancellationToken)
+    {
+        var bytesRead = await source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        remaining -= bytesRead;
+        return bytesRead;
+    }
+}

--- a/src/Dotsider.Core/Analysis/SingleFileBundleReader.cs
+++ b/src/Dotsider.Core/Analysis/SingleFileBundleReader.cs
@@ -1,9 +1,8 @@
 using Dotsider.Core.Analysis.Models;
+using System.Buffers.Binary;
 using System.IO.Compression;
-using System.IO.MemoryMappedFiles;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Dotsider.Core.Analysis;
@@ -14,6 +13,15 @@ namespace Dotsider.Core.Analysis;
 /// </summary>
 public static class SingleFileBundleReader
 {
+    private const long MaxManifestBytes = 16L * 1024 * 1024;
+    private const int MaxEntryCount = 100_000;
+    private const int MaxStringBytes = 32 * 1024;
+    private const long MaxMaterializedEntryBytes = 512L * 1024 * 1024;
+    private const int BundleLocatorLength = sizeof(long) + 32;
+    private const int BundleScanBufferSize = 64 * 1024;
+    private const int MinimumV1EntryBytes = (sizeof(long) * 2) + sizeof(byte) + sizeof(byte);
+    private const int MinimumV6EntryBytes = (sizeof(long) * 3) + sizeof(byte) + sizeof(byte);
+
     // SHA-256 for ".net core bundle"
     private static readonly byte[] BundleSignature =
     [
@@ -22,6 +30,8 @@ public static class SingleFileBundleReader
         0x13, 0xf5, 0xb9, 0xe6, 0xef, 0xae, 0x33, 0x18,
         0xee, 0x3b, 0x2d, 0xce, 0x24, 0xb3, 0x6a, 0xae
     ];
+
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
     /// <summary>
     /// Checks whether the file at <paramref name="filePath"/> is a .NET single-file bundle.
@@ -37,26 +47,32 @@ public static class SingleFileBundleReader
         try
         {
             var fileInfo = new FileInfo(filePath);
-            if (!fileInfo.Exists || fileInfo.Length < BundleSignature.Length + sizeof(long))
+            if (!fileInfo.Exists || fileInfo.Length < BundleLocatorLength)
                 return false;
 
-            using var mmf = MemoryMappedFile.CreateFromFile(
-                filePath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
-            using var accessor = mmf.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
-
-            unsafe
+            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var buffer = new byte[BundleScanBufferSize + BundleLocatorLength - 1];
+            var bufferedBytes = 0;
+            while (true)
             {
-                byte* ptr = null;
-                accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
-                try
+                var bytesRead = stream.Read(buffer, bufferedBytes, buffer.Length - bufferedBytes);
+                if (bytesRead == 0)
+                    return false;
+
+                var availableBytes = bufferedBytes + bytesRead;
+                var data = buffer.AsSpan(0, availableBytes);
+                if (TryFindBundleLocator(data, fileInfo.Length, out headerOffset))
+                    return true;
+
+                bufferedBytes = Math.Min(BundleLocatorLength - 1, availableBytes);
+                if (bufferedBytes > 0)
                 {
-                    var length = checked((int)fileInfo.Length);
-                    var data = new ReadOnlySpan<byte>(ptr, length);
-                    return IsBundle(data, out headerOffset);
-                }
-                finally
-                {
-                    accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+                    Buffer.BlockCopy(
+                        buffer,
+                        availableBytes - bufferedBytes,
+                        buffer,
+                        0,
+                        bufferedBytes);
                 }
             }
         }
@@ -77,28 +93,10 @@ public static class SingleFileBundleReader
     public static bool IsBundle(ReadOnlySpan<byte> data, out long headerOffset)
     {
         headerOffset = 0;
-        if (data.Length < BundleSignature.Length + sizeof(long))
+        if (data.Length < BundleLocatorLength)
             return false;
 
-        var signature = new ReadOnlySpan<byte>(BundleSignature);
-        var end = data.Length - signature.Length;
-
-        for (var i = 0; i < end; i++)
-        {
-            if (data[i] == 0x8b && data.Slice(i, signature.Length).SequenceEqual(signature))
-            {
-                if (i < sizeof(long))
-                    continue;
-
-                headerOffset = Unsafe.ReadUnaligned<long>(
-                    ref Unsafe.AsRef(in data[i - sizeof(long)]));
-
-                if (headerOffset > 0 && headerOffset < data.Length)
-                    return true;
-            }
-        }
-
-        return false;
+        return TryFindBundleLocator(data, data.Length, out headerOffset);
     }
 
     /// <summary>
@@ -109,50 +107,94 @@ public static class SingleFileBundleReader
     /// The byte offset of the bundle header, as returned by <see cref="IsBundle(string, out long)"/>.
     /// </param>
     /// <returns>The parsed bundle manifest.</returns>
-    /// <exception cref="InvalidDataException">The bundle version is unsupported.</exception>
+    /// <exception cref="InvalidDataException">
+    /// The header offset is invalid, the manifest is malformed, or the bundle version is unsupported.
+    /// </exception>
     public static BundleManifest ReadManifest(string filePath, long headerOffset)
     {
         using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        stream.Seek(headerOffset, SeekOrigin.Begin);
+        if (headerOffset < 0 || headerOffset >= stream.Length)
+            throw CreateMalformedManifestException();
+
+        stream.Position = headerOffset;
         return ReadManifest(stream);
     }
 
     /// <summary>
-    /// Reads the bundle manifest from a stream positioned at the header.
+    /// Reads the bundle manifest from a readable, seekable stream positioned at the header.
     /// </summary>
-    /// <param name="stream">A readable stream positioned at the bundle header offset.</param>
+    /// <param name="stream">A readable, seekable stream positioned at the bundle header offset.</param>
     /// <returns>The parsed bundle manifest.</returns>
-    /// <exception cref="InvalidDataException">The bundle version is unsupported.</exception>
+    /// <exception cref="InvalidDataException">
+    /// The stream is unsuitable, the manifest is malformed, or the bundle version is unsupported.
+    /// </exception>
     public static BundleManifest ReadManifest(Stream stream)
     {
-        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+        ArgumentNullException.ThrowIfNull(stream);
 
-        var majorVersion = reader.ReadUInt32();
-        var minorVersion = reader.ReadUInt32();
+        if (!stream.CanRead || !stream.CanSeek)
+            throw CreateMalformedManifestException();
 
-        // Versions 3, 4, 5 were skipped to align with .NET versioning
-        if (majorVersion is < 1 or > 6)
-            throw new InvalidDataException(
-                $"Unsupported bundle version: {majorVersion}.{minorVersion}");
-
-        var fileCount = reader.ReadInt32();
-        var bundleId = reader.ReadString();
-
-        // v2+ adds deps.json/runtimeconfig offsets and flags
-        if (majorVersion >= 2)
+        try
         {
-            reader.ReadInt64(); // DepsJsonOffset
-            reader.ReadInt64(); // DepsJsonSize
-            reader.ReadInt64(); // RuntimeConfigJsonOffset
-            reader.ReadInt64(); // RuntimeConfigJsonSize
-            reader.ReadUInt64(); // Flags
+            var manifestStart = stream.Position;
+            var remainingFileBytes = stream.Length - manifestStart;
+            if (manifestStart < 0 || remainingFileBytes < 0)
+                throw CreateMalformedManifestException();
+
+            var manifestEnd = manifestStart + Math.Min(remainingFileBytes, MaxManifestBytes);
+            using var reader = new BinaryReader(stream, StrictUtf8, leaveOpen: true);
+
+            var majorVersion = ReadUInt32(reader, stream, manifestEnd);
+            var minorVersion = ReadUInt32(reader, stream, manifestEnd);
+
+            // Versions 3, 4, 5 were skipped to align with .NET versioning.
+            if (majorVersion is < 1 or > 6)
+                throw new InvalidDataException("The single-file bundle manifest version is unsupported.");
+
+            var fileCount = ReadInt32(reader, stream, manifestEnd);
+            if (fileCount is <= 0 or > MaxEntryCount)
+                throw CreateMalformedManifestException();
+
+            var bundleId = ReadManifestString(reader, stream, manifestEnd);
+
+            if (majorVersion >= 2)
+            {
+                var depsJsonOffset = ReadInt64(reader, stream, manifestEnd);
+                var depsJsonSize = ReadInt64(reader, stream, manifestEnd);
+                var runtimeConfigJsonOffset = ReadInt64(reader, stream, manifestEnd);
+                var runtimeConfigJsonSize = ReadInt64(reader, stream, manifestEnd);
+                _ = ReadUInt64(reader, stream, manifestEnd);
+
+                ValidateOptionalDataRange(depsJsonOffset, depsJsonSize, manifestStart);
+                ValidateOptionalDataRange(runtimeConfigJsonOffset, runtimeConfigJsonSize, manifestStart);
+            }
+
+            var minimumEntryBytes = majorVersion >= 6 ? MinimumV6EntryBytes : MinimumV1EntryBytes;
+            if (fileCount > GetRemainingManifestBytes(stream, manifestEnd) / minimumEntryBytes)
+                throw CreateMalformedManifestException();
+
+            var entries = new BundleEntry[fileCount];
+            for (var i = 0; i < entries.Length; i++)
+                entries[i] = ReadManifestEntry(reader, stream, manifestEnd, manifestStart, majorVersion);
+
+            return new BundleManifest(majorVersion, minorVersion, fileCount, bundleId, entries);
         }
-
-        var entries = new BundleEntry[fileCount];
-        for (var i = 0; i < fileCount; i++)
-            entries[i] = ReadEntry(reader, majorVersion);
-
-        return new BundleManifest(majorVersion, minorVersion, fileCount, bundleId, entries);
+        catch (InvalidDataException)
+        {
+            throw;
+        }
+        catch (Exception exception) when (
+            exception is ArgumentException
+            or DecoderFallbackException
+            or EndOfStreamException
+            or FormatException
+            or IOException
+            or NotSupportedException
+            or OverflowException)
+        {
+            throw CreateMalformedManifestException(exception);
+        }
     }
 
     /// <summary>
@@ -161,9 +203,12 @@ public static class SingleFileBundleReader
     /// <param name="filePath">Path to the bundle file.</param>
     /// <param name="manifest">The bundle manifest.</param>
     /// <param name="entryRelativePath">The <see cref="BundleEntry.RelativePath"/> to read.</param>
-    /// <returns>The entry's bytes, or <c>null</c> if the entry was not found.</returns>
+    /// <returns>The entry's bytes, or <c>null</c> if the entry was not found, is unsafe, or cannot be read.</returns>
     public static byte[]? ReadEntry(string filePath, BundleManifest manifest, string entryRelativePath)
     {
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(entryRelativePath);
+
         var entry = manifest.Entries.FirstOrDefault(e =>
             string.Equals(e.RelativePath, entryRelativePath, StringComparison.OrdinalIgnoreCase));
         return entry is null ? null : ReadEntryBytes(filePath, entry);
@@ -175,9 +220,12 @@ public static class SingleFileBundleReader
     /// <param name="filePath">Path to the bundle file.</param>
     /// <param name="manifest">The bundle manifest.</param>
     /// <param name="assemblyName">Assembly name without extension (e.g. "System.Runtime").</param>
-    /// <returns>The assembly bytes, or <c>null</c> if not found in the bundle.</returns>
+    /// <returns>The assembly bytes, or <c>null</c> if the entry is not found, is unsafe, or cannot be read.</returns>
     public static byte[]? ReadAssembly(string filePath, BundleManifest manifest, string assemblyName)
     {
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(assemblyName);
+
         var dllName = assemblyName + ".dll";
         var entry = manifest.Entries.FirstOrDefault(e =>
             e.Type == BundleFileType.Assembly
@@ -193,8 +241,8 @@ public static class SingleFileBundleReader
     /// </summary>
     /// <param name="bundlePath">Path to the potential bundle file.</param>
     /// <returns>
-    /// The entry assembly bytes and name, or <c>null</c> if the file is not a bundle
-    /// or no entry assembly could be identified.
+    /// The entry assembly bytes and name, or <c>null</c> if the file is not a bundle,
+    /// the manifest is invalid, or no entry assembly could be identified.
     /// </returns>
     public static (byte[] Bytes, string Name)? FindEntryAssembly(string bundlePath)
     {
@@ -224,7 +272,7 @@ public static class SingleFileBundleReader
             && string.Equals(Path.GetFileName(e.RelativePath), entryDllName,
                 StringComparison.OrdinalIgnoreCase));
 
-        // Fallback: match by BundleId
+        // Fallback: match by BundleId.
         if (entry is null)
         {
             var idDllName = manifest.BundleId + ".dll";
@@ -241,7 +289,7 @@ public static class SingleFileBundleReader
         if (bytes is null)
             return null;
 
-        // Verify the extracted bytes are a valid PE with metadata
+        // Verify the extracted bytes are a valid PE with metadata.
         try
         {
             using var ms = new MemoryStream(bytes, writable: false);
@@ -258,14 +306,188 @@ public static class SingleFileBundleReader
         return (bytes, Path.GetFileName(entry.RelativePath));
     }
 
-    private static BundleEntry ReadEntry(BinaryReader reader, uint majorVersion)
+    private static InvalidDataException CreateMalformedManifestException(Exception? innerException = null)
     {
-        var offset = reader.ReadInt64();
-        var size = reader.ReadInt64();
-        var compressedSize = majorVersion >= 6 ? reader.ReadInt64() : 0;
-        var type = (BundleFileType)reader.ReadByte();
-        var relativePath = reader.ReadString();
+        return new InvalidDataException("The single-file bundle manifest is malformed.", innerException);
+    }
+
+    private static bool TryFindBundleLocator(
+        ReadOnlySpan<byte> data,
+        long fileLength,
+        out long headerOffset)
+    {
+        headerOffset = 0;
+        if (data.Length < BundleLocatorLength)
+            return false;
+
+        var finalLocatorStart = data.Length - BundleLocatorLength;
+        for (var locatorStart = 0; locatorStart <= finalLocatorStart; locatorStart++)
+        {
+            var signatureStart = locatorStart + sizeof(long);
+            if (data[signatureStart] != BundleSignature[0]
+                || !data.Slice(signatureStart, BundleSignature.Length).SequenceEqual(BundleSignature))
+            {
+                continue;
+            }
+
+            var candidateHeaderOffset = BinaryPrimitives.ReadInt64LittleEndian(data.Slice(locatorStart));
+            if (candidateHeaderOffset > 0 && candidateHeaderOffset < fileLength)
+            {
+                headerOffset = candidateHeaderOffset;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static long GetRemainingManifestBytes(Stream stream, long manifestEnd)
+    {
+        if (stream.Position < 0 || stream.Position > manifestEnd)
+            throw CreateMalformedManifestException();
+
+        return manifestEnd - stream.Position;
+    }
+
+    private static BundleEntry ReadManifestEntry(
+        BinaryReader reader,
+        Stream stream,
+        long manifestEnd,
+        long manifestStart,
+        uint majorVersion)
+    {
+        var offset = ReadInt64(reader, stream, manifestEnd);
+        var size = ReadInt64(reader, stream, manifestEnd);
+        var compressedSize = majorVersion >= 6 ? ReadInt64(reader, stream, manifestEnd) : 0;
+        var type = (BundleFileType)ReadByte(reader, stream, manifestEnd);
+        var relativePath = ReadManifestString(reader, stream, manifestEnd);
+
+        ValidateEntry(offset, size, compressedSize, type, relativePath, manifestStart);
         return new BundleEntry(offset, size, compressedSize, type, relativePath);
+    }
+
+    private static string ReadManifestString(BinaryReader reader, Stream stream, long manifestEnd)
+    {
+        var byteLength = Read7BitEncodedInt(reader, stream, manifestEnd);
+        if (byteLength is <= 0 or > MaxStringBytes)
+            throw CreateMalformedManifestException();
+
+        EnsureAvailable(stream, manifestEnd, byteLength);
+        var bytes = reader.ReadBytes(byteLength);
+        if (bytes.Length != byteLength)
+            throw CreateMalformedManifestException();
+
+        var value = StrictUtf8.GetString(bytes);
+        if (value.Length == 0 || value.IndexOf('\0') >= 0)
+            throw CreateMalformedManifestException();
+
+        return value;
+    }
+
+    private static int Read7BitEncodedInt(BinaryReader reader, Stream stream, long manifestEnd)
+    {
+        uint value = 0;
+
+        for (var shift = 0; shift < 35; shift += 7)
+        {
+            var current = ReadByte(reader, stream, manifestEnd);
+            if (shift == 28 && (current & 0xf0) != 0)
+                throw CreateMalformedManifestException();
+
+            value |= (uint)(current & 0x7f) << shift;
+            if ((current & 0x80) == 0)
+            {
+                if (value > int.MaxValue || (shift > 0 && value < (1u << shift)))
+                    throw CreateMalformedManifestException();
+
+                return (int)value;
+            }
+        }
+
+        throw CreateMalformedManifestException();
+    }
+
+    private static int ReadInt32(BinaryReader reader, Stream stream, long manifestEnd)
+    {
+        EnsureAvailable(stream, manifestEnd, sizeof(int));
+        return reader.ReadInt32();
+    }
+
+    private static long ReadInt64(BinaryReader reader, Stream stream, long manifestEnd)
+    {
+        EnsureAvailable(stream, manifestEnd, sizeof(long));
+        return reader.ReadInt64();
+    }
+
+    private static uint ReadUInt32(BinaryReader reader, Stream stream, long manifestEnd)
+    {
+        EnsureAvailable(stream, manifestEnd, sizeof(uint));
+        return reader.ReadUInt32();
+    }
+
+    private static ulong ReadUInt64(BinaryReader reader, Stream stream, long manifestEnd)
+    {
+        EnsureAvailable(stream, manifestEnd, sizeof(ulong));
+        return reader.ReadUInt64();
+    }
+
+    private static byte ReadByte(BinaryReader reader, Stream stream, long manifestEnd)
+    {
+        EnsureAvailable(stream, manifestEnd, sizeof(byte));
+        return reader.ReadByte();
+    }
+
+    private static void EnsureAvailable(Stream stream, long manifestEnd, int requiredBytes)
+    {
+        if (requiredBytes < 0 || GetRemainingManifestBytes(stream, manifestEnd) < requiredBytes)
+            throw CreateMalformedManifestException();
+    }
+
+    private static void ValidateEntry(
+        long offset,
+        long size,
+        long compressedSize,
+        BundleFileType type,
+        string relativePath,
+        long dataBoundary)
+    {
+        if (offset <= 0
+            || size < 0
+            || compressedSize < 0
+            || type > BundleFileType.Symbols
+            || string.IsNullOrEmpty(relativePath)
+            || relativePath.IndexOf('\0') >= 0)
+        {
+            throw CreateMalformedManifestException();
+        }
+
+        var storedSize = compressedSize > 0 ? compressedSize : size;
+        ValidateDataRange(offset, storedSize, dataBoundary);
+    }
+
+    private static void ValidateOptionalDataRange(long offset, long size, long dataBoundary)
+    {
+        if (offset == 0)
+        {
+            if (size == 0)
+                return;
+
+            throw CreateMalformedManifestException();
+        }
+
+        ValidateDataRange(offset, size, dataBoundary);
+    }
+
+    private static void ValidateDataRange(long offset, long size, long dataBoundary)
+    {
+        if (offset < 0
+            || size < 0
+            || dataBoundary < 0
+            || offset > dataBoundary
+            || size > dataBoundary - offset)
+        {
+            throw CreateMalformedManifestException();
+        }
     }
 
     private static byte[]? ReadEntryBytes(string filePath, BundleEntry entry)
@@ -273,40 +495,46 @@ public static class SingleFileBundleReader
         try
         {
             using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            ValidateEntry(
+                entry.Offset,
+                entry.Size,
+                entry.CompressedSize,
+                entry.Type,
+                entry.RelativePath,
+                stream.Length);
 
+            var storedSize = entry.CompressedSize > 0 ? entry.CompressedSize : entry.Size;
+            if (entry.Size > MaxMaterializedEntryBytes || storedSize > MaxMaterializedEntryBytes)
+                return null;
+
+            stream.Position = entry.Offset;
             if (entry.CompressedSize > 0)
-            {
-                // v6+ compressed entry — DeflateStream
-                stream.Seek(entry.Offset, SeekOrigin.Begin);
-                var compressedBytes = new byte[entry.CompressedSize];
-                stream.ReadExactly(compressedBytes);
+                return ReadCompressedEntry(stream, entry);
 
-                using var compressedStream = new MemoryStream(compressedBytes, writable: false);
-                using var deflate = new DeflateStream(compressedStream, CompressionMode.Decompress);
-                var decompressed = new MemoryStream((int)entry.Size);
-                deflate.CopyTo(decompressed);
-
-                if (decompressed.Length != entry.Size)
-                    throw new InvalidDataException(
-                        $"Corrupted single-file entry '{entry.RelativePath}'. "
-                        + $"Declared size {entry.Size} != actual {decompressed.Length}.");
-
-                return decompressed.ToArray();
-            }
-
-            // Uncompressed entry — direct read
-            stream.Seek(entry.Offset, SeekOrigin.Begin);
-            var bytes = new byte[entry.Size];
+            var bytes = new byte[checked((int)entry.Size)];
             stream.ReadExactly(bytes);
             return bytes;
         }
-        catch (InvalidDataException)
-        {
-            throw;
-        }
-        catch
+        catch (Exception exception) when (
+            exception is ArgumentException
+            or InvalidDataException
+            or IOException
+            or OverflowException)
         {
             return null;
         }
+    }
+
+    private static byte[]? ReadCompressedEntry(Stream stream, BundleEntry entry)
+    {
+        using var compressedStream = new BoundedReadStream(stream, entry.CompressedSize, leaveOpen: true);
+        using var deflate = new DeflateStream(compressedStream, CompressionMode.Decompress, leaveOpen: true);
+        var bytes = new byte[checked((int)entry.Size)];
+
+        deflate.ReadExactly(bytes);
+        if (deflate.ReadByte() != -1)
+            return null;
+
+        return bytes;
     }
 }

--- a/src/Dotsider.Mcp/Tools/BundleTools.cs
+++ b/src/Dotsider.Mcp/Tools/BundleTools.cs
@@ -1,4 +1,5 @@
 using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
 using Dotsider.Core.Protocol;
 using ModelContextProtocol.Server;
 using System.Text.Json;
@@ -28,7 +29,18 @@ public sealed partial class BundleTools
             return Task.FromResult(JsonSerializer.Serialize(
                 new { IsBundle = false }, DotsiderJsonOptions.Default));
 
-        var manifest = SingleFileBundleReader.ReadManifest(assemblyPath, headerOffset);
+        BundleManifest manifest;
+        try
+        {
+            manifest = SingleFileBundleReader.ReadManifest(assemblyPath, headerOffset);
+        }
+        catch (InvalidDataException)
+        {
+            return Task.FromResult(JsonSerializer.Serialize(
+                new { IsBundle = false, Error = "Invalid single-file bundle manifest." },
+                DotsiderJsonOptions.Default));
+        }
+
         return Task.FromResult(JsonSerializer.Serialize(new
         {
             IsBundle = true,
@@ -36,7 +48,7 @@ public sealed partial class BundleTools
             manifest.MinorVersion,
             manifest.FileCount,
             manifest.BundleId,
-            TotalSize = manifest.Entries.Sum(e => e.Size)
+            TotalSize = CalculateTotalSize(manifest.Entries)
         }, DotsiderJsonOptions.Default));
     }
 
@@ -56,7 +68,16 @@ public sealed partial class BundleTools
         if (!SingleFileBundleReader.IsBundle(assemblyPath, out var headerOffset))
             return Task.FromResult("Error: File is not a single-file bundle.");
 
-        var manifest = SingleFileBundleReader.ReadManifest(assemblyPath, headerOffset);
+        BundleManifest manifest;
+        try
+        {
+            manifest = SingleFileBundleReader.ReadManifest(assemblyPath, headerOffset);
+        }
+        catch (InvalidDataException)
+        {
+            return Task.FromResult("Error: Invalid single-file bundle manifest.");
+        }
+
         var entries = manifest.Entries.Select(e => new
         {
             e.RelativePath,
@@ -65,5 +86,19 @@ public sealed partial class BundleTools
             e.CompressedSize
         });
         return Task.FromResult(JsonSerializer.Serialize(entries, DotsiderJsonOptions.Default));
+    }
+
+    private static long CalculateTotalSize(IEnumerable<BundleEntry> entries)
+    {
+        var totalSize = 0L;
+        foreach (var entry in entries)
+        {
+            if (entry.Size > long.MaxValue - totalSize)
+                return long.MaxValue;
+
+            totalSize += entry.Size;
+        }
+
+        return totalSize;
     }
 }

--- a/src/Dotsider/Commands/AnalyzeCommand.cs
+++ b/src/Dotsider/Commands/AnalyzeCommand.cs
@@ -1264,7 +1264,16 @@ internal static class AnalyzeCommand
             return 1;
         }
 
-        var manifest = SingleFileBundleReader.ReadManifest(filePath, offset);
+        BundleManifest manifest;
+        try
+        {
+            manifest = SingleFileBundleReader.ReadManifest(filePath, offset);
+        }
+        catch (InvalidDataException)
+        {
+            OutputFormatter.WriteError("Error: Invalid single-file bundle manifest");
+            return 1;
+        }
 
         if (fmt.JsonMode)
         {

--- a/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
+++ b/src/Dotsider/Diagnostics/DotsiderDiagnosticsListener.cs
@@ -1121,8 +1121,15 @@ internal sealed class DotsiderDiagnosticsListener(
         if (!SingleFileBundleReader.IsBundle(request.AssemblyPath, out var headerOffset))
             return DotsiderResponse.Fail("File is not a single-file bundle");
 
-        var manifest = SingleFileBundleReader.ReadManifest(request.AssemblyPath, headerOffset);
-        return DotsiderResponse.Ok(manifest);
+        try
+        {
+            var manifest = SingleFileBundleReader.ReadManifest(request.AssemblyPath, headerOffset);
+            return DotsiderResponse.Ok(manifest);
+        }
+        catch (InvalidDataException)
+        {
+            return DotsiderResponse.Fail("Invalid single-file bundle manifest");
+        }
     }
 
     // --- Assembly Resolution Handlers ---

--- a/tests/Dotsider.Mcp.Tests/BundleToolsTests.cs
+++ b/tests/Dotsider.Mcp.Tests/BundleToolsTests.cs
@@ -1,3 +1,4 @@
+using Dotsider.Tests.Shared;
 using System.Text.Json;
 
 namespace Dotsider.Mcp.Tests;
@@ -49,6 +50,39 @@ public class BundleToolsTests : McpServerTestBase
         Assert.IsNotNull(text);
         var json = JsonSerializer.Deserialize<JsonElement>(text);
         Assert.IsFalse(json.GetProperty("isBundle").GetBoolean());
+    }
+
+    /// <summary>
+    /// Verifies that malformed recognized bundles return stable tool results instead of a server exception.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task MalformedBundle_ReturnsSafeErrors()
+    {
+        var path = SyntheticSingleFileBundle.Create(fileCount: 0);
+        try
+        {
+            await StartServerAsync();
+            await using var client = await CreateClientAsync();
+
+            var infoResult = await client.CallToolAsync("get_bundle_info",
+                new Dictionary<string, object?> { ["assemblyPath"] = path },
+                cancellationToken: TestCancellationToken);
+            var infoText = GetTextContent(infoResult);
+            Assert.IsNotNull(infoText);
+            var info = JsonSerializer.Deserialize<JsonElement>(infoText);
+            Assert.IsFalse(info.GetProperty("isBundle").GetBoolean());
+            Assert.AreEqual("Invalid single-file bundle manifest.", info.GetProperty("error").GetString());
+
+            var entriesResult = await client.CallToolAsync("list_bundle_entries",
+                new Dictionary<string, object?> { ["assemblyPath"] = path },
+                cancellationToken: TestCancellationToken);
+            Assert.AreEqual("Error: Invalid single-file bundle manifest.", GetTextContent(entriesResult));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     /// <summary>

--- a/tests/Dotsider.Tests/AssemblyLoaderTests.cs
+++ b/tests/Dotsider.Tests/AssemblyLoaderTests.cs
@@ -57,6 +57,35 @@ public sealed class AssemblyLoaderTests
         bundle.EntryAnalyzer.Dispose();
     }
 
+    /// <summary>
+    /// Verifies that a recognized bundle with a malformed manifest never creates a bundle-backed analyzer.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Open_MalformedSingleFileBundle_DoesNotCreateBundleEntry()
+    {
+        Assert.IsNotNull(Samples.SelfContainedConsoleExe);
+        var path = Path.Combine(Path.GetTempPath(), $"dotsider-malformed-bundle-{Guid.NewGuid():N}.exe");
+        try
+        {
+            File.Copy(Samples.SelfContainedConsoleExe!, path);
+            Assert.IsTrue(SingleFileBundleReader.IsBundle(path, out var headerOffset));
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.None))
+            {
+                stream.Position = headerOffset + (sizeof(uint) * 2);
+                stream.Write(BitConverter.GetBytes(0));
+            }
+
+            var result = AssemblyLoader.Open(path);
+            Assert.IsExactInstanceOfType<AssemblyOpenResult.Direct>(result);
+            ((AssemblyOpenResult.Direct)result).Analyzer.Dispose();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
     /// <summary>Verifies that bundle-backed analyzers expose correct capabilities.</summary>
     [TestMethod]
     [Timeout(30_000, CooperativeCancellation = true)]

--- a/tests/Dotsider.Tests/CliTests.cs
+++ b/tests/Dotsider.Tests/CliTests.cs
@@ -1,3 +1,5 @@
+using Dotsider.Tests.Shared;
+
 namespace Dotsider.Tests;
 
 /// <summary>
@@ -390,6 +392,28 @@ public class CliTests
 
         Assert.AreNotEqual(0, exitCode);
         Assert.Contains("not a single-file bundle", stderr);
+    }
+
+    /// <summary>
+    /// Verifies that the real CLI reports a malformed recognized bundle without exposing parser details.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task Analyze_Bundle_MalformedManifest_ReturnsStableError()
+    {
+        var path = SyntheticSingleFileBundle.Create(fileCount: 0);
+        try
+        {
+            var (exitCode, _, stderr) = await RunDotsiderAsync("analyze", path, "--bundle");
+
+            Assert.AreEqual(1, exitCode);
+            Assert.Contains("Error: Invalid single-file bundle manifest", stderr);
+            Assert.DoesNotContain("file count", stderr, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     /// <summary>Verifies that --bundle -o rejects writing to the same input file.</summary>

--- a/tests/Dotsider.Tests/SessionBundleTests.cs
+++ b/tests/Dotsider.Tests/SessionBundleTests.cs
@@ -1,6 +1,7 @@
 using Dotsider.Core.Protocol;
 using Dotsider.Diagnostics;
 using Dotsider.Infrastructure;
+using Dotsider.Tests.Shared;
 using Hex1b;
 using Hex1b.Documents;
 using Hex1b.Widgets;
@@ -298,6 +299,31 @@ public class SessionBundleTests : IAsyncDisposable
 
         var data = (response.Data as JsonElement?)!.Value;
         Assert.IsGreaterThan(0, data.GetProperty("fileCount").GetInt32());
+    }
+
+    /// <summary>
+    /// Verifies that diagnostics reports a malformed recognized bundle with a stable generic failure.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task GetBundleManifest_MalformedBundle_ReturnsSafeFailure()
+    {
+        var path = SyntheticSingleFileBundle.Create(fileCount: 0);
+        try
+        {
+            var ct = CancellationToken.None;
+            var (_, socketPath) = await StartTuiWithDiagnosticsAsync(Samples.HelloWorldDll, ct);
+
+            var response = await DotsiderClient.SendAsync(socketPath,
+                new DotsiderRequest { Method = "get-bundle-manifest", AssemblyPath = path }, ct);
+
+            Assert.IsFalse(response.Success);
+            Assert.AreEqual("Invalid single-file bundle manifest", response.Error);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     // --- resolve-assembly ---

--- a/tests/Dotsider.Tests/SingleFileBundleReaderTests.cs
+++ b/tests/Dotsider.Tests/SingleFileBundleReaderTests.cs
@@ -1,5 +1,8 @@
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using Dotsider.Tests.Shared;
+using System.IO.Compression;
+using System.Text;
 
 namespace Dotsider.Tests;
 
@@ -81,6 +84,7 @@ public sealed class SingleFileBundleReaderTests
     {
         Assert.IsTrue(SingleFileBundleReader.IsBundle(Samples.SelfContainedConsoleExe!, out var offset));
         var manifest = SingleFileBundleReader.ReadManifest(Samples.SelfContainedConsoleExe!, offset);
+        Assert.Contains(e => e.CompressedSize > 0, manifest.Entries);
         var bytes = SingleFileBundleReader.ReadAssembly(Samples.SelfContainedConsoleExe!, manifest, "System.Runtime");
         Assert.IsNotNull(bytes);
         // Verify it's a valid PE — MZ header
@@ -110,5 +114,376 @@ public sealed class SingleFileBundleReaderTests
         using var analyzer = new AssemblyAnalyzer(result.Value.Bytes, result.Value.Name);
         Assert.IsTrue(analyzer.HasMetadata);
         Assert.AreEqual("SelfContainedConsole", analyzer.AssemblyName);
+    }
+
+    /// <summary>
+    /// Verifies that version 1 and version 6 synthetic bundles parse with their expected entry layouts.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ReadManifest_SyntheticV1AndV6_ParsesEntries()
+    {
+        var v1Path = SyntheticSingleFileBundle.Create(majorVersion: 1);
+        var v6Path = SyntheticSingleFileBundle.Create(majorVersion: 6);
+        var unknownTypePath = SyntheticSingleFileBundle.Create(type: BundleFileType.Unknown);
+        try
+        {
+            var v1 = SingleFileBundleReader.ReadManifest(v1Path, SyntheticSingleFileBundle.HeaderOffset);
+            var v6 = SingleFileBundleReader.ReadManifest(v6Path, SyntheticSingleFileBundle.HeaderOffset);
+            var unknownType = SingleFileBundleReader.ReadManifest(unknownTypePath, SyntheticSingleFileBundle.HeaderOffset);
+
+            Assert.AreEqual(1u, v1.MajorVersion);
+            Assert.AreEqual(6u, v6.MajorVersion);
+            Assert.HasCount(1, v1.Entries);
+            Assert.HasCount(1, v6.Entries);
+            Assert.AreEqual(0L, v1.Entries[0].CompressedSize);
+            Assert.AreEqual(0L, v6.Entries[0].CompressedSize);
+            Assert.AreEqual(BundleFileType.Unknown, unknownType.Entries[0].Type);
+        }
+        finally
+        {
+            DeleteFile(v1Path);
+            DeleteFile(v6Path);
+            DeleteFile(unknownTypePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a signature beginning at the final legal span offset is found.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void IsBundle_SignatureAtFinalLegalOffset_ReturnsTrue()
+    {
+        var path = SyntheticSingleFileBundle.Create();
+        try
+        {
+            var bytes = File.ReadAllBytes(path);
+            Assert.IsTrue(SingleFileBundleReader.IsBundle(bytes, out var headerOffset));
+            Assert.AreEqual(SyntheticSingleFileBundle.HeaderOffset, headerOffset);
+        }
+        finally
+        {
+            DeleteFile(path);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that invalid entry counts are rejected before an entries array is allocated.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ReadManifest_InvalidFileCount_ThrowsInvalidDataException()
+    {
+        foreach (var fileCount in new[] { -1, 0, int.MaxValue })
+        {
+            var path = SyntheticSingleFileBundle.Create(fileCount: fileCount);
+            try
+            {
+                AssertInvalidManifest(path);
+                if (fileCount == 0)
+                    Assert.IsNull(SingleFileBundleReader.FindEntryAssembly(path));
+            }
+            finally
+            {
+                DeleteFile(path);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that malformed header, string, path, and entry-kind encodings fail closed.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ReadManifest_MalformedHeaderAndStrings_ThrowsInvalidDataException()
+    {
+        using var truncated = new MemoryStream([0x06, 0x00, 0x00, 0x00], writable: false);
+        Assert.ThrowsExactly<InvalidDataException>(() => SingleFileBundleReader.ReadManifest(truncated));
+
+        var invalidUtf8Path = SyntheticSingleFileBundle.Create();
+        var malformedLengthPath = SyntheticSingleFileBundle.Create();
+        var nonCanonicalLengthPath = SyntheticSingleFileBundle.Create();
+        var oversizedStringPath = SyntheticSingleFileBundle.Create();
+        var emptyRelativePath = SyntheticSingleFileBundle.Create(relativePath: string.Empty);
+        var unknownTypePath = SyntheticSingleFileBundle.Create(type: (BundleFileType)255);
+        try
+        {
+            WriteBytes(invalidUtf8Path, SyntheticSingleFileBundle.HeaderOffset + 13, [0xff]);
+            WriteBytes(malformedLengthPath, SyntheticSingleFileBundle.HeaderOffset + 12,
+                [0x80, 0x80, 0x80, 0x80, 0x80]);
+            WriteBytes(nonCanonicalLengthPath, SyntheticSingleFileBundle.HeaderOffset + 12,
+                [0x8a, 0x00]);
+            WriteBytes(oversizedStringPath, SyntheticSingleFileBundle.HeaderOffset + 12,
+                [0x81, 0x80, 0x02]);
+
+            AssertInvalidManifest(invalidUtf8Path);
+            AssertInvalidManifest(malformedLengthPath);
+            AssertInvalidManifest(nonCanonicalLengthPath);
+            AssertInvalidManifest(oversizedStringPath);
+            AssertInvalidManifest(emptyRelativePath);
+            AssertInvalidManifest(unknownTypePath);
+        }
+        finally
+        {
+            DeleteFile(invalidUtf8Path);
+            DeleteFile(malformedLengthPath);
+            DeleteFile(nonCanonicalLengthPath);
+            DeleteFile(oversizedStringPath);
+            DeleteFile(emptyRelativePath);
+            DeleteFile(unknownTypePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the strict UTF-8 string limit accepts the maximum valid byte length.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ReadManifest_MaximumLengthRelativePath_Parses()
+    {
+        var relativePath = new string('a', (32 * 1024) - ".dll".Length) + ".dll";
+        var path = SyntheticSingleFileBundle.Create(relativePath: relativePath);
+        try
+        {
+            var manifest = SingleFileBundleReader.ReadManifest(path, SyntheticSingleFileBundle.HeaderOffset);
+            Assert.AreEqual(relativePath, manifest.Entries[0].RelativePath);
+        }
+        finally
+        {
+            DeleteFile(path);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that v2 locations and entry ranges cannot point beyond the manifest data boundary.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ReadManifest_InvalidLocationsAndRanges_ThrowsInvalidDataException()
+    {
+        var invalidV2LocationPath = SyntheticSingleFileBundle.Create();
+        var crossManifestBoundaryPath = SyntheticSingleFileBundle.Create(offset: 127, size: 2);
+        var overflowPath = SyntheticSingleFileBundle.Create(offset: long.MaxValue, size: 1);
+        var negativeSizePath = SyntheticSingleFileBundle.Create(size: -1);
+        var invalidCompressedRangePath = SyntheticSingleFileBundle.Create(offset: 127, size: 1, compressedSize: 2);
+        try
+        {
+            var depsJsonOffset = SyntheticSingleFileBundle.HeaderOffset + (sizeof(uint) * 2) + sizeof(int) + 1 + "TestBundle".Length;
+            WriteInt64(invalidV2LocationPath, depsJsonOffset, -1);
+
+            AssertInvalidManifest(invalidV2LocationPath);
+            AssertInvalidManifest(crossManifestBoundaryPath);
+            AssertInvalidManifest(overflowPath);
+            AssertInvalidManifest(negativeSizePath);
+            AssertInvalidManifest(invalidCompressedRangePath);
+        }
+        finally
+        {
+            DeleteFile(invalidV2LocationPath);
+            DeleteFile(crossManifestBoundaryPath);
+            DeleteFile(overflowPath);
+            DeleteFile(negativeSizePath);
+            DeleteFile(invalidCompressedRangePath);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a readable but non-seekable manifest stream is rejected.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ReadManifest_NonSeekableStream_ThrowsInvalidDataException()
+    {
+        var path = SyntheticSingleFileBundle.Create();
+        try
+        {
+            var compressed = SyntheticSingleFileBundle.Deflate(File.ReadAllBytes(path));
+            using var compressedStream = new MemoryStream(compressed, writable: false);
+            using var nonSeekableStream = new DeflateStream(compressedStream, CompressionMode.Decompress);
+
+            Assert.ThrowsExactly<InvalidDataException>(() => SingleFileBundleReader.ReadManifest(nonSeekableStream));
+        }
+        finally
+        {
+            DeleteFile(path);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that compressed entries are decompressed through the bounded source stream.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ReadEntry_CompressedEntry_ReturnsExactLogicalBytes()
+    {
+        var logicalBytes = Encoding.UTF8.GetBytes("compressed bundle entry");
+        var compressedBytes = SyntheticSingleFileBundle.Deflate(logicalBytes);
+        var path = SyntheticSingleFileBundle.Create(
+            size: logicalBytes.Length,
+            compressedSize: compressedBytes.Length,
+            payload: compressedBytes);
+        try
+        {
+            var manifest = SingleFileBundleReader.ReadManifest(path, SyntheticSingleFileBundle.HeaderOffset);
+            var bytes = SingleFileBundleReader.ReadEntry(path, manifest, "Test.dll");
+
+            Assert.IsNotNull(bytes);
+            Assert.AreSequenceEqual(logicalBytes, bytes);
+        }
+        finally
+        {
+            DeleteFile(path);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that compressed output longer than the declared logical length is rejected.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ReadEntry_CompressedEntryWithTrailingOutput_ReturnsNull()
+    {
+        var compressedBytes = SyntheticSingleFileBundle.Deflate(new byte[4096]);
+        var path = SyntheticSingleFileBundle.Create(
+            size: 1,
+            compressedSize: compressedBytes.Length,
+            payload: compressedBytes);
+        try
+        {
+            var manifest = SingleFileBundleReader.ReadManifest(path, SyntheticSingleFileBundle.HeaderOffset);
+            Assert.IsNull(SingleFileBundleReader.ReadEntry(path, manifest, "Test.dll"));
+        }
+        finally
+        {
+            DeleteFile(path);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a truncated compressed stream cannot produce a partial entry.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ReadEntry_TruncatedCompressedEntry_ReturnsNull()
+    {
+        var compressedBytes = SyntheticSingleFileBundle.Deflate(Encoding.UTF8.GetBytes("truncated bundle entry"));
+        var truncatedBytes = compressedBytes[..^5];
+        var path = SyntheticSingleFileBundle.Create(
+            size: "truncated bundle entry".Length,
+            compressedSize: truncatedBytes.Length,
+            payload: truncatedBytes);
+        try
+        {
+            var manifest = SingleFileBundleReader.ReadManifest(path, SyntheticSingleFileBundle.HeaderOffset);
+            Assert.IsNull(SingleFileBundleReader.ReadEntry(path, manifest, "Test.dll"));
+        }
+        finally
+        {
+            DeleteFile(path);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that oversized and externally constructed entry descriptors are not materialized.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ReadEntry_UnsafeEntryDescriptors_ReturnNull()
+    {
+        var path = SyntheticSingleFileBundle.Create();
+        try
+        {
+            var oversizedLogicalEntry = new BundleManifest(
+                6,
+                0,
+                1,
+                "TestBundle",
+                [new BundleEntry(32, (512L * 1024 * 1024) + 1, 1, BundleFileType.Assembly, "Test.dll")]);
+            var outOfRangeRawEntry = new BundleManifest(
+                6,
+                0,
+                1,
+                "TestBundle",
+                [new BundleEntry(32, long.MaxValue, 0, BundleFileType.Assembly, "Test.dll")]);
+            var oversizedStoredEntry = new BundleManifest(
+                6,
+                0,
+                1,
+                "TestBundle",
+                [new BundleEntry(32, 1, (512L * 1024 * 1024) + 1, BundleFileType.Assembly, "Test.dll")]);
+
+            Assert.IsNull(SingleFileBundleReader.ReadEntry(path, oversizedLogicalEntry, "Test.dll"));
+            Assert.IsNull(SingleFileBundleReader.ReadEntry(path, outOfRangeRawEntry, "Test.dll"));
+            Assert.IsNull(SingleFileBundleReader.ReadEntry(path, oversizedStoredEntry, "Test.dll"));
+            Assert.IsNull(SingleFileBundleReader.ReadAssembly(path, oversizedLogicalEntry, "Test"));
+        }
+        finally
+        {
+            DeleteFile(path);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that bounded mutations either parse safely or report only invalid manifest data.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ReadManifest_BoundedMutations_DoNotEscapeInvalidDataException()
+    {
+        var path = SyntheticSingleFileBundle.Create();
+        try
+        {
+            var source = File.ReadAllBytes(path);
+            var random = new Random(217);
+            for (var i = 0; i < 128; i++)
+            {
+                var mutated = source.ToArray();
+                var position = random.Next(SyntheticSingleFileBundle.HeaderOffset, mutated.Length);
+                mutated[position] ^= (byte)(1 << random.Next(8));
+
+                using var stream = new MemoryStream(mutated, writable: false)
+                {
+                    Position = SyntheticSingleFileBundle.HeaderOffset
+                };
+                try
+                {
+                    _ = SingleFileBundleReader.ReadManifest(stream);
+                }
+                catch (InvalidDataException)
+                {
+                }
+            }
+        }
+        finally
+        {
+            DeleteFile(path);
+        }
+    }
+
+    private static void AssertInvalidManifest(string path)
+    {
+        Assert.ThrowsExactly<InvalidDataException>(
+            () => SingleFileBundleReader.ReadManifest(path, SyntheticSingleFileBundle.HeaderOffset));
+    }
+
+    private static void DeleteFile(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+
+    private static void WriteBytes(string path, long position, byte[] bytes)
+    {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.None);
+        stream.Position = position;
+        stream.Write(bytes);
+    }
+
+    private static void WriteInt64(string path, long position, long value)
+    {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.None);
+        stream.Position = position;
+        stream.Write(BitConverter.GetBytes(value));
     }
 }

--- a/tests/Shared/SyntheticSingleFileBundle.cs
+++ b/tests/Shared/SyntheticSingleFileBundle.cs
@@ -1,0 +1,103 @@
+using Dotsider.Core.Analysis.Models;
+using System.IO.Compression;
+using System.Text;
+
+namespace Dotsider.Tests.Shared;
+
+/// <summary>
+/// Creates minimal single-file bundle fixtures for parser and containment tests.
+/// </summary>
+internal static class SyntheticSingleFileBundle
+{
+    private const int PayloadOffset = 32;
+
+    /// <summary>
+    /// Gets the fixed offset at which generated manifests begin.
+    /// </summary>
+    internal const int HeaderOffset = 128;
+
+    private static readonly byte[] s_bundleSignature =
+    [
+        0x8b, 0x12, 0x02, 0xb9, 0x6a, 0x61, 0x20, 0x38,
+        0x72, 0x7b, 0x93, 0x02, 0x14, 0xd7, 0xa0, 0x32,
+        0x13, 0xf5, 0xb9, 0xe6, 0xef, 0xae, 0x33, 0x18,
+        0xee, 0x3b, 0x2d, 0xce, 0x24, 0xb3, 0x6a, 0xae
+    ];
+
+    /// <summary>
+    /// Creates a minimal bundle with one configurable manifest entry.
+    /// </summary>
+    /// <param name="majorVersion">The bundle major version to encode.</param>
+    /// <param name="fileCount">The manifest file count to encode.</param>
+    /// <param name="bundleId">The bundle identifier to encode.</param>
+    /// <param name="offset">The entry offset to encode.</param>
+    /// <param name="size">The logical entry size to encode.</param>
+    /// <param name="compressedSize">The compressed entry size to encode.</param>
+    /// <param name="type">The entry type to encode.</param>
+    /// <param name="relativePath">The entry relative path to encode.</param>
+    /// <param name="payload">The payload to place before the manifest.</param>
+    /// <returns>The path of the generated bundle file.</returns>
+    internal static string Create(
+        uint majorVersion = 6,
+        int fileCount = 1,
+        string bundleId = "TestBundle",
+        long offset = 32,
+        long size = 4,
+        long compressedSize = 0,
+        BundleFileType type = BundleFileType.Assembly,
+        string relativePath = "Test.dll",
+        byte[]? payload = null)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"dotsider-single-file-{Guid.NewGuid():N}.bundle");
+        payload ??= [0x4d, 0x5a, 0x90, 0x00];
+
+        using var stream = new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
+        stream.SetLength(HeaderOffset);
+        stream.Position = PayloadOffset;
+        stream.Write(payload);
+        stream.Position = HeaderOffset;
+
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+        writer.Write(majorVersion);
+        writer.Write(0u);
+        writer.Write(fileCount);
+        writer.Write(bundleId);
+
+        if (majorVersion >= 2)
+        {
+            writer.Write(0L);
+            writer.Write(0L);
+            writer.Write(0L);
+            writer.Write(0L);
+            writer.Write(0UL);
+        }
+
+        if (fileCount > 0)
+        {
+            writer.Write(offset);
+            writer.Write(size);
+            if (majorVersion >= 6)
+                writer.Write(compressedSize);
+            writer.Write((byte)type);
+            writer.Write(relativePath);
+        }
+
+        writer.Write((long)HeaderOffset);
+        writer.Write(s_bundleSignature);
+        return path;
+    }
+
+    /// <summary>
+    /// Compresses <paramref name="bytes"/> using the Deflate format used by compressed bundle entries.
+    /// </summary>
+    /// <param name="bytes">The logical entry bytes to compress.</param>
+    /// <returns>The compressed bytes.</returns>
+    internal static byte[] Deflate(byte[] bytes)
+    {
+        using var stream = new MemoryStream();
+        using (var deflate = new DeflateStream(stream, CompressionLevel.SmallestSize, leaveOpen: true))
+            deflate.Write(bytes);
+
+        return stream.ToArray();
+    }
+}


### PR DESCRIPTION
Bounds bundle manifests and entry extraction before allocating or decompressing data, and reports malformed bundles consistently across the CLI, MCP tools, diagnostics, and loader. Adds compressed real-fixture coverage plus parser and boundary regressions. Fixes: #217