### PR TITLE
Prevent aborted WebSocket handshakes from exhausting demo sessions

### DIFF
--- a/src/Dotsider.Website/DemoSessionRateLimitingExtensions.cs
+++ b/src/Dotsider.Website/DemoSessionRateLimitingExtensions.cs
@@ -1,0 +1,41 @@
+using System.Threading.RateLimiting;
+
+namespace Dotsider.Website;
+
+internal static class DemoSessionRateLimitingExtensions
+{
+    internal const string PolicyName = "demo-sessions";
+
+    private const string NonWebSocketPartition = "non-websocket";
+    private const string RejectionMessage = "Too many active sessions";
+    private const string WebSocketPartition = "websocket";
+
+    internal static IServiceCollection AddDemoSessionRateLimiting(
+        this IServiceCollection services,
+        int maxSessions)
+    {
+        if (maxSessions <= 0)
+            throw new InvalidOperationException("Demo:MaxSessions must be greater than zero.");
+
+        return services.AddRateLimiter(options =>
+        {
+            options.RejectionStatusCode = StatusCodes.Status503ServiceUnavailable;
+            options.OnRejected = static async (context, cancellationToken) =>
+            {
+                await context.HttpContext.Response.WriteAsync(RejectionMessage, cancellationToken);
+            };
+
+            options.AddPolicy<string>(PolicyName, context =>
+                context.WebSockets.IsWebSocketRequest
+                    ? RateLimitPartition.GetConcurrencyLimiter(
+                        WebSocketPartition,
+                        _ => new ConcurrencyLimiterOptions
+                        {
+                            PermitLimit = maxSessions,
+                            QueueLimit = 0,
+                            QueueProcessingOrder = QueueProcessingOrder.OldestFirst
+                        })
+                    : RateLimitPartition.GetNoLimiter(NonWebSocketPartition));
+        });
+    }
+}

--- a/src/Dotsider.Website/DemoWebSocketSessionHandler.cs
+++ b/src/Dotsider.Website/DemoWebSocketSessionHandler.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using System.Net.WebSockets;
+
+namespace Dotsider.Website;
+
+internal sealed class DemoWebSocketSessionHandler
+{
+    private readonly IHostApplicationLifetime _applicationLifetime;
+    private readonly ILogger _logger;
+    private readonly int _maxSessions;
+    private readonly Func<WebSocket, CancellationToken, Task> _runSession;
+    private readonly TimeSpan _sessionTimeout;
+    private int _activeSessions;
+
+    internal DemoWebSocketSessionHandler(
+        IHostApplicationLifetime applicationLifetime,
+        ILogger logger,
+        int maxSessions,
+        TimeSpan sessionTimeout,
+        Func<WebSocket, CancellationToken, Task> runSession)
+    {
+        _applicationLifetime = applicationLifetime;
+        _logger = logger;
+        _maxSessions = maxSessions;
+        _sessionTimeout = sessionTimeout;
+        _runSession = runSession;
+    }
+
+    internal int ActiveSessions => Volatile.Read(ref _activeSessions);
+
+    internal async Task HandleAsync(HttpContext context)
+    {
+        if (!context.WebSockets.IsWebSocketRequest)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await context.Response.WriteAsync("WebSocket connections only");
+            return;
+        }
+
+        var ipAddress = GetClientIpAddress(context);
+        var userAgent = context.Request.Headers.UserAgent.ToString();
+        var sessionId = Guid.NewGuid().ToString("N")[..12];
+
+        using var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+
+        var sessionStart = DateTimeOffset.UtcNow;
+        var activeSessions = Interlocked.Increment(ref _activeSessions);
+
+        try
+        {
+            Log.AuditConnect(_logger, sessionId, ipAddress, userAgent);
+            Log.SessionStarted(_logger, activeSessions, _maxSessions);
+
+            using var sessionCts = CancellationTokenSource.CreateLinkedTokenSource(
+                context.RequestAborted,
+                _applicationLifetime.ApplicationStopping);
+            sessionCts.CancelAfter(_sessionTimeout);
+
+            await _runSession(webSocket, sessionCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (WebSocketException)
+        {
+        }
+        catch (Exception exception)
+        {
+            Log.SessionError(_logger, exception);
+        }
+        finally
+        {
+            var remainingSessions = Interlocked.Decrement(ref _activeSessions);
+            Log.AuditDisconnect(
+                _logger,
+                sessionId,
+                ipAddress,
+                (DateTimeOffset.UtcNow - sessionStart).TotalSeconds);
+            Log.SessionEnded(_logger, remainingSessions, _maxSessions);
+        }
+    }
+
+    private static IPAddress GetClientIpAddress(HttpContext context)
+    {
+        var ipAddress = context.Connection.RemoteIpAddress ?? IPAddress.Loopback;
+        if (!context.Request.Headers.TryGetValue("X-Forwarded-For", out var forwarded))
+            return ipAddress;
+
+        var firstAddress = forwarded.ToString().Split(',', StringSplitOptions.TrimEntries)[0];
+        return IPAddress.TryParse(firstAddress, out var parsedAddress)
+            ? parsedAddress
+            : ipAddress;
+    }
+}

--- a/src/Dotsider.Website/Program.cs
+++ b/src/Dotsider.Website/Program.cs
@@ -3,23 +3,20 @@ using Dotsider.Infrastructure;
 using Dotsider.Website;
 using Hex1b;
 using System.Collections.Concurrent;
-using System.Net;
 using System.Net.WebSockets;
 
 var builder = WebApplication.CreateBuilder(args);
 
+var maxSessions = builder.Configuration.GetValue("Demo:MaxSessions", 50);
+var sessionTimeout = TimeSpan.FromMinutes(builder.Configuration.GetValue("Demo:SessionTimeoutMinutes", 10));
+var sampleAssembly = builder.Configuration.GetValue<string>("Demo:SampleAssembly") ?? "sample.dll";
+var allowedOrigins = builder.Configuration.GetSection("Demo:AllowedOrigins").Get<string[]>() ?? ["*"];
+
 builder.Services.AddCors();
+builder.Services.AddDemoSessionRateLimiting(maxSessions);
 
 var app = builder.Build();
-
-var config = app.Configuration;
 var logger = app.Logger;
-var maxSessions = config.GetValue("Demo:MaxSessions", 50);
-var sessionTimeout = TimeSpan.FromMinutes(config.GetValue("Demo:SessionTimeoutMinutes", 10));
-var sampleAssembly = config.GetValue<string>("Demo:SampleAssembly") ?? "sample.dll";
-var allowedOrigins = config.GetSection("Demo:AllowedOrigins").Get<string[]>() ?? ["*"];
-
-var activeSessions = 0;
 
 app.UseCors(policy =>
 {
@@ -30,72 +27,25 @@ app.UseCors(policy =>
 });
 
 app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(30) });
+app.UseRateLimiter();
+
+var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
+var sessionHandler = new DemoWebSocketSessionHandler(
+    lifetime,
+    logger,
+    maxSessions,
+    sessionTimeout,
+    RunDotsiderSession);
 
 app.MapGet("/health", () => Results.Ok(new
 {
     status = "ok",
-    activeSessions,
+    activeSessions = sessionHandler.ActiveSessions,
     maxSessions,
 }));
 
-var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
-
-app.Map("/ws", async context =>
-{
-    if (!context.WebSockets.IsWebSocketRequest)
-    {
-        context.Response.StatusCode = 400;
-        await context.Response.WriteAsync("WebSocket connections only");
-        return;
-    }
-
-    // Resolve client IP (trust X-Forwarded-For from Caddy)
-    var ip = context.Connection.RemoteIpAddress ?? IPAddress.Loopback;
-    if (context.Request.Headers.TryGetValue("X-Forwarded-For", out var forwarded))
-    {
-        var first = forwarded.ToString().Split(',', StringSplitOptions.TrimEntries)[0];
-        if (IPAddress.TryParse(first, out var parsed))
-            ip = parsed;
-    }
-
-    var userAgent = context.Request.Headers.UserAgent.ToString();
-    var sessionId = Guid.NewGuid().ToString("N")[..12];
-
-    // Global session cap
-    if (Interlocked.Increment(ref activeSessions) > maxSessions)
-    {
-        Interlocked.Decrement(ref activeSessions);
-        context.Response.StatusCode = 503;
-        await context.Response.WriteAsync("Too many active sessions");
-        return;
-    }
-
-    using var ws = await context.WebSockets.AcceptWebSocketAsync();
-
-    Log.AuditConnect(logger, sessionId, ip, userAgent);
-    Log.SessionStarted(logger, activeSessions, maxSessions);
-
-    var sessionStart = DateTimeOffset.UtcNow;
-
-    var sessionCts = CancellationTokenSource.CreateLinkedTokenSource(
-        context.RequestAborted, lifetime.ApplicationStopping);
-    sessionCts.CancelAfter(sessionTimeout);
-
-    try
-    {
-        await RunDotsiderSession(ws, sessionCts.Token);
-    }
-    catch (OperationCanceledException) { }
-    catch (WebSocketException) { }
-    catch (Exception ex) { Log.SessionError(logger, ex); }
-    finally
-    {
-        Interlocked.Decrement(ref activeSessions);
-        Log.AuditDisconnect(logger, sessionId, ip, (DateTimeOffset.UtcNow - sessionStart).TotalSeconds);
-        Log.SessionEnded(logger, activeSessions, maxSessions);
-        sessionCts.Dispose();
-    }
-});
+app.Map("/ws", sessionHandler.HandleAsync)
+    .RequireRateLimiting(DemoSessionRateLimitingExtensions.PolicyName);
 
 app.Run();
 

--- a/src/Dotsider.Website/README.md
+++ b/src/Dotsider.Website/README.md
@@ -7,7 +7,7 @@ WebSocket server that powers the live demo on [dotsider.dev](https://dotsider.de
 | Path | Description |
 |------|-------------|
 | `/ws` | WebSocket — spawns a dotsider TUI session for the connecting client |
-| `/health` | JSON health check — active sessions, max sessions |
+| `/health` | JSON health check — accepted active sessions, max sessions |
 
 ## Configuration
 
@@ -15,12 +15,13 @@ All settings are read from `IConfiguration` under the `Demo:` prefix:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `Demo:MaxSessions` | 50 | Global concurrent session limit |
+| `Demo:MaxSessions` | 50 | Positive global WebSocket limit covering handshakes and accepted sessions |
 | `Demo:SessionTimeoutMinutes` | 10 | Max session duration before forced disconnect |
 | `Demo:SampleAssembly` | `sample.dll` | Path to the assembly loaded in the TUI |
 | `Demo:AllowedOrigins` | `*` | CORS allowed origins |
 
 All sessions are logged with structured audit events (`CONNECT`, `DISCONNECT`).
+Connections above `Demo:MaxSessions` are rejected immediately with HTTP 503 rather than queued.
 
 ## Deployment
 

--- a/tests/Dotsider.Website.Tests/AbortingWebSocketFeature.cs
+++ b/tests/Dotsider.Website.Tests/AbortingWebSocketFeature.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using System.Net.WebSockets;
+
+namespace Dotsider.Website.Tests;
+
+internal sealed class AbortingWebSocketFeature : IHttpWebSocketFeature
+{
+    internal static AbortingWebSocketFeature Instance { get; } = new();
+
+    private AbortingWebSocketFeature()
+    {
+    }
+
+    bool IHttpWebSocketFeature.IsWebSocketRequest => true;
+
+    Task<WebSocket> IHttpWebSocketFeature.AcceptAsync(WebSocketAcceptContext context)
+    {
+        return Task.FromException<WebSocket>(
+            new ConnectionAbortedException("The client disconnected during the WebSocket handshake."));
+    }
+}

--- a/tests/Dotsider.Website.Tests/DemoSessionRateLimitingTests.cs
+++ b/tests/Dotsider.Website.Tests/DemoSessionRateLimitingTests.cs
@@ -1,0 +1,403 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Net.WebSockets;
+
+namespace Dotsider.Website.Tests;
+
+/// <summary>
+/// Verifies the demo WebSocket concurrency limit and accepted-session lifecycle.
+/// </summary>
+/// <param name="testContext">The context for the current test.</param>
+[TestClass]
+public sealed class DemoSessionRateLimitingTests(TestContext testContext)
+{
+    private readonly TestContext _testContext = testContext;
+
+    /// <summary>
+    /// Verifies that invalid configured session limits fail during service registration.
+    /// </summary>
+    /// <param name="maxSessions">The invalid configured session limit.</param>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(-1)]
+    public void AddDemoSessionRateLimiting_NonPositiveLimit_Throws(int maxSessions)
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => services.AddDemoSessionRateLimiting(maxSessions));
+
+        Assert.AreEqual("Demo:MaxSessions must be greater than zero.", exception.Message);
+    }
+
+    /// <summary>
+    /// Verifies that failed WebSocket acceptance never consumes a concurrency permit.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task WebSocketAcceptFailure_RepeatedAborts_ReleasePermit()
+    {
+        const int maxSessions = 3;
+        var abortHandshake = true;
+        var finishSession = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sessionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        DemoWebSocketSessionHandler? sessionHandler = null;
+
+        using var host = await StartHostAsync(
+            maxSessions,
+            _ => Volatile.Read(ref abortHandshake)
+                ? AbortingWebSocketFeature.Instance
+                : null,
+            (services, endpoints) =>
+            {
+                sessionHandler = CreateSessionHandler(
+                    services,
+                    maxSessions,
+                    async (_, cancellationToken) =>
+                    {
+                        sessionStarted.SetResult();
+                        await finishSession.Task.WaitAsync(cancellationToken);
+                    });
+
+                endpoints.Map("/ws", sessionHandler.HandleAsync)
+                    .RequireRateLimiting(DemoSessionRateLimitingExtensions.PolicyName);
+            },
+            _testContext.CancellationToken);
+
+        Assert.IsNotNull(sessionHandler);
+        using var client = host.GetTestClient();
+
+        for (var attempt = 0; attempt < maxSessions * 2; attempt++)
+        {
+            await Assert.ThrowsExactlyAsync<ConnectionAbortedException>(
+                () => client.GetAsync("/ws", _testContext.CancellationToken));
+            Assert.AreEqual(0, sessionHandler.ActiveSessions);
+        }
+
+        Volatile.Write(ref abortHandshake, false);
+
+        var webSocketClient = host.GetTestServer().CreateWebSocketClient();
+        using var webSocket = await webSocketClient.ConnectAsync(
+            new Uri("ws://localhost/ws"),
+            _testContext.CancellationToken);
+
+        await sessionStarted.Task.WaitAsync(_testContext.CancellationToken);
+        Assert.AreEqual(1, sessionHandler.ActiveSessions);
+
+        finishSession.SetResult();
+        await WaitUntilAsync(
+            () => sessionHandler.ActiveSessions == 0,
+            _testContext.CancellationToken);
+        Assert.AreEqual(0, sessionHandler.ActiveSessions);
+    }
+
+    /// <summary>
+    /// Verifies that the concurrency policy admits only the configured number of WebSocket requests.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task WebSocketRequests_AtCapacity_RejectImmediatelyAndRecover()
+    {
+        const int excessRequests = 8;
+        const int maxSessions = 3;
+        var activeRequests = 0;
+        var maximumActiveRequests = 0;
+        using var admitted = new SemaphoreSlim(0);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        DemoWebSocketSessionHandler? sessionHandler = null;
+
+        using var host = await StartHostAsync(
+            maxSessions,
+            context => context.Request.Query.ContainsKey("websocket")
+                ? AbortingWebSocketFeature.Instance
+                : null,
+            (services, endpoints) =>
+            {
+                sessionHandler = CreateSessionHandler(
+                    services,
+                    maxSessions,
+                    static (_, _) => Task.CompletedTask);
+
+                endpoints.Map(
+                        "/ws",
+                        async context =>
+                        {
+                            if (!context.WebSockets.IsWebSocketRequest)
+                            {
+                                await sessionHandler.HandleAsync(context);
+                                return;
+                            }
+
+                            var active = Interlocked.Increment(ref activeRequests);
+                            UpdateMaximum(ref maximumActiveRequests, active);
+                            admitted.Release();
+
+                            try
+                            {
+                                await release.Task.WaitAsync(context.RequestAborted);
+                                context.Response.StatusCode = StatusCodes.Status204NoContent;
+                            }
+                            finally
+                            {
+                                Interlocked.Decrement(ref activeRequests);
+                            }
+                        })
+                    .RequireRateLimiting(DemoSessionRateLimitingExtensions.PolicyName);
+            },
+            _testContext.CancellationToken);
+
+        Assert.IsNotNull(sessionHandler);
+        using var client = host.GetTestClient();
+        var admittedRequests = Enumerable.Range(0, maxSessions)
+            .Select(_ => client.GetAsync("/ws?websocket=true", _testContext.CancellationToken))
+            .ToArray();
+
+        for (var request = 0; request < maxSessions; request++)
+            await admitted.WaitAsync(_testContext.CancellationToken);
+
+        var rejectedRequests = await Task.WhenAll(
+            Enumerable.Range(0, excessRequests)
+                .Select(_ => client.GetAsync("/ws?websocket=true", _testContext.CancellationToken)));
+
+        foreach (var response in rejectedRequests)
+        {
+            using (response)
+            {
+                Assert.AreEqual(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+                Assert.AreEqual(
+                    "Too many active sessions",
+                    await response.Content.ReadAsStringAsync(_testContext.CancellationToken));
+            }
+        }
+
+        using (var nonWebSocketResponse =
+               await client.GetAsync("/ws", _testContext.CancellationToken))
+        {
+            Assert.AreEqual(HttpStatusCode.BadRequest, nonWebSocketResponse.StatusCode);
+            Assert.AreEqual(
+                "WebSocket connections only",
+                await nonWebSocketResponse.Content.ReadAsStringAsync(_testContext.CancellationToken));
+        }
+
+        Assert.AreEqual(maxSessions, maximumActiveRequests);
+        release.SetResult();
+
+        var completedRequests = await Task.WhenAll(admittedRequests);
+        foreach (var response in completedRequests)
+        {
+            using (response)
+                Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+        }
+
+        using var recoveredResponse =
+            await client.GetAsync("/ws?websocket=true", _testContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.NoContent, recoveredResponse.StatusCode);
+        Assert.AreEqual(0, Volatile.Read(ref activeRequests));
+    }
+
+    /// <summary>
+    /// Verifies that health reports only accepted sessions and returns to zero after completion.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task AcceptedWebSocket_WhileSessionRuns_HealthTracksSession()
+    {
+        const int maxSessions = 1;
+        var sessionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var finishSession = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        DemoWebSocketSessionHandler? sessionHandler = null;
+
+        using var host = await StartHostAsync(
+            maxSessions,
+            featureFactory: null,
+            (services, endpoints) =>
+            {
+                sessionHandler = CreateSessionHandler(
+                    services,
+                    maxSessions,
+                    async (_, cancellationToken) =>
+                    {
+                        sessionStarted.SetResult();
+                        await finishSession.Task.WaitAsync(cancellationToken);
+                    });
+
+                endpoints.Map("/ws", sessionHandler.HandleAsync)
+                    .RequireRateLimiting(DemoSessionRateLimitingExtensions.PolicyName);
+                endpoints.MapGet("/health", () => Results.Ok(new
+                {
+                    activeSessions = sessionHandler.ActiveSessions,
+                    maxSessions
+                }));
+            },
+            _testContext.CancellationToken);
+
+        Assert.IsNotNull(sessionHandler);
+        using var httpClient = host.GetTestClient();
+        var webSocketClient = host.GetTestServer().CreateWebSocketClient();
+        using var webSocket = await webSocketClient.ConnectAsync(
+            new Uri("ws://localhost/ws"),
+            _testContext.CancellationToken);
+
+        await sessionStarted.Task.WaitAsync(_testContext.CancellationToken);
+
+        using (var activeResponse =
+               await httpClient.GetAsync("/health", _testContext.CancellationToken))
+        {
+            Assert.AreEqual(HttpStatusCode.OK, activeResponse.StatusCode);
+            Assert.Contains(
+                "\"activeSessions\":1",
+                await activeResponse.Content.ReadAsStringAsync(_testContext.CancellationToken));
+        }
+
+        finishSession.SetResult();
+        await WaitUntilAsync(
+            () => sessionHandler.ActiveSessions == 0,
+            _testContext.CancellationToken);
+
+        using var completedResponse =
+            await httpClient.GetAsync("/health", _testContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.OK, completedResponse.StatusCode);
+        Assert.Contains(
+            "\"activeSessions\":0",
+            await completedResponse.Content.ReadAsStringAsync(_testContext.CancellationToken));
+    }
+
+    /// <summary>
+    /// Verifies that an unexpected session failure releases accepted-session state.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task SessionRunnerFailure_AfterAcceptance_ReleasesSession()
+    {
+        const int maxSessions = 1;
+        var sessionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var failSession = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        DemoWebSocketSessionHandler? sessionHandler = null;
+
+        using var host = await StartHostAsync(
+            maxSessions,
+            featureFactory: null,
+            (services, endpoints) =>
+            {
+                sessionHandler = CreateSessionHandler(
+                    services,
+                    maxSessions,
+                    async (_, cancellationToken) =>
+                    {
+                        sessionStarted.SetResult();
+                        await failSession.Task.WaitAsync(cancellationToken);
+                        throw new InvalidOperationException("Expected test failure.");
+                    });
+
+                endpoints.Map("/ws", sessionHandler.HandleAsync)
+                    .RequireRateLimiting(DemoSessionRateLimitingExtensions.PolicyName);
+            },
+            _testContext.CancellationToken);
+
+        Assert.IsNotNull(sessionHandler);
+        var webSocketClient = host.GetTestServer().CreateWebSocketClient();
+        using var webSocket = await webSocketClient.ConnectAsync(
+            new Uri("ws://localhost/ws"),
+            _testContext.CancellationToken);
+
+        await sessionStarted.Task.WaitAsync(_testContext.CancellationToken);
+        Assert.AreEqual(1, sessionHandler.ActiveSessions);
+
+        failSession.SetResult();
+        await WaitUntilAsync(
+            () => sessionHandler.ActiveSessions == 0,
+            _testContext.CancellationToken);
+
+        Assert.AreEqual(0, sessionHandler.ActiveSessions);
+    }
+
+    private static DemoWebSocketSessionHandler CreateSessionHandler(
+        IServiceProvider services,
+        int maxSessions,
+        Func<WebSocket, CancellationToken, Task> runSession)
+    {
+        return new DemoWebSocketSessionHandler(
+            services.GetRequiredService<IHostApplicationLifetime>(),
+            services.GetRequiredService<ILogger<DemoWebSocketSessionHandler>>(),
+            maxSessions,
+            TimeSpan.FromMinutes(10),
+            runSession);
+    }
+
+    private static async Task<IHost> StartHostAsync(
+        int maxSessions,
+        Func<HttpContext, IHttpWebSocketFeature?>? featureFactory,
+        Action<IServiceProvider, IEndpointRouteBuilder> configureEndpoints,
+        CancellationToken cancellationToken)
+    {
+        var host = await new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.ConfigureServices(services =>
+                {
+                    services.AddDemoSessionRateLimiting(maxSessions);
+                    services.AddRouting();
+                });
+                webHost.Configure(app =>
+                {
+                    app.UseWebSockets();
+
+                    if (featureFactory is not null)
+                    {
+                        app.Use((context, next) =>
+                        {
+                            var feature = featureFactory(context);
+                            if (feature is not null)
+                                context.Features.Set(feature);
+
+                            return next(context);
+                        });
+                    }
+
+                    app.UseRouting();
+                    app.UseRateLimiter();
+                    app.UseEndpoints(
+                        endpoints => configureEndpoints(app.ApplicationServices, endpoints));
+                });
+            })
+            .StartAsync(cancellationToken);
+
+        return host;
+    }
+
+    private static async Task WaitUntilAsync(
+        Func<bool> condition,
+        CancellationToken cancellationToken)
+    {
+        while (!condition())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+        }
+    }
+
+    private static void UpdateMaximum(ref int maximum, int candidate)
+    {
+        var observed = Volatile.Read(ref maximum);
+        while (candidate > observed)
+        {
+            var original = Interlocked.CompareExchange(ref maximum, candidate, observed);
+            if (original == observed)
+                return;
+
+            observed = original;
+        }
+    }
+}

--- a/tests/Dotsider.Website.Tests/Dotsider.Website.Tests.csproj
+++ b/tests/Dotsider.Website.Tests/Dotsider.Website.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Use ASP.NET Core's concurrency limiter to hold a demo session permit for the complete WebSocket request, so failed handshakes and later session errors release capacity automatically. Accepted sessions are tracked separately for health reporting while the existing 400 and 503 behavior stays intact.

Adds in-process coverage for handshake aborts, saturation, recovery, and accepted-session cleanup, and documents the precise MaxSessions behavior.

Fixes: #210