### PR TITLE
Harden demo WebSocket origin and session admission

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -51,3 +51,9 @@ Internet → Caddy (:443) → /ws, /health → Dotsider.Website (:5100)
                         → /*           → /var/www/dotsider-docs/ (static)
                         → :2019        → Prometheus scrape (internal only)
 ```
+
+Caddy replaces `X-Forwarded-For` with the direct client's address. The website
+trusts one forwarded hop from the local loopback proxy, which keeps per-client
+WebSocket limits meaningful without accepting spoofed forwarding headers.
+Deployments that move the proxy off-host must configure a specific trusted
+proxy or network instead of broadening trust to all peers.

--- a/deploy/dotsider-website.service
+++ b/deploy/dotsider-website.service
@@ -15,6 +15,7 @@ Environment=ASPNETCORE_URLS=http://localhost:5100
 Environment=DOTNET_ENVIRONMENT=Production
 Environment=Demo__SampleAssembly=/opt/dotsider-website/sample/RichLibrary.dll
 Environment=Demo__MaxSessions=50
+Environment=Demo__MaxSessionsPerClient=3
 Environment=Demo__SessionTimeoutMinutes=10
 Environment=Demo__AllowedOrigins__0=https://dotsider.dev
 

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -68,6 +68,7 @@ Environment=ASPNETCORE_URLS=http://localhost:5100
 Environment=DOTNET_ENVIRONMENT=Production
 Environment=Demo__SampleAssembly=/opt/dotsider-website/sample/RichLibrary.dll
 Environment=Demo__MaxSessions=50
+Environment=Demo__MaxSessionsPerClient=3
 Environment=Demo__SessionTimeoutMinutes=10
 Environment=Demo__AllowedOrigins__0=https://dotsider.dev
 

--- a/src/Dotsider.Website/DemoClientIdentity.cs
+++ b/src/Dotsider.Website/DemoClientIdentity.cs
@@ -1,0 +1,18 @@
+namespace Dotsider.Website;
+
+internal static class DemoClientIdentity
+{
+    private const string UnknownClient = "unknown";
+
+    internal static string GetPartitionKey(HttpContext context)
+    {
+        var address = context.Connection.RemoteIpAddress;
+        if (address is null)
+            return UnknownClient;
+
+        if (address.IsIPv4MappedToIPv6)
+            address = address.MapToIPv4();
+
+        return address.ToString();
+    }
+}

--- a/src/Dotsider.Website/DemoClientSessionRateLimiterPolicy.cs
+++ b/src/Dotsider.Website/DemoClientSessionRateLimiterPolicy.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.RateLimiting;
+using System.Threading.RateLimiting;
+
+namespace Dotsider.Website;
+
+internal sealed class DemoClientSessionRateLimiterPolicy : IRateLimiterPolicy<string>
+{
+    private const string NonWebSocketPartition = "non-websocket";
+    private const string RejectionMessage = "Too many active sessions for this client";
+    private readonly int _permitLimit;
+
+    internal DemoClientSessionRateLimiterPolicy(int permitLimit)
+    {
+        _permitLimit = permitLimit;
+    }
+
+    Func<OnRejectedContext, CancellationToken, ValueTask>?
+        IRateLimiterPolicy<string>.OnRejected => OnRejectedAsync;
+
+    RateLimitPartition<string> IRateLimiterPolicy<string>.GetPartition(
+        HttpContext httpContext)
+    {
+        return httpContext.WebSockets.IsWebSocketRequest
+            ? RateLimitPartition.GetConcurrencyLimiter(
+                DemoClientIdentity.GetPartitionKey(httpContext),
+                _ => new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = _permitLimit,
+                    QueueLimit = 0,
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst
+                })
+            : RateLimitPartition.GetNoLimiter(NonWebSocketPartition);
+    }
+
+    private static async ValueTask OnRejectedAsync(
+        OnRejectedContext context,
+        CancellationToken cancellationToken)
+    {
+        context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        await context.HttpContext.Response.WriteAsync(
+            RejectionMessage,
+            cancellationToken);
+    }
+}

--- a/src/Dotsider.Website/DemoOptions.cs
+++ b/src/Dotsider.Website/DemoOptions.cs
@@ -1,0 +1,31 @@
+namespace Dotsider.Website;
+
+internal sealed class DemoOptions
+{
+    internal const string SectionName = "Demo";
+
+    /// <summary>
+    /// Gets or sets the origins allowed to establish WebSocket connections.
+    /// </summary>
+    public string[] AllowedOrigins { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent demo sessions.
+    /// </summary>
+    public int MaxSessions { get; set; } = 50;
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent demo sessions per client address.
+    /// </summary>
+    public int MaxSessionsPerClient { get; set; } = 3;
+
+    /// <summary>
+    /// Gets or sets the sample assembly opened by the demo.
+    /// </summary>
+    public string SampleAssembly { get; set; } = "sample.dll";
+
+    /// <summary>
+    /// Gets or sets the maximum session duration in minutes.
+    /// </summary>
+    public int SessionTimeoutMinutes { get; set; } = 10;
+}

--- a/src/Dotsider.Website/DemoOptionsServiceCollectionExtensions.cs
+++ b/src/Dotsider.Website/DemoOptionsServiceCollectionExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Options;
+
+namespace Dotsider.Website;
+
+internal static class DemoOptionsServiceCollectionExtensions
+{
+    internal static IServiceCollection AddDemoOptions(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var section = configuration.GetSection(DemoOptions.SectionName);
+        var originsConfigured = section.GetSection(nameof(DemoOptions.AllowedOrigins)).Exists();
+
+        services.AddSingleton<IValidateOptions<DemoOptions>, DemoOptionsValidator>();
+        services.AddOptions<DemoOptions>()
+            .Bind(section)
+            .PostConfigure(options =>
+            {
+                if (!originsConfigured)
+                    options.AllowedOrigins = ["*"];
+            })
+            .ValidateOnStart();
+        services.AddSingleton(static serviceProvider =>
+            DemoOriginPolicy.Create(
+                serviceProvider.GetRequiredService<IOptions<DemoOptions>>().Value.AllowedOrigins));
+        services.Configure<ForwardedHeadersOptions>(static options =>
+        {
+            options.ForwardedHeaders = ForwardedHeaders.XForwardedFor;
+            options.ForwardLimit = 1;
+        });
+
+        return services;
+    }
+}

--- a/src/Dotsider.Website/DemoOptionsValidator.cs
+++ b/src/Dotsider.Website/DemoOptionsValidator.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Options;
+
+namespace Dotsider.Website;
+
+internal sealed class DemoOptionsValidator : IValidateOptions<DemoOptions>
+{
+    ValidateOptionsResult IValidateOptions<DemoOptions>.Validate(
+        string? name,
+        DemoOptions options)
+    {
+        var failures = new List<string>();
+
+        if (options.MaxSessions <= 0)
+            failures.Add("Demo:MaxSessions must be greater than zero.");
+
+        if (options.MaxSessionsPerClient <= 0)
+            failures.Add("Demo:MaxSessionsPerClient must be greater than zero.");
+        else if (options.MaxSessionsPerClient > options.MaxSessions)
+        {
+            failures.Add(
+                "Demo:MaxSessionsPerClient must not exceed Demo:MaxSessions.");
+        }
+
+        if (!DemoOriginPolicy.TryCreate(options.AllowedOrigins, out _, out var originFailure))
+            failures.Add(originFailure);
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/Dotsider.Website/DemoOriginPolicy.cs
+++ b/src/Dotsider.Website/DemoOriginPolicy.cs
@@ -1,0 +1,102 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Dotsider.Website;
+
+internal sealed class DemoOriginPolicy
+{
+    private DemoOriginPolicy(string[] allowedOrigins, bool allowsAnyOrigin)
+    {
+        AllowedOrigins = allowedOrigins;
+        AllowsAnyOrigin = allowsAnyOrigin;
+    }
+
+    internal string[] AllowedOrigins { get; }
+
+    internal bool AllowsAnyOrigin { get; }
+
+    internal static DemoOriginPolicy Create(string[]? configuredOrigins)
+    {
+        if (TryCreate(configuredOrigins, out var policy, out var failure))
+            return policy;
+
+        throw new InvalidOperationException(failure);
+    }
+
+    internal static bool TryCreate(
+        string[]? configuredOrigins,
+        [NotNullWhen(true)] out DemoOriginPolicy? policy,
+        [NotNullWhen(false)] out string? failure)
+    {
+        policy = null;
+
+        if (configuredOrigins is null || configuredOrigins.Length == 0)
+        {
+            failure = "Demo:AllowedOrigins must contain at least one origin.";
+            return false;
+        }
+
+        var normalizedOrigins = new List<string>(configuredOrigins.Length);
+        var uniqueOrigins = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var configuredOrigin in configuredOrigins)
+        {
+            if (string.IsNullOrWhiteSpace(configuredOrigin))
+            {
+                failure = "Demo:AllowedOrigins entries must not be empty.";
+                return false;
+            }
+
+            var origin = configuredOrigin.Trim();
+            if (origin == "*")
+            {
+                if (configuredOrigins.Length != 1)
+                {
+                    failure =
+                        "Demo:AllowedOrigins cannot combine '*' with explicit origins.";
+                    return false;
+                }
+
+                policy = new DemoOriginPolicy(["*"], allowsAnyOrigin: true);
+                failure = null;
+                return true;
+            }
+
+            if (!TryNormalizeOrigin(origin, out var normalizedOrigin))
+            {
+                failure =
+                    $"Demo:AllowedOrigins entry '{origin}' must be an HTTP or HTTPS origin without credentials, a path, query, or fragment.";
+                return false;
+            }
+
+            if (uniqueOrigins.Add(normalizedOrigin))
+                normalizedOrigins.Add(normalizedOrigin);
+        }
+
+        policy = new DemoOriginPolicy([.. normalizedOrigins], allowsAnyOrigin: false);
+        failure = null;
+        return true;
+    }
+
+    private static bool TryNormalizeOrigin(
+        string origin,
+        [NotNullWhen(true)] out string? normalizedOrigin)
+    {
+        normalizedOrigin = null;
+
+        if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) ||
+            string.IsNullOrEmpty(uri.Host) ||
+            !string.IsNullOrEmpty(uri.UserInfo) ||
+            (uri.AbsolutePath != "/" && uri.AbsolutePath.Length != 0) ||
+            !string.IsNullOrEmpty(uri.Query) ||
+            !string.IsNullOrEmpty(uri.Fragment))
+        {
+            return false;
+        }
+
+        normalizedOrigin = uri.GetComponents(
+            UriComponents.SchemeAndServer,
+            UriFormat.UriEscaped);
+        return true;
+    }
+}

--- a/src/Dotsider.Website/DemoSessionRateLimitingExtensions.cs
+++ b/src/Dotsider.Website/DemoSessionRateLimitingExtensions.cs
@@ -1,41 +1,53 @@
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
 using System.Threading.RateLimiting;
 
 namespace Dotsider.Website;
 
 internal static class DemoSessionRateLimitingExtensions
 {
-    internal const string PolicyName = "demo-sessions";
+    internal const string PolicyName = "demo-client-sessions";
 
     private const string NonWebSocketPartition = "non-websocket";
     private const string RejectionMessage = "Too many active sessions";
     private const string WebSocketPartition = "websocket";
 
     internal static IServiceCollection AddDemoSessionRateLimiting(
-        this IServiceCollection services,
-        int maxSessions)
+        this IServiceCollection services)
     {
-        if (maxSessions <= 0)
-            throw new InvalidOperationException("Demo:MaxSessions must be greater than zero.");
-
-        return services.AddRateLimiter(options =>
-        {
-            options.RejectionStatusCode = StatusCodes.Status503ServiceUnavailable;
-            options.OnRejected = static async (context, cancellationToken) =>
+        services.AddRateLimiter();
+        services.AddOptions<RateLimiterOptions>()
+            .Configure<IOptions<DemoOptions>>(static (options, configuredOptions) =>
             {
-                await context.HttpContext.Response.WriteAsync(RejectionMessage, cancellationToken);
-            };
+                var demoOptions = configuredOptions.Value;
 
-            options.AddPolicy<string>(PolicyName, context =>
-                context.WebSockets.IsWebSocketRequest
-                    ? RateLimitPartition.GetConcurrencyLimiter(
-                        WebSocketPartition,
-                        _ => new ConcurrencyLimiterOptions
-                        {
-                            PermitLimit = maxSessions,
-                            QueueLimit = 0,
-                            QueueProcessingOrder = QueueProcessingOrder.OldestFirst
-                        })
-                    : RateLimitPartition.GetNoLimiter(NonWebSocketPartition));
-        });
+                options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(
+                    context => context.WebSockets.IsWebSocketRequest
+                        ? RateLimitPartition.GetConcurrencyLimiter(
+                            WebSocketPartition,
+                            _ => new ConcurrencyLimiterOptions
+                            {
+                                PermitLimit = demoOptions.MaxSessions,
+                                QueueLimit = 0,
+                                QueueProcessingOrder = QueueProcessingOrder.OldestFirst
+                            })
+                        : RateLimitPartition.GetNoLimiter(NonWebSocketPartition));
+                options.RejectionStatusCode = StatusCodes.Status503ServiceUnavailable;
+                options.OnRejected = static async (context, cancellationToken) =>
+                {
+                    context.HttpContext.Response.StatusCode =
+                        StatusCodes.Status503ServiceUnavailable;
+                    await context.HttpContext.Response.WriteAsync(
+                        RejectionMessage,
+                        cancellationToken);
+                };
+
+                options.AddPolicy(
+                    PolicyName,
+                    new DemoClientSessionRateLimiterPolicy(
+                        demoOptions.MaxSessionsPerClient));
+            });
+
+        return services;
     }
 }

--- a/src/Dotsider.Website/DemoWebSocketOriginMiddleware.cs
+++ b/src/Dotsider.Website/DemoWebSocketOriginMiddleware.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Primitives;
+
+namespace Dotsider.Website;
+
+/// <summary>
+/// Rejects WebSocket upgrade requests that omit a required origin.
+/// </summary>
+/// <param name="next">The next middleware in the request pipeline.</param>
+/// <param name="requireOrigin">
+/// A value indicating whether WebSocket requests must supply an origin.
+/// </param>
+internal sealed class DemoWebSocketOriginMiddleware(
+    RequestDelegate next,
+    bool requireOrigin)
+{
+    private static readonly PathString WebSocketPath = new("/ws");
+    private readonly RequestDelegate _next = next;
+    private readonly bool _requireOrigin = requireOrigin;
+
+    /// <summary>
+    /// Rejects WebSocket upgrade requests that omit a required origin.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <returns>A task that represents the middleware operation.</returns>
+    public Task InvokeAsync(HttpContext context)
+    {
+        if (_requireOrigin &&
+            context.Request.Path == WebSocketPath &&
+            context.WebSockets.IsWebSocketRequest &&
+            StringValues.IsNullOrEmpty(context.Request.Headers.Origin))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            return Task.CompletedTask;
+        }
+
+        return _next(context);
+    }
+}

--- a/src/Dotsider.Website/DemoWebSocketSessionHandler.cs
+++ b/src/Dotsider.Website/DemoWebSocketSessionHandler.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Net.WebSockets;
 
 namespace Dotsider.Website;
@@ -37,7 +36,7 @@ internal sealed class DemoWebSocketSessionHandler
             return;
         }
 
-        var ipAddress = GetClientIpAddress(context);
+        var clientAddress = DemoClientIdentity.GetPartitionKey(context);
         var userAgent = context.Request.Headers.UserAgent.ToString();
         var sessionId = Guid.NewGuid().ToString("N")[..12];
 
@@ -48,7 +47,7 @@ internal sealed class DemoWebSocketSessionHandler
 
         try
         {
-            Log.AuditConnect(_logger, sessionId, ipAddress, userAgent);
+            Log.AuditConnect(_logger, sessionId, clientAddress, userAgent);
             Log.SessionStarted(_logger, activeSessions, _maxSessions);
 
             using var sessionCts = CancellationTokenSource.CreateLinkedTokenSource(
@@ -74,21 +73,10 @@ internal sealed class DemoWebSocketSessionHandler
             Log.AuditDisconnect(
                 _logger,
                 sessionId,
-                ipAddress,
+                clientAddress,
                 (DateTimeOffset.UtcNow - sessionStart).TotalSeconds);
             Log.SessionEnded(_logger, remainingSessions, _maxSessions);
         }
     }
 
-    private static IPAddress GetClientIpAddress(HttpContext context)
-    {
-        var ipAddress = context.Connection.RemoteIpAddress ?? IPAddress.Loopback;
-        if (!context.Request.Headers.TryGetValue("X-Forwarded-For", out var forwarded))
-            return ipAddress;
-
-        var firstAddress = forwarded.ToString().Split(',', StringSplitOptions.TrimEntries)[0];
-        return IPAddress.TryParse(firstAddress, out var parsedAddress)
-            ? parsedAddress
-            : ipAddress;
-    }
 }

--- a/src/Dotsider.Website/Log.cs
+++ b/src/Dotsider.Website/Log.cs
@@ -1,5 +1,3 @@
-using System.Net;
-
 namespace Dotsider.Website;
 
 /// <summary>
@@ -9,22 +7,53 @@ internal static partial class Log
 {
     // ── Session lifecycle ────────────────────────────────────────────
 
+    /// <summary>
+    /// Logs that a demo session has started.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="active">The number of active sessions.</param>
+    /// <param name="max">The global session limit.</param>
     [LoggerMessage(Level = LogLevel.Information, Message = "Session started ({Active}/{Max})")]
     public static partial void SessionStarted(ILogger logger, int active, int max);
 
+    /// <summary>
+    /// Logs that a demo session has ended.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="active">The number of active sessions.</param>
+    /// <param name="max">The global session limit.</param>
     [LoggerMessage(Level = LogLevel.Information, Message = "Session ended ({Active}/{Max})")]
     public static partial void SessionEnded(ILogger logger, int active, int max);
 
+    /// <summary>
+    /// Logs an unexpected demo session failure.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="ex">The session exception.</param>
     [LoggerMessage(Level = LogLevel.Error, Message = "Session error")]
     public static partial void SessionError(ILogger logger, Exception ex);
 
     // ── Audit trail ──────────────────────────────────────────────────
 
+    /// <summary>
+    /// Logs a demo session connection for the audit trail.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="sessionId">The session identifier.</param>
+    /// <param name="ip">The resolved client address.</param>
+    /// <param name="userAgent">The client user agent.</param>
     [LoggerMessage(Level = LogLevel.Information,
         Message = "CONNECT session={SessionId} ip={Ip} ua={UserAgent}")]
-    public static partial void AuditConnect(ILogger logger, string sessionId, IPAddress ip, string? userAgent);
+    public static partial void AuditConnect(ILogger logger, string sessionId, string ip, string? userAgent);
 
+    /// <summary>
+    /// Logs a demo session disconnection for the audit trail.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="sessionId">The session identifier.</param>
+    /// <param name="ip">The resolved client address.</param>
+    /// <param name="durationSec">The session duration in seconds.</param>
     [LoggerMessage(Level = LogLevel.Information,
         Message = "DISCONNECT session={SessionId} ip={Ip} duration={DurationSec:F1}s")]
-    public static partial void AuditDisconnect(ILogger logger, string sessionId, IPAddress ip, double durationSec);
+    public static partial void AuditDisconnect(ILogger logger, string sessionId, string ip, double durationSec);
 }

--- a/src/Dotsider.Website/Program.cs
+++ b/src/Dotsider.Website/Program.cs
@@ -2,31 +2,43 @@ using Dotsider;
 using Dotsider.Infrastructure;
 using Dotsider.Website;
 using Hex1b;
+using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
 using System.Net.WebSockets;
 
 var builder = WebApplication.CreateBuilder(args);
 
-var maxSessions = builder.Configuration.GetValue("Demo:MaxSessions", 50);
-var sessionTimeout = TimeSpan.FromMinutes(builder.Configuration.GetValue("Demo:SessionTimeoutMinutes", 10));
-var sampleAssembly = builder.Configuration.GetValue<string>("Demo:SampleAssembly") ?? "sample.dll";
-var allowedOrigins = builder.Configuration.GetSection("Demo:AllowedOrigins").Get<string[]>() ?? ["*"];
-
 builder.Services.AddCors();
-builder.Services.AddDemoSessionRateLimiting(maxSessions);
+builder.Services.AddDemoOptions(builder.Configuration);
+builder.Services.AddDemoSessionRateLimiting();
 
 var app = builder.Build();
+var demoOptions = app.Services.GetRequiredService<IOptions<DemoOptions>>().Value;
 var logger = app.Logger;
+var maxSessions = demoOptions.MaxSessions;
+var maxSessionsPerClient = demoOptions.MaxSessionsPerClient;
+var originPolicy = app.Services.GetRequiredService<DemoOriginPolicy>();
+var sampleAssembly = demoOptions.SampleAssembly;
+var sessionTimeout = TimeSpan.FromMinutes(demoOptions.SessionTimeoutMinutes);
 
+app.UseForwardedHeaders();
 app.UseCors(policy =>
 {
-    if (allowedOrigins is ["*"])
+    if (originPolicy.AllowsAnyOrigin)
         policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod();
     else
-        policy.WithOrigins(allowedOrigins).AllowAnyHeader().AllowAnyMethod();
+        policy.WithOrigins(originPolicy.AllowedOrigins).AllowAnyHeader().AllowAnyMethod();
 });
 
-app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(30) });
+var webSocketOptions = new WebSocketOptions
+{
+    KeepAliveInterval = TimeSpan.FromSeconds(30)
+};
+foreach (var origin in originPolicy.AllowedOrigins)
+    webSocketOptions.AllowedOrigins.Add(origin);
+
+app.UseWebSockets(webSocketOptions);
+app.UseMiddleware<DemoWebSocketOriginMiddleware>(!originPolicy.AllowsAnyOrigin);
 app.UseRateLimiter();
 
 var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
@@ -42,6 +54,7 @@ app.MapGet("/health", () => Results.Ok(new
     status = "ok",
     activeSessions = sessionHandler.ActiveSessions,
     maxSessions,
+    maxSessionsPerClient
 }));
 
 app.Map("/ws", sessionHandler.HandleAsync)

--- a/src/Dotsider.Website/README.md
+++ b/src/Dotsider.Website/README.md
@@ -7,7 +7,7 @@ WebSocket server that powers the live demo on [dotsider.dev](https://dotsider.de
 | Path | Description |
 |------|-------------|
 | `/ws` | WebSocket — spawns a dotsider TUI session for the connecting client |
-| `/health` | JSON health check — accepted active sessions, max sessions |
+| `/health` | JSON health check — accepted active sessions and configured global and per-client limits |
 
 ## Configuration
 
@@ -16,13 +16,26 @@ All settings are read from `IConfiguration` under the `Demo:` prefix:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `Demo:MaxSessions` | 50 | Positive global WebSocket limit covering handshakes and accepted sessions |
+| `Demo:MaxSessionsPerClient` | 3 | Positive concurrent WebSocket limit per resolved client address; cannot exceed `Demo:MaxSessions` |
 | `Demo:SessionTimeoutMinutes` | 10 | Max session duration before forced disconnect |
 | `Demo:SampleAssembly` | `sample.dll` | Path to the assembly loaded in the TUI |
-| `Demo:AllowedOrigins` | `*` | CORS allowed origins |
+| `Demo:AllowedOrigins` | `*` | HTTP and WebSocket origins; `*` is development mode and must be the only entry |
 
 All sessions are logged with structured audit events (`CONNECT`, `DISCONNECT`).
-Connections above `Demo:MaxSessions` are rejected immediately with HTTP 503 rather than queued.
+Connections above `Demo:MaxSessionsPerClient` are rejected immediately with HTTP 429,
+while site-wide exhaustion returns HTTP 503. Neither limit queues connections.
+
+An explicit origin allowlist rejects foreign and missing WebSocket origins with HTTP
+403. Wildcard mode accepts arbitrary and missing origins for local tools and
+non-browser clients. Origin validation protects the browser boundary but is not
+authentication.
 
 ## Deployment
 
 Published as a self-contained `linux-x64` binary and deployed to a Hetzner VM behind Caddy. See `deploy/` for the Caddyfile, systemd unit, and setup script.
+
+The application accepts `X-Forwarded-For` only from the framework's trusted
+loopback proxy boundary and consumes one forwarded hop. Caddy replaces the
+incoming header with its direct client's address. Deployments with a different
+proxy topology must configure an equally narrow trusted-proxy boundary rather
+than forwarding arbitrary client-supplied values.

--- a/src/Dotsider.Website/appsettings.json
+++ b/src/Dotsider.Website/appsettings.json
@@ -8,6 +8,7 @@
     "DotsiderPath": "dotsider",
     "SampleAssembly": "../../samples/RichLibrary/bin/Debug/net10.0/RichLibrary.dll",
     "MaxSessions": 50,
+    "MaxSessionsPerClient": 3,
     "SessionTimeoutMinutes": 10,
     "AllowedOrigins": ["*"]
   }

--- a/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/StandardModeYankIntegrationTests.cs
@@ -1496,7 +1496,9 @@ public class StandardModeYankIntegrationTests : IDisposable
         // Yank the selection
         await new Hex1bTerminalInputSequenceBuilder()
             .Type("y")
-            .WaitUntil(s => s.ContainsText("Yanked"), TimeSpan.FromSeconds(5))
+            .WaitUntil(
+                snapshot => _clipboardAdapter!.ClipboardWrites.TryPeek(out _),
+                TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal, ct);
 

--- a/tests/Dotsider.Website.Tests/DemoClientIdentityTests.cs
+++ b/tests/Dotsider.Website.Tests/DemoClientIdentityTests.cs
@@ -1,0 +1,181 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.Net;
+
+namespace Dotsider.Website.Tests;
+
+/// <summary>
+/// Verifies trusted proxy processing and client partition identities.
+/// </summary>
+/// <param name="testContext">The context for the current test.</param>
+[TestClass]
+public sealed class DemoClientIdentityTests(TestContext testContext)
+{
+    private readonly TestContext _testContext = testContext;
+
+    /// <summary>
+    /// Verifies that an untrusted peer cannot replace its address with a forwarded value.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task ForwardedFor_UntrustedPeer_IsIgnored()
+    {
+        using var host = await StartHostAsync(_testContext.CancellationToken);
+
+        var identity = await SendIdentityAsync(
+            host.GetTestServer(),
+            IPAddress.Parse("203.0.113.10"),
+            "198.51.100.10",
+            _testContext.CancellationToken);
+
+        Assert.AreEqual("203.0.113.10", identity);
+    }
+
+    /// <summary>
+    /// Verifies that the same-host proxy can supply the original client address.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task ForwardedFor_LoopbackProxy_IsApplied()
+    {
+        using var host = await StartHostAsync(_testContext.CancellationToken);
+
+        var identity = await SendIdentityAsync(
+            host.GetTestServer(),
+            IPAddress.Loopback,
+            "198.51.100.20",
+            _testContext.CancellationToken);
+
+        Assert.AreEqual("198.51.100.20", identity);
+    }
+
+    /// <summary>
+    /// Verifies that only the nearest forwarded hop is consumed.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task ForwardedFor_MultipleValues_UsesNearestHopOnly()
+    {
+        using var host = await StartHostAsync(_testContext.CancellationToken);
+
+        var identity = await SendIdentityAsync(
+            host.GetTestServer(),
+            IPAddress.Loopback,
+            "198.51.100.30, 203.0.113.30",
+            _testContext.CancellationToken);
+
+        Assert.AreEqual("203.0.113.30", identity);
+    }
+
+    /// <summary>
+    /// Verifies that malformed forwarded addresses do not replace the proxy address.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task ForwardedFor_MalformedValue_IsIgnored()
+    {
+        using var host = await StartHostAsync(_testContext.CancellationToken);
+
+        var identity = await SendIdentityAsync(
+            host.GetTestServer(),
+            IPAddress.Loopback,
+            "not-an-address",
+            _testContext.CancellationToken);
+
+        Assert.AreEqual(IPAddress.Loopback.ToString(), identity);
+    }
+
+    /// <summary>
+    /// Verifies that IPv4 and mapped IPv6 addresses share one partition identity.
+    /// </summary>
+    [TestMethod]
+    public void GetPartitionKey_IPv4MappedAddress_NormalizesToIPv4()
+    {
+        var ipv4Context = new DefaultHttpContext();
+        ipv4Context.Connection.RemoteIpAddress = IPAddress.Parse("192.0.2.40");
+        var mappedContext = new DefaultHttpContext();
+        mappedContext.Connection.RemoteIpAddress =
+            IPAddress.Parse("::ffff:192.0.2.40");
+
+        var ipv4Identity = DemoClientIdentity.GetPartitionKey(ipv4Context);
+        var mappedIdentity = DemoClientIdentity.GetPartitionKey(mappedContext);
+
+        Assert.AreEqual(ipv4Identity, mappedIdentity);
+        Assert.AreEqual("192.0.2.40", mappedIdentity);
+    }
+
+    /// <summary>
+    /// Verifies that requests without a transport address share a bounded fallback partition.
+    /// </summary>
+    [TestMethod]
+    public void GetPartitionKey_MissingAddress_UsesSharedFallback()
+    {
+        var firstContext = new DefaultHttpContext();
+        var secondContext = new DefaultHttpContext();
+
+        var firstIdentity = DemoClientIdentity.GetPartitionKey(firstContext);
+        var secondIdentity = DemoClientIdentity.GetPartitionKey(secondContext);
+
+        Assert.AreEqual("unknown", firstIdentity);
+        Assert.AreEqual(firstIdentity, secondIdentity);
+    }
+
+    private static async Task<string> SendIdentityAsync(
+        TestServer server,
+        IPAddress remoteAddress,
+        string forwardedFor,
+        CancellationToken cancellationToken)
+    {
+        var context = await server.SendAsync(
+            context =>
+            {
+                context.Connection.RemoteIpAddress = remoteAddress;
+                context.Request.Headers["X-Forwarded-For"] = forwardedFor;
+                context.Request.Method = HttpMethods.Get;
+                context.Request.Path = "/identity";
+            },
+            cancellationToken);
+
+        return context.Response.Headers["X-Test-Client-Identity"].ToString();
+    }
+
+    private static async Task<IHost> StartHostAsync(CancellationToken cancellationToken)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection()
+            .Build();
+        var host = await new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.ConfigureServices(services =>
+                {
+                    services.AddDemoOptions(configuration);
+                    services.AddRouting();
+                });
+                webHost.Configure(app =>
+                {
+                    app.UseForwardedHeaders();
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapGet("/identity", context =>
+                        {
+                            context.Response.Headers["X-Test-Client-Identity"] =
+                                DemoClientIdentity.GetPartitionKey(context);
+                            return Task.CompletedTask;
+                        });
+                    });
+                });
+            })
+            .StartAsync(cancellationToken);
+
+        return host;
+    }
+}

--- a/tests/Dotsider.Website.Tests/DemoOptionsTests.cs
+++ b/tests/Dotsider.Website.Tests/DemoOptionsTests.cs
@@ -1,0 +1,215 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Dotsider.Website.Tests;
+
+/// <summary>
+/// Verifies validation and normalization of demo security settings.
+/// </summary>
+/// <param name="testContext">The context for the current test.</param>
+[TestClass]
+public sealed class DemoOptionsTests(TestContext testContext)
+{
+    private readonly TestContext _testContext = testContext;
+
+    /// <summary>
+    /// Verifies that invalid per-client limits fail validation.
+    /// </summary>
+    /// <param name="maxSessions">The configured global limit.</param>
+    /// <param name="maxSessionsPerClient">The configured per-client limit.</param>
+    /// <param name="expectedFailure">The expected validation failure.</param>
+    [TestMethod]
+    [DataRow(10, 0, "Demo:MaxSessionsPerClient must be greater than zero.")]
+    [DataRow(10, -1, "Demo:MaxSessionsPerClient must be greater than zero.")]
+    [DataRow(
+        2,
+        3,
+        "Demo:MaxSessionsPerClient must not exceed Demo:MaxSessions.")]
+    public void Validate_InvalidPerClientLimit_Fails(
+        int maxSessions,
+        int maxSessionsPerClient,
+        string expectedFailure)
+    {
+        var options = new DemoOptions
+        {
+            MaxSessions = maxSessions,
+            MaxSessionsPerClient = maxSessionsPerClient
+        };
+
+        var result = Validate(options);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsNotNull(result.Failures);
+        Assert.Contains(expectedFailure, result.Failures);
+    }
+
+    /// <summary>
+    /// Verifies that malformed or non-origin values fail validation.
+    /// </summary>
+    /// <param name="origin">The invalid configured origin.</param>
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("ftp://example.com")]
+    [DataRow("https://example.com/#fragment")]
+    [DataRow("https://example.com/?query=true")]
+    [DataRow("https://example.com/path")]
+    [DataRow("https://user@example.com")]
+    [DataRow("not an origin")]
+    [DataRow("null")]
+    public void Validate_InvalidOrigin_Fails(string origin)
+    {
+        var options = new DemoOptions
+        {
+            AllowedOrigins = [origin]
+        };
+
+        var result = Validate(options);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsNotNull(result.Failures);
+        Assert.Contains("Demo:AllowedOrigins", Assert.ContainsSingle(result.Failures));
+    }
+
+    /// <summary>
+    /// Verifies that an empty origin collection fails validation.
+    /// </summary>
+    [TestMethod]
+    public void Validate_NoOrigins_Fails()
+    {
+        var options = new DemoOptions
+        {
+            AllowedOrigins = []
+        };
+
+        var result = Validate(options);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsNotNull(result.Failures);
+        Assert.Contains(
+            "Demo:AllowedOrigins must contain at least one origin.",
+            result.Failures);
+    }
+
+    /// <summary>
+    /// Verifies that wildcard mode cannot be combined with explicit origins.
+    /// </summary>
+    [TestMethod]
+    public void Validate_WildcardAndExplicitOrigin_Fails()
+    {
+        var options = new DemoOptions
+        {
+            AllowedOrigins = ["*", "https://dotsider.dev"]
+        };
+
+        var result = Validate(options);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsNotNull(result.Failures);
+        Assert.Contains(
+            "Demo:AllowedOrigins cannot combine '*' with explicit origins.",
+            result.Failures);
+    }
+
+    /// <summary>
+    /// Verifies that equivalent explicit origins are normalized and deduplicated.
+    /// </summary>
+    [TestMethod]
+    public void Create_EquivalentOrigins_NormalizesAndDeduplicates()
+    {
+        var policy = DemoOriginPolicy.Create(
+            [" HTTPS://DOTSIDER.DEV:443/ ", "https://dotsider.dev"]);
+
+        Assert.IsFalse(policy.AllowsAnyOrigin);
+        Assert.HasCount(1, policy.AllowedOrigins);
+        Assert.AreEqual("https://dotsider.dev", policy.AllowedOrigins[0]);
+    }
+
+    /// <summary>
+    /// Verifies that HTTP localhost origins with explicit ports remain valid.
+    /// </summary>
+    [TestMethod]
+    public void Create_LocalDevelopmentOrigin_PreservesPort()
+    {
+        var policy = DemoOriginPolicy.Create(["http://localhost:4321"]);
+
+        Assert.IsFalse(policy.AllowsAnyOrigin);
+        Assert.HasCount(1, policy.AllowedOrigins);
+        Assert.AreEqual("http://localhost:4321", policy.AllowedOrigins[0]);
+    }
+
+    /// <summary>
+    /// Verifies that wildcard mode remains available for local development.
+    /// </summary>
+    [TestMethod]
+    public void Create_Wildcard_AllowsAnyOrigin()
+    {
+        var policy = DemoOriginPolicy.Create(["*"]);
+
+        Assert.IsTrue(policy.AllowsAnyOrigin);
+        Assert.HasCount(1, policy.AllowedOrigins);
+        Assert.AreEqual("*", policy.AllowedOrigins[0]);
+    }
+
+    /// <summary>
+    /// Verifies that a deployment override replaces the development wildcard by index.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task StartAsync_ExplicitDeploymentOrigin_ReplacesDefaultWildcard()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Demo:AllowedOrigins:0"] = "*"
+            })
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Demo:AllowedOrigins:0"] = "https://dotsider.dev"
+            })
+            .Build();
+        using var host = new HostBuilder()
+            .ConfigureServices(services => services.AddDemoOptions(configuration))
+            .Build();
+
+        await host.StartAsync(_testContext.CancellationToken);
+        var policy = host.Services.GetRequiredService<DemoOriginPolicy>();
+
+        Assert.IsFalse(policy.AllowsAnyOrigin);
+        Assert.HasCount(1, policy.AllowedOrigins);
+        Assert.AreEqual("https://dotsider.dev", policy.AllowedOrigins[0]);
+    }
+
+    /// <summary>
+    /// Verifies that options validation runs when the host starts.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task StartAsync_InvalidConfiguration_FailsBeforeServingRequests()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Demo:MaxSessions"] = "2",
+                ["Demo:MaxSessionsPerClient"] = "3"
+            })
+            .Build();
+        using var host = new HostBuilder()
+            .ConfigureServices(services => services.AddDemoOptions(configuration))
+            .Build();
+
+        var exception = await Assert.ThrowsExactlyAsync<OptionsValidationException>(
+            () => host.StartAsync(_testContext.CancellationToken));
+
+        Assert.Contains(
+            "Demo:MaxSessionsPerClient must not exceed Demo:MaxSessions.",
+            exception.Failures);
+    }
+
+    private static ValidateOptionsResult Validate(DemoOptions options)
+    {
+        var validator = (IValidateOptions<DemoOptions>)new DemoOptionsValidator();
+        return validator.Validate(name: null, options);
+    }
+}

--- a/tests/Dotsider.Website.Tests/DemoSessionRateLimitingTests.cs
+++ b/tests/Dotsider.Website.Tests/DemoSessionRateLimitingTests.cs
@@ -5,9 +5,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.WebSockets;
 
@@ -20,6 +23,7 @@ namespace Dotsider.Website.Tests;
 [TestClass]
 public sealed class DemoSessionRateLimitingTests(TestContext testContext)
 {
+    private const string TestRemoteAddressHeader = "X-Test-Remote-Address";
     private readonly TestContext _testContext = testContext;
 
     /// <summary>
@@ -31,12 +35,20 @@ public sealed class DemoSessionRateLimitingTests(TestContext testContext)
     [DataRow(-1)]
     public void AddDemoSessionRateLimiting_NonPositiveLimit_Throws(int maxSessions)
     {
-        var services = new ServiceCollection();
+        var options = new DemoOptions
+        {
+            MaxSessions = maxSessions,
+            MaxSessionsPerClient = 1
+        };
+        var validator = (IValidateOptions<DemoOptions>)new DemoOptionsValidator();
 
-        var exception = Assert.ThrowsExactly<InvalidOperationException>(
-            () => services.AddDemoSessionRateLimiting(maxSessions));
+        var result = validator.Validate(name: null, options);
 
-        Assert.AreEqual("Demo:MaxSessions must be greater than zero.", exception.Message);
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsNotNull(result.Failures);
+        Assert.Contains(
+            "Demo:MaxSessions must be greater than zero.",
+            result.Failures);
     }
 
     /// <summary>
@@ -206,6 +218,142 @@ public sealed class DemoSessionRateLimitingTests(TestContext testContext)
     }
 
     /// <summary>
+    /// Verifies that one client cannot consume another client's available session share.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task WebSocketRequests_ClientAtCapacity_OtherClientStillConnects()
+    {
+        const string firstClient = "192.0.2.10";
+        const int maxSessions = 4;
+        const int maxSessionsPerClient = 3;
+        var activeByClient = new ConcurrentDictionary<string, int>();
+        var activeRequests = 0;
+        var maximumActiveRequests = 0;
+        var maximumFirstClientRequests = 0;
+        using var admitted = new SemaphoreSlim(0);
+        var release = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var host = await StartHostAsync(
+            new DemoOptions
+            {
+                AllowedOrigins = ["*"],
+                MaxSessions = maxSessions,
+                MaxSessionsPerClient = maxSessionsPerClient
+            },
+            context => context.Request.Query.ContainsKey("websocket")
+                ? AbortingWebSocketFeature.Instance
+                : null,
+            (_, endpoints) =>
+            {
+                endpoints.Map(
+                        "/ws",
+                        async context =>
+                        {
+                            var identity = DemoClientIdentity.GetPartitionKey(context);
+                            var clientActive = activeByClient.AddOrUpdate(
+                                identity,
+                                1,
+                                static (_, active) => active + 1);
+                            var totalActive = Interlocked.Increment(ref activeRequests);
+                            UpdateMaximum(ref maximumActiveRequests, totalActive);
+                            if (identity == firstClient)
+                            {
+                                UpdateMaximum(
+                                    ref maximumFirstClientRequests,
+                                    clientActive);
+                            }
+
+                            admitted.Release();
+
+                            try
+                            {
+                                await release.Task.WaitAsync(context.RequestAborted);
+                                context.Response.StatusCode =
+                                    StatusCodes.Status204NoContent;
+                            }
+                            finally
+                            {
+                                activeByClient.AddOrUpdate(
+                                    identity,
+                                    0,
+                                    static (_, active) => active - 1);
+                                Interlocked.Decrement(ref activeRequests);
+                            }
+                        })
+                    .RequireRateLimiting(
+                        DemoSessionRateLimitingExtensions.PolicyName);
+            },
+            _testContext.CancellationToken);
+
+        using var client = host.GetTestClient();
+        var firstClientRequests = Enumerable.Range(0, maxSessionsPerClient)
+            .Select(_ => SendWebSocketRequestAsync(
+                client,
+                firstClient,
+                _testContext.CancellationToken))
+            .ToArray();
+        for (var request = 0; request < maxSessionsPerClient; request++)
+            await admitted.WaitAsync(_testContext.CancellationToken);
+
+        using (var clientRejectedResponse = await SendWebSocketRequestAsync(
+                   client,
+                   firstClient,
+                   _testContext.CancellationToken))
+        {
+            Assert.AreEqual(
+                HttpStatusCode.TooManyRequests,
+                clientRejectedResponse.StatusCode);
+            Assert.AreEqual(
+                "Too many active sessions for this client",
+                await clientRejectedResponse.Content.ReadAsStringAsync(
+                    _testContext.CancellationToken));
+        }
+
+        var secondClientRequest = SendWebSocketRequestAsync(
+            client,
+            "192.0.2.20",
+            _testContext.CancellationToken);
+        await admitted.WaitAsync(_testContext.CancellationToken);
+
+        using (var globallyRejectedResponse = await SendWebSocketRequestAsync(
+                   client,
+                   "192.0.2.30",
+                   _testContext.CancellationToken))
+        {
+            Assert.AreEqual(
+                HttpStatusCode.ServiceUnavailable,
+                globallyRejectedResponse.StatusCode);
+            Assert.AreEqual(
+                "Too many active sessions",
+                await globallyRejectedResponse.Content.ReadAsStringAsync(
+                    _testContext.CancellationToken));
+        }
+
+        Assert.AreEqual(maxSessionsPerClient, maximumFirstClientRequests);
+        Assert.AreEqual(maxSessions, maximumActiveRequests);
+
+        release.SetResult();
+
+        var completedResponses = await Task.WhenAll(
+            [.. firstClientRequests, secondClientRequest]);
+        foreach (var response in completedResponses)
+        {
+            using (response)
+                Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+        }
+
+        using var recoveredResponse = await SendWebSocketRequestAsync(
+            client,
+            firstClient,
+            _testContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.NoContent, recoveredResponse.StatusCode);
+        Assert.AreEqual(0, Volatile.Read(ref activeRequests));
+    }
+
+    /// <summary>
     /// Verifies that health reports only accepted sessions and returns to zero after completion.
     /// </summary>
     [TestMethod]
@@ -236,7 +384,8 @@ public sealed class DemoSessionRateLimitingTests(TestContext testContext)
                 endpoints.MapGet("/health", () => Results.Ok(new
                 {
                     activeSessions = sessionHandler.ActiveSessions,
-                    maxSessions
+                    maxSessions,
+                    maxSessionsPerClient = maxSessions
                 }));
             },
             _testContext.CancellationToken);
@@ -256,6 +405,9 @@ public sealed class DemoSessionRateLimitingTests(TestContext testContext)
             Assert.AreEqual(HttpStatusCode.OK, activeResponse.StatusCode);
             Assert.Contains(
                 "\"activeSessions\":1",
+                await activeResponse.Content.ReadAsStringAsync(_testContext.CancellationToken));
+            Assert.Contains(
+                "\"maxSessionsPerClient\":1",
                 await activeResponse.Content.ReadAsStringAsync(_testContext.CancellationToken));
         }
 
@@ -341,18 +493,75 @@ public sealed class DemoSessionRateLimitingTests(TestContext testContext)
         Action<IServiceProvider, IEndpointRouteBuilder> configureEndpoints,
         CancellationToken cancellationToken)
     {
+        return await StartHostAsync(
+            new DemoOptions
+            {
+                AllowedOrigins = ["*"],
+                MaxSessions = maxSessions,
+                MaxSessionsPerClient = Math.Min(maxSessions, 3)
+            },
+            featureFactory,
+            configureEndpoints,
+            cancellationToken);
+    }
+
+    private static async Task<IHost> StartHostAsync(
+        DemoOptions demoOptions,
+        Func<HttpContext, IHttpWebSocketFeature?>? featureFactory,
+        Action<IServiceProvider, IEndpointRouteBuilder> configureEndpoints,
+        CancellationToken cancellationToken)
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            ["Demo:MaxSessions"] = demoOptions.MaxSessions.ToString(),
+            ["Demo:MaxSessionsPerClient"] =
+                demoOptions.MaxSessionsPerClient.ToString()
+        };
+        for (var index = 0; index < demoOptions.AllowedOrigins.Length; index++)
+        {
+            settings[$"Demo:AllowedOrigins:{index}"] =
+                demoOptions.AllowedOrigins[index];
+        }
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
         var host = await new HostBuilder()
             .ConfigureWebHost(webHost =>
             {
                 webHost.UseTestServer();
                 webHost.ConfigureServices(services =>
                 {
-                    services.AddDemoSessionRateLimiting(maxSessions);
+                    services.AddDemoOptions(configuration);
+                    services.AddDemoSessionRateLimiting();
                     services.AddRouting();
                 });
                 webHost.Configure(app =>
                 {
-                    app.UseWebSockets();
+                    app.Use((context, next) =>
+                    {
+                        if (context.Request.Headers.TryGetValue(
+                                TestRemoteAddressHeader,
+                                out var remoteAddress) &&
+                            IPAddress.TryParse(
+                                remoteAddress.ToString(),
+                                out var parsedAddress))
+                        {
+                            context.Connection.RemoteIpAddress = parsedAddress;
+                            context.Request.Headers.Remove(TestRemoteAddressHeader);
+                        }
+
+                        return next(context);
+                    });
+                    app.UseForwardedHeaders();
+
+                    var originPolicy =
+                        app.ApplicationServices.GetRequiredService<DemoOriginPolicy>();
+                    var webSocketOptions = new WebSocketOptions();
+                    foreach (var origin in originPolicy.AllowedOrigins)
+                        webSocketOptions.AllowedOrigins.Add(origin);
+
+                    app.UseWebSockets(webSocketOptions);
 
                     if (featureFactory is not null)
                     {
@@ -366,6 +575,8 @@ public sealed class DemoSessionRateLimitingTests(TestContext testContext)
                         });
                     }
 
+                    app.UseMiddleware<DemoWebSocketOriginMiddleware>(
+                        !originPolicy.AllowsAnyOrigin);
                     app.UseRouting();
                     app.UseRateLimiter();
                     app.UseEndpoints(
@@ -375,6 +586,19 @@ public sealed class DemoSessionRateLimitingTests(TestContext testContext)
             .StartAsync(cancellationToken);
 
         return host;
+    }
+
+    private static async Task<HttpResponseMessage> SendWebSocketRequestAsync(
+        HttpClient client,
+        string remoteAddress,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            "/ws?websocket=true");
+        request.Headers.Add(TestRemoteAddressHeader, remoteAddress);
+
+        return await client.SendAsync(request, cancellationToken);
     }
 
     private static async Task WaitUntilAsync(

--- a/tests/Dotsider.Website.Tests/DemoWebSocketOriginTests.cs
+++ b/tests/Dotsider.Website.Tests/DemoWebSocketOriginTests.cs
@@ -1,0 +1,243 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using System.Net;
+using System.Net.WebSockets;
+
+namespace Dotsider.Website.Tests;
+
+/// <summary>
+/// Verifies WebSocket origin enforcement at the production middleware boundary.
+/// </summary>
+/// <param name="testContext">The context for the current test.</param>
+[TestClass]
+public sealed class DemoWebSocketOriginTests(TestContext testContext)
+{
+    private const string AllowedOrigin = "https://dotsider.dev";
+    private readonly TestContext _testContext = testContext;
+
+    /// <summary>
+    /// Verifies that foreign, multiple, and missing origins are rejected before admission.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task ExplicitOrigins_InvalidRequests_AreRejectedBeforeAdmission()
+    {
+        var finishSession = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var sessionStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var sessionInvocations = 0;
+
+        using var host = await StartHostAsync(
+            [AllowedOrigin],
+            async (_, cancellationToken) =>
+            {
+                Interlocked.Increment(ref sessionInvocations);
+                sessionStarted.SetResult();
+                await finishSession.Task.WaitAsync(cancellationToken);
+            },
+            _testContext.CancellationToken);
+        var server = host.GetTestServer();
+
+        var foreignContext = await SendUpgradeRequestAsync(
+            server,
+            ["https://attacker.example"],
+            _testContext.CancellationToken);
+        var missingContext = await SendUpgradeRequestAsync(
+            server,
+            origins: null,
+            _testContext.CancellationToken);
+        var multipleContext = await SendUpgradeRequestAsync(
+            server,
+            [AllowedOrigin, "https://attacker.example"],
+            _testContext.CancellationToken);
+        var wrongSchemeContext = await SendUpgradeRequestAsync(
+            server,
+            ["http://dotsider.dev"],
+            _testContext.CancellationToken);
+        var wrongPortContext = await SendUpgradeRequestAsync(
+            server,
+            ["https://dotsider.dev:444"],
+            _testContext.CancellationToken);
+
+        Assert.AreEqual(StatusCodes.Status403Forbidden, foreignContext.Response.StatusCode);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, missingContext.Response.StatusCode);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, multipleContext.Response.StatusCode);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, wrongSchemeContext.Response.StatusCode);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, wrongPortContext.Response.StatusCode);
+        Assert.AreEqual(0, Volatile.Read(ref sessionInvocations));
+
+        var webSocketClient = server.CreateWebSocketClient();
+        webSocketClient.ConfigureRequest =
+            request => request.Headers.Origin = AllowedOrigin;
+        using var webSocket = await webSocketClient.ConnectAsync(
+            new Uri("ws://localhost/ws"),
+            _testContext.CancellationToken);
+
+        await sessionStarted.Task.WaitAsync(_testContext.CancellationToken);
+        Assert.AreEqual(1, Volatile.Read(ref sessionInvocations));
+
+        finishSession.SetResult();
+    }
+
+    /// <summary>
+    /// Verifies that wildcard development mode accepts missing and arbitrary origins.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task WildcardOrigin_MissingAndArbitraryOrigins_AreAccepted()
+    {
+        var sessionInvocations = 0;
+        using var invoked = new SemaphoreSlim(0);
+        using var host = await StartHostAsync(
+            ["*"],
+            (_, _) =>
+            {
+                Interlocked.Increment(ref sessionInvocations);
+                invoked.Release();
+                return Task.CompletedTask;
+            },
+            _testContext.CancellationToken,
+            maxSessions: 2);
+        var server = host.GetTestServer();
+
+        var missingOriginClient = server.CreateWebSocketClient();
+        using var missingOriginSocket = await missingOriginClient.ConnectAsync(
+            new Uri("ws://localhost/ws"),
+            _testContext.CancellationToken);
+
+        var arbitraryOriginClient = server.CreateWebSocketClient();
+        arbitraryOriginClient.ConfigureRequest =
+            request => request.Headers.Origin = "https://arbitrary.example";
+        using var arbitraryOriginSocket = await arbitraryOriginClient.ConnectAsync(
+            new Uri("ws://localhost/ws"),
+            _testContext.CancellationToken);
+
+        await invoked.WaitAsync(_testContext.CancellationToken);
+        await invoked.WaitAsync(_testContext.CancellationToken);
+        Assert.AreEqual(2, Volatile.Read(ref sessionInvocations));
+    }
+
+    /// <summary>
+    /// Verifies that an ordinary HTTP request is not subject to WebSocket origin checks.
+    /// </summary>
+    [TestMethod]
+    [Timeout(10_000, CooperativeCancellation = true)]
+    public async Task NonWebSocketRequest_WithoutOrigin_RetainsBadRequestResponse()
+    {
+        using var host = await StartHostAsync(
+            [AllowedOrigin],
+            static (_, _) => Task.CompletedTask,
+            _testContext.CancellationToken);
+        using var client = host.GetTestClient();
+
+        using var response = await client.GetAsync(
+            "/ws",
+            _testContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.AreEqual(
+            "WebSocket connections only",
+            await response.Content.ReadAsStringAsync(_testContext.CancellationToken));
+    }
+
+    private static async Task<HttpContext> SendUpgradeRequestAsync(
+        TestServer server,
+        string[]? origins,
+        CancellationToken cancellationToken)
+    {
+        return await server.SendAsync(
+            context =>
+            {
+                context.Connection.RemoteIpAddress = IPAddress.Loopback;
+                context.Features.Set<IHttpUpgradeFeature>(
+                    TestUpgradableRequestFeature.Instance);
+                context.Request.Headers.Connection = "Upgrade";
+                if (origins is not null)
+                    context.Request.Headers.Origin = new StringValues(origins);
+                context.Request.Headers.SecWebSocketKey =
+                    "dGhlIHNhbXBsZSBub25jZQ==";
+                context.Request.Headers.SecWebSocketVersion = "13";
+                context.Request.Headers.Upgrade = "websocket";
+                context.Request.Method = HttpMethods.Get;
+                context.Request.Path = "/ws";
+            },
+            cancellationToken);
+    }
+
+    private static async Task<IHost> StartHostAsync(
+        string[] allowedOrigins,
+        Func<WebSocket, CancellationToken, Task> runSession,
+        CancellationToken cancellationToken,
+        int maxSessions = 1)
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            ["Demo:MaxSessions"] = maxSessions.ToString(),
+            ["Demo:MaxSessionsPerClient"] = maxSessions.ToString()
+        };
+        for (var index = 0; index < allowedOrigins.Length; index++)
+            settings[$"Demo:AllowedOrigins:{index}"] = allowedOrigins[index];
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+        var host = await new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.ConfigureServices(services =>
+                {
+                    services.AddDemoOptions(configuration);
+                    services.AddDemoSessionRateLimiting();
+                    services.AddRouting();
+                });
+                webHost.Configure(app =>
+                {
+                    var options = app.ApplicationServices
+                        .GetRequiredService<
+                            Microsoft.Extensions.Options.IOptions<DemoOptions>>()
+                        .Value;
+                    var originPolicy =
+                        app.ApplicationServices.GetRequiredService<DemoOriginPolicy>();
+                    var webSocketOptions = new WebSocketOptions();
+                    foreach (var origin in originPolicy.AllowedOrigins)
+                        webSocketOptions.AllowedOrigins.Add(origin);
+
+                    app.UseForwardedHeaders();
+                    app.UseWebSockets(webSocketOptions);
+                    app.UseMiddleware<DemoWebSocketOriginMiddleware>(
+                        !originPolicy.AllowsAnyOrigin);
+                    app.UseRouting();
+                    app.UseRateLimiter();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        var handler = new DemoWebSocketSessionHandler(
+                            app.ApplicationServices
+                                .GetRequiredService<IHostApplicationLifetime>(),
+                            app.ApplicationServices
+                                .GetRequiredService<
+                                    ILogger<DemoWebSocketSessionHandler>>(),
+                            options.MaxSessions,
+                            TimeSpan.FromMinutes(options.SessionTimeoutMinutes),
+                            runSession);
+
+                        endpoints.Map("/ws", handler.HandleAsync)
+                            .RequireRateLimiting(
+                                DemoSessionRateLimitingExtensions.PolicyName);
+                    });
+                });
+            })
+            .StartAsync(cancellationToken);
+
+        return host;
+    }
+}

--- a/tests/Dotsider.Website.Tests/TestUpgradableRequestFeature.cs
+++ b/tests/Dotsider.Website.Tests/TestUpgradableRequestFeature.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Dotsider.Website.Tests;
+
+internal sealed class TestUpgradableRequestFeature : IHttpUpgradeFeature
+{
+    internal static TestUpgradableRequestFeature Instance { get; } = new();
+
+    private TestUpgradableRequestFeature()
+    {
+    }
+
+    bool IHttpUpgradeFeature.IsUpgradableRequest => true;
+
+    Task<Stream> IHttpUpgradeFeature.UpgradeAsync()
+    {
+        return Task.FromException<Stream>(
+            new NotSupportedException("Rejected requests must not be upgraded."));
+    }
+}

--- a/tests/deploy/README.md
+++ b/tests/deploy/README.md
@@ -23,7 +23,7 @@ bash tests/deploy/run.sh integrity-check
 
 | Suite | Tests | What it verifies |
 |-------|-------|------------------|
-| `setup.bats` | 42 | .NET 10 installed, Caddy installed and running with metrics, Prometheus installed and healthy, brandon user with sudo, deploy directories, systemd units enabled, Caddyfile content (X-Forwarded-For, cache headers), prometheus.yml scrape targets, caddy-report timer active, integrity-check timer active, logrotate config, ufw firewall rules |
+| `setup.bats` | 43 | .NET 10 installed, Caddy installed and running with metrics, Prometheus installed and healthy, brandon user with sudo, deploy directories, systemd units and session limits, Caddyfile content (X-Forwarded-For, cache headers), prometheus.yml scrape targets, caddy-report timer active, integrity-check timer active, logrotate config, ufw firewall rules |
 | `preflight.bats` | 18 | All preflight checks pass on a configured system, zero failures reported, each service and directory detected, failure detection when dotnet is missing or a directory is removed |
 | `caddy-report.bats` | 10 | Script exits successfully, writes to log file, log line format (ISO 8601 timestamp, req/s, err/s, p95, inflight, upstream_healthy), multiple runs append, graceful N/A output when Prometheus is down |
 | `integrity-check.bats` | 10 | Clean exit when DLL matches hash, corruption detection and auto-restore from backup, log format with expected/actual hashes, graceful handling of missing files, recovery from repeated corruption |

--- a/tests/deploy/setup.bats
+++ b/tests/deploy/setup.bats
@@ -160,9 +160,14 @@ load 'helpers/common'
         "Demo__SampleAssembly=/opt/dotsider-website/sample/RichLibrary.dll"
 }
 
-@test "dotsider-website.service restricts CORS to dotsider.dev" {
+@test "dotsider-website.service restricts browser origins to dotsider.dev" {
     assert_file_contains /etc/systemd/system/dotsider-website.service \
         "Demo__AllowedOrigins__0=https://dotsider.dev"
+}
+
+@test "dotsider-website.service limits concurrent sessions per client" {
+    assert_file_contains /etc/systemd/system/dotsider-website.service \
+        "Demo__MaxSessionsPerClient=3"
 }
 
 # ── Metrics report ────────────────────────────────────────────────


### PR DESCRIPTION
Browsers can now open the demo WebSocket only from configured origins, and explicit origin policies also reject origin-less upgrades. Session admission keeps the global limit while adding a three-session share per resolved client address, with forwarded addresses accepted only from the trusted local proxy. Configuration validation, health reporting, deployment settings, and deterministic coverage document the 403, 429, and 503 behavior.

Fixes: #227