### PR TITLE
Harden native image bounds validation

### DIFF
--- a/docs/src/content/docs/usage/pe-metadata.md
+++ b/docs/src/content/docs/usage/pe-metadata.md
@@ -33,7 +33,7 @@ R2R Sections and AOT Types apply to Native AOT binaries. ILC strips ECMA-335 met
 
 ## Malformed metadata
 
-Dotsider treats metadata and signature blobs as untrusted. When an image is otherwise readable, cyclic or excessively nested type relationships and malformed ECMA-335 or ReadyToRun signatures are contained: affected names use token or unknown fallbacks, navigation remains unresolved, and unreadable native mappings are omitted instead of being guessed or terminating the analysis.
+Dotsider treats metadata, signatures, and native container headers as untrusted. When an image is otherwise readable, cyclic or excessively nested type relationships and malformed ECMA-335 or ReadyToRun signatures are contained: affected names use token or unknown fallbacks and navigation remains unresolved. Truncated or overflowing PE, ELF, and Mach-O tables and mappings are treated as malformed, and analysis continues with the affected data omitted.
 
 Metadata names, recovered strings, IL, symbols, and other artifact-controlled text are rendered
 through a shared terminal-safe projection. Control and Unicode formatting characters appear

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -830,7 +830,8 @@ public sealed class AssemblyAnalyzer : IDisposable
 
     /// <summary>
     /// The virtual-address to file-offset map for a native image, or null when the format
-    /// is unrecognized. Shared by the Native AOT section and object readers.
+    /// is unrecognized, malformed, or truncated. Shared by the Native AOT section and object
+    /// readers.
     /// </summary>
     private NativeAddressSpace? AddressSpace
     {

--- a/src/Dotsider.Core/Analysis/CodeViewId.cs
+++ b/src/Dotsider.Core/Analysis/CodeViewId.cs
@@ -1,0 +1,9 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Identifies a native PDB through a PE CodeView record.
+/// </summary>
+/// <param name="Guid">The PDB GUID.</param>
+/// <param name="Age">The PDB age.</param>
+/// <param name="PdbPath">The path recorded in the PE image.</param>
+internal readonly record struct CodeViewId(Guid Guid, int Age, string PdbPath);

--- a/src/Dotsider.Core/Analysis/Disasm/NativeDisassembler.cs
+++ b/src/Dotsider.Core/Analysis/Disasm/NativeDisassembler.cs
@@ -32,7 +32,8 @@ public static class NativeDisassembler
         NativeSymbolResolver? resolver = null)
     {
         var result = new List<NativeInstruction>();
-        var windowEnd = baseAddress + (ulong)code.Length;
+        if (!NativeImageRange.TryAdd(baseAddress, (ulong)code.Length, out var windowEnd))
+            return result;
         var offset = 0;
 
         var decodable = NativeDecoderRegistry.IsSupported(arch);
@@ -145,8 +146,16 @@ public static class NativeDisassembler
         // native code lives in the code image. Slice (and resolve imports) from there for R2R.
         var codeImage = analyzer.IsReadyToRun ? analyzer.ReadyToRunCodeImage ?? analyzer : analyzer;
         var raw = codeImage.RawBytes;
-        if (fileOffset < 0 || fileOffset + symbol.Size > raw.Length) return null;
-        var code = raw.Span.Slice((int)fileOffset, (int)symbol.Size).ToArray();
+        if (fileOffset < 0
+            || symbol.Size > int.MaxValue
+            || !NativeImageRange.TryGet(
+                raw.Length,
+                (ulong)fileOffset,
+                (ulong)symbol.Size,
+                out var codeOffset,
+                out var codeSize))
+            return null;
+        var code = raw.Span.Slice(codeOffset, codeSize).ToArray();
 
         if (arch == NativeArchitecture.Wasm32 && codeImage.WasmModuleInfo is not null)
             return Wasm.WasmDisassembler.DisassembleSymbol(codeImage, symbol);

--- a/src/Dotsider.Core/Analysis/Disasm/NativeImportResolver.cs
+++ b/src/Dotsider.Core/Analysis/Disasm/NativeImportResolver.cs
@@ -76,7 +76,9 @@ public sealed class NativeImportResolver
 
             for (var i = 0; i < 4096; i++)
             {
-                var descriptorRva = directory.RelativeVirtualAddress + i * 20;
+                var descriptorRvaValue = (long)directory.RelativeVirtualAddress + i * 20L;
+                if (descriptorRvaValue > int.MaxValue) break;
+                var descriptorRva = (int)descriptorRvaValue;
                 var d = ReaderAt(pe, descriptorRva, 20);
                 if (d is null) break;
 
@@ -173,10 +175,20 @@ public sealed class NativeImportResolver
 
     private static string? ReadElfSymbolName(byte[] dynsym, byte[] dynstr, int symbolIndex)
     {
+        if (symbolIndex < 0
+            || !NativeImageRange.TryGetTable(
+                dynsym.Length,
+                0,
+                (ulong)symbolIndex + 1,
+                24,
+                4,
+                out _,
+                out _))
+            return null;
+
         var offset = symbolIndex * 24; // sizeof(Elf64_Sym); st_name is the leading uint32.
-        if (symbolIndex < 0 || offset + 4 > dynsym.Length) return null;
         var stName = BinaryPrimitives.ReadUInt32LittleEndian(dynsym.AsSpan(offset));
-        return ReadCString(dynstr, (int)stName);
+        return stName <= int.MaxValue ? ReadCString(dynstr, (int)stName) : null;
     }
 
     private static string? ReadCString(byte[] data, int offset)
@@ -219,7 +231,14 @@ public sealed class NativeImportResolver
                     if (symbolIndex is null || (symbolIndex.Value & 0xC000_0000) != 0) continue;
 
                     var name = ReadMachOSymbolName(bytes, symtab, (int)symbolIndex.Value);
-                    if (name is not null) slots[section.Address + (ulong)(i * stride)] = name;
+                    if (name is not null
+                        && NativeImageRange.TryAdd(
+                            section.Address,
+                            (ulong)(i * stride),
+                            out var slotAddress))
+                    {
+                        slots[slotAddress] = name;
+                    }
                 }
             }
 
@@ -248,31 +267,39 @@ public sealed class NativeImportResolver
             _ => 0u,
         };
         var slice = slices.FirstOrDefault(s => s.CpuType == wanted, slices[0]);
-        if (slice.Offset < 0 || slice.Offset >= rawBytes.Length) return rawBytes;
-
-        var end = (int)Math.Min(slice.Offset + slice.Size, rawBytes.Length);
-        return rawBytes[(int)slice.Offset..end];
+        return rawBytes.Slice((int)slice.Offset, (int)slice.Size);
     }
 
-    private static uint? ReadIndirectSymbol(ReadOnlySpan<byte> bytes, (int Offset, int Count) indirect, int index)
+    private static uint? ReadIndirectSymbol(
+        ReadOnlySpan<byte> bytes,
+        MachOIndirectSymbolTable indirect,
+        int index)
     {
         if (index < 0 || index >= indirect.Count) return null;
         var offset = indirect.Offset + index * 4;
-        if (offset < 0 || offset + 4 > bytes.Length) return null;
+        if (!NativeImageRange.TryGet(bytes.Length, offset, sizeof(uint), out _, out _)) return null;
         return BinaryPrimitives.ReadUInt32LittleEndian(bytes[offset..]);
     }
 
     private static string? ReadMachOSymbolName(
-        ReadOnlySpan<byte> bytes, (int Offset, int Count, int StringOffset) symtab, int symbolIndex)
+        ReadOnlySpan<byte> bytes,
+        MachOSymbolTable symtab,
+        int symbolIndex)
     {
         if (symbolIndex < 0 || symbolIndex >= symtab.Count) return null;
         var nlist = symtab.Offset + symbolIndex * 16; // sizeof(nlist_64); n_strx is the leading uint32
-        if (nlist < 0 || nlist + 4 > bytes.Length) return null;
+        var stringOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[nlist..]);
+        if (stringOffset >= (uint)symtab.StringSize
+            || !NativeImageRange.TryAdd(
+                (ulong)symtab.StringOffset,
+                stringOffset,
+                out var nameOffsetValue)
+            || !NativeImageRange.TryGet(bytes.Length, nameOffsetValue, 1, out var nameOffset, out _))
+        {
+            return null;
+        }
 
-        var nameOffset = symtab.StringOffset + (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[nlist..]);
-        if (nameOffset < 0 || nameOffset >= bytes.Length) return null;
-
-        var slice = bytes[nameOffset..];
+        var slice = bytes.Slice(nameOffset, symtab.StringSize - (int)stringOffset);
         var end = slice.IndexOf((byte)0);
         return end <= 0 ? null : Encoding.ASCII.GetString(slice[..end]);
     }
@@ -283,14 +310,18 @@ public sealed class NativeImportResolver
     {
         for (var i = 0; i < 8192; i++)
         {
-            var entry = ReaderAt(pe, (int)thunkRva + i * ptrSize, ptrSize);
+            var entryRva = (ulong)thunkRva + (ulong)(i * ptrSize);
+            if (entryRva > int.MaxValue) break;
+            var entry = ReaderAt(pe, (int)entryRva, ptrSize);
             if (entry is null) break;
 
             var reader = entry.Value;
             var value = is64 ? reader.ReadUInt64() : reader.ReadUInt32();
             if (value == 0) break;
 
-            var slotVa = imageBase + iatRva + (ulong)(i * ptrSize);
+            if (!NativeImageRange.TryAdd(imageBase, iatRva, out var tableAddress)
+                || !NativeImageRange.TryAdd(tableAddress, (ulong)(i * ptrSize), out var slotVa))
+                break;
             var isOrdinal = is64 ? (value & 0x8000_0000_0000_0000) != 0 : (value & 0x8000_0000) != 0;
             if (isOrdinal)
             {
@@ -299,7 +330,8 @@ public sealed class NativeImportResolver
             }
 
             // The low bits are the RVA of an IMAGE_IMPORT_BY_NAME (2-byte hint + ASCII name).
-            var name = ReadAscii(pe, (int)(value & 0x7FFF_FFFF) + 2);
+            var nameRva = (value & 0x7FFF_FFFF) + 2;
+            var name = nameRva <= int.MaxValue ? ReadAscii(pe, (int)nameRva) : null;
             if (name is not null)
                 slots[slotVa] = $"{module}!{name}";
         }
@@ -309,7 +341,7 @@ public sealed class NativeImportResolver
     {
         var image = pe.GetEntireImage();
         var offset = RvaToOffset(pe, rva);
-        if (offset < 0 || offset + size > image.Length) return null;
+        if (!NativeImageRange.TryGet(image.Length, offset, size, out _, out _)) return null;
         return new PEMemoryBlockReader(image, offset);
     }
 
@@ -326,10 +358,25 @@ public sealed class NativeImportResolver
 
     private static int RvaToOffset(PEReader pe, int rva)
     {
+        if (rva < 0) return -1;
         foreach (var section in pe.PEHeaders.SectionHeaders)
         {
-            if (rva >= section.VirtualAddress && rva < section.VirtualAddress + section.VirtualSize)
-                return section.PointerToRawData + (rva - section.VirtualAddress);
+            if (section.VirtualAddress < 0
+                || section.VirtualSize <= 0
+                || section.PointerToRawData < 0
+                || rva < section.VirtualAddress)
+                continue;
+
+            var delta = (uint)(rva - section.VirtualAddress);
+            if (delta >= (uint)section.VirtualSize
+                || !NativeImageRange.TryAdd(
+                    (uint)section.PointerToRawData,
+                    delta,
+                    out var offset)
+                || offset > int.MaxValue)
+                continue;
+
+            return (int)offset;
         }
 
         return -1;

--- a/src/Dotsider.Core/Analysis/EhFrameReader.cs
+++ b/src/Dotsider.Core/Analysis/EhFrameReader.cs
@@ -31,28 +31,43 @@ internal static class EhFrameReader
         var result = new List<RawNativeSymbol>();
         var sections = ElfImageReader.ReadSections(imageBytes);
         if (!ElfImageReader.TryGetSection(imageBytes, ".eh_frame", out var ehFrame)) return result;
-        if (ehFrame.FileOffset < 0 || ehFrame.FileOffset + ehFrame.Size > imageBytes.Length) return result;
+        if (!NativeImageRange.TryGet(
+            imageBytes.Length,
+            ehFrame.FileOffset,
+            ehFrame.Size,
+            out var sectionOffset,
+            out var sectionSize))
+            return result;
 
-        var data = imageBytes.Slice(ehFrame.FileOffset, ehFrame.Size);
+        var data = imageBytes.Slice(sectionOffset, sectionSize);
         var cieEncodings = new Dictionary<long, byte>();
 
         try
         {
             var position = 0;
-            for (var entries = 0; entries < MaxEntries && position + 4 <= data.Length; entries++)
+            for (var entries = 0; entries < MaxEntries && position <= data.Length - 4; entries++)
             {
                 var entryStart = position;
-                long length = BinaryPrimitives.ReadUInt32LittleEndian(data[position..]);
+                ulong length = BinaryPrimitives.ReadUInt32LittleEndian(data[position..]);
                 position += 4;
                 if (length == 0) break; // terminator
                 if (length == 0xFFFF_FFFF)
                 {
-                    length = (long)BinaryPrimitives.ReadUInt64LittleEndian(data[position..]);
+                    if (position > data.Length - sizeof(ulong)) break;
+                    length = BinaryPrimitives.ReadUInt64LittleEndian(data[position..]);
                     position += 8;
                 }
 
-                var next = position + length;
-                if (length < 4 || next > data.Length) break;
+                if (length < 4
+                    || !NativeImageRange.TryGet(
+                        data.Length,
+                        (ulong)position,
+                        length,
+                        out _,
+                        out var entryLength))
+                    break;
+
+                var next = position + entryLength;
 
                 var idPosition = position;
                 var id = BinaryPrimitives.ReadUInt32LittleEndian(data[position..]);
@@ -69,7 +84,7 @@ internal static class EhFrameReader
                     result.Add(Boundary(va, size, sections));
                 }
 
-                position = (int)next;
+                position = next;
             }
         }
         catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
@@ -137,13 +152,17 @@ internal static class EhFrameReader
         var application = encoding & PeApplicationMask;
         if (application is not (0 or PePcrel)) return false; // text/data/func-relative: no base here
 
-        var fieldVa = sectionAddress + (ulong)position;
+        if (!NativeImageRange.TryAdd(sectionAddress, (ulong)position, out var fieldVa))
+            return false;
         var initialLocation = DecodePointer(data, ref position, encoding, fieldVa);
         if (initialLocation is not { } location) return false;
 
         // The range is a length: same format, no application.
         var range = DecodePointer(data, ref position, (byte)(encoding & PeFormatMask), fieldVa: 0);
-        if (range is not { } r) return false;
+        if (range is not { } r
+            || r > long.MaxValue
+            || !NativeImageRange.TryAdd(location, r, out _))
+            return false;
 
         va = location;
         size = r;
@@ -196,7 +215,22 @@ internal static class EhFrameReader
                 return null;
         }
 
-        return (encoding & PeApplicationMask) == PePcrel ? fieldVa + value : value;
+        if ((encoding & PeApplicationMask) != PePcrel) return value;
+
+        var format = encoding & PeFormatMask;
+        if (format is not (0x09 or 0x0A or 0x0B or 0x0C))
+            return NativeImageRange.TryAdd(fieldVa, value, out var unsignedAddress)
+                ? unsignedAddress
+                : null;
+
+        var signedValue = unchecked((long)value);
+        if (signedValue >= 0)
+            return NativeImageRange.TryAdd(fieldVa, (ulong)signedValue, out var positiveAddress)
+                ? positiveAddress
+                : null;
+
+        var magnitude = (ulong)(-(signedValue + 1)) + 1;
+        return magnitude <= fieldVa ? fieldVa - magnitude : null;
     }
 
     private static ulong ReadUleb(ReadOnlySpan<byte> data, ref int position)

--- a/src/Dotsider.Core/Analysis/ElfImageReader.cs
+++ b/src/Dotsider.Core/Analysis/ElfImageReader.cs
@@ -38,48 +38,84 @@ internal static class ElfImageReader
 
     /// <summary>
     /// Walks the section headers into named sections, or an empty list when the image is not a
-    /// little-endian 64-bit ELF or carries no section headers.
+    /// little-endian 64-bit ELF or its structural tables are absent, malformed, or truncated.
     /// </summary>
     /// <param name="bytes">The raw image bytes.</param>
     internal static IReadOnlyList<ElfSection> ReadSections(ReadOnlySpan<byte> bytes)
     {
-        try
-        {
-            if (!IsElf(bytes) || bytes[5] != 1) return [];
+        if (!IsElf(bytes) || bytes[5] != 1) return [];
 
-            var sectionOffset = (long)BinaryPrimitives.ReadUInt64LittleEndian(bytes[40..]);
-            var sectionEntrySize = BinaryPrimitives.ReadUInt16LittleEndian(bytes[58..]);
-            var sectionCount = BinaryPrimitives.ReadUInt16LittleEndian(bytes[60..]);
-            var stringSectionIndex = BinaryPrimitives.ReadUInt16LittleEndian(bytes[62..]);
-            if (sectionOffset <= 0 || sectionEntrySize < SectionHeaderSize || sectionCount == 0)
-                return [];
-
-            var shStrTableOffset = (long)BinaryPrimitives.ReadUInt64LittleEndian(
-                bytes[(int)(sectionOffset + (long)stringSectionIndex * sectionEntrySize + 24)..]);
-
-            var sections = new List<ElfSection>(sectionCount);
-            for (var i = 0; i < sectionCount; i++)
-            {
-                var header = sectionOffset + (long)i * sectionEntrySize;
-                if (header + SectionHeaderSize > bytes.Length) break;
-                var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)header..]);
-                var type = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)(header + 4)..]);
-                var flags = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 8)..]);
-                var address = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 16)..]);
-                var offset = (int)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 24)..]);
-                var size = (int)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(header + 32)..]);
-                var link = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)(header + 40)..]);
-                var info = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)(header + 44)..]);
-                var name = ReadString(bytes, shStrTableOffset, nameOffset) ?? "";
-                sections.Add(new ElfSection(name, type, address, offset, size, link, info, flags));
-            }
-
-            return sections;
-        }
-        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        var sectionOffset = BinaryPrimitives.ReadUInt64LittleEndian(bytes[40..]);
+        var sectionEntrySize = BinaryPrimitives.ReadUInt16LittleEndian(bytes[58..]);
+        var sectionCount = BinaryPrimitives.ReadUInt16LittleEndian(bytes[60..]);
+        var stringSectionIndex = BinaryPrimitives.ReadUInt16LittleEndian(bytes[62..]);
+        if (sectionOffset == 0
+            || sectionCount == 0
+            || stringSectionIndex >= sectionCount
+            || !NativeImageRange.TryGetTable(
+                bytes.Length,
+                sectionOffset,
+                sectionCount,
+                sectionEntrySize,
+                SectionHeaderSize,
+                out var tableOffset,
+                out _))
         {
             return [];
         }
+
+        var stringHeader = tableOffset + stringSectionIndex * sectionEntrySize;
+        var stringType = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(stringHeader + 4)..]);
+        var stringOffsetValue = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(stringHeader + 24)..]);
+        var stringSizeValue = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(stringHeader + 32)..]);
+        if (stringType == ShtNoBits
+            || !NativeImageRange.TryGet(
+                bytes.Length,
+                stringOffsetValue,
+                stringSizeValue,
+                out var stringOffset,
+                out var stringSize))
+        {
+            return [];
+        }
+
+        var sections = new List<ElfSection>(sectionCount);
+        for (var i = 0; i < sectionCount; i++)
+        {
+            var header = tableOffset + i * sectionEntrySize;
+            var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[header..]);
+            var type = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(header + 4)..]);
+            var flags = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(header + 8)..]);
+            var address = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(header + 16)..]);
+            var offsetValue = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(header + 24)..]);
+            var sizeValue = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(header + 32)..]);
+            var link = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(header + 40)..]);
+            var info = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(header + 44)..]);
+
+            int offset;
+            int size;
+            if (type == ShtNoBits)
+            {
+                if (offsetValue > int.MaxValue || sizeValue > int.MaxValue) return [];
+                offset = (int)offsetValue;
+                size = (int)sizeValue;
+            }
+            else if (!NativeImageRange.TryGet(
+                bytes.Length,
+                offsetValue,
+                sizeValue,
+                out offset,
+                out size))
+            {
+                return [];
+            }
+
+            var name = ReadBoundedString(bytes, stringOffset, stringSize, nameOffset);
+            if (name is null) return [];
+            sections.Add(new ElfSection(name, type, address, offset, size, link, info, flags));
+        }
+
+        return sections;
     }
 
     /// <summary>Finds a section by name.</summary>
@@ -278,12 +314,22 @@ internal static class ElfImageReader
     {
         foreach (var section in sections)
         {
-            if (section.Address != 0 && va >= section.Address && va < section.Address + (ulong)section.Size)
-            {
-                sectionName = section.Name;
-                fileOffset = section.FileOffset + (long)(va - section.Address);
-                return true;
-            }
+            if (section.Type == ShtNoBits
+                || section.Address == 0
+                || section.FileOffset < 0
+                || section.Size <= 0
+                || va < section.Address)
+                continue;
+
+            var delta = va - section.Address;
+            if (delta >= (ulong)section.Size
+                || !NativeImageRange.TryAdd((ulong)section.FileOffset, delta, out var offset)
+                || offset > long.MaxValue)
+                continue;
+
+            sectionName = section.Name;
+            fileOffset = (long)offset;
+            return true;
         }
 
         sectionName = "";
@@ -301,23 +347,48 @@ internal static class ElfImageReader
     {
         buildId = [];
         if (!TryGetSection(bytes, ".note.gnu.build-id", out var section)) return false;
-        if (section.FileOffset < 0 || section.FileOffset + section.Size > bytes.Length) return false;
+        if (!NativeImageRange.TryGet(
+            bytes.Length,
+            section.FileOffset,
+            section.Size,
+            out var sectionOffset,
+            out var sectionSize))
+            return false;
 
-        var data = bytes.Slice(section.FileOffset, section.Size);
+        var data = bytes.Slice(sectionOffset, sectionSize);
         var position = 0;
-        while (position + 12 <= data.Length)
+        while (position <= data.Length - 12)
         {
             var nameSize = BinaryPrimitives.ReadUInt32LittleEndian(data[position..]);
             var descSize = BinaryPrimitives.ReadUInt32LittleEndian(data[(position + 4)..]);
             var type = BinaryPrimitives.ReadUInt32LittleEndian(data[(position + 8)..]);
-            var namePosition = position + 12;
-            var descPosition = namePosition + (int)((nameSize + 3) & ~3u);
-            var next = descPosition + (int)((descSize + 3) & ~3u);
-            if (nameSize > (uint)data.Length || descSize > (uint)data.Length || next > data.Length) return false;
-
-            if (type == 3 && nameSize == 4 && data.Slice(namePosition, 4).SequenceEqual("GNU\0"u8))
+            if (!NativeImageRange.TryAlignUp(nameSize, 4, out var paddedNameSize)
+                || !NativeImageRange.TryAlignUp(descSize, 4, out var paddedDescSize)
+                || !NativeImageRange.TryAdd((ulong)position, 12, out var namePositionValue)
+                || !NativeImageRange.TryAdd(namePositionValue, paddedNameSize, out var descPositionValue)
+                || !NativeImageRange.TryAdd(descPositionValue, paddedDescSize, out var nextValue)
+                || !NativeImageRange.TryGet(
+                    data.Length,
+                    namePositionValue,
+                    nameSize,
+                    out var namePosition,
+                    out var nameLength)
+                || !NativeImageRange.TryGet(
+                    data.Length,
+                    descPositionValue,
+                    descSize,
+                    out var descPosition,
+                    out var descLength)
+                || !NativeImageRange.TryGet(data.Length, 0, nextValue, out _, out var next))
             {
-                buildId = data.Slice(descPosition, (int)descSize).ToArray();
+                return false;
+            }
+
+            if (type == 3
+                && nameLength == 4
+                && data.Slice(namePosition, nameLength).SequenceEqual("GNU\0"u8))
+            {
+                buildId = data.Slice(descPosition, descLength).ToArray();
                 return buildId.Length > 0;
             }
 
@@ -339,31 +410,32 @@ internal static class ElfImageReader
         fileName = "";
         crc = 0;
         if (!TryGetSection(bytes, ".gnu_debuglink", out var section)) return false;
-        if (section.FileOffset < 0 || section.FileOffset + section.Size > bytes.Length) return false;
+        if (!NativeImageRange.TryGet(
+            bytes.Length,
+            section.FileOffset,
+            section.Size,
+            out var sectionOffset,
+            out var sectionSize))
+            return false;
 
-        var data = bytes.Slice(section.FileOffset, section.Size);
+        var data = bytes.Slice(sectionOffset, sectionSize);
         var end = data.IndexOf((byte)0);
         if (end <= 0) return false;
 
-        var crcOffset = (end + 1 + 3) & ~3;
-        if (crcOffset + 4 > data.Length) return false;
+        if (!NativeImageRange.TryAlignUp((ulong)end + 1, 4, out var crcOffsetValue)
+            || !NativeImageRange.TryGet(
+                data.Length,
+                crcOffsetValue,
+                sizeof(uint),
+                out var crcOffset,
+                out _))
+        {
+            return false;
+        }
 
         fileName = Encoding.UTF8.GetString(data[..end]);
         crc = BinaryPrimitives.ReadUInt32LittleEndian(data[crcOffset..]);
         return true;
-    }
-
-    private static string? ReadString(ReadOnlySpan<byte> bytes, long tableOffset, uint offset)
-    {
-        var start = tableOffset + offset;
-        if (start < 0 || start >= bytes.Length) return null;
-
-        var slice = bytes[(int)start..];
-        var end = slice.IndexOf((byte)0);
-        if (end < 0) end = Math.Min(slice.Length, MaxStringLength);
-        if (end > MaxStringLength) return null;
-
-        return Encoding.UTF8.GetString(slice[..end]);
     }
 
     /// <summary>
@@ -406,8 +478,5 @@ internal static class ElfImageReader
     /// <param name="imageLength">The complete image length.</param>
     /// <returns>True when the range is safe to slice.</returns>
     internal static bool TryGetFileRange(int offset, int size, int imageLength) =>
-        offset >= 0
-        && size >= 0
-        && offset <= imageLength
-        && size <= imageLength - offset;
+        NativeImageRange.TryGet(imageLength, offset, size, out _, out _);
 }

--- a/src/Dotsider.Core/Analysis/ElfSymtabReader.cs
+++ b/src/Dotsider.Core/Analysis/ElfSymtabReader.cs
@@ -44,14 +44,27 @@ internal static class ElfSymtabReader
 
             if (symtab.Type != ShtSymTab || symtab.Link >= sections.Count) return result;
             var strtab = sections[(int)symtab.Link];
-            if (symtab.FileOffset < 0 || symtab.FileOffset + symtab.Size > symbolBytes.Length) return result;
-            if (strtab.FileOffset < 0 || strtab.FileOffset + strtab.Size > symbolBytes.Length) return result;
+            if (!NativeImageRange.TryGet(
+                    symbolBytes.Length,
+                    symtab.FileOffset,
+                    symtab.Size,
+                    out var symbolOffset,
+                    out var symbolSize)
+                || !NativeImageRange.TryGet(
+                    symbolBytes.Length,
+                    strtab.FileOffset,
+                    strtab.Size,
+                    out var stringOffset,
+                    out var stringSize))
+            {
+                return result;
+            }
 
-            var strings = symbolBytes.Slice(strtab.FileOffset, strtab.Size);
-            var count = Math.Min(symtab.Size / SymbolSize, MaxSymbols);
+            var strings = symbolBytes.Slice(stringOffset, stringSize);
+            var count = Math.Min(symbolSize / SymbolSize, MaxSymbols);
             for (var i = 1; i < count; i++) // entry 0 is the reserved null symbol
             {
-                var entry = symbolBytes.Slice(symtab.FileOffset + i * SymbolSize, SymbolSize);
+                var entry = symbolBytes.Slice(symbolOffset + i * SymbolSize, SymbolSize);
                 if ((entry[4] & 0xF) != SttObject) continue;
 
                 var sectionIndex = BinaryPrimitives.ReadUInt16LittleEndian(entry[6..]);

--- a/src/Dotsider.Core/Analysis/MachOFatSlice.cs
+++ b/src/Dotsider.Core/Analysis/MachOFatSlice.cs
@@ -1,0 +1,9 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Describes one validated architecture slice in a Mach-O universal binary.
+/// </summary>
+/// <param name="CpuType">The slice's Mach CPU type.</param>
+/// <param name="Offset">The slice's file offset in the universal binary.</param>
+/// <param name="Size">The slice's byte size.</param>
+internal readonly record struct MachOFatSlice(uint CpuType, long Offset, long Size);

--- a/src/Dotsider.Core/Analysis/MachOImageReader.cs
+++ b/src/Dotsider.Core/Analysis/MachOImageReader.cs
@@ -10,6 +10,8 @@ namespace Dotsider.Core.Analysis;
 /// Imports are the loaded dylibs (each with the undefined external symbols bound to
 /// it through the two-level namespace library ordinal); exports are the defined
 /// external symbols. Fat archives and 32-bit images yield empty results.
+/// Malformed or overflowing structural ranges also yield empty results rather than
+/// partially trusted tables.
 /// </summary>
 internal static class MachOImageReader
 {
@@ -36,6 +38,9 @@ internal static class MachOImageReader
 
     private const int Segment64HeaderSize = 72;
     private const int Section64Size = 80;
+    private const uint SectionTypeGbZeroFill = 0xC;
+    private const uint SectionTypeThreadLocalZeroFill = 0x12;
+    private const uint SectionTypeZeroFill = 0x1;
 
     private const byte NStab = 0xE0;
     private const byte NType = 0x0E;
@@ -53,12 +58,6 @@ internal static class MachOImageReader
         bytes.Length >= 8
         && BinaryPrimitives.ReadUInt32BigEndian(bytes) is FatMagic or FatMagic64;
 
-    /// <summary>One architecture slice of a fat/universal archive.</summary>
-    /// <param name="CpuType">The slice's <c>cputype</c>.</param>
-    /// <param name="Offset">The slice's byte offset in the archive.</param>
-    /// <param name="Size">The slice's byte size.</param>
-    internal readonly record struct MachOFatSlice(uint CpuType, long Offset, long Size);
-
     /// <summary>
     /// Enumerates the architecture slices of a fat archive (both the 32- and 64-bit header
     /// forms, which are big-endian), or an empty list for thin images.
@@ -66,39 +65,46 @@ internal static class MachOImageReader
     /// <param name="bytes">The raw archive bytes.</param>
     internal static IReadOnlyList<MachOFatSlice> ReadFatSlices(ReadOnlySpan<byte> bytes)
     {
-        var slices = new List<MachOFatSlice>();
-        try
+        if (!IsFat(bytes)) return [];
+        var is64 = BinaryPrimitives.ReadUInt32BigEndian(bytes) == FatMagic64;
+        var count = BinaryPrimitives.ReadUInt32BigEndian(bytes[4..]);
+        var entrySize = is64 ? 32U : 20U;
+        if (count > MaxFatSlices
+            || !NativeImageRange.TryGetTable(
+                bytes.Length,
+                8,
+                count,
+                entrySize,
+                entrySize,
+                out var tableOffset,
+                out _))
         {
-            if (!IsFat(bytes)) return slices;
-            var is64 = BinaryPrimitives.ReadUInt32BigEndian(bytes) == FatMagic64;
-            var count = BinaryPrimitives.ReadUInt32BigEndian(bytes[4..]);
-            if (count > MaxFatSlices) return slices;
-
-            var entrySize = is64 ? 32 : 20;
-            for (var i = 0; i < count; i++)
-            {
-                var entry = 8 + i * entrySize;
-                if (entry + entrySize > bytes.Length) break;
-                var cpuType = BinaryPrimitives.ReadUInt32BigEndian(bytes[entry..]);
-                long offset, size;
-                if (is64)
-                {
-                    offset = (long)BinaryPrimitives.ReadUInt64BigEndian(bytes[(entry + 8)..]);
-                    size = (long)BinaryPrimitives.ReadUInt64BigEndian(bytes[(entry + 16)..]);
-                }
-                else
-                {
-                    offset = BinaryPrimitives.ReadUInt32BigEndian(bytes[(entry + 8)..]);
-                    size = BinaryPrimitives.ReadUInt32BigEndian(bytes[(entry + 12)..]);
-                }
-
-                if (offset < 0 || size <= 0 || offset + size > bytes.Length) continue;
-                slices.Add(new MachOFatSlice(cpuType, offset, size));
-            }
+            return [];
         }
-        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+
+        var slices = new List<MachOFatSlice>((int)count);
+        for (var i = 0; i < count; i++)
         {
-            // Keep the slices parsed so far.
+            var entry = tableOffset + (int)(i * entrySize);
+            var cpuType = BinaryPrimitives.ReadUInt32BigEndian(bytes[entry..]);
+            var offset = is64
+                ? BinaryPrimitives.ReadUInt64BigEndian(bytes[(entry + 8)..])
+                : BinaryPrimitives.ReadUInt32BigEndian(bytes[(entry + 8)..]);
+            var size = is64
+                ? BinaryPrimitives.ReadUInt64BigEndian(bytes[(entry + 16)..])
+                : BinaryPrimitives.ReadUInt32BigEndian(bytes[(entry + 12)..]);
+            if (size == 0
+                || !NativeImageRange.TryGet(
+                    bytes.Length,
+                    offset,
+                    size,
+                    out var sliceOffset,
+                    out var sliceSize))
+            {
+                return [];
+            }
+
+            slices.Add(new MachOFatSlice(cpuType, sliceOffset, sliceSize));
         }
 
         return slices;
@@ -110,7 +116,8 @@ internal static class MachOImageReader
     internal static bool TryReadUuid(ReadOnlySpan<byte> bytes, out byte[] uuid)
     {
         uuid = [];
-        foreach (var (cmd, offset, size) in Commands(bytes))
+        if (!TryReadCommands(bytes, out var commands)) return false;
+        foreach (var (cmd, offset, size) in commands)
         {
             if (cmd != LcUuid || size < 24) continue;
             uuid = bytes.Slice(offset + 8, 16).ToArray();
@@ -120,30 +127,6 @@ internal static class MachOImageReader
         return false;
     }
 
-    /// <summary>One Mach-O section's identity, location, and flags.</summary>
-    /// <param name="Name">The section name (e.g. <c>__text</c>).</param>
-    /// <param name="Segment">The owning segment's name (e.g. <c>__TEXT</c>).</param>
-    /// <param name="Address">The section's virtual address.</param>
-    /// <param name="FileOffset">The section's file offset.</param>
-    /// <param name="Size">The section's byte size.</param>
-    /// <param name="Flags">The section flags (instruction attributes mark executable code).</param>
-    /// <param name="Ordinal">The 1-based ordinal <c>n_sect</c> refers to, across all segments in load order.</param>
-    /// <param name="IndirectSymbolIndex">The <c>reserved1</c> field — a stub/pointer section's base index into the indirect symbol table.</param>
-    /// <param name="StubSize">The <c>reserved2</c> field — the byte size of each entry in a symbol-stub section, else 0.</param>
-    internal readonly record struct MachOSection(
-        string Name, string Segment, ulong Address, long FileOffset, long Size, uint Flags, int Ordinal,
-        int IndirectSymbolIndex = 0, int StubSize = 0)
-    {
-        /// <summary>The section type (low byte of the flags), e.g. stubs (0x8) or symbol pointers (0x6/0x7).</summary>
-        public uint Type => Flags & 0xFF;
-
-        /// <summary>
-        /// Whether the section holds code: ILC uses <c>__text</c>, <c>__managedcode</c>, and the
-        /// <c>__unbox</c> stubs, so the instruction attributes decide, not the name.
-        /// </summary>
-        public bool IsExecutable => (Flags & 0x8000_0400) != 0; // S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS
-    }
-
     /// <summary>
     /// Walks every <c>LC_SEGMENT_64</c> into its sections, in load order, with the running
     /// 1-based ordinals the symbol table's <c>n_sect</c> field references.
@@ -151,37 +134,77 @@ internal static class MachOImageReader
     /// <param name="bytes">The raw image bytes.</param>
     internal static IReadOnlyList<MachOSection> ReadSectionList(ReadOnlySpan<byte> bytes)
     {
-        var sections = new List<MachOSection>();
-        try
-        {
-            var ordinal = 0;
-            foreach (var (cmd, offset, size) in Commands(bytes))
-            {
-                if (cmd != LcSegment64 || size < Segment64HeaderSize) continue;
-                var segmentName = ReadFixedName(bytes, offset + 8);
-                var sectionCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 64)..]);
+        if (!TryReadCommands(bytes, out var commands)) return [];
 
-                for (var i = 0; i < sectionCount; i++)
-                {
-                    var s = offset + Segment64HeaderSize + i * Section64Size;
-                    if (s + Section64Size > offset + size || s + Section64Size > bytes.Length) break;
-                    ordinal++;
-                    sections.Add(new MachOSection(
-                        Name: ReadFixedName(bytes, s),
-                        Segment: segmentName,
-                        Address: BinaryPrimitives.ReadUInt64LittleEndian(bytes[(s + 32)..]),
-                        FileOffset: BinaryPrimitives.ReadUInt32LittleEndian(bytes[(s + 48)..]),
-                        Size: (long)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(s + 40)..]),
-                        Flags: BinaryPrimitives.ReadUInt32LittleEndian(bytes[(s + 64)..]),
-                        Ordinal: ordinal,
-                        IndirectSymbolIndex: (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(s + 72)..]),
-                        StubSize: (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(s + 76)..])));
-                }
-            }
-        }
-        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        var sections = new List<MachOSection>();
+        var ordinal = 0;
+        foreach (var (cmd, offset, size) in commands)
         {
-            // Keep the sections parsed so far.
+            if (cmd != LcSegment64) continue;
+            if (size < Segment64HeaderSize) return [];
+            var segmentName = ReadFixedName(bytes, offset + 8);
+            var sectionCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 64)..]);
+            if (!NativeImageRange.TryGetTable(
+                offset + size,
+                (ulong)(offset + Segment64HeaderSize),
+                sectionCount,
+                Section64Size,
+                Section64Size,
+                out var sectionTable,
+                out _))
+            {
+                return [];
+            }
+
+            for (var i = 0; i < sectionCount; i++)
+            {
+                var sectionOffset = sectionTable + (int)(i * Section64Size);
+                var address = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(sectionOffset + 32)..]);
+                var sizeValue = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(sectionOffset + 40)..]);
+                var fileOffsetValue = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(sectionOffset + 48)..]);
+                var flags = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(sectionOffset + 64)..]);
+                var indirectSymbolIndex = BinaryPrimitives.ReadUInt32LittleEndian(
+                    bytes[(sectionOffset + 72)..]);
+                var stubSize = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(sectionOffset + 76)..]);
+                if (sizeValue > long.MaxValue
+                    || indirectSymbolIndex > int.MaxValue
+                    || stubSize > int.MaxValue
+                    || !NativeImageRange.TryAdd(address, sizeValue, out _))
+                {
+                    return [];
+                }
+
+                long fileOffset;
+                if (IsZeroFill(flags))
+                {
+                    fileOffset = fileOffsetValue;
+                }
+                else if (!NativeImageRange.TryGet(
+                    bytes.Length,
+                    fileOffsetValue,
+                    sizeValue,
+                    out var validatedFileOffset,
+                    out _))
+                {
+                    return [];
+                }
+                else
+                {
+                    fileOffset = validatedFileOffset;
+                }
+
+                ordinal++;
+                sections.Add(new MachOSection(
+                    Name: ReadFixedName(bytes, sectionOffset),
+                    Segment: segmentName,
+                    Address: address,
+                    FileOffset: fileOffset,
+                    Size: (long)sizeValue,
+                    Flags: flags,
+                    Ordinal: ordinal,
+                    IndirectSymbolIndex: (int)indirectSymbolIndex,
+                    StubSize: (int)stubSize));
+            }
         }
 
         return sections;
@@ -196,7 +219,8 @@ internal static class MachOImageReader
     internal static bool TryGetTextBase(ReadOnlySpan<byte> bytes, out ulong vmaddr)
     {
         vmaddr = 0;
-        foreach (var (cmd, offset, size) in Commands(bytes))
+        if (!TryReadCommands(bytes, out var commands)) return false;
+        foreach (var (cmd, offset, size) in commands)
         {
             if (cmd != LcSegment64 || size < Segment64HeaderSize) continue;
             if (ReadFixedName(bytes, offset + 8) != "__TEXT") continue;
@@ -215,12 +239,19 @@ internal static class MachOImageReader
     {
         fileOffset = 0;
         size = 0;
-        foreach (var (cmd, offset, cmdSize) in Commands(bytes))
+        if (!TryReadCommands(bytes, out var commands)) return false;
+        foreach (var (cmd, offset, cmdSize) in commands)
         {
             if (cmd != LcFunctionStarts || cmdSize < 16) continue;
-            fileOffset = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 8)..]);
-            size = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 12)..]);
-            return fileOffset >= 0 && size > 0 && fileOffset + size <= bytes.Length;
+            var fileOffsetValue = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 8)..]);
+            var sizeValue = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 12)..]);
+            return sizeValue > 0
+                && NativeImageRange.TryGet(
+                    bytes.Length,
+                    fileOffsetValue,
+                    sizeValue,
+                    out fileOffset,
+                    out size);
         }
 
         return false;
@@ -228,18 +259,15 @@ internal static class MachOImageReader
 
     /// <summary>Finds the <c>LC_SYMTAB</c> table locations.</summary>
     /// <param name="bytes">The raw image bytes.</param>
-    /// <param name="symtab">The nlist array's offset and count, and the string table's offset.</param>
-    internal static bool TryGetSymtab(ReadOnlySpan<byte> bytes, out (int Offset, int Count, int StringOffset) symtab)
+    /// <param name="symtab">The validated symbol and string table ranges.</param>
+    internal static bool TryGetSymtab(ReadOnlySpan<byte> bytes, out MachOSymbolTable symtab)
     {
         symtab = default;
-        foreach (var (cmd, offset, size) in Commands(bytes))
+        if (!TryReadCommands(bytes, out var commands)) return false;
+        foreach (var (cmd, offset, size) in commands)
         {
             if (cmd != LcSymtab || size < 24) continue;
-            symtab = (
-                (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 8)..]),
-                (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 12)..]),
-                (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 16)..]));
-            return symtab.Count > 0;
+            return TryReadSymbolTable(bytes, offset, out symtab);
         }
 
         return false;
@@ -247,43 +275,98 @@ internal static class MachOImageReader
 
     /// <summary>Finds the <c>LC_DYSYMTAB</c> indirect symbol table, which maps stub/pointer slots to symbols.</summary>
     /// <param name="bytes">The raw image bytes.</param>
-    /// <param name="table">The indirect symbol table's file offset and entry count (each a uint32 symbol index).</param>
-    internal static bool TryGetIndirectSymbolTable(ReadOnlySpan<byte> bytes, out (int Offset, int Count) table)
+    /// <param name="table">The validated indirect-symbol table.</param>
+    internal static bool TryGetIndirectSymbolTable(
+        ReadOnlySpan<byte> bytes,
+        out MachOIndirectSymbolTable table)
     {
         table = default;
-        foreach (var (cmd, offset, size) in Commands(bytes))
+        if (!TryReadCommands(bytes, out var commands)) return false;
+        foreach (var (cmd, offset, size) in commands)
         {
             if (cmd != LcDysymtab || size < 80) continue;
-            table = (
-                (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 56)..]),  // indirectsymoff
-                (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 60)..])); // nindirectsyms
-            return table.Count > 0;
+            var tableOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 56)..]);
+            var count = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(offset + 60)..]);
+            if (count == 0
+                || !NativeImageRange.TryGetTable(
+                    bytes.Length,
+                    tableOffset,
+                    count,
+                    sizeof(uint),
+                    sizeof(uint),
+                    out var fileOffset,
+                    out _))
+            {
+                return false;
+            }
+
+            table = new MachOIndirectSymbolTable(fileOffset, (int)count);
+            return true;
         }
 
         return false;
     }
 
-    /// <summary>Enumerates the load commands of a thin image as (cmd, offset, size) triples.</summary>
-    private static List<(uint Cmd, int Offset, int Size)> Commands(ReadOnlySpan<byte> bytes)
+    private static bool IsZeroFill(uint flags) =>
+        (flags & 0xFF) is SectionTypeZeroFill or SectionTypeGbZeroFill or SectionTypeThreadLocalZeroFill;
+
+    /// <summary>Enumerates fully validated load commands of a thin image.</summary>
+    private static bool TryReadCommands(
+        ReadOnlySpan<byte> bytes,
+        out List<(uint Cmd, int Offset, int Size)> commands)
     {
-        var commands = new List<(uint, int, int)>();
-        if (!IsMachO(bytes)) return commands;
+        commands = [];
+        if (!IsMachO(bytes)) return false;
 
         var commandCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes[16..]);
-        if (commandCount > MaxCommands) return commands;
+        var commandsSize = BinaryPrimitives.ReadUInt32LittleEndian(bytes[20..]);
+        if (commandCount > MaxCommands
+            || !NativeImageRange.TryGet(
+                bytes.Length,
+                HeaderSize,
+                commandsSize,
+                out var command,
+                out var commandBytes))
+        {
+            return false;
+        }
 
-        var command = HeaderSize;
+        var commandsEnd = command + commandBytes;
+        commands = new List<(uint, int, int)>((int)commandCount);
         for (var i = 0; i < commandCount; i++)
         {
-            if (command + 8 > bytes.Length) break;
+            if (!NativeImageRange.TryGet(commandsEnd, command, 8, out _, out _))
+            {
+                commands = [];
+                return false;
+            }
+
             var cmd = BinaryPrimitives.ReadUInt32LittleEndian(bytes[command..]);
-            var cmdSize = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 4)..]);
-            if (cmdSize < 8 || command + cmdSize > bytes.Length) break;
+            var cmdSizeValue = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 4)..]);
+            if (cmdSizeValue < 8
+                || (cmdSizeValue & 7) != 0
+                || !NativeImageRange.TryGet(
+                    commandsEnd,
+                    (ulong)command,
+                    cmdSizeValue,
+                    out _,
+                    out var cmdSize))
+            {
+                commands = [];
+                return false;
+            }
+
             commands.Add((cmd, command, cmdSize));
             command += cmdSize;
         }
 
-        return commands;
+        if (command != commandsEnd)
+        {
+            commands = [];
+            return false;
+        }
+
+        return true;
     }
 
     private static string ReadFixedName(ReadOnlySpan<byte> bytes, int offset)
@@ -297,118 +380,105 @@ internal static class MachOImageReader
     /// <summary>Reads the loaded dylibs and the undefined external symbols bound to each.</summary>
     internal static IReadOnlyList<ImportedModuleInfo> ReadImports(ReadOnlySpan<byte> bytes)
     {
-        try
+        if (!IsMachO(bytes)) return [];
+        if (Parse(bytes) is not { } image) return [];
+
+        var modules = image.Dylibs
+            .Select(d => (Name: d, Functions: new List<ImportedFunctionInfo>()))
+            .ToList();
+
+        if (image.Symbols is { } symtab)
         {
-            if (!IsMachO(bytes)) return [];
-            if (Parse(bytes) is not { } image) return [];
-
-            var modules = image.Dylibs
-                .Select(d => (Name: d, Functions: new List<ImportedFunctionInfo>()))
-                .ToList();
-
-            if (image.Symbols is { } symtab)
-            {
-                for (var i = 0; i < symtab.Count && i < MaxSymbols; i++)
-                {
-                    var entry = symtab.Offset + i * NListSize;
-                    var type = bytes[entry + 4];
-                    if ((type & NStab) != 0) continue;
-                    if ((type & NExt) == 0 || (type & NType) != NUndef) continue;
-
-                    var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[entry..]);
-                    var desc = BinaryPrimitives.ReadUInt16LittleEndian(bytes[(entry + 6)..]);
-                    var name = ReadString(bytes, symtab.StringOffset, nameOffset);
-                    if (string.IsNullOrEmpty(name)) continue;
-
-                    // Two-level namespace: high byte of n_desc is the 1-based dylib ordinal.
-                    var ordinal = (desc >> 8) & 0xFF;
-                    if (ordinal >= 1 && ordinal <= modules.Count)
-                        modules[ordinal - 1].Functions.Add(
-                            new ImportedFunctionInfo(name, Ordinal: null, Hint: null));
-                }
-            }
-
-            return [.. modules.Select(m => new ImportedModuleInfo(m.Name, m.Functions))];
-        }
-        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
-        {
-            return [];
-        }
-    }
-
-    /// <summary>Reads the defined external symbols (the exported symbols).</summary>
-    internal static IReadOnlyList<ExportedFunctionInfo> ReadExports(ReadOnlySpan<byte> bytes)
-    {
-        try
-        {
-            if (!IsMachO(bytes)) return [];
-            if (Parse(bytes) is not { Symbols: { } symtab }) return [];
-
-            var exports = new List<ExportedFunctionInfo>();
             for (var i = 0; i < symtab.Count && i < MaxSymbols; i++)
             {
                 var entry = symtab.Offset + i * NListSize;
                 var type = bytes[entry + 4];
                 if ((type & NStab) != 0) continue;
-                if ((type & NExt) == 0 || (type & NType) != NSect) continue;
+                if ((type & NExt) == 0 || (type & NType) != NUndef) continue;
 
                 var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[entry..]);
-                var value = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(entry + 8)..]);
-                var name = ReadString(bytes, symtab.StringOffset, nameOffset);
+                var desc = BinaryPrimitives.ReadUInt16LittleEndian(bytes[(entry + 6)..]);
+                var name = ReadString(
+                    bytes,
+                    symtab.StringOffset,
+                    symtab.StringSize,
+                    nameOffset);
                 if (string.IsNullOrEmpty(name)) continue;
 
-                exports.Add(new ExportedFunctionInfo(
-                    Ordinal: i, Name: name, Rva: (int)value, ForwardedTo: null));
+                // Two-level namespace: high byte of n_desc is the 1-based dylib ordinal.
+                var ordinal = (desc >> 8) & 0xFF;
+                if (ordinal >= 1 && ordinal <= modules.Count)
+                    modules[ordinal - 1].Functions.Add(
+                        new ImportedFunctionInfo(name, Ordinal: null, Hint: null));
             }
+        }
 
-            return exports;
-        }
-        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
-        {
-            return [];
-        }
+        return [.. modules.Select(m => new ImportedModuleInfo(m.Name, m.Functions))];
     }
 
-    private static MachOImage? Parse(ReadOnlySpan<byte> bytes)
+    /// <summary>Reads the defined external symbols (the exported symbols).</summary>
+    internal static IReadOnlyList<ExportedFunctionInfo> ReadExports(ReadOnlySpan<byte> bytes)
     {
-        var commandCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes[16..]);
-        if (commandCount > MaxCommands) return null;
+        if (!IsMachO(bytes)) return [];
+        if (Parse(bytes) is not { Symbols: { } symtab }) return [];
+
+        var exports = new List<ExportedFunctionInfo>();
+        for (var i = 0; i < symtab.Count && i < MaxSymbols; i++)
+        {
+            var entry = symtab.Offset + i * NListSize;
+            var type = bytes[entry + 4];
+            if ((type & NStab) != 0) continue;
+            if ((type & NExt) == 0 || (type & NType) != NSect) continue;
+
+            var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[entry..]);
+            var value = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(entry + 8)..]);
+            var name = ReadString(
+                bytes,
+                symtab.StringOffset,
+                symtab.StringSize,
+                nameOffset);
+            if (string.IsNullOrEmpty(name)) continue;
+
+            exports.Add(new ExportedFunctionInfo(
+                Ordinal: i, Name: name, Rva: (int)value, ForwardedTo: null));
+        }
+
+        return exports;
+    }
+
+    private static (IReadOnlyList<string> Dylibs, MachOSymbolTable? Symbols)? Parse(
+        ReadOnlySpan<byte> bytes)
+    {
+        if (!TryReadCommands(bytes, out var commands)) return null;
 
         var dylibs = new List<string>();
-        (int Offset, int Count, int StringOffset)? symbols = null;
+        MachOSymbolTable? symbols = null;
 
-        var command = HeaderSize;
-        for (var i = 0; i < commandCount; i++)
+        foreach (var (cmd, command, cmdSize) in commands)
         {
-            if (command + 8 > bytes.Length) break;
-            var cmd = BinaryPrimitives.ReadUInt32LittleEndian(bytes[command..]);
-            var cmdSize = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 4)..]);
-            if (cmdSize < 8 || command + cmdSize > bytes.Length) break;
-
             switch (cmd)
             {
                 case LcLoadDylib or LcLoadWeakDylib or LcReexportDylib or LcLoadUpwardDylib:
                 {
+                    if (cmdSize < 24) return null;
                     var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 8)..]);
-                    var name = ReadString(bytes, command, nameOffset);
+                    var name = ReadString(bytes, command, cmdSize, nameOffset);
                     dylibs.Add(string.IsNullOrEmpty(name) ? "(unknown)" : ShortDylibName(name));
                     break;
                 }
 
                 case LcSymtab:
                 {
-                    var symOffset = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 8)..]);
-                    var symCount = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 12)..]);
-                    var stringOffset = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 16)..]);
-                    symbols = (symOffset, symCount, stringOffset);
+                    if (cmdSize < 24
+                        || !TryReadSymbolTable(bytes, command, out var symbolTable))
+                        return null;
+                    symbols = symbolTable;
                     break;
                 }
             }
-
-            command += cmdSize;
         }
 
-        return new MachOImage(dylibs, symbols);
+        return (dylibs, symbols);
     }
 
     private static string ShortDylibName(string path)
@@ -417,19 +487,68 @@ internal static class MachOImageReader
         return slash >= 0 && slash < path.Length - 1 ? path[(slash + 1)..] : path;
     }
 
-    private static string? ReadString(ReadOnlySpan<byte> bytes, long tableOffset, uint offset)
+    private static string? ReadString(
+        ReadOnlySpan<byte> bytes,
+        int tableOffset,
+        int tableSize,
+        uint offset)
     {
-        var start = tableOffset + offset;
-        if (start < 0 || start >= bytes.Length) return null;
+        if (offset >= (uint)tableSize
+            || !NativeImageRange.TryGet(
+                bytes.Length,
+                tableOffset,
+                tableSize,
+                out _,
+                out _)
+            || !NativeImageRange.TryAdd((ulong)tableOffset, offset, out var startValue)
+            || !NativeImageRange.TryGet(bytes.Length, startValue, 1, out var start, out _))
+        {
+            return null;
+        }
 
-        var slice = bytes[(int)start..];
+        var available = tableSize - (int)offset;
+        var slice = bytes.Slice(start, Math.Min(available, MaxStringLength + 1));
         var end = slice.IndexOf((byte)0);
-        if (end < 0) end = Math.Min(slice.Length, MaxStringLength);
-        if (end > MaxStringLength) return null;
+        if (end < 0 || end > MaxStringLength) return null;
 
         return Encoding.UTF8.GetString(slice[..end]);
     }
 
-    private readonly record struct MachOImage(
-        IReadOnlyList<string> Dylibs, (int Offset, int Count, int StringOffset)? Symbols);
+    private static bool TryReadSymbolTable(
+        ReadOnlySpan<byte> bytes,
+        int commandOffset,
+        out MachOSymbolTable symbolTable)
+    {
+        var symbolOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(commandOffset + 8)..]);
+        var symbolCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(commandOffset + 12)..]);
+        var stringOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(commandOffset + 16)..]);
+        var stringSize = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(commandOffset + 20)..]);
+        if (symbolCount == 0
+            || !NativeImageRange.TryGetTable(
+                bytes.Length,
+                symbolOffset,
+                symbolCount,
+                NListSize,
+                NListSize,
+                out var symbols,
+                out _)
+            || !NativeImageRange.TryGet(
+                bytes.Length,
+                stringOffset,
+                stringSize,
+                out var strings,
+                out var stringsLength))
+        {
+            symbolTable = default;
+            return false;
+        }
+
+        symbolTable = new MachOSymbolTable(
+            symbols,
+            (int)symbolCount,
+            strings,
+            stringsLength);
+        return true;
+    }
+
 }

--- a/src/Dotsider.Core/Analysis/MachOIndirectSymbolTable.cs
+++ b/src/Dotsider.Core/Analysis/MachOIndirectSymbolTable.cs
@@ -1,0 +1,8 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Describes a validated Mach-O indirect-symbol table.
+/// </summary>
+/// <param name="Offset">The table's file offset.</param>
+/// <param name="Count">The number of four-byte symbol indexes.</param>
+internal readonly record struct MachOIndirectSymbolTable(int Offset, int Count);

--- a/src/Dotsider.Core/Analysis/MachOSection.cs
+++ b/src/Dotsider.Core/Analysis/MachOSection.cs
@@ -1,0 +1,33 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Describes one validated Mach-O section.
+/// </summary>
+/// <param name="Name">The section name.</param>
+/// <param name="Segment">The owning segment name.</param>
+/// <param name="Address">The section's virtual address.</param>
+/// <param name="FileOffset">The section's file offset.</param>
+/// <param name="Size">The section's byte size.</param>
+/// <param name="Flags">The section flags.</param>
+/// <param name="Ordinal">The one-based section ordinal used by symbol records.</param>
+/// <param name="IndirectSymbolIndex">The section's first indirect-symbol index.</param>
+/// <param name="StubSize">The byte size of each symbol stub.</param>
+internal readonly record struct MachOSection(
+    string Name,
+    string Segment,
+    ulong Address,
+    long FileOffset,
+    long Size,
+    uint Flags,
+    int Ordinal,
+    int IndirectSymbolIndex = 0,
+    int StubSize = 0)
+{
+    /// <summary>The section type stored in the low byte of <see cref="Flags"/>.</summary>
+    public uint Type => Flags & 0xFF;
+
+    /// <summary>
+    /// Gets a value indicating whether the section carries executable instructions.
+    /// </summary>
+    public bool IsExecutable => (Flags & 0x8000_0400) != 0;
+}

--- a/src/Dotsider.Core/Analysis/MachOSymbolReader.cs
+++ b/src/Dotsider.Core/Analysis/MachOSymbolReader.cs
@@ -45,13 +45,16 @@ internal static class MachOSymbolReader
             for (var i = 0; i < count; i++)
             {
                 var entry = symtab.Offset + i * NListSize;
-                if (entry < 0 || entry + NListSize > bytes.Length) break;
 
                 var type = bytes[entry + 4];
                 var ordinal = bytes[entry + 5];
                 var value = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(entry + 8)..]);
                 var nameOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[entry..]);
-                var name = ReadName(bytes, symtab.StringOffset, nameOffset);
+                var name = ReadName(
+                    bytes,
+                    symtab.StringOffset,
+                    symtab.StringSize,
+                    nameOffset);
 
                 if ((type & NStab) != 0)
                 {
@@ -131,7 +134,8 @@ internal static class MachOSymbolReader
                 while ((b & 0x80) != 0);
 
                 if (delta == 0) break; // padding terminates the stream
-                address += delta;
+                if (!NativeImageRange.TryAdd(address, delta, out address))
+                    return Finish(starts, sections, result);
                 starts.Add(address);
             }
 
@@ -144,7 +148,7 @@ internal static class MachOSymbolReader
     }
 
     private static List<RawNativeSymbol> Finish(
-        List<ulong> starts, IReadOnlyList<MachOImageReader.MachOSection> sections, List<RawNativeSymbol> result)
+        List<ulong> starts, IReadOnlyList<MachOSection> sections, List<RawNativeSymbol> result)
     {
         for (var i = 0; i < starts.Count; i++)
         {
@@ -152,12 +156,17 @@ internal static class MachOSymbolReader
             var section = FindSectionByAddress(sections, va);
             var end = i + 1 < starts.Count
                 ? starts[i + 1]
-                : section is { } s ? s.Address + (ulong)s.Size : va;
-            if (section is { } clamp && end > clamp.Address + (ulong)clamp.Size)
-                end = clamp.Address + (ulong)clamp.Size;
+                : section is { } s && TryGetSectionEnd(s, out var sectionEnd) ? sectionEnd : va;
+            if (section is { } clamp
+                && TryGetSectionEnd(clamp, out var clampEnd)
+                && end > clampEnd)
+                end = clampEnd;
             if (end <= va) continue;
 
-            long? fileOffset = section is { } fo ? fo.FileOffset + (long)(va - fo.Address) : null;
+            long? fileOffset = section is { } fo
+                && TryMapFileOffset(fo, va, out var mappedOffset)
+                ? mappedOffset
+                : null;
             result.Add(new RawNativeSymbol(
                 Name: $"sub_{va:x}",
                 VirtualAddress: va,
@@ -176,7 +185,7 @@ internal static class MachOSymbolReader
 
     private static void AppendSizedFunctions(
         List<(string Name, ulong Va, int Ordinal, long Size)> functions,
-        IReadOnlyList<MachOImageReader.MachOSection> sections, List<RawNativeSymbol> result)
+        IReadOnlyList<MachOSection> sections, List<RawNativeSymbol> result)
     {
         // nlist carries no sizes: sort and size each unsized function by the next start,
         // clamped to its containing section's end so the last one never bleeds across sections.
@@ -191,9 +200,13 @@ internal static class MachOSymbolReader
                 while (j < functions.Count && functions[j].Va <= va) j++;
                 var end = j < functions.Count
                     ? functions[j].Va
-                    : section is { } s ? s.Address + (ulong)s.Size : va;
-                if (section is { } clamp && end > clamp.Address + (ulong)clamp.Size)
-                    end = clamp.Address + (ulong)clamp.Size;
+                    : section is { } s && TryGetSectionEnd(s, out var sectionEnd)
+                        ? sectionEnd
+                        : va;
+                if (section is { } clamp
+                    && TryGetSectionEnd(clamp, out var clampEnd)
+                    && end > clampEnd)
+                    end = clampEnd;
                 size = end > va ? (long)(end - va) : 0;
             }
 
@@ -203,14 +216,12 @@ internal static class MachOSymbolReader
     }
 
     private static RawNativeSymbol Raw(
-        string name, ulong va, MachOImageReader.MachOSection section, long size, bool isData) =>
+        string name, ulong va, MachOSection section, long size, bool isData) =>
         new(
             Name: name,
             VirtualAddress: va,
             Rva: null,
-            FileOffset: va >= section.Address && va < section.Address + (ulong)section.Size
-                ? section.FileOffset + (long)(va - section.Address)
-                : null,
+            FileOffset: TryMapFileOffset(section, va, out var fileOffset) ? fileOffset : null,
             Section: section.Name,
             Size: size,
             IsData: isData,
@@ -218,8 +229,8 @@ internal static class MachOSymbolReader
             SourceFile: null,
             Line: null);
 
-    private static MachOImageReader.MachOSection? FindSection(
-        IReadOnlyList<MachOImageReader.MachOSection> sections, int ordinal)
+    private static MachOSection? FindSection(
+        IReadOnlyList<MachOSection> sections, int ordinal)
     {
         foreach (var section in sections)
         {
@@ -229,12 +240,15 @@ internal static class MachOSymbolReader
         return null;
     }
 
-    private static MachOImageReader.MachOSection? FindSectionByAddress(
-        IReadOnlyList<MachOImageReader.MachOSection> sections, ulong va)
+    private static MachOSection? FindSectionByAddress(
+        IReadOnlyList<MachOSection> sections, ulong va)
     {
         foreach (var section in sections)
         {
-            if (section.Address != 0 && va >= section.Address && va < section.Address + (ulong)section.Size)
+            if (section.Address != 0
+                && va >= section.Address
+                && TryGetSectionEnd(section, out var end)
+                && va < end)
                 return section;
         }
 
@@ -242,14 +256,57 @@ internal static class MachOSymbolReader
     }
 
     /// <summary>Reads a symbol name, stripping the Mach-O leading underscore.</summary>
-    private static string ReadName(ReadOnlySpan<byte> bytes, int stringOffset, uint nameOffset)
+    private static string ReadName(
+        ReadOnlySpan<byte> bytes,
+        int stringOffset,
+        int stringSize,
+        uint nameOffset)
     {
-        var start = (long)stringOffset + nameOffset;
-        if (start < 0 || start >= bytes.Length) return "";
-        var slice = bytes[(int)start..];
+        if (nameOffset >= (uint)stringSize
+            || !NativeImageRange.TryAdd((ulong)stringOffset, nameOffset, out var startValue)
+            || !NativeImageRange.TryGet(bytes.Length, startValue, 1, out var start, out _))
+            return "";
+
+        var available = stringSize - (int)nameOffset;
+        var slice = bytes.Slice(start, available);
         var end = slice.IndexOf((byte)0);
-        if (end < 0) end = slice.Length;
+        if (end < 0) return "";
         var name = Encoding.UTF8.GetString(slice[..end]);
         return name.StartsWith('_') ? name[1..] : name;
+    }
+
+    private static bool TryGetSectionEnd(MachOSection section, out ulong end)
+    {
+        if (section.Size < 0)
+        {
+            end = 0;
+            return false;
+        }
+
+        return NativeImageRange.TryAdd(section.Address, (ulong)section.Size, out end);
+    }
+
+    private static bool TryMapFileOffset(MachOSection section, ulong address, out long fileOffset)
+    {
+        if (section.FileOffset < 0
+            || section.Size <= 0
+            || section.Type is 0x1 or 0xC or 0x12
+            || address < section.Address)
+        {
+            fileOffset = 0;
+            return false;
+        }
+
+        var delta = address - section.Address;
+        if (delta >= (ulong)section.Size
+            || !NativeImageRange.TryAdd((ulong)section.FileOffset, delta, out var offset)
+            || offset > long.MaxValue)
+        {
+            fileOffset = 0;
+            return false;
+        }
+
+        fileOffset = (long)offset;
+        return true;
     }
 }

--- a/src/Dotsider.Core/Analysis/MachOSymbolTable.cs
+++ b/src/Dotsider.Core/Analysis/MachOSymbolTable.cs
@@ -1,0 +1,14 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Describes validated Mach-O symbol and string tables.
+/// </summary>
+/// <param name="Offset">The symbol table's file offset.</param>
+/// <param name="Count">The number of symbol records.</param>
+/// <param name="StringOffset">The string table's file offset.</param>
+/// <param name="StringSize">The string table's byte size.</param>
+internal readonly record struct MachOSymbolTable(
+    int Offset,
+    int Count,
+    int StringOffset,
+    int StringSize);

--- a/src/Dotsider.Core/Analysis/NativeAddressSegment.cs
+++ b/src/Dotsider.Core/Analysis/NativeAddressSegment.cs
@@ -1,0 +1,12 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Describes a validated file-backed segment in a native image.
+/// </summary>
+/// <param name="VirtualAddress">The segment's starting virtual address.</param>
+/// <param name="FileOffset">The segment's starting file offset.</param>
+/// <param name="FileSize">The number of file-backed bytes in the segment.</param>
+internal readonly record struct NativeAddressSegment(
+    ulong VirtualAddress,
+    int FileOffset,
+    int FileSize);

--- a/src/Dotsider.Core/Analysis/NativeAddressSpace.cs
+++ b/src/Dotsider.Core/Analysis/NativeAddressSpace.cs
@@ -10,24 +10,28 @@ namespace Dotsider.Core.Analysis;
 /// nothing — callers treat that as "not file-backed" rather than an error.
 ///
 /// On Mach-O the section pointers are chained-fixup encoded rather than stored as plain
-/// addresses; <see cref="DecodeChainedRebase"/> decodes them, and the caller determines
+/// addresses; <see cref="TryDecodeChainedRebase"/> decodes them, and the caller determines
 /// which of the two rebase forms the image uses (see the ReadyToRun reader's calibration).
 /// </summary>
 internal sealed class NativeAddressSpace
 {
+    private const int CoffHeaderSize = 24;
+    private const int Elf64HeaderSize = 64;
+    private const int Elf64ProgramHeaderSize = 56;
+    private const int MachHeader64Size = 32;
+    private const int MachSegment64Size = 72;
+    private const int PeSectionHeaderSize = 40;
+
     /// <summary>The 36-bit target field of a DYLD_CHAINED_PTR_64 rebase pointer.</summary>
     private const ulong ChainedTargetMask = 0xF_FFFF_FFFF;
 
-    private readonly List<Segment> _segments;
-    private readonly int _byteLength;
-
+    private readonly List<NativeAddressSegment> _segments;
     private NativeAddressSpace(
-        int pointerSize, List<Segment> segments, int byteLength,
+        int pointerSize, List<NativeAddressSegment> segments,
         bool machOChained = false, ulong machOImageBase = 0)
     {
         PointerSize = pointerSize;
         _segments = segments;
-        _byteLength = byteLength;
         MachOChained = machOChained;
         MachOImageBase = machOImageBase;
     }
@@ -43,7 +47,7 @@ internal sealed class NativeAddressSpace
 
     /// <summary>
     /// Builds an address space from a native image, or returns null when the format is
-    /// unrecognized or has no mappable segments.
+    /// unrecognized, malformed, truncated, or has no mappable segments.
     /// </summary>
     /// <param name="bytes">The raw bytes of the image.</param>
     public static NativeAddressSpace? Create(ReadOnlySpan<byte> bytes)
@@ -66,18 +70,38 @@ internal sealed class NativeAddressSpace
     /// Decodes a Mach-O chained-fixup rebase pointer to the virtual address it targets. The
     /// low 36 bits are the target; <paramref name="offsetForm"/> selects whether that is an
     /// offset from the image base (DYLD_CHAINED_PTR_64_OFFSET, arm64) or an absolute address
-    /// (DYLD_CHAINED_PTR_64, x64). Returns the input unchanged for a null or import-bind value.
+    /// (DYLD_CHAINED_PTR_64, x64). Null and import-bind values are returned unchanged.
     /// </summary>
-    public static ulong DecodeChainedRebase(ulong raw, bool offsetForm, ulong imageBase)
+    /// <param name="raw">The encoded pointer.</param>
+    /// <param name="offsetForm">Whether the target is relative to <paramref name="imageBase"/>.</param>
+    /// <param name="imageBase">The Mach-O image base.</param>
+    /// <param name="address">The decoded address.</param>
+    /// <returns>True when the decoded address is representable.</returns>
+    public static bool TryDecodeChainedRebase(
+        ulong raw,
+        bool offsetForm,
+        ulong imageBase,
+        out ulong address)
     {
-        if (raw == 0 || (raw >> 63) != 0) return raw;
+        if (raw == 0 || (raw >> 63) != 0)
+        {
+            address = raw;
+            return true;
+        }
+
         var target = raw & ChainedTargetMask;
-        return offsetForm ? imageBase + target : (((raw >> 36) & 0xFF) << 56) | target;
+        if (!offsetForm)
+        {
+            address = (((raw >> 36) & 0xFF) << 56) | target;
+            return true;
+        }
+
+        return NativeImageRange.TryAdd(imageBase, target, out address);
     }
 
     /// <summary>
     /// Translates a virtual address to a file offset when it falls inside file-backed data.
-    /// The address must already be decoded (see <see cref="DecodeChainedRebase"/> for Mach-O).
+    /// The address must already be decoded (see <see cref="TryDecodeChainedRebase"/> for Mach-O).
     /// </summary>
     /// <param name="virtualAddress">The virtual address to translate.</param>
     /// <param name="fileOffset">The resulting file offset.</param>
@@ -92,14 +116,7 @@ internal sealed class NativeAddressSpace
             if (delta >= (ulong)segment.FileSize) continue;
 
             fileOffset = segment.FileOffset + (int)delta;
-            if (fileOffset < 0 || fileOffset > _byteLength)
-            {
-                fileOffset = 0;
-                available = 0;
-                return false;
-            }
-
-            available = Math.Min(segment.FileSize - (int)delta, _byteLength - fileOffset);
+            available = segment.FileSize - (int)delta;
             return true;
         }
 
@@ -111,17 +128,40 @@ internal sealed class NativeAddressSpace
     private static NativeAddressSpace? CreatePe(ReadOnlySpan<byte> bytes)
     {
         if (bytes.Length < 0x40) return null;
-        var peHeader = BinaryPrimitives.ReadInt32LittleEndian(bytes[0x3C..]);
-        if (peHeader <= 0 || peHeader + 24 > bytes.Length) return null;
+        var peHeaderValue = BinaryPrimitives.ReadUInt32LittleEndian(bytes[0x3C..]);
+        if (peHeaderValue == 0
+            || !NativeImageRange.TryGet(
+                bytes.Length,
+                peHeaderValue,
+                CoffHeaderSize,
+                out var peHeader,
+                out _))
+        {
+            return null;
+        }
+
         if (BinaryPrimitives.ReadUInt32LittleEndian(bytes[peHeader..]) != 0x00004550) return null; // "PE\0\0"
 
         var sectionCount = BinaryPrimitives.ReadUInt16LittleEndian(bytes[(peHeader + 6)..]);
         var optionalHeaderSize = BinaryPrimitives.ReadUInt16LittleEndian(bytes[(peHeader + 20)..]);
-        var optionalHeader = peHeader + 24;
-        if (optionalHeader + 2 > bytes.Length) return null;
+        var optionalHeader = peHeader + CoffHeaderSize;
+        if (!NativeImageRange.TryGet(
+                bytes.Length,
+                (ulong)optionalHeader,
+                optionalHeaderSize,
+                out _,
+                out _)
+            || optionalHeaderSize < 32)
+        {
+            return null;
+        }
 
         var magic = BinaryPrimitives.ReadUInt16LittleEndian(bytes[optionalHeader..]);
+        if (magic is not (0x10B or 0x20B)) return null;
+
         var is64Bit = magic == 0x20B;
+        var minimumOptionalHeaderSize = is64Bit ? 112 : 96;
+        if (optionalHeaderSize < minimumOptionalHeaderSize) return null;
         var pointerSize = is64Bit ? 8 : 4;
 
         // ImageBase: u64 at optional+24 (PE32+) or u32 at optional+28 (PE32)
@@ -130,84 +170,175 @@ internal sealed class NativeAddressSpace
             : BinaryPrimitives.ReadUInt32LittleEndian(bytes[(optionalHeader + 28)..]);
 
         var sectionTable = optionalHeader + optionalHeaderSize;
-        var segments = new List<Segment>(sectionCount);
+        if (!NativeImageRange.TryGetTable(
+                bytes.Length,
+                (ulong)sectionTable,
+                sectionCount,
+                PeSectionHeaderSize,
+                PeSectionHeaderSize,
+                out _,
+                out _))
+        {
+            return null;
+        }
+
+        var segments = new List<NativeAddressSegment>(sectionCount);
         for (var i = 0; i < sectionCount; i++)
         {
-            var entry = sectionTable + i * 40;
-            if (entry + 40 > bytes.Length) break;
+            var entry = sectionTable + i * PeSectionHeaderSize;
 
             var virtualAddress = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(entry + 12)..]);
             var rawSize = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(entry + 16)..]);
             var rawOffset = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(entry + 20)..]);
             if (rawSize == 0) continue;
 
-            segments.Add(new Segment(imageBase + virtualAddress, (int)rawOffset, (int)rawSize));
+            if (!NativeImageRange.TryGet(
+                    bytes.Length,
+                    rawOffset,
+                    rawSize,
+                    out var fileOffset,
+                    out var fileSize)
+                || !NativeImageRange.TryAdd(imageBase, virtualAddress, out var sectionAddress)
+                || !NativeImageRange.TryAdd(sectionAddress, rawSize, out _))
+            {
+                return null;
+            }
+
+            segments.Add(new NativeAddressSegment(sectionAddress, fileOffset, fileSize));
         }
 
-        return segments.Count > 0 ? new NativeAddressSpace(pointerSize, segments, bytes.Length) : null;
+        return segments.Count > 0 ? new NativeAddressSpace(pointerSize, segments) : null;
     }
 
     private static NativeAddressSpace? CreateElf(ReadOnlySpan<byte> bytes)
     {
-        if (bytes.Length < 64 || bytes[5] != 1) return null; // 64-bit little-endian only
+        if (bytes.Length < Elf64HeaderSize || bytes[5] != 1) return null; // 64-bit little-endian only
         if (bytes[4] != 2) return null;
 
-        var programHeaderOffset = (long)BinaryPrimitives.ReadUInt64LittleEndian(bytes[0x20..]);
+        var programHeaderOffset = BinaryPrimitives.ReadUInt64LittleEndian(bytes[0x20..]);
         var entrySize = BinaryPrimitives.ReadUInt16LittleEndian(bytes[0x36..]);
         var entryCount = BinaryPrimitives.ReadUInt16LittleEndian(bytes[0x38..]);
-        if (programHeaderOffset <= 0 || entrySize < 56) return null;
-
-        var segments = new List<Segment>(entryCount);
-        for (var i = 0; i < entryCount; i++)
+        if (programHeaderOffset == 0
+            || entryCount == 0
+            || !NativeImageRange.TryGetTable(
+                bytes.Length,
+                programHeaderOffset,
+                entryCount,
+                entrySize,
+                Elf64ProgramHeaderSize,
+                out var tableOffset,
+                out _))
         {
-            var entry = programHeaderOffset + (long)i * entrySize;
-            if (entry + 56 > bytes.Length) break;
-
-            var type = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(int)entry..]);
-            if (type != 1) continue; // PT_LOAD
-
-            var fileOffset = (long)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(entry + 8)..]);
-            var virtualAddress = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(entry + 16)..]);
-            var fileSize = (long)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(int)(entry + 32)..]);
-            if (fileSize == 0) continue;
-
-            segments.Add(new Segment(virtualAddress, (int)fileOffset, (int)fileSize));
+            return null;
         }
 
-        return segments.Count > 0 ? new NativeAddressSpace(8, segments, bytes.Length) : null;
+        var segments = new List<NativeAddressSegment>(entryCount);
+        for (var i = 0; i < entryCount; i++)
+        {
+            var entry = tableOffset + i * entrySize;
+
+            var type = BinaryPrimitives.ReadUInt32LittleEndian(bytes[entry..]);
+            if (type != 1) continue; // PT_LOAD
+
+            var fileOffsetValue = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(entry + 8)..]);
+            var virtualAddress = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(entry + 16)..]);
+            var fileSizeValue = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(entry + 32)..]);
+            var memorySize = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(entry + 40)..]);
+            if (fileSizeValue > memorySize) return null;
+            if (fileSizeValue == 0) continue;
+
+            if (!NativeImageRange.TryGet(
+                    bytes.Length,
+                    fileOffsetValue,
+                    fileSizeValue,
+                    out var fileOffset,
+                    out var fileSize)
+                || !NativeImageRange.TryAdd(virtualAddress, fileSizeValue, out _))
+            {
+                return null;
+            }
+
+            segments.Add(new NativeAddressSegment(virtualAddress, fileOffset, fileSize));
+        }
+
+        return segments.Count > 0 ? new NativeAddressSpace(8, segments) : null;
     }
 
     private static NativeAddressSpace? CreateMachO(ReadOnlySpan<byte> bytes)
     {
-        if (bytes.Length < 32) return null;
+        if (bytes.Length < MachHeader64Size) return null;
         var commandCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes[16..]);
-        if (commandCount > 4096) return null;
+        var commandsSize = BinaryPrimitives.ReadUInt32LittleEndian(bytes[20..]);
+        if (commandCount > 4096
+            || !NativeImageRange.TryGet(
+                bytes.Length,
+                MachHeader64Size,
+                commandsSize,
+                out var command,
+                out var commandsLength))
+        {
+            return null;
+        }
 
         const uint lcSegment64 = 0x19;
         const uint lcDyldChainedFixups = 0x80000034;
 
-        var segments = new List<Segment>();
+        var commandsEnd = command + commandsLength;
+        var segments = new List<NativeAddressSegment>();
         var chained = false;
         var imageBase = ulong.MaxValue;
-        var command = 32;
         for (var i = 0; i < commandCount; i++)
         {
-            if (command + 8 > bytes.Length) break;
-            var cmd = BinaryPrimitives.ReadUInt32LittleEndian(bytes[command..]);
-            var cmdSize = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 4)..]);
-            if (cmdSize < 8 || command + cmdSize > bytes.Length) break;
+            if (!NativeImageRange.TryGet(
+                    commandsEnd,
+                    (ulong)command,
+                    8,
+                    out _,
+                    out _))
+            {
+                return null;
+            }
 
-            if (cmd == lcDyldChainedFixups)
+            var cmd = BinaryPrimitives.ReadUInt32LittleEndian(bytes[command..]);
+            var cmdSizeValue = BinaryPrimitives.ReadUInt32LittleEndian(bytes[(command + 4)..]);
+            if (cmdSizeValue < 8
+                || (cmdSizeValue & 7) != 0
+                || !NativeImageRange.TryGet(
+                    commandsEnd,
+                    (ulong)command,
+                    cmdSizeValue,
+                    out _,
+                    out var cmdSize))
+            {
+                return null;
+            }
+
+            if (cmd == lcDyldChainedFixups && cmdSize >= 16)
                 chained = true;
 
-            if (cmd == lcSegment64 && command + 56 <= bytes.Length)
+            if (cmd == lcSegment64)
             {
+                if (cmdSize < MachSegment64Size) return null;
+
                 var virtualAddress = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(command + 24)..]);
-                var fileOffset = (long)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(command + 40)..]);
-                var fileSize = (long)BinaryPrimitives.ReadUInt64LittleEndian(bytes[(command + 48)..]);
-                if (fileSize > 0)
+                var memorySize = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(command + 32)..]);
+                var fileOffsetValue = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(command + 40)..]);
+                var fileSizeValue = BinaryPrimitives.ReadUInt64LittleEndian(bytes[(command + 48)..]);
+                if (fileSizeValue > memorySize) return null;
+                if (fileSizeValue > 0)
                 {
-                    segments.Add(new Segment(virtualAddress, (int)fileOffset, (int)fileSize));
+                    if (!NativeImageRange.TryGet(
+                            bytes.Length,
+                            fileOffsetValue,
+                            fileSizeValue,
+                            out var fileOffset,
+                            out var fileSize)
+                        || !NativeImageRange.TryAdd(virtualAddress, fileSizeValue, out _))
+                    {
+                        return null;
+                    }
+
+                    segments.Add(new NativeAddressSegment(virtualAddress, fileOffset, fileSize));
                     // The image base is the mach header's address — the lowest file-backed
                     // segment (__TEXT); chained rebase offsets are relative to it.
                     if (virtualAddress < imageBase) imageBase = virtualAddress;
@@ -217,11 +348,12 @@ internal sealed class NativeAddressSpace
             command += cmdSize;
         }
 
+        if (command != commandsEnd) return null;
+
         return segments.Count > 0
-            ? new NativeAddressSpace(8, segments, bytes.Length, chained,
+            ? new NativeAddressSpace(8, segments, chained,
                 imageBase == ulong.MaxValue ? 0 : imageBase)
             : null;
     }
 
-    private readonly record struct Segment(ulong VirtualAddress, int FileOffset, int FileSize);
 }

--- a/src/Dotsider.Core/Analysis/NativeImageRange.cs
+++ b/src/Dotsider.Core/Analysis/NativeImageRange.cs
@@ -1,0 +1,135 @@
+namespace Dotsider.Core.Analysis;
+
+/// <summary>
+/// Validates file ranges from untrusted native-image fields before they are narrowed to the
+/// signed offsets accepted by span and memory APIs.
+/// </summary>
+internal static class NativeImageRange
+{
+    /// <summary>
+    /// Validates a file range without adding its attacker-controlled offset and length.
+    /// </summary>
+    /// <param name="imageLength">The complete image length.</param>
+    /// <param name="offset">The unsigned file offset from the image.</param>
+    /// <param name="length">The unsigned byte length of the range.</param>
+    /// <param name="fileOffset">The validated signed file offset.</param>
+    /// <param name="byteLength">The validated signed byte length.</param>
+    /// <returns>True when the complete range is representable and contained in the image.</returns>
+    internal static bool TryGet(
+        int imageLength,
+        ulong offset,
+        ulong length,
+        out int fileOffset,
+        out int byteLength)
+    {
+        if (imageLength < 0
+            || offset > (ulong)imageLength
+            || length > (ulong)imageLength - offset)
+        {
+            fileOffset = 0;
+            byteLength = 0;
+            return false;
+        }
+
+        fileOffset = (int)offset;
+        byteLength = (int)length;
+        return true;
+    }
+
+    /// <summary>
+    /// Validates a signed file range without adding its offset and length.
+    /// </summary>
+    /// <param name="imageLength">The complete image length.</param>
+    /// <param name="offset">The file offset from the image.</param>
+    /// <param name="length">The byte length of the range.</param>
+    /// <param name="fileOffset">The validated file offset.</param>
+    /// <param name="byteLength">The validated byte length.</param>
+    /// <returns>True when the values are non-negative and the complete range is contained.</returns>
+    internal static bool TryGet(
+        int imageLength,
+        int offset,
+        int length,
+        out int fileOffset,
+        out int byteLength)
+    {
+        if (offset < 0 || length < 0)
+        {
+            fileOffset = 0;
+            byteLength = 0;
+            return false;
+        }
+
+        return TryGet(imageLength, (ulong)offset, (ulong)length, out fileOffset, out byteLength);
+    }
+
+    /// <summary>
+    /// Validates a fixed-stride table before any row is read or a count-sized collection is
+    /// allocated.
+    /// </summary>
+    /// <param name="imageLength">The complete image length.</param>
+    /// <param name="offset">The table's unsigned file offset.</param>
+    /// <param name="count">The number of declared rows.</param>
+    /// <param name="stride">The declared byte stride between rows.</param>
+    /// <param name="minimumStride">The minimum number of bytes read from each row.</param>
+    /// <param name="fileOffset">The validated signed table offset.</param>
+    /// <param name="byteLength">The validated signed table length.</param>
+    /// <returns>True when the stride is sufficient and the complete table is contained.</returns>
+    internal static bool TryGetTable(
+        int imageLength,
+        ulong offset,
+        ulong count,
+        ulong stride,
+        ulong minimumStride,
+        out int fileOffset,
+        out int byteLength)
+    {
+        if (stride < minimumStride || (count != 0 && stride > ulong.MaxValue / count))
+        {
+            fileOffset = 0;
+            byteLength = 0;
+            return false;
+        }
+
+        return TryGet(imageLength, offset, count * stride, out fileOffset, out byteLength);
+    }
+
+    /// <summary>
+    /// Adds two unsigned native-image values only when the sum is representable.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <param name="sum">The sum when it is representable.</param>
+    /// <returns>True when the addition does not overflow.</returns>
+    internal static bool TryAdd(ulong left, ulong right, out ulong sum)
+    {
+        if (right > ulong.MaxValue - left)
+        {
+            sum = 0;
+            return false;
+        }
+
+        sum = left + right;
+        return true;
+    }
+
+    /// <summary>
+    /// Rounds an unsigned native-image value up to a power-of-two alignment without overflow.
+    /// </summary>
+    /// <param name="value">The value to align.</param>
+    /// <param name="alignment">The non-zero power-of-two alignment.</param>
+    /// <param name="aligned">The aligned value when it is representable.</param>
+    /// <returns>True when the alignment is valid and the result does not overflow.</returns>
+    internal static bool TryAlignUp(ulong value, ulong alignment, out ulong aligned)
+    {
+        if (alignment == 0
+            || (alignment & (alignment - 1)) != 0
+            || !TryAdd(value, alignment - 1, out var rounded))
+        {
+            aligned = 0;
+            return false;
+        }
+
+        aligned = rounded & ~(alignment - 1);
+        return true;
+    }
+}

--- a/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
+++ b/src/Dotsider.Core/Analysis/NativeSymbolReader.cs
@@ -48,8 +48,14 @@ public static class NativeSymbolReader
     private static NativeArchitecture PeArch(ReadOnlySpan<byte> image)
     {
         if (image.Length < 0x40) return NativeArchitecture.Unknown;
-        var peOffset = BinaryPrimitives.ReadInt32LittleEndian(image[0x3C..]);
-        if (peOffset < 0 || peOffset + 6 > image.Length) return NativeArchitecture.Unknown;
+        var peOffsetValue = BinaryPrimitives.ReadUInt32LittleEndian(image[0x3C..]);
+        if (!NativeImageRange.TryGet(
+            image.Length,
+            peOffsetValue,
+            6,
+            out var peOffset,
+            out _))
+            return NativeArchitecture.Unknown;
         return BinaryPrimitives.ReadUInt16LittleEndian(image[(peOffset + 4)..]) switch
         {
             0x014C => NativeArchitecture.X86,
@@ -163,7 +169,7 @@ public static class NativeSymbolReader
     /// then the Native AOT signal; -1 when nothing disambiguates.
     /// </summary>
     private static int ChooseFatSlice(
-        ReadOnlySpan<byte> archive, IReadOnlyList<MachOImageReader.MachOFatSlice> slices,
+        ReadOnlySpan<byte> archive, IReadOnlyList<MachOFatSlice> slices,
         List<byte[]>? dsymSlices)
     {
         if (slices.Count == 1) return 0;
@@ -267,7 +273,7 @@ public static class NativeSymbolReader
 
     /// <summary>Walks the dSYM's <c>__DWARF</c> sections into function records.</summary>
     private static void AppendMachODwarfFunctions(
-        byte[] dsymBytes, IReadOnlyList<MachOImageReader.MachOSection> imageSections,
+        byte[] dsymBytes, IReadOnlyList<MachOSection> imageSections,
         long sliceShift, List<RawNativeSymbol> raw)
     {
         var sections = MachOImageReader.ReadSectionList(dsymBytes);
@@ -295,27 +301,52 @@ public static class NativeSymbolReader
 
     /// <summary>Re-anchors a dSYM-derived symbol's section and file offset onto the analyzed image.</summary>
     private static RawNativeSymbol RemapToImage(
-        RawNativeSymbol symbol, IReadOnlyList<MachOImageReader.MachOSection> imageSections, long sliceShift)
+        RawNativeSymbol symbol, IReadOnlyList<MachOSection> imageSections, long sliceShift)
     {
         var (section, fileOffset) = MapMachOAddress(imageSections, symbol.VirtualAddress, sliceShift);
         return symbol with { Section = section ?? symbol.Section, FileOffset = fileOffset };
     }
 
     private static (string? Section, long? FileOffset) MapMachOAddress(
-        IReadOnlyList<MachOImageReader.MachOSection> sections, ulong va, long sliceShift)
+        IReadOnlyList<MachOSection> sections, ulong va, long sliceShift)
     {
         foreach (var section in sections)
         {
-            if (section.Address != 0 && va >= section.Address && va < section.Address + (ulong)section.Size)
-                return (section.Name, sliceShift + section.FileOffset + (long)(va - section.Address));
+            if (section.Address == 0
+                || section.Size <= 0
+                || section.FileOffset < 0
+                || section.Type is 0x1 or 0xC or 0x12
+                || sliceShift < 0
+                || va < section.Address)
+                continue;
+
+            var delta = va - section.Address;
+            if (delta >= (ulong)section.Size
+                || !NativeImageRange.TryAdd((ulong)section.FileOffset, delta, out var relativeOffset)
+                || !NativeImageRange.TryAdd((ulong)sliceShift, relativeOffset, out var fileOffset)
+                || fileOffset > long.MaxValue)
+                continue;
+
+            return (section.Name, (long)fileOffset);
         }
 
         return (null, null);
     }
 
     /// <summary>Shifts a fat-slice-relative file offset to the whole archive.</summary>
-    private static RawNativeSymbol Shift(RawNativeSymbol symbol, long sliceShift) =>
-        symbol.FileOffset is { } offset ? symbol with { FileOffset = offset + sliceShift } : symbol;
+    private static RawNativeSymbol Shift(RawNativeSymbol symbol, long sliceShift)
+    {
+        if (symbol.FileOffset is not { } offset
+            || offset < 0
+            || sliceShift < 0
+            || !NativeImageRange.TryAdd((ulong)offset, (ulong)sliceShift, out var shifted)
+            || shifted > long.MaxValue)
+        {
+            return symbol with { FileOffset = null };
+        }
+
+        return symbol with { FileOffset = (long)shifted };
+    }
 
     private static NativeSymbolInfo ReadElf(string imagePath, ReadOnlyMemory<byte> imageBytes, IlcNameDemangler demangler)
     {
@@ -570,7 +601,7 @@ public static class NativeSymbolReader
     /// mismatching or unreadable candidates exist, the first is reported so a stale or corrupt
     /// sidecar is visible to callers.
     /// </summary>
-    private static (PdbProbe Outcome, string? Path) ProbePdb(string imagePath, PeCodeView.CodeViewId id)
+    private static (PdbProbe Outcome, string? Path) ProbePdb(string imagePath, CodeViewId id)
     {
         var directory = Path.GetDirectoryName(imagePath);
         if (string.IsNullOrEmpty(directory)) return (PdbProbe.None, null);

--- a/src/Dotsider.Core/Analysis/PdataReader.cs
+++ b/src/Dotsider.Core/Analysis/PdataReader.cs
@@ -22,67 +22,102 @@ internal static class PdataReader
     /// <param name="peBytes">The raw PE image bytes.</param>
     public static IReadOnlyList<RawNativeSymbol> ReadBoundaries(ReadOnlyMemory<byte> peBytes)
     {
-        try
-        {
-            var pe = peBytes.Span;
-            if (pe.Length < 0x40 || pe[0] != (byte)'M' || pe[1] != (byte)'Z') return [];
-            var peHeader = BinaryPrimitives.ReadInt32LittleEndian(pe[0x3C..]);
-            if (peHeader <= 0 || peHeader + 24 > pe.Length) return [];
-            if (BinaryPrimitives.ReadUInt32LittleEndian(pe[peHeader..]) != 0x0000_4550) return [];
-
-            var machine = BinaryPrimitives.ReadUInt16LittleEndian(pe[(peHeader + 4)..]);
-            if (machine is not (MachineAmd64 or MachineArm64)) return [];
-
-            var optional = peHeader + 24;
-            var magic = BinaryPrimitives.ReadUInt16LittleEndian(pe[optional..]);
-            var imageBase = magic == 0x20B
-                ? BinaryPrimitives.ReadUInt64LittleEndian(pe[(optional + 24)..])
-                : BinaryPrimitives.ReadUInt32LittleEndian(pe[(optional + 28)..]);
-            var directoriesStart = optional + (magic == 0x20B ? 112 : 96);
-            var entry = directoriesStart + ExceptionDirectoryIndex * 8;
-            if (entry + 8 > pe.Length) return [];
-
-            var directoryRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[entry..]);
-            var directorySize = BinaryPrimitives.ReadUInt32LittleEndian(pe[(entry + 4)..]);
-            if (directoryRva == 0 || directorySize == 0) return [];
-
-            var addressSpace = NativeAddressSpace.Create(pe);
-            if (addressSpace is null
-                || !addressSpace.TryGetFileOffset(imageBase + directoryRva, out var tableOffset, out _))
-            {
-                return [];
-            }
-
-            return machine == MachineAmd64
-                ? ReadAmd64(pe, tableOffset, (int)directorySize, imageBase, addressSpace)
-                : ReadArm64(pe, tableOffset, (int)directorySize, imageBase, addressSpace);
-        }
-        catch (ArgumentOutOfRangeException)
+        var pe = peBytes.Span;
+        if (pe.Length < 0x40 || pe[0] != (byte)'M' || pe[1] != (byte)'Z') return [];
+        var peHeaderValue = BinaryPrimitives.ReadUInt32LittleEndian(pe[0x3C..]);
+        if (!NativeImageRange.TryGet(
+                pe.Length,
+                peHeaderValue,
+                24,
+                out var peHeader,
+                out _)
+            || BinaryPrimitives.ReadUInt32LittleEndian(pe[peHeader..]) != 0x0000_4550)
         {
             return [];
         }
+
+        var machine = BinaryPrimitives.ReadUInt16LittleEndian(pe[(peHeader + 4)..]);
+        if (machine is not (MachineAmd64 or MachineArm64)) return [];
+
+        var optionalSize = BinaryPrimitives.ReadUInt16LittleEndian(pe[(peHeader + 20)..]);
+        var optional = peHeader + 24;
+        if (!NativeImageRange.TryGet(
+                pe.Length,
+                optional,
+                optionalSize,
+                out _,
+                out _)
+            || optionalSize < sizeof(ushort))
+        {
+            return [];
+        }
+
+        var magic = BinaryPrimitives.ReadUInt16LittleEndian(pe[optional..]);
+        var directoriesOffset = magic switch
+        {
+            0x10B => 96,
+            0x20B => 112,
+            _ => 0,
+        };
+        const int directoryEntrySize = 8;
+        var exceptionEntryOffset = directoriesOffset + ExceptionDirectoryIndex * directoryEntrySize;
+        if (directoriesOffset == 0
+            || optionalSize < exceptionEntryOffset + directoryEntrySize)
+            return [];
+
+        var imageBase = magic == 0x20B
+            ? BinaryPrimitives.ReadUInt64LittleEndian(pe[(optional + 24)..])
+            : BinaryPrimitives.ReadUInt32LittleEndian(pe[(optional + 28)..]);
+        var entry = optional + exceptionEntryOffset;
+        var directoryRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[entry..]);
+        var directorySize = BinaryPrimitives.ReadUInt32LittleEndian(pe[(entry + 4)..]);
+        var recordSize = machine == MachineAmd64 ? 12U : 8U;
+        if (directoryRva == 0
+            || directorySize == 0
+            || directorySize % recordSize != 0)
+            return [];
+
+        var addressSpace = NativeAddressSpace.Create(pe);
+        if (addressSpace is null
+            || !NativeImageRange.TryAdd(imageBase, directoryRva, out var directoryAddress)
+            || !addressSpace.TryGetFileOffset(
+                directoryAddress,
+                out var tableOffset,
+                out var available)
+            || directorySize > (uint)available)
+        {
+            return [];
+        }
+
+        return machine == MachineAmd64
+            ? ReadAmd64(pe, tableOffset, (int)directorySize, imageBase, addressSpace)
+            : ReadArm64(pe, tableOffset, (int)directorySize, imageBase, addressSpace);
     }
 
     private static List<RawNativeSymbol> ReadAmd64(
         ReadOnlySpan<byte> pe, int tableOffset, int directorySize, ulong imageBase, NativeAddressSpace addressSpace)
     {
         var result = new List<RawNativeSymbol>();
-        for (var offset = tableOffset; offset + 12 <= pe.Length && offset < tableOffset + directorySize; offset += 12)
+        var table = pe.Slice(tableOffset, directorySize);
+        for (var offset = 0; offset < table.Length; offset += 12)
         {
-            var beginRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[offset..]);
-            var endRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[(offset + 4)..]);
-            var unwindInfoRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[(offset + 8)..]);
+            var entry = table[offset..];
+            var beginRva = BinaryPrimitives.ReadUInt32LittleEndian(entry);
+            var endRva = BinaryPrimitives.ReadUInt32LittleEndian(entry[4..]);
+            var unwindInfoRva = BinaryPrimitives.ReadUInt32LittleEndian(entry[8..]);
             if (endRva <= beginRva) continue;
 
             // A chained entry is a fragment of a function whose primary entry appears elsewhere;
             // folding it in avoids counting one function as several boundaries.
-            if (addressSpace.TryGetFileOffset(imageBase + unwindInfoRva, out var unwindOffset, out var avail)
+            if (NativeImageRange.TryAdd(imageBase, unwindInfoRva, out var unwindAddress)
+                && addressSpace.TryGetFileOffset(unwindAddress, out var unwindOffset, out var avail)
                 && avail >= 1 && ((pe[unwindOffset] >> 3) & UnwFlagChainInfo) != 0)
             {
                 continue;
             }
 
-            result.Add(Boundary(beginRva, endRva - beginRva, imageBase, addressSpace));
+            if (Boundary(beginRva, endRva - beginRva, imageBase, addressSpace) is { } boundary)
+                result.Add(boundary);
         }
 
         return result;
@@ -92,10 +127,12 @@ internal static class PdataReader
         ReadOnlySpan<byte> pe, int tableOffset, int directorySize, ulong imageBase, NativeAddressSpace addressSpace)
     {
         var result = new List<RawNativeSymbol>();
-        for (var offset = tableOffset; offset + 8 <= pe.Length && offset < tableOffset + directorySize; offset += 8)
+        var table = pe.Slice(tableOffset, directorySize);
+        for (var offset = 0; offset < table.Length; offset += 8)
         {
-            var beginRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[offset..]);
-            var unwindData = BinaryPrimitives.ReadUInt32LittleEndian(pe[(offset + 4)..]);
+            var entry = table[offset..];
+            var beginRva = BinaryPrimitives.ReadUInt32LittleEndian(entry);
+            var unwindData = BinaryPrimitives.ReadUInt32LittleEndian(entry[4..]);
 
             uint functionLength;
             if ((unwindData & 0x3) != 0)
@@ -106,7 +143,8 @@ internal static class PdataReader
             else
             {
                 // Full .xdata record: the first word's low 18 bits are FunctionLength in words.
-                if (!addressSpace.TryGetFileOffset(imageBase + unwindData, out var xdataOffset, out var avail)
+                if (!NativeImageRange.TryAdd(imageBase, unwindData, out var unwindAddress)
+                    || !addressSpace.TryGetFileOffset(unwindAddress, out var xdataOffset, out var avail)
                     || avail < 4)
                 {
                     continue;
@@ -116,16 +154,17 @@ internal static class PdataReader
             }
 
             if (functionLength == 0) continue;
-            result.Add(Boundary(beginRva, functionLength, imageBase, addressSpace));
+            if (Boundary(beginRva, functionLength, imageBase, addressSpace) is { } boundary)
+                result.Add(boundary);
         }
 
         return result;
     }
 
-    private static RawNativeSymbol Boundary(
+    private static RawNativeSymbol? Boundary(
         uint rva, uint size, ulong imageBase, NativeAddressSpace addressSpace)
     {
-        var va = imageBase + rva;
+        if (!NativeImageRange.TryAdd(imageBase, rva, out var va)) return null;
         long? fileOffset = addressSpace.TryGetFileOffset(va, out var fo, out _) ? fo : null;
         return new RawNativeSymbol(
             Name: $"sub_{rva:x}",

--- a/src/Dotsider.Core/Analysis/PeCodeView.cs
+++ b/src/Dotsider.Core/Analysis/PeCodeView.cs
@@ -10,78 +10,103 @@ namespace Dotsider.Core.Analysis;
 /// </summary>
 internal static class PeCodeView
 {
-    /// <summary>The RSDS identity of a PE image.</summary>
-    /// <param name="Guid">The PDB GUID.</param>
-    /// <param name="Age">The PDB age.</param>
-    /// <param name="PdbPath">The recorded PDB path (its file name is used for same-directory probing).</param>
-    internal readonly record struct CodeViewId(Guid Guid, int Age, string PdbPath);
-
     /// <summary>Reads the RSDS CodeView identity, or null when the image has none.</summary>
     /// <param name="pe">The raw PE image bytes.</param>
     public static CodeViewId? TryRead(ReadOnlySpan<byte> pe)
     {
-        try
-        {
-            if (pe.Length < 0x40 || pe[0] != (byte)'M' || pe[1] != (byte)'Z') return null;
-            var peHeader = BinaryPrimitives.ReadInt32LittleEndian(pe[0x3C..]);
-            if (peHeader <= 0 || peHeader + 24 > pe.Length) return null;
-            if (BinaryPrimitives.ReadUInt32LittleEndian(pe[peHeader..]) != 0x0000_4550) return null;
-
-            var optional = peHeader + 24;
-            var magic = BinaryPrimitives.ReadUInt16LittleEndian(pe[optional..]);
-            var directoriesStart = optional + (magic == 0x20B ? 112 : 96);
-            const int debugDirectoryIndex = 6;
-            var debugEntry = directoriesStart + debugDirectoryIndex * 8;
-            if (debugEntry + 8 > pe.Length) return null;
-
-            var debugRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[debugEntry..]);
-            var debugSize = BinaryPrimitives.ReadUInt32LittleEndian(pe[(debugEntry + 4)..]);
-            if (debugRva == 0 || debugSize == 0) return null;
-
-            var addressSpace = NativeAddressSpace.Create(pe);
-            if (addressSpace is null
-                || !addressSpace.TryGetFileOffset(ReadImageBase(pe) + debugRva, out var tableOffset, out _))
-            {
-                return null;
-            }
-
-            // Walk the 28-byte IMAGE_DEBUG_DIRECTORY entries for a CodeView (type 2) RSDS record.
-            for (var offset = tableOffset; offset + 28 <= pe.Length && offset < tableOffset + (int)debugSize; offset += 28)
-            {
-                var type = BinaryPrimitives.ReadUInt32LittleEndian(pe[(offset + 12)..]);
-                if (type != 2) continue; // IMAGE_DEBUG_TYPE_CODEVIEW
-                var pointerToRawData = (int)BinaryPrimitives.ReadUInt32LittleEndian(pe[(offset + 24)..]);
-                if (pointerToRawData <= 0 || pointerToRawData + 24 > pe.Length) continue;
-
-                if (BinaryPrimitives.ReadUInt32LittleEndian(pe[pointerToRawData..]) != 0x5344_5352) continue; // "RSDS"
-                var guid = new Guid(pe.Slice(pointerToRawData + 4, 16));
-                var age = BinaryPrimitives.ReadInt32LittleEndian(pe[(pointerToRawData + 20)..]);
-                var path = ReadCString(pe[(pointerToRawData + 24)..]);
-                return new CodeViewId(guid, age, path);
-            }
-
-            return null;
-        }
-        catch (ArgumentOutOfRangeException)
+        if (pe.Length < 0x40 || pe[0] != (byte)'M' || pe[1] != (byte)'Z') return null;
+        var peHeaderValue = BinaryPrimitives.ReadUInt32LittleEndian(pe[0x3C..]);
+        if (!NativeImageRange.TryGet(
+                pe.Length,
+                peHeaderValue,
+                24,
+                out var peHeader,
+                out _)
+            || BinaryPrimitives.ReadUInt32LittleEndian(pe[peHeader..]) != 0x0000_4550)
         {
             return null;
         }
-    }
 
-    private static ulong ReadImageBase(ReadOnlySpan<byte> pe)
-    {
-        var peHeader = BinaryPrimitives.ReadInt32LittleEndian(pe[0x3C..]);
+        var optionalSize = BinaryPrimitives.ReadUInt16LittleEndian(pe[(peHeader + 20)..]);
         var optional = peHeader + 24;
+        if (!NativeImageRange.TryGet(
+            pe.Length,
+            optional,
+            optionalSize,
+            out _,
+            out _)
+            || optionalSize < sizeof(ushort))
+            return null;
+
         var magic = BinaryPrimitives.ReadUInt16LittleEndian(pe[optional..]);
-        return magic == 0x20B
+        var directoriesOffset = magic switch
+        {
+            0x10B => 96,
+            0x20B => 112,
+            _ => 0,
+        };
+        const int debugDirectoryIndex = 6;
+        const int directoryEntrySize = 8;
+        var debugEntryOffset = directoriesOffset + debugDirectoryIndex * directoryEntrySize;
+        if (directoriesOffset == 0
+            || optionalSize < debugEntryOffset + directoryEntrySize)
+            return null;
+
+        var debugEntry = optional + debugEntryOffset;
+        var debugRva = BinaryPrimitives.ReadUInt32LittleEndian(pe[debugEntry..]);
+        var debugSize = BinaryPrimitives.ReadUInt32LittleEndian(pe[(debugEntry + 4)..]);
+        if (debugRva == 0 || debugSize == 0 || debugSize % 28 != 0) return null;
+
+        var imageBase = magic == 0x20B
             ? BinaryPrimitives.ReadUInt64LittleEndian(pe[(optional + 24)..])
             : BinaryPrimitives.ReadUInt32LittleEndian(pe[(optional + 28)..]);
+        var addressSpace = NativeAddressSpace.Create(pe);
+        if (addressSpace is null
+            || !NativeImageRange.TryAdd(imageBase, debugRva, out var debugAddress)
+            || !addressSpace.TryGetFileOffset(
+                debugAddress,
+                out var tableOffset,
+                out var available)
+            || debugSize > (uint)available)
+        {
+            return null;
+        }
+
+        // Walk the 28-byte IMAGE_DEBUG_DIRECTORY entries for a CodeView (type 2) RSDS record.
+        var table = pe.Slice(tableOffset, (int)debugSize);
+        for (var offset = 0; offset < table.Length; offset += 28)
+        {
+            var entry = table[offset..];
+            var type = BinaryPrimitives.ReadUInt32LittleEndian(entry[12..]);
+            if (type != 2) continue; // IMAGE_DEBUG_TYPE_CODEVIEW
+
+            var dataSize = BinaryPrimitives.ReadUInt32LittleEndian(entry[16..]);
+            var dataOffset = BinaryPrimitives.ReadUInt32LittleEndian(entry[24..]);
+            if (dataSize < 24
+                || !NativeImageRange.TryGet(
+                    pe.Length,
+                    dataOffset,
+                    dataSize,
+                    out var codeViewOffset,
+                    out var codeViewSize))
+                continue;
+
+            var codeView = pe.Slice(codeViewOffset, codeViewSize);
+            if (BinaryPrimitives.ReadUInt32LittleEndian(codeView) != 0x5344_5352) continue; // "RSDS"
+            var guid = new Guid(codeView.Slice(4, 16));
+            var age = BinaryPrimitives.ReadInt32LittleEndian(codeView[20..]);
+            var path = ReadCString(codeView[24..]);
+            if (path is null) continue;
+            return new CodeViewId(guid, age, path);
+        }
+
+        return null;
     }
 
-    private static string ReadCString(ReadOnlySpan<byte> span)
+    private static string? ReadCString(ReadOnlySpan<byte> span)
     {
         var end = span.IndexOf((byte)0);
-        if (end < 0) end = span.Length;
+        if (end < 0) return null;
         return Encoding.UTF8.GetString(span[..end]);
     }
 }

--- a/src/Dotsider.Core/Analysis/ReadyToRunReader.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRunReader.cs
@@ -64,15 +64,37 @@ internal static class ReadyToRunReader
             long size;
             if (hasEndField)
             {
-                start = Decode(ReadPointer(bytes, row + 8, pointerSize), addressSpace, offsetForm);
-                var end = Decode(ReadPointer(bytes, row + 8 + pointerSize, pointerSize), addressSpace, offsetForm);
+                if (!TryDecode(
+                        ReadPointer(bytes, row + 8, pointerSize),
+                        addressSpace,
+                        offsetForm,
+                        out start)
+                    || !TryDecode(
+                        ReadPointer(bytes, row + 8 + pointerSize, pointerSize),
+                        addressSpace,
+                        offsetForm,
+                        out var end))
+                {
+                    continue;
+                }
+
                 // TypeManagerIndirection (204) records End = 0; its size is not expressed here.
-                size = end > start ? (long)(end - start) : 0;
+                var sectionSize = end > start ? end - start : 0;
+                if (sectionSize > long.MaxValue) continue;
+                size = (long)sectionSize;
             }
             else
             {
                 size = BinaryPrimitives.ReadInt32LittleEndian(bytes[(row + 4)..]);
-                start = Decode(ReadPointer(bytes, row + 8, pointerSize), addressSpace, offsetForm);
+                if (size < 0) continue;
+                if (!TryDecode(
+                    ReadPointer(bytes, row + 8, pointerSize),
+                    addressSpace,
+                    offsetForm,
+                    out start))
+                {
+                    continue;
+                }
             }
 
             int? fileOffset = addressSpace.TryGetFileOffset(start, out var offset, out _)
@@ -88,10 +110,24 @@ internal static class ReadyToRunReader
     /// <summary>
     /// Decodes a section pointer, applying the Mach-O chained-fixup rebase decode when needed.
     /// </summary>
-    private static ulong Decode(ulong raw, NativeAddressSpace addressSpace, bool offsetForm) =>
-        addressSpace.MachOChained
-            ? NativeAddressSpace.DecodeChainedRebase(raw, offsetForm, addressSpace.MachOImageBase)
-            : raw;
+    private static bool TryDecode(
+        ulong raw,
+        NativeAddressSpace addressSpace,
+        bool offsetForm,
+        out ulong address)
+    {
+        if (addressSpace.MachOChained)
+        {
+            return NativeAddressSpace.TryDecodeChainedRebase(
+                raw,
+                offsetForm,
+                addressSpace.MachOImageBase,
+                out address);
+        }
+
+        address = raw;
+        return true;
+    }
 
     /// <summary>
     /// Determines the Mach-O chained rebase form by decoding the embedded metadata section's
@@ -110,8 +146,12 @@ internal static class ReadyToRunReader
             var raw = ReadPointer(bytes, row + 8, addressSpace.PointerSize);
             foreach (var offsetForm in stackalloc[] { true, false })
             {
-                var va = NativeAddressSpace.DecodeChainedRebase(raw, offsetForm, addressSpace.MachOImageBase);
-                if (addressSpace.TryGetFileOffset(va, out var offset, out var available)
+                if (NativeAddressSpace.TryDecodeChainedRebase(
+                        raw,
+                        offsetForm,
+                        addressSpace.MachOImageBase,
+                        out var va)
+                    && addressSpace.TryGetFileOffset(va, out var offset, out var available)
                     && available >= sizeof(uint)
                     && BinaryPrimitives.ReadUInt32LittleEndian(bytes[offset..]) == NativeMetadataSignature)
                 {

--- a/tests/Dotsider.Tests/NativeAddressSpaceTests.cs
+++ b/tests/Dotsider.Tests/NativeAddressSpaceTests.cs
@@ -10,7 +10,7 @@ namespace Dotsider.Tests;
 /// image-base-relative offsets (arm64) and absolute targets (x64).
 /// </summary>
 [TestClass]
-public class NativeAddressSpaceTests
+public sealed class NativeAddressSpaceTests
 {
     private const ulong ImageBase = 0x1_0000_0000;
 
@@ -30,7 +30,11 @@ public class NativeAddressSpaceTests
         Assert.AreEqual(ImageBase, space.MachOImageBase);
 
         var raw = (0x123UL << 51) | 0x40; // next bits set; low 36 hold the offset
-        var va = NativeAddressSpace.DecodeChainedRebase(raw, offsetForm: true, space.MachOImageBase);
+        Assert.IsTrue(NativeAddressSpace.TryDecodeChainedRebase(
+            raw,
+            offsetForm: true,
+            space.MachOImageBase,
+            out var va));
         Assert.AreEqual(ImageBase + 0x40, va);
 
         Assert.IsTrue(space.TryGetFileOffset(va, out var fileOffset, out _));
@@ -49,7 +53,11 @@ public class NativeAddressSpaceTests
         Assert.IsNotNull(space);
 
         var raw = (0x123UL << 51) | (ImageBase + 0x80); // next bits set; low 36 hold the address
-        var va = NativeAddressSpace.DecodeChainedRebase(raw, offsetForm: false, space.MachOImageBase);
+        Assert.IsTrue(NativeAddressSpace.TryDecodeChainedRebase(
+            raw,
+            offsetForm: false,
+            space.MachOImageBase,
+            out var va));
         Assert.AreEqual(ImageBase + 0x80, va);
 
         Assert.IsTrue(space.TryGetFileOffset(va, out var fileOffset, out _));
@@ -65,7 +73,29 @@ public class NativeAddressSpaceTests
     public void DecodeChainedRebase_BindPointer_IsNotDecoded()
     {
         var bind = 0x8000_0000_0000_0000UL | 0x40;
-        Assert.AreEqual(bind, NativeAddressSpace.DecodeChainedRebase(bind, offsetForm: true, ImageBase));
+        Assert.IsTrue(NativeAddressSpace.TryDecodeChainedRebase(
+            bind,
+            offsetForm: true,
+            ImageBase,
+            out var address));
+        Assert.AreEqual(bind, address);
+    }
+
+    /// <summary>
+    /// Verifies an image-base-relative target whose addition would overflow remains unmapped
+    /// rather than wrapping to a plausible low address.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void DecodeChainedRebase_OverflowingOffset_DoesNotWrap()
+    {
+        const ulong raw = 0x40;
+
+        Assert.IsFalse(NativeAddressSpace.TryDecodeChainedRebase(
+            raw,
+            offsetForm: true,
+            ulong.MaxValue - 0x20,
+            out _));
     }
 
     /// <summary>
@@ -75,40 +105,28 @@ public class NativeAddressSpaceTests
     private static byte[] BuildMachO()
     {
         var image = new byte[0x2000];
-        var w = new Writer(image);
 
         // mach_header_64
-        w.U32(0, 0xFEEDFACF);        // magic (64-bit little-endian)
-        w.U32(4, 0x0100000C);        // cputype ARM64
-        w.U32(16, 2);                // ncmds
-        w.U32(20, 88);               // sizeofcmds
+        BinaryPrimitives.WriteUInt32LittleEndian(image, 0xFEEDFACF); // magic
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(4), 0x0100000C); // ARM64
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(16), 2); // ncmds
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(20), 88); // sizeofcmds
 
         // LC_SEGMENT_64 __TEXT, covering the whole file
-        w.U32(32, 0x19);             // cmd
-        w.U32(36, 72);               // cmdsize
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(32), 0x19);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(36), 72);
         System.Text.Encoding.ASCII.GetBytes("__TEXT").CopyTo(image, 40);
-        w.U64(56, ImageBase);        // vmaddr
-        w.U64(64, 0x2000);           // vmsize
-        w.U64(72, 0);                // fileoff
-        w.U64(80, 0x2000);           // filesize
+        BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(56), ImageBase);
+        BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(64), 0x2000);
+        BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(72), 0);
+        BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(80), 0x2000);
 
         // LC_DYLD_CHAINED_FIXUPS (presence marks the image as chained)
-        w.U32(104, 0x80000034);      // cmd
-        w.U32(108, 16);              // cmdsize
-        w.U32(112, 0x200);           // dataoff
-        w.U32(116, 0x100);           // datasize
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(104), 0x80000034);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(108), 16);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(112), 0x200);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(116), 0x100);
 
         return image;
-    }
-
-    private readonly ref struct Writer(Span<byte> span)
-    {
-        private readonly Span<byte> _span = span;
-
-        public void U32(int offset, uint value) =>
-            BinaryPrimitives.WriteUInt32LittleEndian(_span[offset..], value);
-
-        public void U64(int offset, ulong value) =>
-            BinaryPrimitives.WriteUInt64LittleEndian(_span[offset..], value);
     }
 }

--- a/tests/Dotsider.Tests/NativeImageBoundsTests.cs
+++ b/tests/Dotsider.Tests/NativeImageBoundsTests.cs
@@ -1,0 +1,451 @@
+using Dotsider.Core.Analysis;
+using System.Buffers.Binary;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Verifies untrusted PE, ELF, and Mach-O ranges are validated before arithmetic, narrowing,
+/// slicing, or publication through the native-analysis facade.
+/// </summary>
+[TestClass]
+public sealed class NativeImageBoundsTests
+{
+    private const ulong ElfImageBase = 0x400000;
+    private const ulong MachOImageBase = 0x1_0000_0000;
+    private const ulong PeImageBase = 0x1_4000_0000;
+
+    private static SampleAssemblyFixture Samples => SampleAssemblyHost.Instance;
+
+    /// <summary>
+    /// Verifies exact-end and empty ranges are accepted while one-byte overflow, unrepresentable,
+    /// and overflowing table ranges are rejected.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void NativeImageRange_Boundaries_ValidateWithoutOverflow()
+    {
+        Assert.IsTrue(NativeImageRange.TryGet(16, 8, 8, out var offset, out var length));
+        Assert.AreEqual(8, offset);
+        Assert.AreEqual(8, length);
+        Assert.IsTrue(NativeImageRange.TryGet(16, 16, 0, out offset, out length));
+        Assert.AreEqual(16, offset);
+        Assert.AreEqual(0, length);
+
+        Assert.IsFalse(NativeImageRange.TryGet(16, 16, 1, out _, out _));
+        Assert.IsFalse(NativeImageRange.TryGet(16, ulong.MaxValue, 2, out _, out _));
+        Assert.IsFalse(NativeImageRange.TryGetTable(
+            16, 8, ulong.MaxValue, 8, 8, out _, out _));
+        Assert.IsTrue(NativeImageRange.TryAlignUp(13, 4, out var aligned));
+        Assert.AreEqual(16UL, aligned);
+        Assert.IsFalse(NativeImageRange.TryAlignUp(ulong.MaxValue, 4, out _));
+    }
+
+    /// <summary>
+    /// Verifies valid PE32, PE32+, ELF64, and Mach-O segments map their first and last file-backed
+    /// bytes with the exact number of remaining bytes.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void NativeAddressSpace_ValidFormats_MapExactBoundaries()
+    {
+        var pe32 = BuildPe32();
+        AssertMapping(
+            NativeAddressSpace.Create(pe32),
+            0x401000,
+            0x400,
+            0x200);
+
+        var pe32Plus = SyntheticImageBuilders.BuildPe(
+            0x8664, [], exceptionRva: 0, exceptionSize: 0, PeImageBase);
+        AssertMapping(
+            NativeAddressSpace.Create(pe32Plus),
+            PeImageBase + 0x1000,
+            0x400,
+            0x200);
+
+        var elf = BuildElfAddressSpace();
+        AssertMapping(NativeAddressSpace.Create(elf), ElfImageBase, 0, elf.Length);
+
+        var machO = BuildMachOAddressSpace();
+        AssertMapping(NativeAddressSpace.Create(machO), MachOImageBase, 0, machO.Length);
+    }
+
+    /// <summary>
+    /// Verifies PE header, optional-header, section-table, raw-section, and virtual-address
+    /// overflows fail closed without publishing a partial address map.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void NativeAddressSpace_MalformedPeHeaders_ReturnNull()
+    {
+        var image = SyntheticImageBuilders.BuildPe(
+            0x8664, [], exceptionRva: 0, exceptionSize: 0, PeImageBase);
+        var peHeader = BinaryPrimitives.ReadInt32LittleEndian(image.AsSpan(0x3C));
+        var optional = peHeader + 24;
+        var section = optional + 240;
+
+        Assert.IsNull(NativeAddressSpace.Create(PatchUInt32(image, 0x3C, uint.MaxValue)));
+        Assert.IsNull(NativeAddressSpace.Create(PatchUInt16(image, peHeader + 20, 31)));
+        Assert.IsNull(NativeAddressSpace.Create(PatchUInt16(image, peHeader + 20, 111)));
+        Assert.IsNull(NativeAddressSpace.Create(PatchUInt16(image, optional, 0x777)));
+        Assert.IsNull(NativeAddressSpace.Create(PatchUInt16(image, peHeader + 6, ushort.MaxValue)));
+        Assert.IsNull(NativeAddressSpace.Create(PatchUInt32(image, section + 20, uint.MaxValue)));
+        Assert.IsNull(NativeAddressSpace.Create(PatchUInt64(image, optional + 24, ulong.MaxValue)));
+    }
+
+    /// <summary>
+    /// Verifies overflowing ELF program-header tables, file extents, and virtual extents are
+    /// rejected before their unsigned fields are narrowed.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void NativeAddressSpace_MalformedElfProgramHeaders_ReturnNull()
+    {
+        var image = BuildElfAddressSpace();
+        const int programHeader = 64;
+
+        Assert.IsNull(NativeAddressSpace.Create(PatchUInt64(image, 0x20, ulong.MaxValue)));
+        Assert.IsNull(NativeAddressSpace.Create(PatchUInt16(image, 0x38, ushort.MaxValue)));
+        Assert.IsNull(NativeAddressSpace.Create(
+            PatchUInt64(image, programHeader + 8, ulong.MaxValue)));
+        Assert.IsNull(NativeAddressSpace.Create(
+            PatchUInt64(image, programHeader + 32, ulong.MaxValue)));
+        Assert.IsNull(NativeAddressSpace.Create(
+            PatchUInt64(image, programHeader + 16, ulong.MaxValue)));
+    }
+
+    /// <summary>
+    /// Verifies malformed Mach-O command regions and segment extents fail closed rather than
+    /// producing a partial address space.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void NativeAddressSpace_MalformedMachOCommands_ReturnNull()
+    {
+        var image = BuildMachOAddressSpace();
+        const int segmentCommand = 32;
+
+        Assert.IsNull(NativeAddressSpace.Create(PatchUInt32(image, 16, 2)));
+        Assert.IsNull(NativeAddressSpace.Create(PatchUInt32(image, 20, uint.MaxValue)));
+        Assert.IsNull(NativeAddressSpace.Create(
+            PatchUInt32(image, segmentCommand + 4, uint.MaxValue)));
+        Assert.IsNull(NativeAddressSpace.Create(
+            PatchUInt64(image, segmentCommand + 40, ulong.MaxValue)));
+        Assert.IsNull(NativeAddressSpace.Create(
+            PatchUInt64(image, segmentCommand + 48, ulong.MaxValue)));
+        Assert.IsNull(NativeAddressSpace.Create(
+            PatchUInt64(image, segmentCommand + 24, ulong.MaxValue)));
+    }
+
+    /// <summary>
+    /// Verifies ELF section tables, section-name tables, file extents, and names reject
+    /// overflowing values as one malformed structural unit.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ElfSections_OverflowingStructuralFields_ReturnEmpty()
+    {
+        var image = SyntheticImageBuilders.BuildElf(
+            (".text", 0x401000, new byte[] { 0x90 }));
+        var table = (int)BinaryPrimitives.ReadUInt64LittleEndian(image.AsSpan(40));
+        const int userSection = 64;
+        var section = table + userSection;
+        var count = BinaryPrimitives.ReadUInt16LittleEndian(image.AsSpan(60));
+
+        Assert.IsEmpty(ElfImageReader.ReadSections(PatchUInt64(image, 40, ulong.MaxValue)));
+        Assert.IsEmpty(ElfImageReader.ReadSections(PatchUInt16(image, 62, count)));
+        Assert.IsEmpty(ElfImageReader.ReadSections(PatchUInt32(image, section, uint.MaxValue)));
+        Assert.IsEmpty(ElfImageReader.ReadSections(
+            PatchUInt64(image, section + 24, ulong.MaxValue)));
+        Assert.IsEmpty(ElfImageReader.ReadSections(
+            PatchUInt64(image, section + 32, ulong.MaxValue)));
+
+        var noBits = SyntheticImageBuilders.BuildElf(
+            (".bss", 0x500000, Array.Empty<byte>(), 8u, 0u));
+        var sections = ElfImageReader.ReadSections(noBits);
+        Assert.IsNotEmpty(sections);
+        Assert.IsFalse(ElfImageReader.TryMapAddress(sections, 0x500000, out _, out _));
+    }
+
+    /// <summary>
+    /// Verifies GNU build-id and debug-link records reject padded-length overflow and truncated
+    /// CRC data without indexing beyond their containing sections.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void ElfSidecarRecords_OverflowingLengths_ReturnFalse()
+    {
+        var note = new byte[12];
+        BinaryPrimitives.WriteUInt32LittleEndian(note, uint.MaxValue);
+        var image = SyntheticImageBuilders.BuildElf((".note.gnu.build-id", 0, note));
+        Assert.IsFalse(ElfImageReader.TryReadBuildId(image, out _));
+
+        note = new byte[12];
+        BinaryPrimitives.WriteUInt32LittleEndian(note, 4);
+        BinaryPrimitives.WriteUInt32LittleEndian(note.AsSpan(4), uint.MaxValue);
+        image = SyntheticImageBuilders.BuildElf((".note.gnu.build-id", 0, note));
+        Assert.IsFalse(ElfImageReader.TryReadBuildId(image, out _));
+
+        image = SyntheticImageBuilders.BuildElf(
+            (".gnu_debuglink", 0, new byte[] { (byte)'a', 0, 0, 0 }));
+        Assert.IsFalse(ElfImageReader.TryReadDebugLink(image, out _, out _));
+    }
+
+    /// <summary>
+    /// Verifies Mach-O fat slices, command regions, section extents, function-start data, and
+    /// symbol tables reject overflowing ranges.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void MachOReaders_OverflowingRanges_ReturnAbsent()
+    {
+        var thin = SyntheticImageBuilders.BuildMachO(
+            [("__TEXT", MachOImageBase,
+                new[] { ("__text", MachOImageBase, 0x8000_0400u, new byte[] { 0xC3 }) })],
+            symbols: [("_main", 0x0F, 1, MachOImageBase)],
+            functionStarts: [1, 0]);
+
+        Assert.IsEmpty(MachOImageReader.ReadSectionList(PatchUInt32(thin, 20, uint.MaxValue)));
+
+        var sectionCommand = FindMachOCommand(thin, 0x19);
+        Assert.IsGreaterThanOrEqualTo(0, sectionCommand);
+        Assert.IsEmpty(MachOImageReader.ReadSectionList(
+            PatchUInt64(thin, sectionCommand + 72 + 40, ulong.MaxValue)));
+
+        var functionStarts = FindMachOCommand(thin, 0x26);
+        Assert.IsGreaterThanOrEqualTo(0, functionStarts);
+        Assert.IsFalse(MachOImageReader.TryGetFunctionStarts(
+            PatchUInt32(thin, functionStarts + 8, uint.MaxValue), out _, out _));
+
+        var symbolTable = FindMachOCommand(thin, 0x2);
+        Assert.IsGreaterThanOrEqualTo(0, symbolTable);
+        Assert.IsFalse(MachOImageReader.TryGetSymtab(
+            PatchUInt32(thin, symbolTable + 8, uint.MaxValue), out _));
+
+        var fat = SyntheticImageBuilders.BuildFat(thin);
+        Assert.IsEmpty(MachOImageReader.ReadFatSlices(PatchUInt32(fat, 16, uint.MaxValue)));
+        Assert.IsEmpty(MachOImageReader.ReadFatSlices(PatchUInt32(fat, 20, uint.MaxValue)));
+    }
+
+    /// <summary>
+    /// Verifies PE exception and debug-directory consumers reject ranges larger than the
+    /// containing file-backed segment.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void PeConsumers_OverflowingDirectorySizes_ReturnAbsent()
+    {
+        var pdata = SyntheticImageBuilders.BuildPe(
+            0x8664,
+            new byte[0x200],
+            exceptionRva: 0x1000,
+            exceptionSize: uint.MaxValue,
+            PeImageBase);
+        Assert.IsEmpty(PdataReader.ReadBoundaries(pdata));
+
+        var codeView = SyntheticImageBuilders.BuildPe(
+            0x8664, new byte[0x200], exceptionRva: 0, exceptionSize: 0, PeImageBase);
+        var peHeader = BinaryPrimitives.ReadInt32LittleEndian(codeView.AsSpan(0x3C));
+        var debugDirectory = peHeader + 24 + 112 + 6 * 8;
+        BinaryPrimitives.WriteUInt32LittleEndian(codeView.AsSpan(debugDirectory), 0x1000);
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            codeView.AsSpan(debugDirectory + 4),
+            uint.MaxValue);
+
+        Assert.IsNull(PeCodeView.TryRead(codeView));
+    }
+
+    /// <summary>
+    /// Verifies a real host-native NativeAOT image with an overflowing native container field
+    /// remains analyzable and exposes no guessed ReadyToRun mappings.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void AssemblyAnalyzer_RealNativeAotWithOverflowingHeader_DegradesGracefully()
+    {
+        TestSkip.When(
+            Samples.NativeAotConsoleExe is null || !File.Exists(Samples.NativeAotConsoleExe),
+            "NativeAOT sample was not built");
+
+        var bytes = File.ReadAllBytes(Samples.NativeAotConsoleExe!);
+        var patched = PatchHostNativeHeader(bytes);
+
+        using var analyzer = new AssemblyAnalyzer(
+            patched,
+            Samples.NativeAotConsoleExe!);
+
+        Assert.AreEqual(patched.Length, analyzer.FileSize);
+        Assert.IsFalse(analyzer.HasMetadata);
+        Assert.IsEmpty(analyzer.ReadyToRunSections);
+        _ = analyzer.Imports;
+        _ = analyzer.NativeSymbols;
+    }
+
+    private static void AssertMapping(
+        NativeAddressSpace? addressSpace,
+        ulong virtualAddress,
+        int fileOffset,
+        int size)
+    {
+        Assert.IsNotNull(addressSpace);
+        Assert.IsTrue(addressSpace.TryGetFileOffset(
+            virtualAddress,
+            out var firstOffset,
+            out var firstAvailable));
+        Assert.AreEqual(fileOffset, firstOffset);
+        Assert.AreEqual(size, firstAvailable);
+
+        Assert.IsTrue(addressSpace.TryGetFileOffset(
+            virtualAddress + (ulong)size - 1,
+            out var lastOffset,
+            out var lastAvailable));
+        Assert.AreEqual(fileOffset + size - 1, lastOffset);
+        Assert.AreEqual(1, lastAvailable);
+        Assert.IsFalse(addressSpace.TryGetFileOffset(
+            virtualAddress + (ulong)size,
+            out _,
+            out _));
+    }
+
+    private static byte[] BuildElfAddressSpace()
+    {
+        var image = new byte[0x200];
+        image[0] = 0x7F;
+        image[1] = (byte)'E';
+        image[2] = (byte)'L';
+        image[3] = (byte)'F';
+        image[4] = 2;
+        image[5] = 1;
+        BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(0x20), 64);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(0x36), 56);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(0x38), 1);
+
+        const int programHeader = 64;
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(programHeader), 1);
+        BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(programHeader + 8), 0);
+        BinaryPrimitives.WriteUInt64LittleEndian(
+            image.AsSpan(programHeader + 16),
+            ElfImageBase);
+        BinaryPrimitives.WriteUInt64LittleEndian(
+            image.AsSpan(programHeader + 32),
+            (ulong)image.Length);
+        BinaryPrimitives.WriteUInt64LittleEndian(
+            image.AsSpan(programHeader + 40),
+            (ulong)image.Length);
+        return image;
+    }
+
+    private static byte[] BuildMachOAddressSpace()
+    {
+        var image = new byte[0x200];
+        BinaryPrimitives.WriteUInt32LittleEndian(image, 0xFEEDFACF);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(16), 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(20), 72);
+
+        const int segmentCommand = 32;
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(segmentCommand), 0x19);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(segmentCommand + 4), 72);
+        BinaryPrimitives.WriteUInt64LittleEndian(
+            image.AsSpan(segmentCommand + 24),
+            MachOImageBase);
+        BinaryPrimitives.WriteUInt64LittleEndian(
+            image.AsSpan(segmentCommand + 32),
+            (ulong)image.Length);
+        BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(segmentCommand + 40), 0);
+        BinaryPrimitives.WriteUInt64LittleEndian(
+            image.AsSpan(segmentCommand + 48),
+            (ulong)image.Length);
+        return image;
+    }
+
+    private static byte[] BuildPe32()
+    {
+        const int peHeader = 0x80;
+        const int optionalSize = 224;
+        const int rawOffset = 0x400;
+        const int rawSize = 0x200;
+        var image = new byte[rawOffset + rawSize];
+        image[0] = (byte)'M';
+        image[1] = (byte)'Z';
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(0x3C), peHeader);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(peHeader), 0x0000_4550);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(peHeader + 4), 0x14C);
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(peHeader + 6), 1);
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            image.AsSpan(peHeader + 20),
+            optionalSize);
+
+        var optional = peHeader + 24;
+        BinaryPrimitives.WriteUInt16LittleEndian(image.AsSpan(optional), 0x10B);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(optional + 28), 0x400000);
+
+        var section = optional + optionalSize;
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(section + 12), 0x1000);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(section + 16), rawSize);
+        BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(section + 20), rawOffset);
+        return image;
+    }
+
+    private static int FindMachOCommand(byte[] image, uint commandType)
+    {
+        var count = BinaryPrimitives.ReadUInt32LittleEndian(image.AsSpan(16));
+        var command = 32;
+        for (var i = 0; i < count; i++)
+        {
+            if (BinaryPrimitives.ReadUInt32LittleEndian(image.AsSpan(command)) == commandType)
+                return command;
+            command += (int)BinaryPrimitives.ReadUInt32LittleEndian(image.AsSpan(command + 4));
+        }
+
+        return -1;
+    }
+
+    private static byte[] PatchHostNativeHeader(byte[] source)
+    {
+        var image = source.ToArray();
+        if (image.Length >= 0x40 && image[0] == (byte)'M' && image[1] == (byte)'Z')
+        {
+            var peHeader = BinaryPrimitives.ReadInt32LittleEndian(image.AsSpan(0x3C));
+            var optionalSize = BinaryPrimitives.ReadUInt16LittleEndian(image.AsSpan(peHeader + 20));
+            var section = peHeader + 24 + optionalSize;
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(section + 20), uint.MaxValue);
+            return image;
+        }
+
+        if (ElfImageReader.IsElf(image))
+        {
+            BinaryPrimitives.WriteUInt64LittleEndian(image.AsSpan(0x20), ulong.MaxValue);
+            return image;
+        }
+
+        if (MachOImageReader.IsMachO(image))
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(image.AsSpan(20), uint.MaxValue);
+            return image;
+        }
+
+        Assert.Fail("The NativeAOT fixture is not a recognized native image.");
+        return image;
+    }
+
+    private static byte[] PatchUInt16(byte[] source, int offset, ushort value)
+    {
+        var patched = source.ToArray();
+        BinaryPrimitives.WriteUInt16LittleEndian(patched.AsSpan(offset), value);
+        return patched;
+    }
+
+    private static byte[] PatchUInt32(byte[] source, int offset, uint value)
+    {
+        var patched = source.ToArray();
+        BinaryPrimitives.WriteUInt32LittleEndian(patched.AsSpan(offset), value);
+        return patched;
+    }
+
+    private static byte[] PatchUInt64(byte[] source, int offset, ulong value)
+    {
+        var patched = source.ToArray();
+        BinaryPrimitives.WriteUInt64LittleEndian(patched.AsSpan(offset), value);
+        return patched;
+    }
+}


### PR DESCRIPTION
Validates PE, ELF, and Mach-O table, section, mapping, symbol, unwind, debug, and ReadyToRun extents with checked 64-bit arithmetic before reading or allocating. Malformed native ranges degrade to absent data while valid boundary-aligned images retain their existing behavior.

Adds synthetic overflow and truncation regressions alongside real Native AOT coverage on Windows, Linux, and macOS, and documents the malformed-container behavior.

Fixes: #224