### PR TITLE
Harden ReadyToRun function table parsing

### DIFF
--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-AssemblyAnalyzer.md
@@ -618,8 +618,9 @@ public IReadOnlyList<ReadyToRunComponent> ReadyToRunComponents { get; }
 
 ### ReadyToRunIndex
 
-The queryable index over this image's precompiled methods, or null when it is not a
-ReadyToRun image. Built lazily from [ReadyToRunMethods](/api/dotsider.core.analysis.assemblyanalyzer.readytorunmethods/).
+The queryable index over this image's precompiled methods, or null when the image is not
+ReadyToRun or its method-map tables are unavailable. Built lazily from
+[ReadyToRunMethods](/api/dotsider.core.analysis.assemblyanalyzer.readytorunmethods/).
 
 **Returns:** [ReadyToRunIndex](/api/dotsider.core.analysis.readytorunindex/)
 

--- a/docs/src/content/docs/usage/pe-metadata.md
+++ b/docs/src/content/docs/usage/pe-metadata.md
@@ -35,6 +35,8 @@ R2R Sections and AOT Types apply to Native AOT binaries. ILC strips ECMA-335 met
 
 Dotsider treats metadata, signatures, and native container headers as untrusted. When an image is otherwise readable, cyclic or excessively nested type relationships and malformed ECMA-335 or ReadyToRun signatures are contained: affected names use token or unknown fallbacks and navigation remains unresolved. Truncated or overflowing PE, ELF, and Mach-O tables and mappings are treated as malformed, and analysis continues with the affected data omitted.
 
+ReadyToRun runtime-function tables accept up to 1,048,576 complete architecture-sized records. Hot/cold mappings are validated against the accepted runtime-function table before the native method map is built. A malformed image-wide method table keeps the ReadyToRun header, section listing, and managed metadata available while symbols and correlation report the method map's diagnostic.
+
 Metadata names, recovered strings, IL, symbols, and other artifact-controlled text are rendered
 through a shared terminal-safe projection. Control and Unicode formatting characters appear
 visibly in the TUI and human-readable CLI output; JSON retains their exact values.

--- a/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
+++ b/src/Dotsider.Core/Analysis/AssemblyAnalyzer.cs
@@ -378,6 +378,13 @@ public sealed class AssemblyAnalyzer : IDisposable
     /// </summary>
     public IReadOnlyList<ReadyToRunMethodEntry> ReadyToRunMethods => ReadyToRunModel?.Methods ?? [];
 
+    /// <summary>
+    /// The diagnostic reported when the ReadyToRun method-map tables are unavailable, or null when
+    /// the map is usable.
+    /// </summary>
+    internal string? ReadyToRunMethodMapDiagnostic =>
+        ReadyToRunModel is { MapUsable: false } model ? model.Diagnostic : null;
+
     // The resolved composite/component view, built once. Null when this is not a usable R2R image.
     private ReadyToRun.ReadyToRunModel? ReadyToRunModel
     {
@@ -445,8 +452,9 @@ public sealed class AssemblyAnalyzer : IDisposable
     public bool IsReadyToRun => BinaryKind == BinaryKind.ReadyToRun;
 
     /// <summary>
-    /// The queryable index over this image's precompiled methods, or null when it is not a
-    /// ReadyToRun image. Built lazily from <see cref="ReadyToRunMethods"/>.
+    /// The queryable index over this image's precompiled methods, or null when the image is not
+    /// ReadyToRun or its method-map tables are unavailable. Built lazily from
+    /// <see cref="ReadyToRunMethods"/>.
     /// </summary>
     public ReadyToRunIndex? ReadyToRunIndex
     {
@@ -455,9 +463,9 @@ public sealed class AssemblyAnalyzer : IDisposable
             ObjectDisposedException.ThrowIf(_disposed, this);
             if (!_readyToRunIndexProbed)
             {
-                // Only a Valid image builds a model (and thus a usable index); a corrupt or unsupported
-                // image has no map, so the index is null rather than a misleading empty one.
-                _readyToRunIndex = ReadyToRunModel is not null ? ReadyToRunIndex.Build(ReadyToRunMethods) : null;
+                _readyToRunIndex = ReadyToRunModel is { MapUsable: true } model
+                    ? ReadyToRunIndex.Build(model.Methods)
+                    : null;
                 _readyToRunIndexProbed = true;
             }
 
@@ -624,16 +632,23 @@ public sealed class AssemblyAnalyzer : IDisposable
             ObjectDisposedException.ThrowIf(_disposed, this);
             if (!_nativeSymbolsProbed)
             {
-                _nativeSymbols = IsReadyToRun
-                    ? ReadyToRun.ReadyToRunSymbolBuilder.Build(
-                        ReadyToRunMethods, ReadyToRunInfo!.Architecture,
-                        mapUsable: ReadyToRunInfo.Status == ReadyToRunStatus.Valid && ReadyToRunMethods.Count > 0,
-                        diagnostic: ReadyToRunInfo.Diagnostic)
-                    : WasmModuleInfo is { } wasm
+                if (IsReadyToRun)
+                {
+                    var model = ReadyToRunModel;
+                    _nativeSymbols = ReadyToRun.ReadyToRunSymbolBuilder.Build(
+                        model?.Methods ?? [],
+                        ReadyToRunInfo!.Architecture,
+                        mapUsable: model is { MapUsable: true },
+                        diagnostic: model?.Diagnostic ?? ReadyToRunInfo.Diagnostic);
+                }
+                else
+                {
+                    _nativeSymbols = WasmModuleInfo is { } wasm
                         ? Wasm.WasmSymbolBuilder.Build(wasm)
-                    : BinaryKind != BinaryKind.Managed
+                        : BinaryKind != BinaryKind.Managed
                         ? NativeSymbolReader.Read(FilePath, _rawBytes, RecoveredTypes)
                         : null;
+                }
                 _nativeSymbolsProbed = true;
             }
 

--- a/src/Dotsider.Core/Analysis/NativeAddressSpace.cs
+++ b/src/Dotsider.Core/Analysis/NativeAddressSpace.cs
@@ -125,6 +125,35 @@ internal sealed class NativeAddressSpace
         return false;
     }
 
+    /// <summary>
+    /// Gets the bytes remaining in the file-backed segment containing a file offset.
+    /// </summary>
+    /// <param name="fileOffset">The file offset to locate.</param>
+    /// <param name="available">Bytes remaining from the offset to the end of its segment.</param>
+    /// <returns>True when the offset belongs to a validated file-backed segment.</returns>
+    public bool TryGetAvailableBytes(int fileOffset, out int available)
+    {
+        foreach (var segment in _segments)
+        {
+            if (fileOffset < segment.FileOffset)
+            {
+                continue;
+            }
+
+            var delta = fileOffset - segment.FileOffset;
+            if (delta >= segment.FileSize)
+            {
+                continue;
+            }
+
+            available = segment.FileSize - delta;
+            return true;
+        }
+
+        available = 0;
+        return false;
+    }
+
     private static NativeAddressSpace? CreatePe(ReadOnlySpan<byte> bytes)
     {
         if (bytes.Length < 0x40) return null;

--- a/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunHotColdMap.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunHotColdMap.cs
@@ -2,58 +2,177 @@ namespace Dotsider.Core.Analysis.ReadyToRun;
 
 /// <summary>
 /// The <c>HotColdMap</c> section (120): pairs of <c>(cold runtime-function start, hot runtime-function id)</c>
-/// that stitch a method's cold code back to its hot entry. Produces, per hot runtime-function id,
-/// the contiguous block of cold runtime-function indices it owns, plus the index of the first cold
-/// function (below which all functions are hot).
+/// that stitch a method's cold code back to its hot entry. The compact pair table is searched
+/// directly so valid images do not allocate one array per method.
 /// </summary>
 internal sealed class ReadyToRunHotColdMap
 {
-    private readonly Dictionary<int, int[]> _hotToColdIndices;
+    private readonly int[] _mapping;
+    private readonly int _totalRuntimeFunctions;
 
-    private ReadyToRunHotColdMap(Dictionary<int, int[]> hotToColdIndices, int firstColdRuntimeFunction)
+    private ReadyToRunHotColdMap(int[] mapping, int totalRuntimeFunctions)
     {
-        _hotToColdIndices = hotToColdIndices;
-        FirstColdRuntimeFunction = firstColdRuntimeFunction;
+        _mapping = mapping;
+        _totalRuntimeFunctions = totalRuntimeFunctions;
+        FirstColdRuntimeFunction = mapping.Length > 0 ? mapping[0] : totalRuntimeFunctions;
     }
 
     /// <summary>The lowest cold runtime-function index; every index below it is hot.</summary>
     public int FirstColdRuntimeFunction { get; }
 
-    /// <summary>The cold runtime-function indices owned by the hot function at <paramref name="hotRuntimeFunctionId"/>, or null when it has none.</summary>
-    public int[]? ColdIndicesFor(int hotRuntimeFunctionId) =>
-        _hotToColdIndices.TryGetValue(hotRuntimeFunctionId, out var cold) ? cold : null;
+    /// <summary>
+    /// Validates and reads a complete hot/cold map.
+    /// </summary>
+    /// <param name="reader">The image reader.</param>
+    /// <param name="addressSpace">The image's validated address space.</param>
+    /// <param name="sectionFileOffset">The section's file offset, or null when the section is absent.</param>
+    /// <param name="sectionSize">The section's byte size.</param>
+    /// <param name="totalRuntimeFunctions">The runtime-function count that bounds every map index.</param>
+    /// <param name="map">The parsed map when validation succeeds.</param>
+    /// <param name="diagnostic">The validation diagnostic when parsing fails.</param>
+    /// <returns>True when the section is absent or structurally valid and within its enclosing table.</returns>
+    public static bool TryRead(
+        R2RNativeReader reader,
+        NativeAddressSpace addressSpace,
+        int? sectionFileOffset,
+        int sectionSize,
+        int totalRuntimeFunctions,
+        out ReadyToRunHotColdMap? map,
+        out string? diagnostic)
+    {
+        map = null;
+        diagnostic = null;
+
+        if (totalRuntimeFunctions is < 0 or > ReadyToRunRuntimeFunctionTable.MaxRuntimeFunctionCount)
+        {
+            diagnostic = "ReadyToRun HotColdMap has an invalid runtime-function bound.";
+            return false;
+        }
+
+        if (sectionSize < 0)
+        {
+            diagnostic = "ReadyToRun HotColdMap has a negative section size.";
+            return false;
+        }
+
+        if (sectionSize == 0)
+        {
+            map = new ReadyToRunHotColdMap([], totalRuntimeFunctions);
+            return true;
+        }
+
+        if (sectionFileOffset is not { } offset)
+        {
+            diagnostic = "ReadyToRun HotColdMap has no file-backed section range.";
+            return false;
+        }
+
+        if (sectionSize % 8 != 0)
+        {
+            diagnostic = "ReadyToRun HotColdMap does not contain complete 8-byte pairs.";
+            return false;
+        }
+
+        var entryCount = sectionSize / sizeof(int);
+        if (entryCount > totalRuntimeFunctions)
+        {
+            diagnostic =
+                $"ReadyToRun HotColdMap contains {entryCount} indices for {totalRuntimeFunctions} runtime functions.";
+            return false;
+        }
+
+        if (!NativeImageRange.TryGet(reader.Length, offset, sectionSize, out var fileOffset, out var byteLength))
+        {
+            diagnostic = "ReadyToRun HotColdMap lies outside the image.";
+            return false;
+        }
+
+        if (!addressSpace.TryGetAvailableBytes(fileOffset, out var available)
+            || byteLength > available)
+        {
+            diagnostic = "ReadyToRun HotColdMap lies outside its file-backed image segment.";
+            return false;
+        }
+
+        var sectionReader = reader.Slice(fileOffset, byteLength);
+        var mapping = new int[entryCount];
+        var cursor = fileOffset;
+        var previousCold = -1;
+        var previousHot = -1;
+        var firstCold = -1;
+        try
+        {
+            for (var i = 0; i < entryCount; i += 2)
+            {
+                var coldValue = sectionReader.ReadUInt32(ref cursor);
+                var hotValue = sectionReader.ReadUInt32(ref cursor);
+                if (coldValue >= (uint)totalRuntimeFunctions || hotValue >= (uint)totalRuntimeFunctions)
+                {
+                    diagnostic = "ReadyToRun HotColdMap contains an out-of-range runtime-function index.";
+                    return false;
+                }
+
+                var cold = (int)coldValue;
+                var hot = (int)hotValue;
+                firstCold = firstCold < 0 ? cold : firstCold;
+                if (cold <= previousCold || hot <= previousHot || hot >= firstCold)
+                {
+                    diagnostic = "ReadyToRun HotColdMap pairs are not in the required hot/cold order.";
+                    return false;
+                }
+
+                mapping[i] = cold;
+                mapping[i + 1] = hot;
+                previousCold = cold;
+                previousHot = hot;
+            }
+        }
+        catch (BadImageFormatException)
+        {
+            diagnostic = "ReadyToRun HotColdMap is truncated.";
+            return false;
+        }
+
+        map = new ReadyToRunHotColdMap(mapping, totalRuntimeFunctions);
+        return true;
+    }
 
     /// <summary>
-    /// Reads the map, or returns an empty map (no cold code) when the section is absent. A method
-    /// owns no runtime functions above <paramref name="totalRuntimeFunctions"/>.
+    /// Finds the contiguous cold runtime-function range owned by a hot runtime-function.
     /// </summary>
-    public static ReadyToRunHotColdMap Read(
-        R2RNativeReader reader, int? sectionFileOffset, int sectionSize, int totalRuntimeFunctions)
+    /// <param name="hotRuntimeFunctionId">The hot runtime-function index.</param>
+    /// <param name="start">The first owned cold runtime-function index.</param>
+    /// <param name="count">The number of owned cold runtime functions.</param>
+    /// <returns>True when the hot runtime function owns a cold range.</returns>
+    public bool TryGetColdRange(int hotRuntimeFunctionId, out int start, out int count)
     {
-        var map = new Dictionary<int, int[]>();
-        if (sectionFileOffset is not { } offset || sectionSize < 8)
-            return new ReadyToRunHotColdMap(map, totalRuntimeFunctions);
-
-        var count = sectionSize / 8;
-        var pairs = new (int Cold, int Hot)[count];
-        var cursor = offset;
-        for (var i = 0; i < count; i++)
+        var low = 0;
+        var high = _mapping.Length / 2 - 1;
+        while (low <= high)
         {
-            var cold = reader.ReadInt32(ref cursor);
-            var hot = reader.ReadInt32(ref cursor);
-            pairs[i] = (cold, hot);
+            var middle = low + ((high - low) / 2);
+            var hot = _mapping[middle * 2 + 1];
+            if (hot < hotRuntimeFunctionId)
+            {
+                low = middle + 1;
+            }
+            else if (hot > hotRuntimeFunctionId)
+            {
+                high = middle - 1;
+            }
+            else
+            {
+                start = _mapping[middle * 2];
+                var end = middle + 1 < _mapping.Length / 2
+                    ? _mapping[(middle + 1) * 2]
+                    : _totalRuntimeFunctions;
+                count = end - start;
+                return true;
+            }
         }
 
-        for (var i = 0; i < count; i++)
-        {
-            var length = i + 1 < count ? pairs[i + 1].Cold - pairs[i].Cold : totalRuntimeFunctions - pairs[i].Cold;
-            if (length <= 0) continue;
-            var cold = new int[length];
-            for (var j = 0; j < length; j++)
-                cold[j] = pairs[i].Cold + j;
-            map[pairs[i].Hot] = cold;
-        }
-
-        return new ReadyToRunHotColdMap(map, count > 0 ? pairs[0].Cold : totalRuntimeFunctions);
+        start = 0;
+        count = 0;
+        return false;
     }
 }

--- a/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunImageReader.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunImageReader.cs
@@ -7,7 +7,7 @@ namespace Dotsider.Core.Analysis.ReadyToRun;
 /// tables, then joins each metadata source's <c>MethodDefEntryPoints</c> to them. A non-composite
 /// image contributes a single source (itself); a composite resolves one source per component (by
 /// name + MVID) with a shared code image; a component DLL delegates to its owner composite. Never
-/// throws — a malformed table yields the entries that parsed.
+/// throws — a malformed image-wide table produces an explicitly unavailable method map.
 /// </summary>
 internal static class ReadyToRunImageReader
 {
@@ -29,18 +29,21 @@ internal static class ReadyToRunImageReader
     // Metadata and native code in the same file: one source (self), the image's own instance table.
     private static ReadyToRunModel BuildNonComposite(AssemblyAnalyzer analyzer, ReadyToRunInfo info)
     {
-        var self = Empty(analyzer);
-        if (!TryOpenTables(analyzer, info, out var tables)
-            || Section(info, ReadyToRunSectionType.MethodDefEntryPoints)
-                is not { FileOffset: { } entryOffset, Size: > 0 } entryPoints)
+        if (!TryOpenTables(analyzer, info, out var tables, out var tableDiagnostic))
         {
-            return self;
+            return Unavailable(analyzer, tableDiagnostic);
         }
 
         var mvid = ReadMvid(analyzer);
-        var source = new ReadyToRunMethodMapReader.MethodMapSource(
-            analyzer.AssemblyName ?? "", mvid, entryOffset, entryPoints.Size,
-            analyzer.MethodDefs, analyzer.GetMetadataReader());
+        var providers = new Dictionary<Guid, AssemblyAnalyzer> { [mvid] = analyzer };
+        var sources = new List<ReadyToRunMethodMapReader.MethodMapSource>();
+        if (Section(info, ReadyToRunSectionType.MethodDefEntryPoints)
+            is { FileOffset: { } entryOffset, Size: > 0 } entryPoints)
+        {
+            sources.Add(new ReadyToRunMethodMapReader.MethodMapSource(
+                analyzer.AssemblyName ?? "", mvid, entryOffset, entryPoints.Size,
+                analyzer.MethodDefs, analyzer.GetMetadataReader()));
+        }
 
         var instance = Section(info, ReadyToRunSectionType.InstanceMethodEntryPoints);
         var global = instance is { FileOffset: { } io }
@@ -48,19 +51,16 @@ internal static class ReadyToRunImageReader
                 io, instance.Size, analyzer.GetMetadataReader(), analyzer.AssemblyName ?? "", mvid, analyzer.MethodDefs)
             : (ReadyToRunMethodMapReader.GlobalInstanceSource?)null;
 
-        var methods = SafeBuild(tables, [source], global);
+        var methods = SafeBuild(tables, sources, global);
         return new ReadyToRunModel(
-            methods, analyzer,
-            new Dictionary<Guid, AssemblyAnalyzer> { [mvid] = analyzer },
-            [], [], OwnerCompositeMissing: false, null);
+            methods, analyzer, providers, [], [], OwnerCompositeMissing: false, MapUsable: true, null);
     }
 
     // A composite opened directly: one source per resolved component; native code is this file.
     private static ReadyToRunModel BuildComposite(AssemblyAnalyzer analyzer, ReadyToRunInfo info)
     {
-        var self = Empty(analyzer);
-        if (!TryOpenTables(analyzer, info, out var tables))
-            return self;
+        if (!TryOpenTables(analyzer, info, out var tables, out var tableDiagnostic))
+            return Unavailable(analyzer, tableDiagnostic);
 
         var raw = analyzer.RawBytes;
         var imageBase = analyzer.PeHeaders?.ImageBase ?? 0;
@@ -117,7 +117,8 @@ internal static class ReadyToRunImageReader
                 + $"'{Path.GetFileName(analyzer.FilePath)}'; their methods are unnamed"
             : null;
         return new ReadyToRunModel(
-            methods, analyzer, providers, owned, listing, OwnerCompositeMissing: false, diagnostic);
+            methods, analyzer, providers, owned, listing,
+            OwnerCompositeMissing: false, MapUsable: true, diagnostic);
     }
 
     // A component DLL: metadata is self, native code lives in the owner composite (opened sibling).
@@ -128,7 +129,8 @@ internal static class ReadyToRunImageReader
         if (info.OwnerCompositeExecutable is not { Length: > 0 } ownerName)
         {
             return new ReadyToRunModel(
-                [], analyzer, providers, [], [], OwnerCompositeMissing: true, "owner composite is not named");
+                [], analyzer, providers, [], [],
+                OwnerCompositeMissing: true, MapUsable: false, "owner composite is not named");
         }
 
         var directory = Path.GetDirectoryName(analyzer.FilePath) ?? ".";
@@ -136,7 +138,8 @@ internal static class ReadyToRunImageReader
         if (owner is null)
         {
             return new ReadyToRunModel(
-                [], analyzer, providers, [], [], OwnerCompositeMissing: true,
+                [], analyzer, providers, [], [],
+                OwnerCompositeMissing: true, MapUsable: false,
                 $"owner composite '{ownerName}' not found beside the component; native code unavailable");
         }
 
@@ -144,12 +147,15 @@ internal static class ReadyToRunImageReader
         // owner's tables instead of materializing every sibling metadata provider: all entry points
         // are still marked so funclet boundaries are correct, but only this component's metadata is
         // resolved. Disassembly routes through the owner bytes.
+        string? tableDiagnostic = null;
         if (owner.ReadyToRunInfo is not { Status: ReadyToRunStatus.Valid, IsComposite: true } ownerInfo
-            || !TryOpenTables(owner, ownerInfo, out var tables))
+            || !TryOpenTables(owner, ownerInfo, out var tables, out tableDiagnostic))
         {
             return new ReadyToRunModel(
-                [], owner, providers, [owner], [], OwnerCompositeMissing: false,
-                $"owner composite '{ownerName}' does not expose a usable ReadyToRun method map");
+                [], owner, providers, [owner], [],
+                OwnerCompositeMissing: false, MapUsable: false,
+                tableDiagnostic
+                    ?? $"owner composite '{ownerName}' does not expose a usable ReadyToRun method map");
         }
 
         var ownerRaw = owner.RawBytes;
@@ -185,7 +191,9 @@ internal static class ReadyToRunImageReader
         var methods = allMethods
             .Where(m => m.Mvid == mvid || string.Equals(m.AssemblyName, analyzer.AssemblyName, StringComparison.Ordinal))
             .ToList();
-        return new ReadyToRunModel(methods, owner, providers, [owner], listing, OwnerCompositeMissing: false, null);
+        return new ReadyToRunModel(
+            methods, owner, providers, [owner], listing,
+            OwnerCompositeMissing: false, MapUsable: true, null);
     }
 
     private readonly record struct Tables(
@@ -198,29 +206,70 @@ internal static class ReadyToRunImageReader
     // Opens the image-wide tables (runtime functions + hot/cold). The MethodDefEntryPoints table is
     // per-source (top-level for a non-composite, per-component for a composite), so it is not required
     // here — a composite's top-level header carries no section 103.
-    private static bool TryOpenTables(AssemblyAnalyzer analyzer, ReadyToRunInfo info, out Tables tables)
+    private static bool TryOpenTables(
+        AssemblyAnalyzer analyzer,
+        ReadyToRunInfo info,
+        out Tables tables,
+        out string? diagnostic)
     {
         tables = default;
-        if (Section(info, ReadyToRunSectionType.RuntimeFunctions) is not { FileOffset: { } rfOffset } runtimeFunctions)
+        if (Section(info, ReadyToRunSectionType.RuntimeFunctions) is not { } runtimeFunctions)
+        {
+            diagnostic = "ReadyToRun RuntimeFunctions section is missing.";
             return false;
+        }
+
+        if (runtimeFunctions.FileOffset is not { } rfOffset)
+        {
+            diagnostic = "ReadyToRun RuntimeFunctions has no file-backed section range.";
+            return false;
+        }
 
         var addressSpace = NativeAddressSpace.Create(analyzer.RawBytes.Span);
-        if (addressSpace is null) return false;
+        if (addressSpace is null)
+        {
+            diagnostic = "ReadyToRun RuntimeFunctions cannot be mapped through the image address space.";
+            return false;
+        }
         var imageBase = analyzer.PeHeaders?.ImageBase ?? 0;
 
         try
         {
             var reader = new R2RNativeReader(analyzer.RawBytes);
-            var rfTable = new ReadyToRunRuntimeFunctionTable(
-                reader, rfOffset, runtimeFunctions.Size, info.Architecture, imageBase, addressSpace);
+            if (!ReadyToRunRuntimeFunctionTable.TryRead(
+                    reader,
+                    rfOffset,
+                    runtimeFunctions.Size,
+                    info.Architecture,
+                    imageBase,
+                    addressSpace,
+                    out var rfTable,
+                    out diagnostic))
+            {
+                return false;
+            }
+
             var hotCold = Section(info, ReadyToRunSectionType.HotColdMap);
-            var hotColdMap = ReadyToRunHotColdMap.Read(
-                reader, hotCold?.FileOffset, hotCold?.Size ?? 0, rfTable.Count);
-            tables = new Tables(reader, rfTable, hotColdMap, imageBase, addressSpace);
+            if (!ReadyToRunHotColdMap.TryRead(
+                    reader,
+                    addressSpace,
+                    hotCold?.FileOffset,
+                    hotCold?.Size ?? 0,
+                    rfTable!.Count,
+                    out var hotColdMap,
+                    out diagnostic))
+            {
+                return false;
+            }
+
+            tables = new Tables(reader, rfTable, hotColdMap!, imageBase, addressSpace);
             return true;
         }
-        catch (Exception ex) when (ex is BadImageFormatException or IndexOutOfRangeException or ArgumentOutOfRangeException)
+        catch (Exception ex) when (ex is OverflowException or OutOfMemoryException)
         {
+            diagnostic = ex is OutOfMemoryException
+                ? "ReadyToRun method-map tables exceeded available memory."
+                : "ReadyToRun method-map table dimensions overflowed.";
             return false;
         }
     }
@@ -244,8 +293,11 @@ internal static class ReadyToRunImageReader
         }
     }
 
-    private static ReadyToRunModel Empty(AssemblyAnalyzer analyzer) =>
-        new([], analyzer, new Dictionary<Guid, AssemblyAnalyzer>(), [], [], OwnerCompositeMissing: false, null);
+    private static ReadyToRunModel Unavailable(AssemblyAnalyzer analyzer, string? diagnostic) =>
+        new(
+            [], analyzer, new Dictionary<Guid, AssemblyAnalyzer>(), [], [],
+            OwnerCompositeMissing: false, MapUsable: false,
+            diagnostic ?? "ReadyToRun method-map tables are unavailable.");
 
     private static ReadyToRunSectionEntry? Section(ReadyToRunInfo info, ReadyToRunSectionType type)
     {

--- a/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunMethodMapReader.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunMethodMapReader.cs
@@ -268,8 +268,9 @@ internal static class ReadyToRunMethodMapReader
         }
         while (i < isEntryPoint.Length && !isEntryPoint[i] && i < hotColdMap.FirstColdRuntimeFunction);
 
-        var cold = hotColdMap.ColdIndicesFor(entryId);
-        return cold is not null ? (count + cold.Length, cold.Length) : (count, 0);
+        return hotColdMap.TryGetColdRange(entryId, out _, out var coldCount)
+            ? (count + coldCount, coldCount)
+            : (count, 0);
     }
 
     private static List<ReadyToRunCodeRange> BuildRanges(
@@ -277,7 +278,9 @@ internal static class ReadyToRunMethodMapReader
         ulong imageBase, NativeAddressSpace addressSpace, int entryId, int rfCount, int coldCount)
     {
         var hotCount = rfCount - coldCount;
-        var coldIndices = coldCount > 0 ? hotColdMap.ColdIndicesFor(entryId) : null;
+        var coldStart = coldCount > 0 && hotColdMap.TryGetColdRange(entryId, out var start, out _)
+            ? start
+            : 0;
         var ranges = new List<ReadyToRunCodeRange>(rfCount);
 
         for (var k = 0; k < rfCount; k++)
@@ -291,7 +294,7 @@ internal static class ReadyToRunMethodMapReader
             }
             else
             {
-                rfIndex = coldIndices![k - hotCount];
+                rfIndex = coldStart + k - hotCount;
                 kind = ReadyToRunCodeRangeKind.Cold;
             }
 
@@ -299,7 +302,8 @@ internal static class ReadyToRunMethodMapReader
                 continue;
 
             var startRva = runtimeFunctions.StartRva(rfIndex);
-            var va = imageBase + (uint)startRva;
+            if (!NativeImageRange.TryAdd(imageBase, unchecked((uint)startRva), out var va))
+                continue;
             int? fileOffset = addressSpace.TryGetFileOffset(va, out var off, out _) ? off : null;
             ranges.Add(new ReadyToRunCodeRange(kind, startRva, runtimeFunctions.Size(rfIndex), va, fileOffset));
         }

--- a/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunModel.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunModel.cs
@@ -15,6 +15,7 @@ namespace Dotsider.Core.Analysis.ReadyToRun;
 /// <param name="Owned">Sibling analyzers opened for resolution; disposed with the root.</param>
 /// <param name="Components">The component listing (composite only), each with its resolution state.</param>
 /// <param name="OwnerCompositeMissing">Whether this is a component whose owner composite is not on disk.</param>
+/// <param name="MapUsable">Whether the image-wide method-map tables passed validation.</param>
 /// <param name="Diagnostic">A human-readable note when resolution is incomplete, or null.</param>
 internal sealed record ReadyToRunModel(
     IReadOnlyList<ReadyToRunMethodEntry> Methods,
@@ -23,4 +24,5 @@ internal sealed record ReadyToRunModel(
     IReadOnlyList<AssemblyAnalyzer> Owned,
     IReadOnlyList<ReadyToRunComponent> Components,
     bool OwnerCompositeMissing,
+    bool MapUsable,
     string? Diagnostic);

--- a/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunRuntimeFunctionTable.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunRuntimeFunctionTable.cs
@@ -11,50 +11,198 @@ namespace Dotsider.Core.Analysis.ReadyToRun;
 /// </summary>
 internal sealed class ReadyToRunRuntimeFunctionTable
 {
-    private readonly int[] _startRva;
+    /// <summary>
+    /// The largest runtime-function table accepted from one ReadyToRun image.
+    /// </summary>
+    public const int MaxRuntimeFunctionCount = 1_048_576;
+
     private readonly long[] _size;
+    private readonly int[] _startRva;
 
-    /// <summary>Parses the runtime-function records from the section's file offset.</summary>
-    public ReadyToRunRuntimeFunctionTable(
-        R2RNativeReader reader, int sectionFileOffset, int sectionSize,
-        NativeArchitecture arch, ulong imageBase, NativeAddressSpace addressSpace)
+    private ReadyToRunRuntimeFunctionTable(int[] startRva, long[] size)
     {
-        var recordSize = arch == NativeArchitecture.X64 ? 12 : 8;
-        var count = sectionSize / recordSize;
-        _startRva = new int[count];
-        var endRva = arch == NativeArchitecture.X64 ? new int[count] : null;
-        var unwindRva = endRva is null ? new int[count] : null;
-
-        for (var i = 0; i < count; i++)
-        {
-            var offset = sectionFileOffset + i * recordSize;
-            var start = ApplyStartFixup(reader.ReadInt32(ref offset), arch);
-            _startRva[i] = start;
-            endRva?[i] = reader.ReadInt32(ref offset);
-            unwindRva?[i] = reader.ReadInt32(ref offset);
-        }
-
-        _size = new long[count];
-        for (var i = 0; i < count; i++)
-        {
-            long size;
-            if (endRva is not null)
-                size = Math.Max(0, endRva[i] - _startRva[i]);
-            else if (i + 1 < count)
-                size = Math.Max(0, _startRva[i + 1] - _startRva[i]);
-            else if (TryReadUnwindLength(reader, imageBase, addressSpace, arch, unwindRva![i], out var unwindLength))
-                size = unwindLength;
-            else
-                size = 0;
-
-            if (addressSpace.TryGetFileOffset(imageBase + (uint)_startRva[i], out _, out var available))
-                size = size == 0 ? available : Math.Min(size, available);
-            _size[i] = size;
-        }
+        _startRva = startRva;
+        _size = size;
     }
 
     /// <summary>The number of runtime functions.</summary>
     public int Count => _startRva.Length;
+
+    /// <summary>
+    /// Validates and reads a complete runtime-function table.
+    /// </summary>
+    /// <param name="reader">The image reader.</param>
+    /// <param name="sectionFileOffset">The section's file offset.</param>
+    /// <param name="sectionSize">The section's byte size.</param>
+    /// <param name="arch">The image architecture.</param>
+    /// <param name="imageBase">The image base used to map RVAs.</param>
+    /// <param name="addressSpace">The image's validated address space.</param>
+    /// <param name="table">The parsed table when validation succeeds.</param>
+    /// <param name="diagnostic">The validation diagnostic when parsing fails.</param>
+    /// <returns>True when the complete section is structurally valid and within the resource budget.</returns>
+    public static bool TryRead(
+        R2RNativeReader reader,
+        int sectionFileOffset,
+        int sectionSize,
+        NativeArchitecture arch,
+        ulong imageBase,
+        NativeAddressSpace addressSpace,
+        out ReadyToRunRuntimeFunctionTable? table,
+        out string? diagnostic)
+    {
+        table = null;
+        diagnostic = null;
+
+        if (!TryGetRecordSize(arch, out var recordSize))
+        {
+            diagnostic = "ReadyToRun RuntimeFunctions uses an unsupported architecture.";
+            return false;
+        }
+
+        if (sectionSize < 0)
+        {
+            diagnostic = "ReadyToRun RuntimeFunctions has a negative section size.";
+            return false;
+        }
+
+        if (sectionSize % recordSize != 0)
+        {
+            diagnostic = $"ReadyToRun RuntimeFunctions size is not aligned to its {recordSize}-byte record layout.";
+            return false;
+        }
+
+        var count = sectionSize / recordSize;
+        if (count > MaxRuntimeFunctionCount)
+        {
+            diagnostic =
+                $"ReadyToRun RuntimeFunctions contains {count} records; the limit is 1,048,576.";
+            return false;
+        }
+
+        if (!NativeImageRange.TryGet(
+                reader.Length,
+                sectionFileOffset,
+                sectionSize,
+                out var fileOffset,
+                out var byteLength))
+        {
+            diagnostic = "ReadyToRun RuntimeFunctions lies outside the image.";
+            return false;
+        }
+
+        if (!addressSpace.TryGetAvailableBytes(fileOffset, out var available)
+            || byteLength > available)
+        {
+            diagnostic = "ReadyToRun RuntimeFunctions lies outside its file-backed image segment.";
+            return false;
+        }
+
+        var sectionReader = reader.Slice(fileOffset, byteLength);
+        var startRva = new int[count];
+        var size = new long[count];
+        var cursor = fileOffset;
+
+        try
+        {
+            if (arch == NativeArchitecture.X64)
+            {
+                uint previousStart = 0;
+                for (var i = 0; i < count; i++)
+                {
+                    var start = ApplyStartFixup(sectionReader.ReadInt32(ref cursor), arch);
+                    var end = sectionReader.ReadUInt32(ref cursor);
+                    _ = sectionReader.ReadUInt32(ref cursor);
+
+                    startRva[i] = start;
+                    var startValue = unchecked((uint)start);
+                    if ((i > 0 && startValue < previousStart) || end < startValue)
+                    {
+                        diagnostic = "ReadyToRun RuntimeFunctions contains an invalid RVA range order.";
+                        return false;
+                    }
+
+                    var declaredSize = (long)end - startValue;
+                    if (!TryClampSize(
+                            imageBase,
+                            addressSpace,
+                            startValue,
+                            declaredSize,
+                            out size[i]))
+                    {
+                        diagnostic = "ReadyToRun RuntimeFunctions contains an overflowing virtual address.";
+                        return false;
+                    }
+
+                    previousStart = startValue;
+                }
+            }
+            else
+            {
+                uint previousStart = 0;
+                for (var i = 0; i < count; i++)
+                {
+                    var start = ApplyStartFixup(sectionReader.ReadInt32(ref cursor), arch);
+                    var unwindRva = sectionReader.ReadInt32(ref cursor);
+                    var startValue = unchecked((uint)start);
+                    startRva[i] = start;
+
+                    if (i > 0)
+                    {
+                        if (startValue < previousStart)
+                        {
+                            diagnostic = "ReadyToRun RuntimeFunctions contains an invalid RVA range order.";
+                            return false;
+                        }
+
+                        var declaredSize = (long)startValue - previousStart;
+                        if (!TryClampSize(
+                                imageBase,
+                                addressSpace,
+                                previousStart,
+                                declaredSize,
+                                out size[i - 1]))
+                        {
+                            diagnostic = "ReadyToRun RuntimeFunctions contains an overflowing virtual address.";
+                            return false;
+                        }
+                    }
+
+                    if (i == count - 1)
+                    {
+                        var declaredSize = TryReadUnwindLength(
+                            sectionReader,
+                            imageBase,
+                            addressSpace,
+                            arch,
+                            unwindRva,
+                            out var unwindLength)
+                            ? unwindLength
+                            : 0;
+                        if (!TryClampSize(
+                                imageBase,
+                                addressSpace,
+                                startValue,
+                                declaredSize,
+                                out size[i]))
+                        {
+                            diagnostic = "ReadyToRun RuntimeFunctions contains an overflowing virtual address.";
+                            return false;
+                        }
+                    }
+
+                    previousStart = startValue;
+                }
+            }
+        }
+        catch (BadImageFormatException)
+        {
+            diagnostic = "ReadyToRun RuntimeFunctions is truncated.";
+            return false;
+        }
+
+        table = new ReadyToRunRuntimeFunctionTable(startRva, size);
+        return true;
+    }
 
     /// <summary>The start RVA of runtime function <paramref name="index"/> (fixups applied).</summary>
     public int StartRva(int index) => _startRva[index];
@@ -69,7 +217,49 @@ internal sealed class ReadyToRunRuntimeFunctionTable
         // WASM stores the funclet flag in bit 31 and the virtual IP in bits 30:0.
         NativeArchitecture.Wasm32 => startRva & 0x7FFF_FFFF,
         _ => startRva,
+    };
+
+    private static bool TryClampSize(
+        ulong imageBase,
+        NativeAddressSpace addressSpace,
+        uint startRva,
+        long declaredSize,
+        out long size)
+    {
+        size = 0;
+        if (!NativeImageRange.TryAdd(imageBase, startRva, out var virtualAddress))
+        {
+            return false;
+        }
+
+        if (!NativeImageRange.TryAdd(virtualAddress, (ulong)declaredSize, out _))
+        {
+            return false;
+        }
+
+        if (addressSpace.TryGetFileOffset(virtualAddress, out _, out var available))
+        {
+            size = Math.Min(declaredSize, available);
+        }
+
+        return true;
+    }
+
+    private static bool TryGetRecordSize(NativeArchitecture arch, out int recordSize)
+    {
+        recordSize = arch switch
+        {
+            NativeArchitecture.X64 => 12,
+            NativeArchitecture.Arm32
+                or NativeArchitecture.Arm64
+                or NativeArchitecture.LoongArch64
+                or NativeArchitecture.RiscV64
+                or NativeArchitecture.Wasm32
+                or NativeArchitecture.X86 => 8,
+            _ => 0,
         };
+        return recordSize != 0;
+    }
 
     private static bool TryReadUnwindLength(
         R2RNativeReader reader,
@@ -80,8 +270,11 @@ internal sealed class ReadyToRunRuntimeFunctionTable
         out long length)
     {
         length = 0;
-        if (!addressSpace.TryGetFileOffset(imageBase + (uint)unwindRva, out var offset, out _))
+        if (!NativeImageRange.TryAdd(imageBase, unchecked((uint)unwindRva), out var unwindAddress)
+            || !addressSpace.TryGetFileOffset(unwindAddress, out var offset, out _))
+        {
             return false;
+        }
 
         try
         {
@@ -92,11 +285,9 @@ internal sealed class ReadyToRunRuntimeFunctionTable
                     return length > 0;
 
                 case NativeArchitecture.Arm32:
-                {
                     var header = reader.ReadInt32(ref offset);
                     length = (header & 0x3FFFF) * 2L;
                     return length > 0;
-                }
 
                 default:
                     return false;

--- a/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunRuntimeFunctionTable.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRun/ReadyToRunRuntimeFunctionTable.cs
@@ -169,15 +169,19 @@ internal sealed class ReadyToRunRuntimeFunctionTable
 
                     if (i == count - 1)
                     {
-                        var declaredSize = TryReadUnwindLength(
-                            sectionReader,
-                            imageBase,
-                            addressSpace,
-                            arch,
-                            unwindRva,
-                            out var unwindLength)
-                            ? unwindLength
-                            : 0;
+                        if (!TryReadUnwindLength(
+                                reader,
+                                imageBase,
+                                addressSpace,
+                                arch,
+                                unwindRva,
+                                out var declaredSize))
+                        {
+                            diagnostic =
+                                "ReadyToRun RuntimeFunctions contains invalid final unwind data.";
+                            return false;
+                        }
+
                         if (!TryClampSize(
                                 imageBase,
                                 addressSpace,
@@ -271,23 +275,29 @@ internal sealed class ReadyToRunRuntimeFunctionTable
     {
         length = 0;
         if (!NativeImageRange.TryAdd(imageBase, unchecked((uint)unwindRva), out var unwindAddress)
-            || !addressSpace.TryGetFileOffset(unwindAddress, out var offset, out _))
+            || !addressSpace.TryGetFileOffset(unwindAddress, out var offset, out var available))
         {
             return false;
         }
 
         try
         {
+            var unwindReader = reader.Slice(offset, available);
             switch (arch)
             {
                 case NativeArchitecture.X86:
-                    length = reader.DecodeUnsignedGc(ref offset);
+                    length = unwindReader.DecodeUnsignedGc(ref offset);
                     return length > 0;
 
+                // Crossgen2 stores a full-xdata RVA in non-x86 ReadyToRun records. The low
+                // 18 header bits are the function length in architecture instruction units.
                 case NativeArchitecture.Arm32:
-                    var header = reader.ReadInt32(ref offset);
-                    length = (header & 0x3FFFF) * 2L;
-                    return length > 0;
+                case NativeArchitecture.RiscV64:
+                    return TryReadXdataLength(unwindReader, ref offset, 2, out length);
+
+                case NativeArchitecture.Arm64:
+                case NativeArchitecture.LoongArch64:
+                    return TryReadXdataLength(unwindReader, ref offset, 4, out length);
 
                 default:
                     return false;
@@ -298,5 +308,18 @@ internal sealed class ReadyToRunRuntimeFunctionTable
             length = 0;
             return false;
         }
+    }
+
+    private static bool TryReadXdataLength(
+        R2RNativeReader reader,
+        ref int offset,
+        int instructionSize,
+        out long length)
+    {
+        var header = reader.ReadUInt32(ref offset);
+        var version = (header >> 18) & 0x3;
+        var instructionCount = header & 0x3FFFF;
+        length = instructionCount * (long)instructionSize;
+        return version == 0 && length > 0;
     }
 }

--- a/src/Dotsider.Core/Analysis/ReadyToRunCorrelationQuery.cs
+++ b/src/Dotsider.Core/Analysis/ReadyToRunCorrelationQuery.cs
@@ -31,10 +31,25 @@ public static class ReadyToRunCorrelationQuery
         if (analyzer.ReadyToRunInfo is not { Status: ReadyToRunStatus.Valid })
             return ReadyToRunQueryResult.Unavailable(
                 $"the ReadyToRun image is {analyzer.ReadyToRunInfo?.Status}; only header diagnostics are available");
-        if (analyzer.ReadyToRunIndex is not { } index)
-            return ReadyToRunQueryResult.Unavailable("the ReadyToRun method map is unavailable");
-
         var query = methodOrAddress.Trim();
+        if (analyzer.ReadyToRunIndex is not { } index)
+        {
+            if (analyzer.ReadyToRunInfo is { IsComponent: true }
+                && analyzer.ReadyToRunCodeImage is null
+                && !query.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                return ResolveByName(
+                    analyzer,
+                    ReadyToRunIndex.Build([]),
+                    query,
+                    methodOrAddress,
+                    cancellationToken);
+            }
+
+            return ReadyToRunQueryResult.Unavailable(
+                analyzer.ReadyToRunMethodMapDiagnostic ?? "the ReadyToRun method map is unavailable");
+        }
+
         return query.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
             ? ResolveNumeric(analyzer, index, query, methodOrAddress, cancellationToken)
             : ResolveByName(analyzer, index, query, methodOrAddress, cancellationToken);

--- a/tests/Dotsider.Tests/ReadyToRunArchitectureDecoderTests.cs
+++ b/tests/Dotsider.Tests/ReadyToRunArchitectureDecoderTests.cs
@@ -180,13 +180,21 @@ public class ReadyToRunArchitectureDecoderTests
     private static void AssertRealReadyToRunRangesDecode(AssemblyAnalyzer analyzer, NativeArchitecture expected)
     {
         Assert.AreEqual(expected, analyzer.ReadyToRunInfo!.Architecture);
+        Assert.IsNotEmpty(analyzer.ReadyToRunMethods);
 
         var failures = new List<string>();
+        var rangeCount = 0;
         foreach (var method in analyzer.ReadyToRunMethods)
         {
             foreach (var range in method.CodeRanges)
             {
-                if (range.FileOffset is not { } fileOffset || range.Size <= 0)
+                rangeCount++;
+                Assert.IsGreaterThan(
+                    0,
+                    range.Size,
+                    $"{method.DeclaringType}.{method.Name} {range.Kind} must have a positive size.");
+
+                if (range.FileOffset is not { } fileOffset)
                     continue;
 
                 var code = analyzer.RawBytes.Span.Slice(fileOffset, (int)range.Size);
@@ -204,6 +212,7 @@ public class ReadyToRunArchitectureDecoderTests
             }
         }
 
+        Assert.IsGreaterThan(0, rangeCount);
         Assert.IsEmpty(failures, string.Join(Environment.NewLine, failures.Take(20)));
     }
 }

--- a/tests/Dotsider.Tests/ReadyToRunImagePatcher.cs
+++ b/tests/Dotsider.Tests/ReadyToRunImagePatcher.cs
@@ -204,6 +204,41 @@ internal static class ReadyToRunImagePatcher
     }
 
     /// <summary>
+    /// Replaces an image-wide ReadyToRun table with appended bytes and an independently controlled
+    /// signed section size. An absent target can take over an existing section-directory row.
+    /// </summary>
+    /// <param name="path">The real ReadyToRun image to copy and patch.</param>
+    /// <param name="sectionType">The image-wide table to replace.</param>
+    /// <param name="payload">The bytes appended to the image.</param>
+    /// <param name="declaredSize">The signed byte size written to the ReadyToRun section directory.</param>
+    /// <param name="replacementType">
+    /// An existing section row to rename when <paramref name="sectionType"/> is absent.
+    /// </param>
+    /// <returns>The patched image and the appended payload's file offset.</returns>
+    internal static (byte[] Image, int PayloadOffset) PatchImageWideTable(
+        string path,
+        ReadyToRunSectionType sectionType,
+        byte[] payload,
+        int declaredSize,
+        ReadyToRunSectionType? replacementType = null)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        var original = File.ReadAllBytes(path);
+        using var analyzer = new AssemblyAnalyzer(original, path);
+        var info = RequireValidReadyToRunInfo(analyzer);
+        var appended = AppendPayload(original, payload);
+        PatchReadyToRunSection(
+            appended.Image,
+            info,
+            sectionType,
+            appended.Rva,
+            declaredSize,
+            replacementType);
+        return (appended.Image, appended.Offset);
+    }
+
+    /// <summary>
     /// Replaces one component core header's <c>MethodDefEntryPoints</c> section with appended bytes
     /// while independently setting its declared size.
     /// </summary>
@@ -390,20 +425,36 @@ internal static class ReadyToRunImagePatcher
         ReadyToRunInfo info,
         ReadyToRunSectionType sectionType,
         int rva,
-        int size)
+        int size,
+        ReadyToRunSectionType? replacementType = null)
     {
         var headerOffset = RvaToFileOffset(image, info.HeaderRva);
         var rows = checked(headerOffset + 16);
+        int? replacementRow = null;
         for (var index = 0; index < info.SectionCount; index++)
         {
             var row = checked(rows + index * 12);
-            if (BinaryPrimitives.ReadInt32LittleEndian(image.AsSpan(row)) != (int)sectionType)
+            var currentType = BinaryPrimitives.ReadInt32LittleEndian(image.AsSpan(row));
+            if (replacementType is { } replacement && currentType == (int)replacement)
+            {
+                replacementRow = row;
+            }
+
+            if (currentType != (int)sectionType)
             {
                 continue;
             }
 
             BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(row + 4), rva);
             BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(row + 8), size);
+            return;
+        }
+
+        if (replacementRow is { } substitute)
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(substitute), (int)sectionType);
+            BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(substitute + 4), rva);
+            BinaryPrimitives.WriteInt32LittleEndian(image.AsSpan(substitute + 8), size);
             return;
         }
 

--- a/tests/Dotsider.Tests/ReadyToRunMethodMapTests.cs
+++ b/tests/Dotsider.Tests/ReadyToRunMethodMapTests.cs
@@ -1,5 +1,6 @@
 using Dotsider.Core.Analysis;
 using Dotsider.Core.Analysis.Models;
+using System.Runtime.InteropServices;
 
 namespace Dotsider.Tests;
 
@@ -11,7 +12,7 @@ namespace Dotsider.Tests;
 /// rendered instantiation.
 /// </summary>
 [TestClass]
-public class ReadyToRunMethodMapTests
+public sealed class ReadyToRunMethodMapTests
 {
     private static SampleAssemblyFixture Samples => SampleAssemblyHost.Instance;
 
@@ -36,6 +37,31 @@ public class ReadyToRunMethodMapTests
             // Exactly one hot entry per method.
             Assert.ContainsSingle(r => r.Kind == ReadyToRunCodeRangeKind.HotEntry, method.CodeRanges);
         }
+    }
+
+    /// <summary>
+    /// Verifies a real host-produced ARM64 image exposes a positive final code range through the
+    /// public method-map facade.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Arm64_FinalRuntimeFunction_HasPositiveRangeThroughFacade()
+    {
+        TestSkip.When(
+            RuntimeInformation.ProcessArchitecture != Architecture.Arm64,
+            "The host ReadyToRun fixture is ARM64 only on an ARM64 test leg.");
+        TestSkip.When(Samples.ReadyToRunConsoleDll is null, SkipReason);
+
+        using var analyzer = new AssemblyAnalyzer(Samples.ReadyToRunConsoleDll!);
+        var methods = analyzer.ReadyToRunMethods;
+        var finalRange = methods
+            .SelectMany(static method => method.CodeRanges)
+            .MaxBy(static range => range.VirtualAddress);
+
+        Assert.AreEqual(NativeArchitecture.Arm64, analyzer.ReadyToRunInfo!.Architecture);
+        Assert.IsNotEmpty(methods);
+        Assert.IsNotNull(finalRange);
+        Assert.IsGreaterThan(0, finalRange.Size);
     }
 
     /// <summary>The async state machine's MoveNext spans multiple disjoint ranges (hot plus funclet/cold).</summary>

--- a/tests/Dotsider.Tests/ReadyToRunTableBoundsTests.cs
+++ b/tests/Dotsider.Tests/ReadyToRunTableBoundsTests.cs
@@ -75,15 +75,16 @@ public sealed class ReadyToRunTableBoundsTests
     [TestMethod]
     public void RuntimeFunctions_ExactNonAmd64Records_AreAccepted()
     {
-        var records = new byte[16];
+        var records = new byte[0x80];
         WriteNonAmd64Record(records, 0, 0x1000, 0);
-        WriteNonAmd64Record(records, 8, 0x1010, 0);
+        WriteNonAmd64Record(records, 8, 0x1010, 0x1040);
+        BinaryPrimitives.WriteUInt32LittleEndian(records.AsSpan(0x40), 4);
         var (reader, addressSpace) = CreateImage(records);
 
         var valid = ReadyToRunRuntimeFunctionTable.TryRead(
             reader,
             SectionFileOffset,
-            records.Length,
+            16,
             NativeArchitecture.Arm64,
             0x1400_0000_0,
             addressSpace,
@@ -94,8 +95,120 @@ public sealed class ReadyToRunTableBoundsTests
         Assert.IsNotNull(table);
         Assert.AreEqual(2, table.Count);
         Assert.AreEqual(0x10, table.Size(0));
-        Assert.AreEqual(0, table.Size(1));
+        Assert.AreEqual(0x10, table.Size(1));
         Assert.IsNull(diagnostic);
+    }
+
+    /// <summary>
+    /// Verifies the final runtime-function size comes from full xdata outside the table slice.
+    /// </summary>
+    /// <param name="architecture">The architecture-specific full-xdata format.</param>
+    /// <param name="instructionScale">The byte scale applied to the header's function length.</param>
+    /// <param name="unwindRva">The mapped full-xdata RVA, including the exact end boundary.</param>
+    [TestMethod]
+    [DataRow(NativeArchitecture.Arm32, 2, 0x1040)]
+    [DataRow(NativeArchitecture.Arm32, 2, 0x11FC)]
+    [DataRow(NativeArchitecture.Arm64, 4, 0x1040)]
+    [DataRow(NativeArchitecture.Arm64, 4, 0x11FC)]
+    [DataRow(NativeArchitecture.LoongArch64, 4, 0x1040)]
+    [DataRow(NativeArchitecture.LoongArch64, 4, 0x11FC)]
+    [DataRow(NativeArchitecture.RiscV64, 2, 0x1040)]
+    [DataRow(NativeArchitecture.RiscV64, 2, 0x11FC)]
+    public void RuntimeFunctions_FinalXdataRecord_UsesArchitectureScale(
+        NativeArchitecture architecture,
+        int instructionScale,
+        int unwindRva)
+    {
+        const int encodedLength = 9;
+        const int exceptionAndSingleEpilogueFlags = (1 << 20) | (1 << 21);
+        var header = encodedLength | exceptionAndSingleEpilogueFlags;
+        var (reader, addressSpace) = CreateFinalXdataImage(unwindRva, header);
+
+        var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+            reader,
+            SectionFileOffset,
+            8,
+            architecture,
+            0x1400_0000_0,
+            addressSpace,
+            out var table,
+            out var diagnostic);
+
+        Assert.IsTrue(valid);
+        Assert.IsNotNull(table);
+        Assert.AreEqual(1, table.Count);
+        Assert.AreEqual(encodedLength * instructionScale, table.Size(0));
+        Assert.IsNull(diagnostic);
+    }
+
+    /// <summary>Verifies malformed final full-xdata records fail closed.</summary>
+    /// <param name="architecture">The architecture-specific full-xdata format.</param>
+    /// <param name="malformation">The full-xdata rule to violate.</param>
+    [TestMethod]
+    [DataRow(NativeArchitecture.Arm32, "Overflow")]
+    [DataRow(NativeArchitecture.Arm32, "Truncated")]
+    [DataRow(NativeArchitecture.Arm32, "Unmapped")]
+    [DataRow(NativeArchitecture.Arm32, "Version1")]
+    [DataRow(NativeArchitecture.Arm32, "Version2")]
+    [DataRow(NativeArchitecture.Arm32, "Version3")]
+    [DataRow(NativeArchitecture.Arm32, "ZeroLength")]
+    [DataRow(NativeArchitecture.Arm64, "Overflow")]
+    [DataRow(NativeArchitecture.Arm64, "Truncated")]
+    [DataRow(NativeArchitecture.Arm64, "Unmapped")]
+    [DataRow(NativeArchitecture.Arm64, "Version1")]
+    [DataRow(NativeArchitecture.Arm64, "Version2")]
+    [DataRow(NativeArchitecture.Arm64, "Version3")]
+    [DataRow(NativeArchitecture.Arm64, "ZeroLength")]
+    [DataRow(NativeArchitecture.LoongArch64, "Overflow")]
+    [DataRow(NativeArchitecture.LoongArch64, "Truncated")]
+    [DataRow(NativeArchitecture.LoongArch64, "Unmapped")]
+    [DataRow(NativeArchitecture.LoongArch64, "Version1")]
+    [DataRow(NativeArchitecture.LoongArch64, "Version2")]
+    [DataRow(NativeArchitecture.LoongArch64, "Version3")]
+    [DataRow(NativeArchitecture.LoongArch64, "ZeroLength")]
+    [DataRow(NativeArchitecture.RiscV64, "Overflow")]
+    [DataRow(NativeArchitecture.RiscV64, "Truncated")]
+    [DataRow(NativeArchitecture.RiscV64, "Unmapped")]
+    [DataRow(NativeArchitecture.RiscV64, "Version1")]
+    [DataRow(NativeArchitecture.RiscV64, "Version2")]
+    [DataRow(NativeArchitecture.RiscV64, "Version3")]
+    [DataRow(NativeArchitecture.RiscV64, "ZeroLength")]
+    public void RuntimeFunctions_InvalidFinalXdata_IsRejected(
+        NativeArchitecture architecture,
+        string malformation)
+    {
+        var unwindRva = malformation switch
+        {
+            "Truncated" => 0x11FE,
+            "Unmapped" => 0x5000,
+            _ => 0x1040,
+        };
+        var imageBase = malformation == "Overflow"
+            ? ulong.MaxValue - 0x800
+            : 0x1400_0000_0;
+        var header = malformation switch
+        {
+            "Version1" => (1 << 18) | 9,
+            "Version2" => (2 << 18) | 9,
+            "Version3" => (3 << 18) | 9,
+            "ZeroLength" => 0,
+            _ => 9,
+        };
+        var (reader, addressSpace) = CreateFinalXdataImage(unwindRva, header);
+
+        var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+            reader,
+            SectionFileOffset,
+            8,
+            architecture,
+            imageBase,
+            addressSpace,
+            out var table,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(table);
+        Assert.Contains("unwind", diagnostic!, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>Verifies the exact runtime-function resource budget remains accepted.</summary>
@@ -108,13 +221,20 @@ public sealed class ReadyToRunTableBoundsTests
         NativeArchitecture architecture,
         int recordSize)
     {
-        var records = new byte[ReadyToRunRuntimeFunctionTable.MaxRuntimeFunctionCount * recordSize];
+        var declaredSize = ReadyToRunRuntimeFunctionTable.MaxRuntimeFunctionCount * recordSize;
+        var records = new byte[declaredSize + (architecture == NativeArchitecture.X64 ? 0 : sizeof(int))];
+        if (architecture != NativeArchitecture.X64)
+        {
+            var unwindRva = 0x1000 + declaredSize;
+            WriteNonAmd64Record(records, declaredSize - recordSize, 0, unwindRva);
+            BinaryPrimitives.WriteUInt32LittleEndian(records.AsSpan(declaredSize), 1);
+        }
         var (reader, addressSpace) = CreateImage(records);
 
         var valid = ReadyToRunRuntimeFunctionTable.TryRead(
             reader,
             SectionFileOffset,
-            records.Length,
+            declaredSize,
             architecture,
             0x1400_0000_0,
             addressSpace,
@@ -600,6 +720,22 @@ public sealed class ReadyToRunTableBoundsTests
         var addressSpace = NativeAddressSpace.Create(image);
         Assert.IsNotNull(addressSpace);
         return (new R2RNativeReader(image), addressSpace);
+    }
+
+    private static (R2RNativeReader Reader, NativeAddressSpace AddressSpace) CreateFinalXdataImage(
+        int unwindRva,
+        int header)
+    {
+        var section = new byte[0x200];
+        WriteNonAmd64Record(section, 0, 0x1100, unwindRva);
+
+        var xdataOffset = unwindRva - 0x1000;
+        if (xdataOffset >= 0 && xdataOffset <= section.Length - sizeof(int))
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(section.AsSpan(xdataOffset), header);
+        }
+
+        return CreateImage(section);
     }
 
     private static void WriteNonAmd64Record(byte[] destination, int offset, int startRva, int unwindRva)

--- a/tests/Dotsider.Tests/ReadyToRunTableBoundsTests.cs
+++ b/tests/Dotsider.Tests/ReadyToRunTableBoundsTests.cs
@@ -1,0 +1,610 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+using Dotsider.Core.Analysis.ReadyToRun;
+using System.Buffers.Binary;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Verifies the structural and resource boundaries applied before ReadyToRun image-wide tables
+/// allocate or expose method-map data.
+/// </summary>
+[TestClass]
+public sealed class ReadyToRunTableBoundsTests
+{
+    private const int SectionFileOffset = 0x400;
+
+    /// <summary>Verifies empty tables are valid for every supported runtime-function layout.</summary>
+    /// <param name="architecture">A supported architecture.</param>
+    [TestMethod]
+    [DataRow(NativeArchitecture.X64)]
+    [DataRow(NativeArchitecture.Arm64)]
+    [DataRow(NativeArchitecture.X86)]
+    [DataRow(NativeArchitecture.Arm32)]
+    [DataRow(NativeArchitecture.RiscV64)]
+    [DataRow(NativeArchitecture.LoongArch64)]
+    [DataRow(NativeArchitecture.Wasm32)]
+    public void RuntimeFunctions_EmptySupportedLayout_IsAccepted(NativeArchitecture architecture)
+    {
+        var (reader, addressSpace) = CreateImage([]);
+
+        var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+            reader,
+            SectionFileOffset,
+            0,
+            architecture,
+            0x1400_0000_0,
+            addressSpace,
+            out var table,
+            out var diagnostic);
+
+        Assert.IsTrue(valid);
+        Assert.IsNotNull(table);
+        Assert.AreEqual(0, table.Count);
+        Assert.IsNull(diagnostic);
+    }
+
+    /// <summary>Verifies the complete amd64 record layout produces its declared code range.</summary>
+    [TestMethod]
+    public void RuntimeFunctions_ExactAmd64Record_IsAccepted()
+    {
+        var record = SyntheticImageBuilders.Amd64RuntimeFunction(0x1000, 0x1010, 0);
+        var (reader, addressSpace) = CreateImage(record);
+
+        var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+            reader,
+            SectionFileOffset,
+            record.Length,
+            NativeArchitecture.X64,
+            0x1400_0000_0,
+            addressSpace,
+            out var table,
+            out var diagnostic);
+
+        Assert.IsTrue(valid);
+        Assert.IsNotNull(table);
+        Assert.AreEqual(1, table.Count);
+        Assert.AreEqual(0x1000, table.StartRva(0));
+        Assert.AreEqual(0x10, table.Size(0));
+        Assert.IsNull(diagnostic);
+    }
+
+    /// <summary>
+    /// Verifies a non-amd64 layout derives a range from the following runtime-function start.
+    /// </summary>
+    [TestMethod]
+    public void RuntimeFunctions_ExactNonAmd64Records_AreAccepted()
+    {
+        var records = new byte[16];
+        WriteNonAmd64Record(records, 0, 0x1000, 0);
+        WriteNonAmd64Record(records, 8, 0x1010, 0);
+        var (reader, addressSpace) = CreateImage(records);
+
+        var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+            reader,
+            SectionFileOffset,
+            records.Length,
+            NativeArchitecture.Arm64,
+            0x1400_0000_0,
+            addressSpace,
+            out var table,
+            out var diagnostic);
+
+        Assert.IsTrue(valid);
+        Assert.IsNotNull(table);
+        Assert.AreEqual(2, table.Count);
+        Assert.AreEqual(0x10, table.Size(0));
+        Assert.AreEqual(0, table.Size(1));
+        Assert.IsNull(diagnostic);
+    }
+
+    /// <summary>Verifies the exact runtime-function resource budget remains accepted.</summary>
+    /// <param name="architecture">The record layout to exercise.</param>
+    /// <param name="recordSize">The architecture's runtime-function record size.</param>
+    [TestMethod]
+    [DataRow(NativeArchitecture.X64, 12)]
+    [DataRow(NativeArchitecture.Arm64, 8)]
+    public void RuntimeFunctions_ExactRecordBudget_IsAccepted(
+        NativeArchitecture architecture,
+        int recordSize)
+    {
+        var records = new byte[ReadyToRunRuntimeFunctionTable.MaxRuntimeFunctionCount * recordSize];
+        var (reader, addressSpace) = CreateImage(records);
+
+        var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+            reader,
+            SectionFileOffset,
+            records.Length,
+            architecture,
+            0x1400_0000_0,
+            addressSpace,
+            out var table,
+            out var diagnostic);
+
+        Assert.IsTrue(valid);
+        Assert.IsNotNull(table);
+        Assert.AreEqual(ReadyToRunRuntimeFunctionTable.MaxRuntimeFunctionCount, table.Count);
+        Assert.IsNull(diagnostic);
+    }
+
+    /// <summary>Verifies one record above the runtime-function budget is rejected before allocation.</summary>
+    /// <param name="architecture">The record layout to exercise.</param>
+    /// <param name="recordSize">The architecture's runtime-function record size.</param>
+    [TestMethod]
+    [DataRow(NativeArchitecture.X64, 12)]
+    [DataRow(NativeArchitecture.Arm64, 8)]
+    public void RuntimeFunctions_AboveRecordBudget_IsRejected(
+        NativeArchitecture architecture,
+        int recordSize)
+    {
+        var (reader, addressSpace) = CreateImage([]);
+        var declaredSize = checked(
+            (ReadyToRunRuntimeFunctionTable.MaxRuntimeFunctionCount + 1) * recordSize);
+
+        var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+            reader,
+            SectionFileOffset,
+            declaredSize,
+            architecture,
+            0x1400_0000_0,
+            addressSpace,
+            out var table,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(table);
+        Assert.Contains("1,048,576", diagnostic!);
+    }
+
+    /// <summary>Verifies signed and partial-record section sizes are rejected.</summary>
+    /// <param name="sectionSize">The malformed declared size.</param>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(1)]
+    [DataRow(7)]
+    [DataRow(9)]
+    public void RuntimeFunctions_InvalidSectionSize_IsRejected(int sectionSize)
+    {
+        var (reader, addressSpace) = CreateImage(new byte[16]);
+
+        var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+            reader,
+            SectionFileOffset,
+            sectionSize,
+            NativeArchitecture.Arm64,
+            0x1400_0000_0,
+            addressSpace,
+            out var table,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(table);
+        Assert.IsNotEmpty(diagnostic!);
+    }
+
+    /// <summary>Verifies a table cannot consume bytes beyond its file-backed segment.</summary>
+    [TestMethod]
+    public void RuntimeFunctions_RangeBeyondMappedSegment_IsRejected()
+    {
+        var (reader, addressSpace) = CreateImage(new byte[8]);
+
+        var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+            reader,
+            SectionFileOffset,
+            0x208,
+            NativeArchitecture.Arm64,
+            0x1400_0000_0,
+            addressSpace,
+            out var table,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(table);
+        Assert.Contains("file-backed image segment", diagnostic!);
+    }
+
+    /// <summary>Verifies an unsupported architecture never selects a guessed record layout.</summary>
+    [TestMethod]
+    public void RuntimeFunctions_UnknownArchitecture_IsRejected()
+    {
+        var (reader, addressSpace) = CreateImage([]);
+
+        var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+            reader,
+            SectionFileOffset,
+            0,
+            NativeArchitecture.Unknown,
+            0x1400_0000_0,
+            addressSpace,
+            out var table,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(table);
+        Assert.Contains("unsupported architecture", diagnostic!);
+    }
+
+    /// <summary>
+    /// Verifies unsigned RVA differences are widened before subtraction and clamped to mapped bytes.
+    /// </summary>
+    [TestMethod]
+    public void RuntimeFunctions_LargeUnsignedEndRva_IsClampedWithoutOverflow()
+    {
+        var record = SyntheticImageBuilders.Amd64RuntimeFunction(0x1000, 0x8000_0000, 0);
+        var (reader, addressSpace) = CreateImage(record);
+
+        var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+            reader,
+            SectionFileOffset,
+            record.Length,
+            NativeArchitecture.X64,
+            0x1400_0000_0,
+            addressSpace,
+            out var table,
+            out var diagnostic);
+
+        Assert.IsTrue(valid);
+        Assert.IsNotNull(table);
+        Assert.AreEqual(0x200, table.Size(0));
+        Assert.IsNull(diagnostic);
+    }
+
+    /// <summary>Verifies descending starts and amd64 end-before-start records are rejected.</summary>
+    /// <param name="malformation">The RVA-order rule to violate.</param>
+    [TestMethod]
+    [DataRow("DescendingStarts")]
+    [DataRow("EndBeforeStart")]
+    [DataRow("NonAmd64DescendingStarts")]
+    public void RuntimeFunctions_InvalidRvaOrder_IsRejected(string malformation)
+    {
+        (byte[] Records, NativeArchitecture Architecture) testCase = malformation switch
+        {
+            "DescendingStarts" => (
+                [
+                    .. SyntheticImageBuilders.Amd64RuntimeFunction(0x1010, 0x1020, 0),
+                    .. SyntheticImageBuilders.Amd64RuntimeFunction(0x1000, 0x1010, 0),
+                ],
+                NativeArchitecture.X64),
+            "EndBeforeStart" => (
+                SyntheticImageBuilders.Amd64RuntimeFunction(0x1010, 0x1000, 0),
+                NativeArchitecture.X64),
+            "NonAmd64DescendingStarts" => (
+                BuildNonAmd64Records((0x1010, 0), (0x1000, 0)),
+                NativeArchitecture.Arm64),
+            _ => throw new ArgumentOutOfRangeException(nameof(malformation)),
+        };
+        var (reader, addressSpace) = CreateImage(testCase.Records);
+
+        var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+            reader,
+            SectionFileOffset,
+            testCase.Records.Length,
+            testCase.Architecture,
+            0x1400_0000_0,
+            addressSpace,
+            out var table,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(table);
+        Assert.Contains("RVA range order", diagnostic!);
+    }
+
+    /// <summary>Verifies image-base additions for both range boundaries must be representable.</summary>
+    /// <param name="overflow">The range boundary whose addition overflows.</param>
+    [TestMethod]
+    [DataRow("Start")]
+    [DataRow("End")]
+    public void RuntimeFunctions_OverflowingVirtualAddress_IsRejected(string overflow)
+    {
+        var endRva = overflow == "End" ? 0x2000U : 0x1010U;
+        var imageBase = overflow == "End" ? ulong.MaxValue - 0x1800 : ulong.MaxValue - 0x800;
+        var record = SyntheticImageBuilders.Amd64RuntimeFunction(0x1000, endRva, 0);
+        var (reader, addressSpace) = CreateImage(record);
+
+        var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+            reader,
+            SectionFileOffset,
+            record.Length,
+            NativeArchitecture.X64,
+            imageBase,
+            addressSpace,
+            out var table,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(table);
+        Assert.Contains("overflowing virtual address", diagnostic!);
+    }
+
+    /// <summary>Verifies an absent hot/cold section is a valid empty map.</summary>
+    /// <param name="totalRuntimeFunctions">The enclosing runtime-function count.</param>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(10)]
+    public void HotColdMap_AbsentSection_IsAccepted(int totalRuntimeFunctions)
+    {
+        var (reader, addressSpace) = CreateImage([]);
+
+        var valid = ReadyToRunHotColdMap.TryRead(
+            reader,
+            addressSpace,
+            null,
+            0,
+            totalRuntimeFunctions,
+            out var map,
+            out var diagnostic);
+
+        Assert.IsTrue(valid);
+        Assert.IsNotNull(map);
+        Assert.AreEqual(totalRuntimeFunctions, map.FirstColdRuntimeFunction);
+        Assert.IsFalse(map.TryGetColdRange(1, out _, out _));
+        Assert.IsNull(diagnostic);
+    }
+
+    /// <summary>Verifies ordered hot/cold pairs produce exact contiguous cold ranges.</summary>
+    [TestMethod]
+    public void HotColdMap_OrderedPairs_AreAccepted()
+    {
+        var pairs = BuildHotColdPairs((6, 1), (8, 3));
+        var (reader, addressSpace) = CreateImage(pairs);
+
+        var valid = ReadyToRunHotColdMap.TryRead(
+            reader,
+            addressSpace,
+            SectionFileOffset,
+            pairs.Length,
+            10,
+            out var map,
+            out var diagnostic);
+
+        Assert.IsTrue(valid);
+        Assert.IsNotNull(map);
+        Assert.AreEqual(6, map.FirstColdRuntimeFunction);
+        Assert.IsTrue(map.TryGetColdRange(1, out var firstStart, out var firstCount));
+        Assert.AreEqual(6, firstStart);
+        Assert.AreEqual(2, firstCount);
+        Assert.IsTrue(map.TryGetColdRange(3, out var secondStart, out var secondCount));
+        Assert.AreEqual(8, secondStart);
+        Assert.AreEqual(2, secondCount);
+        Assert.IsFalse(map.TryGetColdRange(2, out _, out _));
+        Assert.IsNull(diagnostic);
+    }
+
+    /// <summary>
+    /// Verifies a fully populated hot/cold map at the runtime-function boundary remains accepted.
+    /// </summary>
+    [TestMethod]
+    public void HotColdMap_ExactRuntimeFunctionBoundary_IsAccepted()
+    {
+        var total = ReadyToRunRuntimeFunctionTable.MaxRuntimeFunctionCount;
+        var pairCount = total / 2;
+        var pairs = new byte[total * sizeof(int)];
+        for (var i = 0; i < pairCount; i++)
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(pairs.AsSpan(i * 8), pairCount + i);
+            BinaryPrimitives.WriteInt32LittleEndian(pairs.AsSpan(i * 8 + 4), i);
+        }
+        var (reader, addressSpace) = CreateImage(pairs);
+
+        var valid = ReadyToRunHotColdMap.TryRead(
+            reader,
+            addressSpace,
+            SectionFileOffset,
+            pairs.Length,
+            total,
+            out var map,
+            out var diagnostic);
+
+        Assert.IsTrue(valid);
+        Assert.IsNotNull(map);
+        Assert.AreEqual(pairCount, map.FirstColdRuntimeFunction);
+        Assert.IsTrue(map.TryGetColdRange(pairCount - 1, out var start, out var count));
+        Assert.AreEqual(total - 1, start);
+        Assert.AreEqual(1, count);
+        Assert.IsNull(diagnostic);
+    }
+
+    /// <summary>Verifies a hot/cold section must contain complete pairs.</summary>
+    [TestMethod]
+    public void HotColdMap_PartialPair_IsRejected()
+    {
+        var (reader, addressSpace) = CreateImage(new byte[8]);
+
+        var valid = ReadyToRunHotColdMap.TryRead(
+            reader,
+            addressSpace,
+            SectionFileOffset,
+            4,
+            10,
+            out var map,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(map);
+        Assert.Contains("complete 8-byte pairs", diagnostic!);
+    }
+
+    /// <summary>Verifies invalid signed and absent hot/cold ranges are rejected.</summary>
+    /// <param name="malformation">The section-range rule to violate.</param>
+    [TestMethod]
+    [DataRow("NegativeSize")]
+    [DataRow("MissingOffset")]
+    public void HotColdMap_InvalidSectionRange_IsRejected(string malformation)
+    {
+        var (reader, addressSpace) = CreateImage(new byte[8]);
+        var offset = malformation == "MissingOffset" ? null : (int?)SectionFileOffset;
+        var size = malformation == "NegativeSize" ? -1 : 8;
+
+        var valid = ReadyToRunHotColdMap.TryRead(
+            reader,
+            addressSpace,
+            offset,
+            size,
+            10,
+            out var map,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(map);
+        Assert.IsNotEmpty(diagnostic!);
+    }
+
+    /// <summary>Verifies the flattened hot/cold entry count cannot exceed its runtime-function table.</summary>
+    [TestMethod]
+    public void HotColdMap_EntryCountAboveRuntimeFunctionCount_IsRejected()
+    {
+        var pairs = BuildHotColdPairs((1, 0));
+        var (reader, addressSpace) = CreateImage(pairs);
+
+        var valid = ReadyToRunHotColdMap.TryRead(
+            reader,
+            addressSpace,
+            SectionFileOffset,
+            pairs.Length,
+            1,
+            out var map,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(map);
+        Assert.Contains("2 indices for 1 runtime functions", diagnostic!);
+    }
+
+    /// <summary>Verifies every hot/cold index must lie inside the runtime-function table.</summary>
+    /// <param name="index">The pair field to place outside the table.</param>
+    [TestMethod]
+    [DataRow("Cold")]
+    [DataRow("Hot")]
+    public void HotColdMap_OutOfRangeIndex_IsRejected(string index)
+    {
+        var pairs = index == "Cold"
+            ? BuildHotColdPairs((10, 1))
+            : BuildHotColdPairs((6, 10));
+        var (reader, addressSpace) = CreateImage(pairs);
+
+        var valid = ReadyToRunHotColdMap.TryRead(
+            reader,
+            addressSpace,
+            SectionFileOffset,
+            pairs.Length,
+            10,
+            out var map,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(map);
+        Assert.Contains("out-of-range", diagnostic!);
+    }
+
+    /// <summary>Verifies the enclosing runtime-function count must itself be within its budget.</summary>
+    /// <param name="totalRuntimeFunctions">The invalid enclosing count.</param>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(ReadyToRunRuntimeFunctionTable.MaxRuntimeFunctionCount + 1)]
+    public void HotColdMap_InvalidRuntimeFunctionBound_IsRejected(int totalRuntimeFunctions)
+    {
+        var (reader, addressSpace) = CreateImage([]);
+
+        var valid = ReadyToRunHotColdMap.TryRead(
+            reader,
+            addressSpace,
+            null,
+            0,
+            totalRuntimeFunctions,
+            out var map,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(map);
+        Assert.Contains("invalid runtime-function bound", diagnostic!);
+    }
+
+    /// <summary>Verifies cold and hot indexes obey the runtime's ordered partition.</summary>
+    /// <param name="malformation">The ordering rule to violate.</param>
+    [TestMethod]
+    [DataRow("ColdNotIncreasing")]
+    [DataRow("HotNotIncreasing")]
+    [DataRow("HotInColdRegion")]
+    public void HotColdMap_InvalidOrdering_IsRejected(string malformation)
+    {
+        var pairs = malformation switch
+        {
+            "ColdNotIncreasing" => BuildHotColdPairs((6, 1), (6, 2)),
+            "HotNotIncreasing" => BuildHotColdPairs((6, 2), (8, 1)),
+            "HotInColdRegion" => BuildHotColdPairs((6, 6)),
+            _ => throw new ArgumentOutOfRangeException(nameof(malformation)),
+        };
+        var (reader, addressSpace) = CreateImage(pairs);
+
+        var valid = ReadyToRunHotColdMap.TryRead(
+            reader,
+            addressSpace,
+            SectionFileOffset,
+            pairs.Length,
+            10,
+            out var map,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(map);
+        Assert.Contains("required hot/cold order", diagnostic!);
+    }
+
+    /// <summary>Verifies a hot/cold map cannot consume bytes beyond its file-backed segment.</summary>
+    [TestMethod]
+    public void HotColdMap_RangeBeyondMappedSegment_IsRejected()
+    {
+        var (reader, addressSpace) = CreateImage(new byte[8]);
+
+        var valid = ReadyToRunHotColdMap.TryRead(
+            reader,
+            addressSpace,
+            SectionFileOffset,
+            0x208,
+            0x400,
+            out var map,
+            out var diagnostic);
+
+        Assert.IsFalse(valid);
+        Assert.IsNull(map);
+        Assert.Contains("file-backed image segment", diagnostic!);
+    }
+
+    private static byte[] BuildHotColdPairs(params (int Cold, int Hot)[] pairs)
+    {
+        var bytes = new byte[pairs.Length * 8];
+        for (var i = 0; i < pairs.Length; i++)
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(i * 8), pairs[i].Cold);
+            BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(i * 8 + 4), pairs[i].Hot);
+        }
+
+        return bytes;
+    }
+
+    private static byte[] BuildNonAmd64Records(params (int StartRva, int UnwindRva)[] records)
+    {
+        var bytes = new byte[records.Length * 8];
+        for (var i = 0; i < records.Length; i++)
+        {
+            WriteNonAmd64Record(bytes, i * 8, records[i].StartRva, records[i].UnwindRva);
+        }
+
+        return bytes;
+    }
+
+    private static (R2RNativeReader Reader, NativeAddressSpace AddressSpace) CreateImage(byte[] data)
+    {
+        var image = SyntheticImageBuilders.BuildPe(0x8664, data, 0, 0);
+        var addressSpace = NativeAddressSpace.Create(image);
+        Assert.IsNotNull(addressSpace);
+        return (new R2RNativeReader(image), addressSpace);
+    }
+
+    private static void WriteNonAmd64Record(byte[] destination, int offset, int startRva, int unwindRva)
+    {
+        BinaryPrimitives.WriteInt32LittleEndian(destination.AsSpan(offset), startRva);
+        BinaryPrimitives.WriteInt32LittleEndian(destination.AsSpan(offset + 4), unwindRva);
+    }
+}

--- a/tests/Dotsider.Tests/ReadyToRunTableProductionTests.cs
+++ b/tests/Dotsider.Tests/ReadyToRunTableProductionTests.cs
@@ -1,0 +1,195 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+using Dotsider.Core.Analysis.ReadyToRun;
+using System.Buffers.Binary;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Verifies malformed image-wide ReadyToRun tables fail closed through the public analysis
+/// surfaces while valid real images retain their method maps.
+/// </summary>
+[TestClass]
+public sealed class ReadyToRunTableProductionTests
+{
+    private const string CompositeSkipReason = "ReadyToRun composite publish did not run on this leg.";
+    private const string SkipReason = "ReadyToRun crossgen2 publish did not run on this leg.";
+
+    private static SampleAssemblyFixture Samples => SampleAssemblyHost.Instance;
+
+    /// <summary>
+    /// Verifies malformed real runtime-function sections preserve header and metadata inspection
+    /// while making the method map explicitly unavailable.
+    /// </summary>
+    /// <param name="malformation">The runtime-function section malformation.</param>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    [DataRow("NegativeSize")]
+    [DataRow("PartialRecord")]
+    [DataRow("AboveBudget")]
+    public void RuntimeFunctions_MalformedRealTable_DisablesMethodMap(string malformation)
+    {
+        TestSkip.When(Samples.ReadyToRunConsoleDll is null, SkipReason);
+        using var baseline = new AssemblyAnalyzer(Samples.ReadyToRunConsoleDll!);
+        var baselineInfo = baseline.ReadyToRunInfo;
+        Assert.IsNotNull(baselineInfo);
+        var recordSize = baselineInfo.Architecture == NativeArchitecture.X64 ? 12 : 8;
+        var declaredSize = malformation switch
+        {
+            "NegativeSize" => -1,
+            "PartialRecord" => 1,
+            "AboveBudget" => checked(
+                (ReadyToRunRuntimeFunctionTable.MaxRuntimeFunctionCount + 1) * recordSize),
+            _ => throw new ArgumentOutOfRangeException(nameof(malformation)),
+        };
+        var patched = ReadyToRunImagePatcher.PatchImageWideTable(
+            Samples.ReadyToRunConsoleDll!,
+            ReadyToRunSectionType.RuntimeFunctions,
+            [0],
+            declaredSize);
+
+        using var analyzer = new AssemblyAnalyzer(patched.Image, Samples.ReadyToRunConsoleDll!);
+
+        AssertMethodMapUnavailable(analyzer, "RuntimeFunctions");
+        Assert.Contains(
+            section => section.SectionId == (int)ReadyToRunSectionType.RuntimeFunctions,
+            analyzer.ReadyToRunSections);
+    }
+
+    /// <summary>
+    /// Verifies a malformed hot/cold table patched into a real crossgen2 image disables the complete
+    /// method map and retains the rest of the ReadyToRun model.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void HotColdMap_MalformedRealTable_DisablesMethodMap()
+    {
+        TestSkip.When(Samples.ReadyToRunConsoleDll is null, SkipReason);
+        var patched = ReadyToRunImagePatcher.PatchImageWideTable(
+            Samples.ReadyToRunConsoleDll!,
+            ReadyToRunSectionType.HotColdMap,
+            new byte[8],
+            8,
+            ReadyToRunSectionType.CrossModuleInlineInfo);
+
+        using var analyzer = new AssemblyAnalyzer(patched.Image, Samples.ReadyToRunConsoleDll!);
+
+        AssertMethodMapUnavailable(analyzer, "HotColdMap");
+        Assert.Contains(
+            section => section.SectionId == (int)ReadyToRunSectionType.HotColdMap,
+            analyzer.ReadyToRunSections);
+    }
+
+    /// <summary>
+    /// Verifies a valid hot/cold pair reaches the real method builder and adds the exact compact
+    /// cold range to its owning hot method.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void HotColdMap_ValidRealTable_AddsColdRange()
+    {
+        TestSkip.When(Samples.ReadyToRunConsoleDll is null, SkipReason);
+        int hot;
+        int cold;
+        int expectedColdStartRva;
+        using (var baseline = new AssemblyAnalyzer(Samples.ReadyToRunConsoleDll!))
+        {
+            var info = baseline.ReadyToRunInfo;
+            Assert.IsNotNull(info);
+            var section = info.Sections.Single(
+                static candidate => candidate.Type == (int)ReadyToRunSectionType.RuntimeFunctions);
+            Assert.IsNotNull(section.FileOffset);
+            var addressSpace = NativeAddressSpace.Create(baseline.RawBytes.Span);
+            Assert.IsNotNull(addressSpace);
+            var valid = ReadyToRunRuntimeFunctionTable.TryRead(
+                new R2RNativeReader(baseline.RawBytes),
+                section.FileOffset.Value,
+                section.Size,
+                info.Architecture,
+                baseline.PeHeaders?.ImageBase ?? 0,
+                addressSpace,
+                out var table,
+                out var diagnostic);
+            Assert.IsTrue(valid, diagnostic);
+            Assert.IsNotNull(table);
+
+            cold = table.Count - 1;
+            hot = baseline.ReadyToRunMethods
+                .Select(static method => method.EntryPointRuntimeFunctionId)
+                .First(id => id >= 0 && id < cold);
+            expectedColdStartRva = table.StartRva(cold);
+        }
+
+        var pair = new byte[8];
+        BinaryPrimitives.WriteInt32LittleEndian(pair, cold);
+        BinaryPrimitives.WriteInt32LittleEndian(pair.AsSpan(4), hot);
+        var patched = ReadyToRunImagePatcher.PatchImageWideTable(
+            Samples.ReadyToRunConsoleDll!,
+            ReadyToRunSectionType.HotColdMap,
+            pair,
+            pair.Length,
+            ReadyToRunSectionType.CrossModuleInlineInfo);
+
+        using var analyzer = new AssemblyAnalyzer(patched.Image, Samples.ReadyToRunConsoleDll!);
+        var method = analyzer.ReadyToRunMethods.First(
+            candidate => candidate.EntryPointRuntimeFunctionId == hot);
+        var coldRange = Assert.ContainsSingle(
+            range => range.Kind == ReadyToRunCodeRangeKind.Cold,
+            method.CodeRanges);
+
+        Assert.AreEqual(expectedColdStartRva, coldRange.StartRva);
+        Assert.IsNotNull(analyzer.ReadyToRunIndex);
+        var symbols = analyzer.NativeSymbols;
+        Assert.IsNotNull(symbols);
+        Assert.AreEqual(NativeSymbolStatus.Loaded, symbols.Status);
+    }
+
+    /// <summary>
+    /// Verifies a large real composite image remains below the accepted runtime-function budget and
+    /// exposes its complete method index.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void RuntimeFunctions_LargeRealComposite_RetainsMethodMap()
+    {
+        TestSkip.When(Samples.ReadyToRunCompositeImage is null, CompositeSkipReason);
+        using var analyzer = new AssemblyAnalyzer(Samples.ReadyToRunCompositeImage!);
+        var info = analyzer.ReadyToRunInfo;
+        Assert.IsNotNull(info);
+        var section = info.Sections.Single(
+            static candidate => candidate.Type == (int)ReadyToRunSectionType.RuntimeFunctions);
+        var recordSize = info.Architecture == NativeArchitecture.X64 ? 12 : 8;
+        var runtimeFunctionCount = section.Size / recordSize;
+
+        Assert.AreEqual(ReadyToRunStatus.Valid, info.Status);
+        Assert.IsGreaterThan(200_000, runtimeFunctionCount);
+        Assert.IsLessThanOrEqualTo(
+            ReadyToRunRuntimeFunctionTable.MaxRuntimeFunctionCount,
+            runtimeFunctionCount);
+        Assert.IsNotEmpty(analyzer.ReadyToRunMethods);
+        Assert.IsNotNull(analyzer.ReadyToRunIndex);
+        var symbols = analyzer.NativeSymbols;
+        Assert.IsNotNull(symbols);
+        Assert.AreEqual(NativeSymbolStatus.Loaded, symbols.Status);
+    }
+
+    private static void AssertMethodMapUnavailable(AssemblyAnalyzer analyzer, string tableName)
+    {
+        var info = analyzer.ReadyToRunInfo;
+        Assert.IsNotNull(info);
+        Assert.AreEqual(ReadyToRunStatus.Valid, info.Status);
+        Assert.IsTrue(analyzer.HasMetadata);
+        Assert.IsNotEmpty(analyzer.MethodDefs);
+        Assert.IsEmpty(analyzer.ReadyToRunMethods);
+        Assert.IsNull(analyzer.ReadyToRunIndex);
+
+        var symbols = analyzer.NativeSymbols;
+        Assert.IsNotNull(symbols);
+        Assert.AreEqual(NativeSymbolStatus.CorruptSymbolFile, symbols.Status);
+        Assert.Contains(tableName, symbols.Diagnostic!);
+
+        var result = ReadyToRunCorrelationQuery.Resolve(analyzer, "Greeter.Greet", CancellationToken.None);
+        Assert.AreEqual(ReadyToRunQueryOutcome.Unavailable, result.Outcome);
+        Assert.Contains(tableName, result.Message!);
+    }
+}


### PR DESCRIPTION
Validates ReadyToRun runtime-function and hot/cold tables before allocation or traversal. Malformed tables now leave the image and metadata readable while exposing a precise unavailable-map diagnostic, and valid large tables use bounded compact storage.

Coverage includes exact limits, truncation, overflow, ordering, mapped-range checks, patched real ReadyToRun images, and large composite images across Windows, Linux, and macOS. The PE metadata and API docs describe the resulting availability behavior.

Fixes: #219