### PR TITLE
Harden mstat deduplicated method counts

### DIFF
--- a/.testagent/plan.md
+++ b/.testagent/plan.md
@@ -1,0 +1,50 @@
+# Issue #229 test plan
+
+## Phase 1: Synthetic format-2.2 fixture
+
+- Add `SyntheticMstat22PeBuilder.cs` to serialize the custom `.names` PE section.
+- Add `SyntheticMstat22Fault.cs` to name precise malformed-stream variants.
+- Add `SyntheticMstat22Builder.cs` to emit deterministic metadata, method references,
+  global `Methods`, `Types`, and `DeduplicatedMethods` IL bodies, and serialized names.
+- Validate the fixture through the public `MstatReader.Read(Stream)` facade.
+
+## Phase 2: Functional boundaries and recovery
+
+- `ReadDeduplicatedMethods_ZeroCount_ReturnsEmptyTargetSet` covers zero.
+- `ReadDeduplicatedMethods_ExactCount_ReturnsNamedTarget` covers one exact pair and
+  `.names` resolution using the runtime writer's exact six-byte minimum pair encoding.
+- `ReadDeduplicatedMethods_MultipleCount_ReturnsEveryNamedTargetInOrder` covers multiple
+  pairs and ordering.
+- `ReadDeduplicatedMethods_InvalidCount_OmitsCurrentRowAndPreservesOtherSections` covers
+  negative, impossible, and `int.MaxValue` count values while asserting the independent
+  method/type entries remain exact.
+- `ReadDeduplicatedMethods_TruncatedCount_OmitsCurrentRowAndPreservesOtherSections`
+  covers a physically truncated `ldc.i4` operand.
+- `ReadDeduplicatedMethods_TruncatedPair_KeepsCompletedPrefix` covers a later row whose
+  target pair ends after `ldtoken`, preserving an earlier complete row.
+- `ReadDeduplicatedMethods_MalformedTargetToken_KeepsCompletedPrefix` covers an invalid
+  target-token opcode.
+- `ReadDeduplicatedMethods_MalformedTargetNameOffset_OmitsPartialCurrentRow` lets one
+  target in the current row decode before the next name operand fails, proving the current
+  row is atomic and the completed prefix remains.
+- `ReadDeduplicatedMethods_OutOfRangeTargetNameOffset_KeepsRowWithoutTarget` covers a
+  structurally complete pair whose serialized-name offset cannot be resolved.
+
+## Phase 3: Allocation regression
+
+- `ReadDeduplicatedMethods_InflatedCount_DoesNotAllocateFromDeclaredCount` builds
+  zero-count and 2,000,000-count tiny images once, warms both reads, records five
+  current-thread allocation measurements for each, compares the minima, and requires the
+  hostile input to remain within 1 MiB of baseline. The old capacity-sized list reserves
+  roughly 16 MiB and therefore fails without using an unsafe `int.MaxValue` measurement.
+
+## Phase 4: Validation and review
+
+- Build `tests/Dotsider.Tests/Dotsider.Tests.csproj`.
+- Run the new class with the repository's Microsoft Testing Platform filter syntax.
+- Run final workspace validation once.
+- Re-open every generated test and map every acceptance item to its exact assertion.
+- Perform pseudo-mutation analysis on count sign/boundary, minimum pair size, early-return,
+  and allocation mutations.
+- Classify all assertions and record gap/assertion findings and any fixes in
+  `.testagent/status.md`.

--- a/.testagent/research.md
+++ b/.testagent/research.md
@@ -1,0 +1,61 @@
+# Issue #229 test research
+
+## Bounded target inventory
+
+- Production target: `src/Dotsider.Core/Analysis/MstatReader.cs`, specifically
+  `ReadDeduplicatedMethods`.
+- Supporting cursor: `src/Dotsider.Core/Analysis/IlCursor.cs`, including the unread-byte
+  count used to reject impossible nested counts.
+- Existing paired tests: `tests/Dotsider.Tests/MstatReaderTests.cs`.
+- New fixture target: a deterministic in-process format-2.2 managed PE generated in
+  `tests/Dotsider.Tests`, with the same global-method IL and `.names` section shape as the
+  runtime writer.
+- New regression target: a focused sealed MSTest 4 class in
+  `tests/Dotsider.Tests/MstatDeduplicatedMethodBoundsTests.cs`.
+
+The one-time Roslyn static-pairing scan classified `MstatReader.cs` as paired with
+`MstatReaderTests.cs`. This is a static symbol-pairing heuristic, not line or branch coverage.
+
+## Runtime writer contract
+
+`D:\SRC\runtime\src\coreclr\tools\aot\ILCompiler.Compiler\Compiler\MstatObjectDumper.cs`
+defines mstat format 2.2 and emits each `DeduplicatedMethods` row as:
+
+1. `ldtoken` for the original method.
+2. `ldc.i4` for the number of folded targets.
+3. For each target, `ldtoken` for the target method and `ldc.i4` for its byte offset in
+   the `.names` section.
+
+The writer serializes node names as length-prefixed UTF-8 strings and places them in a
+read-only `.names` PE section. It also emits the independent `Methods` and `Types` global
+method streams.
+
+## Existing conventions
+
+- `MSTest.Sdk` 4.3.0 on `net10.0`, run by Microsoft Testing Platform.
+- Public sealed `[TestClass]` types and public `[TestMethod]` methods.
+- Exact MSTest 4 assertions such as `Assert.HasCount`, `Assert.IsEmpty`,
+  `Assert.AreEqual`, and comparison assertions.
+- Alphabetical using directives, one declared type per file, and XML documentation for
+  public types and members and public members exposed by internal types.
+- Deterministic, in-process synthetic metadata is established practice.
+- Tests must not add subprocess infrastructure, packages, timeout/parallelization changes,
+  or production changes.
+
+## Acceptance checklist
+
+- [ ] Build a deterministic synthetic format-2.2 mstat matching the runtime writer layout.
+- [ ] Include a real `.names` PE section and assert decoded target node names.
+- [ ] Cover valid zero, one, and multiple folded-target counts.
+- [ ] Cover negative, impossible, and `int.MaxValue` counts.
+- [ ] Cover a truncated count, a truncated pair, and malformed target-token/name operands.
+- [ ] Prove completed dedup rows survive later damage.
+- [ ] Prove a partially decoded current row is atomic and omitted.
+- [ ] Prove independent `Methods` and `Types` sections survive dedup-stream damage.
+- [ ] Add a robust allocation regression using
+  `GC.GetAllocatedBytesForCurrentThread`.
+- [ ] Warm both inputs, take five repeated measurements, compare minima, and verify a
+  count of 2,000,000 stays within 1 MiB of the zero-count baseline.
+- [ ] Keep every change confined to tests and `.testagent`.
+- [ ] Build and run the narrow test class, then perform final workspace-level validation.
+- [ ] Perform pseudo-mutation and assertion-quality reviews before completion.

--- a/.testagent/status.md
+++ b/.testagent/status.md
@@ -1,0 +1,62 @@
+# Issue #229 test status
+
+- Research: complete.
+- Plan: complete.
+- Implementation: complete.
+- Narrow build: passed with
+  `dotnet build tests/Dotsider.Tests/Dotsider.Tests.csproj --no-restore`
+  (0 warnings, 0 errors).
+- Narrow test: passed with
+  `dotnet test --project tests/Dotsider.Tests/Dotsider.Tests.csproj --no-build --filter "FullyQualifiedName~Dotsider.Tests.MstatDeduplicatedMethodBoundsTests"`
+  (12 passed, 0 failed).
+- Focused Debug validation: 35 passed, 0 failed
+  (`MstatDeduplicatedMethodBoundsTests`, `MstatReaderTests`, and
+  `MstatLocatorTests`).
+- Focused Release validation: 35 passed, 0 failed over the same scope.
+- Full Debug validation: 3,077 passed, 0 failed, 23 skipped.
+- Full Release validation: 3,077 passed, 0 failed, 23 skipped.
+- Full Release solution build: passed with 0 warnings and 0 errors.
+- Linux x64 focused validation: 12 passed, 0 failed.
+- macOS arm64 focused validation: 12 passed, 0 failed.
+- API generation: 1,659 API items loaded and 227 Markdown files generated with
+  0 warnings and 0 errors.
+- Documentation site build: passed.
+- Allocation audit: every `List<T>` in `MstatReader` now uses a capacity-free
+  constructor; no untrusted stream count controls a list capacity.
+- `git diff --check`: passed.
+
+## Pseudo-mutation review
+
+- Removing the negative-count guard is killed by
+  `ReadDeduplicatedMethods_InvalidCount_OmitsCurrentRowAndPreservesOtherSections`: the
+  malformed row must not appear and the public facade must still return a report.
+- Removing the remaining-byte guard is killed functionally by the impossible-count cases
+  and by the 2,000,000-count allocation comparison.
+- Changing the exact-fit comparison from `>` to `>=`, or increasing the six-byte minimum,
+  is killed by `ReadDeduplicatedMethods_ExactCount_ReturnsNamedTarget`; its target name is
+  at `.names` offset zero, so the pair is exactly five token bytes plus one `ldc.i4.0`.
+- Reintroducing `new List<string>(count)` is killed by
+  `ReadDeduplicatedMethods_InflatedCount_DoesNotAllocateFromDeclaredCount`: the old path
+  reserves roughly 16 MiB, beyond the 1 MiB baseline tolerance.
+- Replacing malformed-pair early returns with partial-row publication is killed by the
+  truncated/malformed prefix tests and
+  `ReadDeduplicatedMethods_MalformedTargetNameOffset_OmitsPartialCurrentRow`.
+- Treating an unavailable `.names` offset as a decoded target is killed by
+  `ReadDeduplicatedMethods_OutOfRangeTargetNameOffset_KeepsRowWithoutTarget`.
+- No high-risk survived mutation remains in the bounded count/allocation behavior. Lowering
+  the conservative six-byte precheck to five can reach the same cursor failure one step
+  later without changing externally visible results; it is behaviorally equivalent for
+  these no-capacity-allocation loops.
+
+## Assertion-quality review
+
+- Ten test methods produce twelve cases and all contain meaningful assertions.
+- No test is assertion-free, trivial-only, self-referential, or dependent on an exception
+  escaping from the lenient public facade.
+- Equality assertions pin format, names, ordering, sizes, and section identity; collection
+  assertions pin row atomicity, completed-prefix retention, and omitted targets; the
+  comparison assertion pins the allocation invariant.
+- The malformed cases assert both the damaged section and independent-section state, so a
+  broad fallback to null/empty cannot satisfy them.
+- Exception assertions are intentionally absent because `MstatReader` promises malformed
+  input does not throw.

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-MstatReader.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-MstatReader.md
@@ -1,6 +1,6 @@
 ---
 title: "MstatReader"
-description: "Reads an ILC size report (.mstat), the file IlcGenerateMstatFile emits when publishing a Native AOT project. The report is itself a valid ECMA-335 assembly: its assembly version carries the format version, and its data is encoded as IL instruction streams in global methods named Methods, Types, Blobs, and (in newer formats) RvaFields, FrozenObjects, ManifestResources, and DeduplicatedMethods. Format 2.0+ also stores each entry's dependency-graph node name in a custom .names PE section; those names equal the node labels in the DGML graphs IlcGenerateDgmlFile emits, which is how sizes join to dependency chains. Malformed input never throws: unreadable files return null, and a truncated IL stream yields the entries parsed before the damage."
+description: "Reads an ILC size report (.mstat), the file IlcGenerateMstatFile emits when publishing a Native AOT project. The report is itself a valid ECMA-335 assembly: its assembly version carries the format version, and its data is encoded as IL instruction streams in global methods named Methods, Types, Blobs, and (in newer formats) RvaFields, FrozenObjects, ManifestResources, and DeduplicatedMethods. Format 2.0+ also stores each entry's dependency-graph node name in a custom .names PE section; those names equal the node labels in the DGML graphs IlcGenerateDgmlFile emits, which is how sizes join to dependency chains. Malformed input never throws: unreadable files return null, and damage within an IL stream, including an impossible nested count, yields the entries parsed before the damage."
 slug: api/dotsider.core.analysis.mstatreader
 sidebar:
   order: 0
@@ -19,8 +19,8 @@ formats) `RvaFields`, `FrozenObjects`, `ManifestResources`, and
 in a custom `.names` PE section; those names equal the node labels in the DGML graphs
 `IlcGenerateDgmlFile` emits, which is how sizes join to dependency chains.
 
-Malformed input never throws: unreadable files return null, and a truncated IL stream
-yields the entries parsed before the damage.
+Malformed input never throws: unreadable files return null, and damage within an IL stream,
+including an impossible nested count, yields the entries parsed before the damage.
 
 ```csharp
 public static class MstatReader

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis.md
@@ -180,8 +180,8 @@ formats) `RvaFields`, `FrozenObjects`, `ManifestResources`, and
 in a custom `.names` PE section; those names equal the node labels in the DGML graphs
 `IlcGenerateDgmlFile` emits, which is how sizes join to dependency chains.
 
-Malformed input never throws: unreadable files return null, and a truncated IL stream
-yields the entries parsed before the damage.
+Malformed input never throws: unreadable files return null, and damage within an IL stream,
+including an impossible nested count, yields the entries parsed before the damage.
 
 ```csharp
 public static class MstatReader

--- a/src/Dotsider.Core/Analysis/IlCursor.cs
+++ b/src/Dotsider.Core/Analysis/IlCursor.cs
@@ -17,6 +17,9 @@ internal struct IlCursor
         _il = il;
     }
 
+    /// <summary>Gets the number of unread bytes in the IL stream.</summary>
+    internal int RemainingByteCount => _il.Length - _position;
+
     internal bool TryReadInt(out int value)
     {
         value = 0;

--- a/src/Dotsider.Core/Analysis/MstatReader.cs
+++ b/src/Dotsider.Core/Analysis/MstatReader.cs
@@ -15,11 +15,13 @@ namespace Dotsider.Core.Analysis;
 /// in a custom <c>.names</c> PE section; those names equal the node labels in the DGML graphs
 /// <c>IlcGenerateDgmlFile</c> emits, which is how sizes join to dependency chains.
 ///
-/// Malformed input never throws: unreadable files return null, and a truncated IL stream
-/// yields the entries parsed before the damage.
+/// Malformed input never throws: unreadable files return null, and damage within an IL stream,
+/// including an impossible nested count, yields the entries parsed before the damage.
 /// </summary>
 public static class MstatReader
 {
+    private const int MinimumDeduplicatedTargetEncodingSize = 6;
+
     /// <summary>
     /// Reads an ILC size report from a file.
     /// </summary>
@@ -376,8 +378,17 @@ public static class MstatReader
         var cursor = new IlCursor(il);
         while (cursor.TryReadToken(out var token) && cursor.TryReadInt(out var count))
         {
+            // Each target is an ldtoken instruction (five bytes) followed by an ldc.i4
+            // instruction (at least one byte). A larger count cannot fit in the remaining
+            // stream and must not influence an allocation or traversal.
+            if (count < 0
+                || count > cursor.RemainingByteCount / MinimumDeduplicatedTargetEncodingSize)
+            {
+                return result;
+            }
+
             var method = resolver.ResolveMethod(token);
-            var targets = new List<string>(count);
+            var targets = new List<string>();
             for (var i = 0; i < count; i++)
             {
                 if (!cursor.TryReadToken(out _) || !cursor.TryReadInt(out var nameOffset))

--- a/tests/Dotsider.Tests/MstatDeduplicatedMethodBoundsTests.cs
+++ b/tests/Dotsider.Tests/MstatDeduplicatedMethodBoundsTests.cs
@@ -1,0 +1,235 @@
+using Dotsider.Core.Analysis;
+using Dotsider.Core.Analysis.Models;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Verifies format-2.2 deduplicated-method count and pair boundaries through the public mstat
+/// reader facade.
+/// </summary>
+[TestClass]
+public sealed class MstatDeduplicatedMethodBoundsTests
+{
+    private const long AllocationTolerance = 1024L * 1024;
+    private const int AllocationMeasurementCount = 5;
+
+    /// <summary>
+    /// A zero target count produces one completed row with an empty target set.
+    /// </summary>
+    [TestMethod]
+    public void ReadDeduplicatedMethods_ZeroCount_ReturnsEmptyTargetSet()
+    {
+        var data = Read(SyntheticMstat22Builder.Create([0], [0]));
+
+        var method = Assert.ContainsSingle(data.DeduplicatedMethods);
+        Assert.AreEqual("Fixture.Worker::Original1", method.Name);
+        Assert.IsEmpty(method.TargetNames);
+    }
+
+    /// <summary>
+    /// One complete target pair resolves its serialized dependency-node name.
+    /// </summary>
+    [TestMethod]
+    public void ReadDeduplicatedMethods_ExactCount_ReturnsNamedTarget()
+    {
+        var data = Read(SyntheticMstat22Builder.Create([1], [1]));
+
+        var method = Assert.ContainsSingle(data.DeduplicatedMethods);
+        Assert.AreEqual("Fixture.Worker::Original1", method.Name);
+        Assert.HasCount(1, method.TargetNames);
+        Assert.AreEqual("Folded target 1", method.TargetNames[0]);
+    }
+
+    /// <summary>
+    /// Multiple complete target pairs preserve every serialized node name in writer order.
+    /// </summary>
+    [TestMethod]
+    public void ReadDeduplicatedMethods_MultipleCount_ReturnsEveryNamedTargetInOrder()
+    {
+        var data = Read(SyntheticMstat22Builder.Create([3], [3]));
+
+        var method = Assert.ContainsSingle(data.DeduplicatedMethods);
+        Assert.HasCount(3, method.TargetNames);
+        Assert.AreEqual("Folded target 1", method.TargetNames[0]);
+        Assert.AreEqual("Folded target 2", method.TargetNames[1]);
+        Assert.AreEqual("Folded target 3", method.TargetNames[2]);
+    }
+
+    /// <summary>
+    /// Counts that are negative or cannot fit in the remaining IL omit the current row while
+    /// preserving independent sections.
+    /// </summary>
+    /// <param name="count">The malformed declared target count.</param>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(1)]
+    [DataRow(int.MaxValue)]
+    public void ReadDeduplicatedMethods_InvalidCount_OmitsCurrentRowAndPreservesOtherSections(
+        int count)
+    {
+        var data = Read(SyntheticMstat22Builder.Create([count], [0]));
+
+        Assert.IsEmpty(data.DeduplicatedMethods);
+        AssertIndependentSections(data);
+    }
+
+    /// <summary>
+    /// A physically truncated four-byte count operand omits the row without damaging
+    /// independent streams.
+    /// </summary>
+    [TestMethod]
+    public void ReadDeduplicatedMethods_TruncatedCount_OmitsCurrentRowAndPreservesOtherSections()
+    {
+        var data = Read(SyntheticMstat22Builder.Create(
+            [0],
+            [0],
+            SyntheticMstat22Fault.TruncatedCount));
+
+        Assert.IsEmpty(data.DeduplicatedMethods);
+        AssertIndependentSections(data);
+    }
+
+    /// <summary>
+    /// A target pair ending after its token omits that row and retains a previously completed
+    /// deduplication row.
+    /// </summary>
+    [TestMethod]
+    public void ReadDeduplicatedMethods_TruncatedPair_KeepsCompletedPrefix()
+    {
+        var data = Read(SyntheticMstat22Builder.Create(
+            [1, 1],
+            [1, 1],
+            SyntheticMstat22Fault.TruncatedTargetNameOffset));
+
+        var completed = Assert.ContainsSingle(data.DeduplicatedMethods);
+        Assert.AreEqual("Fixture.Worker::Original1", completed.Name);
+        Assert.HasCount(1, completed.TargetNames);
+        Assert.AreEqual("Folded target 1", completed.TargetNames[0]);
+        AssertIndependentSections(data);
+    }
+
+    /// <summary>
+    /// An invalid target-token opcode omits the damaged row and retains a previously completed
+    /// deduplication row.
+    /// </summary>
+    [TestMethod]
+    public void ReadDeduplicatedMethods_MalformedTargetToken_KeepsCompletedPrefix()
+    {
+        var data = Read(SyntheticMstat22Builder.Create(
+            [1, 1],
+            [1, 1],
+            SyntheticMstat22Fault.MalformedTargetToken));
+
+        var completed = Assert.ContainsSingle(data.DeduplicatedMethods);
+        Assert.AreEqual("Fixture.Worker::Original1", completed.Name);
+        Assert.AreEqual("Folded target 1", Assert.ContainsSingle(completed.TargetNames));
+        AssertIndependentSections(data);
+    }
+
+    /// <summary>
+    /// A current row remains atomic when one pair completes and the next name operand is
+    /// malformed; only the earlier completed row is returned.
+    /// </summary>
+    [TestMethod]
+    public void ReadDeduplicatedMethods_MalformedTargetNameOffset_OmitsPartialCurrentRow()
+    {
+        var data = Read(SyntheticMstat22Builder.Create(
+            [1, 2],
+            [1, 2],
+            SyntheticMstat22Fault.MalformedTargetNameOffset));
+
+        var completed = Assert.ContainsSingle(data.DeduplicatedMethods);
+        Assert.AreEqual("Fixture.Worker::Original1", completed.Name);
+        Assert.AreEqual("Folded target 1", Assert.ContainsSingle(completed.TargetNames));
+        AssertIndependentSections(data);
+    }
+
+    /// <summary>
+    /// A structurally complete pair whose name offset is out of range keeps the original row
+    /// while omitting the unavailable target name.
+    /// </summary>
+    [TestMethod]
+    public void ReadDeduplicatedMethods_OutOfRangeTargetNameOffset_KeepsRowWithoutTarget()
+    {
+        var data = Read(SyntheticMstat22Builder.Create(
+            [1],
+            [1],
+            SyntheticMstat22Fault.OutOfRangeTargetNameOffset));
+
+        var method = Assert.ContainsSingle(data.DeduplicatedMethods);
+        Assert.AreEqual("Fixture.Worker::Original1", method.Name);
+        Assert.IsEmpty(method.TargetNames);
+        AssertIndependentSections(data);
+    }
+
+    /// <summary>
+    /// A tiny stream declaring two million targets allocates within one MiB of a warmed
+    /// zero-count baseline rather than reserving storage proportional to the declaration.
+    /// </summary>
+    [TestMethod]
+    public void ReadDeduplicatedMethods_InflatedCount_DoesNotAllocateFromDeclaredCount()
+    {
+        var baseline = SyntheticMstat22Builder.Create([0], [0]);
+        var hostile = SyntheticMstat22Builder.Create([2_000_000], [0]);
+        _ = Read(baseline);
+        _ = Read(hostile);
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var baselineMinimum = long.MaxValue;
+        var hostileMinimum = long.MaxValue;
+        for (var i = 0; i < AllocationMeasurementCount; i++)
+        {
+            baselineMinimum = Math.Min(baselineMinimum, MeasureAllocation(baseline, 1));
+            hostileMinimum = Math.Min(hostileMinimum, MeasureAllocation(hostile, 0));
+        }
+
+        Assert.IsLessThanOrEqualTo(
+            baselineMinimum + AllocationTolerance,
+            hostileMinimum,
+            $"Hostile read allocated {hostileMinimum:N0} bytes; baseline allocated "
+            + $"{baselineMinimum:N0} bytes.");
+    }
+
+    private static MstatData Read(byte[] image)
+    {
+        using var stream = new MemoryStream(image, writable: false);
+        var data = MstatReader.Read(stream);
+        Assert.IsNotNull(data);
+        Assert.AreEqual(2, data.FormatMajorVersion);
+        Assert.AreEqual(2, data.FormatMinorVersion);
+        return data;
+    }
+
+    private static void AssertIndependentSections(MstatData data)
+    {
+        var method = Assert.ContainsSingle(data.Methods);
+        Assert.AreEqual("Original1", method.Name);
+        Assert.AreEqual("Fixture.Worker", method.DeclaringType);
+        Assert.AreEqual(17, method.Size);
+        Assert.AreEqual(2, method.GcInfoSize);
+        Assert.AreEqual(1, method.EhInfoSize);
+        Assert.AreEqual("Method entry node", method.NodeName);
+
+        var type = Assert.ContainsSingle(data.Types);
+        Assert.AreEqual("Fixture.Worker", type.Name);
+        Assert.AreEqual("Fixture", type.Namespace);
+        Assert.AreEqual("FixtureAssembly", type.AssemblyName);
+        Assert.AreEqual(24, type.Size);
+        Assert.AreEqual("Type entry node", type.NodeName);
+    }
+
+    private static long MeasureAllocation(byte[] image, int expectedDeduplicatedMethodCount)
+    {
+        using var stream = new MemoryStream(image, writable: false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+
+        var data = MstatReader.Read(stream);
+
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.IsNotNull(data);
+        Assert.HasCount(expectedDeduplicatedMethodCount, data.DeduplicatedMethods);
+        return allocated;
+    }
+}

--- a/tests/Dotsider.Tests/SyntheticMstat22Builder.cs
+++ b/tests/Dotsider.Tests/SyntheticMstat22Builder.cs
@@ -1,0 +1,223 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Builds deterministic format-2.2 mstat images using the runtime writer's metadata, IL, and
+/// serialized-name layout.
+/// </summary>
+internal static class SyntheticMstat22Builder
+{
+    private static readonly Guid ModuleVersionId =
+        new("2558c921-3775-4287-97f5-9de6b3904ed6");
+
+    /// <summary>
+    /// Creates an mstat image with caller-selected declared and physically encoded target
+    /// counts, optionally corrupting the final row.
+    /// </summary>
+    /// <param name="declaredCounts">The target count declared by each original method.</param>
+    /// <param name="encodedTargetCounts">
+    /// The number of target pairs physically encoded for each original method.
+    /// </param>
+    /// <param name="fault">The corruption to apply to the final row.</param>
+    /// <returns>The serialized format-2.2 mstat image.</returns>
+    internal static byte[] Create(
+        IReadOnlyList<int> declaredCounts,
+        IReadOnlyList<int> encodedTargetCounts,
+        SyntheticMstat22Fault fault = SyntheticMstat22Fault.None)
+    {
+        if (declaredCounts.Count != encodedTargetCounts.Count)
+        {
+            throw new ArgumentException(
+                "Declared and encoded target count collections must have the same length.");
+        }
+
+        var metadata = CreateMetadata();
+        var owner = AddFixtureReferences(metadata, out var originals, out var targets);
+        var names = new BlobBuilder();
+        var targetNameOffsets = AddTargetNames(names);
+        var methodNameOffset = AddName(names, "Method entry node");
+        var typeNameOffset = AddName(names, "Type entry node");
+
+        var methodStream = new BlobBuilder();
+        WriteToken(methodStream, originals[0]);
+        WriteInt32(methodStream, 17);
+        WriteInt32(methodStream, 2);
+        WriteInt32(methodStream, 1);
+        WriteInt32(methodStream, methodNameOffset);
+
+        var typeStream = new BlobBuilder();
+        WriteToken(typeStream, owner);
+        WriteInt32(typeStream, 24);
+        WriteInt32(typeStream, typeNameOffset);
+
+        var deduplicatedMethodStream = new BlobBuilder();
+        for (var groupIndex = 0; groupIndex < declaredCounts.Count; groupIndex++)
+        {
+            WriteToken(deduplicatedMethodStream, originals[groupIndex]);
+            var isFinalGroup = groupIndex == declaredCounts.Count - 1;
+            if (isFinalGroup && fault == SyntheticMstat22Fault.TruncatedCount)
+            {
+                deduplicatedMethodStream.WriteByte((byte)ILOpCode.Ldc_i4);
+                deduplicatedMethodStream.WriteByte(0);
+                deduplicatedMethodStream.WriteByte(0);
+                break;
+            }
+
+            WriteInt32(deduplicatedMethodStream, declaredCounts[groupIndex]);
+            for (var targetIndex = 0;
+                targetIndex < encodedTargetCounts[groupIndex];
+                targetIndex++)
+            {
+                var isFaultedTarget = isFinalGroup
+                    && targetIndex == encodedTargetCounts[groupIndex] - 1;
+                if (isFaultedTarget && fault == SyntheticMstat22Fault.MalformedTargetToken)
+                {
+                    deduplicatedMethodStream.WriteBytes(new byte[] { 0, 0, 0, 0, 0, 0 });
+                    break;
+                }
+
+                WriteToken(deduplicatedMethodStream, targets[targetIndex]);
+                if (isFaultedTarget
+                    && fault == SyntheticMstat22Fault.TruncatedTargetNameOffset)
+                {
+                    break;
+                }
+
+                if (isFaultedTarget
+                    && fault == SyntheticMstat22Fault.MalformedTargetNameOffset)
+                {
+                    deduplicatedMethodStream.WriteByte((byte)ILOpCode.Nop);
+                    break;
+                }
+
+                var targetNameOffset = isFaultedTarget
+                    && fault == SyntheticMstat22Fault.OutOfRangeTargetNameOffset
+                        ? int.MaxValue
+                        : targetNameOffsets[targetIndex];
+                WriteInt32(deduplicatedMethodStream, targetNameOffset);
+            }
+        }
+
+        var ilStream = new BlobBuilder();
+        var methodBodies = new MethodBodyStreamEncoder(ilStream);
+        AddGlobalMethod(metadata, methodBodies, "Methods", methodStream);
+        AddGlobalMethod(metadata, methodBodies, "Types", typeStream);
+        AddGlobalMethod(metadata, methodBodies, "Blobs", new BlobBuilder());
+        AddGlobalMethod(metadata, methodBodies, "RvaFields", new BlobBuilder());
+        AddGlobalMethod(metadata, methodBodies, "FrozenObjects", new BlobBuilder());
+        AddGlobalMethod(metadata, methodBodies, "ManifestResources", new BlobBuilder());
+        AddGlobalMethod(metadata, methodBodies, "DeduplicatedMethods", deduplicatedMethodStream);
+
+        var pe = new SyntheticMstat22PeBuilder(metadata, ilStream, names);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    private static MetadataBuilder CreateMetadata()
+    {
+        var metadata = new MetadataBuilder();
+        var assemblyName = metadata.GetOrAddString("SyntheticMstat22");
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("SyntheticMstat22.mstat"),
+            metadata.GetOrAddGuid(ModuleVersionId),
+            default,
+            default);
+        metadata.AddAssembly(
+            assemblyName,
+            new Version(2, 2),
+            default,
+            default,
+            0,
+            AssemblyHashAlgorithm.None);
+        metadata.AddTypeDefinition(
+            TypeAttributes.NotPublic,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        return metadata;
+    }
+
+    private static TypeReferenceHandle AddFixtureReferences(
+        MetadataBuilder metadata,
+        out MemberReferenceHandle[] originals,
+        out MemberReferenceHandle[] targets)
+    {
+        var fixtureAssembly = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("FixtureAssembly"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            0,
+            default);
+        var owner = metadata.AddTypeReference(
+            fixtureAssembly,
+            metadata.GetOrAddString("Fixture"),
+            metadata.GetOrAddString("Worker"));
+        var signature = metadata.GetOrAddBlob(new byte[] { 0x00, 0x00, 0x01 });
+
+        originals = new MemberReferenceHandle[4];
+        targets = new MemberReferenceHandle[4];
+        for (var i = 0; i < originals.Length; i++)
+        {
+            originals[i] = metadata.AddMemberReference(
+                owner,
+                metadata.GetOrAddString($"Original{i + 1}"),
+                signature);
+            targets[i] = metadata.AddMemberReference(
+                owner,
+                metadata.GetOrAddString($"Folded{i + 1}"),
+                signature);
+        }
+
+        return owner;
+    }
+
+    private static int[] AddTargetNames(BlobBuilder names) =>
+    [
+        AddName(names, "Folded target 1"),
+        AddName(names, "Folded target 2"),
+        AddName(names, "Folded target 3"),
+        AddName(names, "Folded target 4"),
+    ];
+
+    private static int AddName(BlobBuilder names, string value)
+    {
+        var offset = names.Count;
+        names.WriteSerializedString(value);
+        return offset;
+    }
+
+    private static void AddGlobalMethod(
+        MetadataBuilder metadata,
+        MethodBodyStreamEncoder methodBodies,
+        string name,
+        BlobBuilder code)
+    {
+        var bodyOffset = methodBodies.AddMethodBody(
+            new InstructionEncoder(code),
+            maxStack: 0);
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString(name),
+            metadata.GetOrAddBlob(new byte[] { 0x00, 0x00, 0x01 }),
+            bodyOffset,
+            parameterList: default);
+    }
+
+    private static void WriteInt32(BlobBuilder stream, int value) =>
+        new InstructionEncoder(stream).LoadConstantI4(value);
+
+    private static void WriteToken(BlobBuilder stream, EntityHandle handle)
+    {
+        stream.WriteByte((byte)ILOpCode.Ldtoken);
+        stream.WriteInt32(MetadataTokens.GetToken(handle));
+    }
+}

--- a/tests/Dotsider.Tests/SyntheticMstat22Fault.cs
+++ b/tests/Dotsider.Tests/SyntheticMstat22Fault.cs
@@ -1,0 +1,26 @@
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Identifies one precise corruption to apply to the final deduplicated-method row in a
+/// synthetic format-2.2 mstat image.
+/// </summary>
+internal enum SyntheticMstat22Fault
+{
+    /// <summary>No corruption is applied.</summary>
+    None,
+
+    /// <summary>The four-byte count operand ends before all operand bytes are present.</summary>
+    TruncatedCount,
+
+    /// <summary>The final target pair ends immediately after its token.</summary>
+    TruncatedTargetNameOffset,
+
+    /// <summary>The final target token starts with an unsupported opcode.</summary>
+    MalformedTargetToken,
+
+    /// <summary>The final target name offset starts with an unsupported opcode.</summary>
+    MalformedTargetNameOffset,
+
+    /// <summary>The final target name offset lies outside the serialized-name section.</summary>
+    OutOfRangeTargetNameOffset,
+}

--- a/tests/Dotsider.Tests/SyntheticMstat22PeBuilder.cs
+++ b/tests/Dotsider.Tests/SyntheticMstat22PeBuilder.cs
@@ -1,0 +1,40 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Adds the runtime mstat writer's read-only <c>.names</c> section to a managed PE image.
+/// </summary>
+internal sealed class SyntheticMstat22PeBuilder : ManagedPEBuilder
+{
+    private readonly BlobBuilder _names;
+
+    /// <summary>
+    /// Initializes a managed PE builder with a custom serialized-names section.
+    /// </summary>
+    /// <param name="metadata">The image metadata.</param>
+    /// <param name="ilStream">The global-method body stream.</param>
+    /// <param name="names">The serialized dependency-node names.</param>
+    internal SyntheticMstat22PeBuilder(
+        MetadataBuilder metadata,
+        BlobBuilder ilStream,
+        BlobBuilder names)
+        : base(
+            new PEHeaderBuilder(imageCharacteristics: Characteristics.Dll),
+            new MetadataRootBuilder(metadata),
+            ilStream)
+    {
+        _names = names;
+    }
+
+    /// <inheritdoc/>
+    protected override ImmutableArray<Section> CreateSections() =>
+        base.CreateSections().Add(new Section(".names", SectionCharacteristics.MemRead));
+
+    /// <inheritdoc/>
+    protected override BlobBuilder SerializeSection(string name, SectionLocation location) =>
+        name == ".names" ? _names : base.SerializeSection(name, location);
+}


### PR DESCRIPTION
An mstat DeduplicatedMethods stream can declare a target count that cannot fit in its remaining IL. The reader now validates that count before resolution or traversal and keeps target storage independent of the serialized value, preserving completed records when a later row is malformed.

Synthetic format 2.2 fixtures cover valid, truncated, malformed, and allocation-boundary cases across Windows, Linux, and macOS. The generated API documentation now describes the fail-closed behavior.

Fixes: #229