### PR TITLE
Scan repository changes for secrets with Picket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,24 @@ on:
     branches: [main]
 
 jobs:
+  secret-scan:
+    name: Secret scan
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Scan for secrets
+        uses: willibrandon/picket@v0.1.10
+        with:
+          cache-mode: secret-hash-only
+          fail-on: findings
+          redact: 100
+          timeout: 300
+
   build-and-test:
     strategy:
       fail-fast: false


### PR DESCRIPTION
Adds a dedicated Picket job to CI for pull requests and pushes to main. The scan runs once on Ubuntu with read-only repository access, secret-hash-only caching, full redaction, and a five-minute scanner deadline, and blocks the workflow when Picket reports a finding or cannot complete the scan.

Closes #256