### PR TITLE
Simplify agent init output handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ dotsider diff <left> <right>    # TUI mode — assembly comparison; AOT size dif
 dotsider analyze <file> [opts]  # CLI mode — headless analysis to stdout or file
 dotsider size-check <target>    # CLI mode — AOT size regression report and CI budget gate
 dotsider sessions <command>     # CLI mode — interact with running dotsider instances
-dotsider agent init [opts]      # CLI mode — generate AI skill file for a provider
+dotsider agent init [opts]      # CLI mode — generate an agent skill file
 dotsider agent mcp              # CLI mode — launch the dotsider MCP server
 
 TUI options:
@@ -173,16 +173,16 @@ dotsider sessions trace stop <pid>              # stop the active trace
 
 ### CLI: `dotsider agent`
 
-MCP server management and AI skill file generation.
+MCP server management and agent skill file generation.
 
 ```
-dotsider agent mcp                              # launch the dotsider MCP server
-dotsider agent init --ai claude                 # generate skill file for a provider
-dotsider agent init --path ./SKILL.md           # write to an explicit path
-dotsider agent init --stdout                    # print skill content to stdout
+dotsider agent mcp                                      # launch the dotsider MCP server
+dotsider agent init                                     # write ./SKILL.md
+dotsider agent init --path ./dotsider/SKILL.md              # write to an explicit path
+dotsider agent init --stdout                            # print skill content to stdout
 ```
 
-Supported `--ai` providers: claude, gemini, copilot, cursor-agent, opencode, codex, windsurf, kilocode, amp, qwen. Each resolves to the provider's conventional skill path relative to the current directory.
+By default, `init` writes `SKILL.md` in the current directory. Use `--path` when your agent expects skills in a specific directory.
 
 ### Keyboard
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -13,7 +13,7 @@ dotsider diff <left> <right>    # TUI — assembly comparison, or AOT size diff 
 dotsider analyze <file> [opts]  # CLI — headless analysis
 dotsider size-check <target>    # CLI — AOT size regression report and CI budget gate
 dotsider sessions <command>     # CLI — interact with running instances
-dotsider agent <command>        # CLI — MCP server and AI skill generation
+dotsider agent <command>        # CLI — MCP server and agent skill generation
 ```
 
 ## TUI options
@@ -190,17 +190,13 @@ delimiter lets child arguments begin with `-`; the launcher uses
 
 ## `dotsider agent`
 
-MCP server management and AI skill file generation.
+MCP server management and agent skill file generation.
 
 ```
-dotsider agent mcp                                # launch the MCP server
-dotsider agent init --ai claude                   # generate skill file
-dotsider agent init --path ./SKILL.md             # write to explicit path
-dotsider agent init --stdout                      # print to stdout
+dotsider agent mcp                                      # launch the MCP server
+dotsider agent init                                     # write ./SKILL.md
+dotsider agent init --path ./dotsider/SKILL.md              # write to an explicit path
+dotsider agent init --stdout                            # print to stdout
 ```
 
-### Supported `--ai` providers
-
-`claude`, `gemini`, `copilot`, `cursor-agent`, `opencode`, `codex`, `windsurf`, `kilocode`, `amp`, `qwen`
-
-Each resolves to the provider's conventional skill path relative to the current directory.
+By default, `init` writes `SKILL.md` in the current directory. Use `--path` when your agent expects skills in a specific directory.

--- a/docs/src/content/docs/reference/mcp.md
+++ b/docs/src/content/docs/reference/mcp.md
@@ -116,10 +116,10 @@ Session sockets are access-controlled. The socket directory and socket file are 
 | Dependency health | Assess dependency risk and freshness |
 | Bundle analysis | Inspect a single-file bundle: structure, entry assembly, and dependency resolution |
 
-## Generating AI skill files
+## Generating agent skill files
 
 ```
-dotsider agent init --ai claude
+dotsider agent init
 ```
 
-This writes a skill file to the provider's conventional location. Supported providers: `claude`, `gemini`, `copilot`, `cursor-agent`, `opencode`, `codex`, `windsurf`, `kilocode`, `amp`, `qwen`.
+This writes `SKILL.md` in the current directory. Use `--path` to write it directly to the location expected by your agent.

--- a/src/Dotsider/Commands/AgentCommand.cs
+++ b/src/Dotsider/Commands/AgentCommand.cs
@@ -5,30 +5,16 @@ using System.Diagnostics;
 namespace Dotsider.Commands;
 
 /// <summary>
-/// Agent command group: MCP server launch and AI skill file initialization.
+/// Agent command group: MCP server launch and agent skill file initialization.
 /// </summary>
 internal static class AgentCommand
 {
-    private static readonly Dictionary<string, string> s_providerPaths = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["claude"] = Path.Combine(".claude", "skills", "dotsider", "SKILL.md"),
-        ["gemini"] = Path.Combine(".gemini", "skills", "dotsider", "SKILL.md"),
-        ["copilot"] = Path.Combine(".github", "skills", "dotsider", "SKILL.md"),
-        ["cursor-agent"] = Path.Combine(".cursor", "skills", "dotsider", "SKILL.md"),
-        ["opencode"] = Path.Combine(".opencode", "skill", "dotsider", "SKILL.md"),
-        ["codex"] = Path.Combine(".agents", "skills", "dotsider", "SKILL.md"),
-        ["windsurf"] = Path.Combine(".windsurf", "skills", "dotsider", "SKILL.md"),
-        ["kilocode"] = Path.Combine(".kilocode", "skills", "dotsider", "SKILL.md"),
-        ["amp"] = Path.Combine(".agents", "skills", "dotsider", "SKILL.md"),
-        ["qwen"] = Path.Combine(".qwen", "skills", "dotsider", "SKILL.md"),
-    };
-
     /// <summary>
     /// Creates the "agent" command with "mcp" and "init" subcommands.
     /// </summary>
     public static Command Create(Option<bool> jsonOption)
     {
-        var command = new Command("agent", "MCP server and AI skill file management");
+        var command = new Command("agent", "MCP server and agent skill file management");
 
         command.Subcommands.Add(CreateMcpCommand());
         command.Subcommands.Add(CreateInitCommand(jsonOption));
@@ -104,14 +90,9 @@ internal static class AgentCommand
 
     private static Command CreateInitCommand(Option<bool> jsonOption)
     {
-        var aiOption = new Option<string?>("--ai")
-        {
-            Description = "AI provider — writes to the provider's skill path relative to the current directory (claude, gemini, copilot, cursor-agent, opencode, codex, windsurf, kilocode, amp, qwen)"
-        };
-
         var pathOption = new Option<string?>("--path")
         {
-            Description = "Explicit output file path"
+            Description = "Output file path (default: ./SKILL.md)"
         };
 
         var forceOption = new Option<bool>("--force")
@@ -124,9 +105,8 @@ internal static class AgentCommand
             Description = "Write skill content to stdout instead of a file"
         };
 
-        var command = new Command("init", "Initialize an AI skill file for dotsider")
+        var command = new Command("init", "Initialize an agent skill file for dotsider")
         {
-            aiOption,
             pathOption,
             forceOption,
             stdoutOption
@@ -134,7 +114,6 @@ internal static class AgentCommand
 
         command.SetAction((parseResult, _) =>
         {
-            var ai = parseResult.GetValue(aiOption);
             var path = parseResult.GetValue(pathOption);
             var force = parseResult.GetValue(forceOption);
             var stdout = parseResult.GetValue(stdoutOption);
@@ -150,28 +129,7 @@ internal static class AgentCommand
                 return Task.FromResult(0);
             }
 
-            // Resolve output path
-            string outputPath;
-            if (path is not null)
-            {
-                outputPath = Path.GetFullPath(path);
-            }
-            else if (ai is not null)
-            {
-                if (!s_providerPaths.TryGetValue(ai, out var relativePath))
-                {
-                    OutputFormatter.WriteError($"Error: Unknown provider '{ai}'.");
-                    OutputFormatter.WriteError($"Valid providers: {string.Join(", ", s_providerPaths.Keys.Order())}");
-                    return Task.FromResult(1);
-                }
-
-                outputPath = Path.GetFullPath(relativePath);
-            }
-            else
-            {
-                OutputFormatter.WriteError("Error: Specify --ai <provider>, --path <file>, or --stdout.");
-                return Task.FromResult(1);
-            }
+            var outputPath = Path.GetFullPath(path ?? "SKILL.md");
 
             // Check for existing file
             if (File.Exists(outputPath) && !force)
@@ -189,7 +147,7 @@ internal static class AgentCommand
             if (json)
             {
                 using var formatter = new OutputFormatter { JsonMode = true };
-                formatter.WriteJson(new { Path = outputPath, Provider = ai ?? "custom" });
+                formatter.WriteJson(new { Path = outputPath });
             }
             else
             {
@@ -204,7 +162,7 @@ internal static class AgentCommand
     }
 
     /// <summary>
-    /// Returns the SKILL.md content for AI provider integration.
+    /// Returns the SKILL.md content for agent integration.
     /// </summary>
     internal static string GetSkillContent() => """
         ---

--- a/src/Dotsider/README.md
+++ b/src/Dotsider/README.md
@@ -55,14 +55,14 @@ dotsider sessions trace stop <pid>          # stop tracing
 
 ### agent
 
-MCP server and AI skill file management.
+MCP server and agent skill file management.
 
 ```
 dotsider agent mcp                          # launch MCP server (dotsider-mcp)
+dotsider agent init                         # create ./SKILL.md
 dotsider agent init --stdout                # print skill file to stdout
-dotsider agent init --ai claude             # create .claude/skills/dotsider/SKILL.md
-dotsider agent init --ai claude --force     # overwrite existing
 dotsider agent init --path /tmp/SKILL.md    # write to explicit path
+dotsider agent init --force                 # overwrite existing ./SKILL.md
 ```
 
 ### diff

--- a/tests/Dotsider.Tests/AgentCliTests.cs
+++ b/tests/Dotsider.Tests/AgentCliTests.cs
@@ -141,7 +141,10 @@ public sealed class AgentCliTests
             Assert.AreEqual(0, exitCode);
             var expectedPath = Path.Combine(tempDir, "SKILL.md");
             Assert.IsTrue(File.Exists(expectedPath), $"Expected file at {expectedPath}");
-            Assert.Contains($"Created: {expectedPath}", stdout);
+            Assert.StartsWith("Created: ", stdout);
+            var createdPath = stdout["Created: ".Length..].Trim();
+            Assert.AreEqual("SKILL.md", Path.GetFileName(createdPath));
+            Assert.IsTrue(File.Exists(createdPath), $"Expected reported file at {createdPath}");
             Assert.Contains("name: dotsider", File.ReadAllText(expectedPath));
         }
         finally

--- a/tests/Dotsider.Tests/AgentCliTests.cs
+++ b/tests/Dotsider.Tests/AgentCliTests.cs
@@ -6,7 +6,7 @@ namespace Dotsider.Tests;
 /// CLI integration tests for the agent command.
 /// </summary>
 [TestClass]
-public class AgentCliTests
+public sealed class AgentCliTests
 {
     private static readonly string s_projectPath = Path.Combine(
         TestHelpers.GetRepoRoot(), "src", "Dotsider");
@@ -124,10 +124,10 @@ public class AgentCliTests
     }
 
     /// <summary>
-    /// Verifies agent init with ai creates correct path.
+    /// Verifies agent init creates SKILL.md in the current directory by default.
     /// </summary>
     [TestMethod]
-    public async Task Agent_Init_WithAi_CreatesCorrectPath()
+    public async Task Agent_Init_NoOptions_CreatesSkillInCurrentDirectory()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"dotsider-test-{Guid.NewGuid():N}");
 
@@ -135,35 +135,20 @@ public class AgentCliTests
         {
             Directory.CreateDirectory(tempDir);
 
-            // --ai claude resolves .claude/skills/dotsider/SKILL.md relative to cwd
             var (exitCode, stdout, _) = await RunDotsiderInDirAsync(
-                tempDir, "agent", "init", "--ai", "claude");
+                tempDir, "agent", "init");
 
             Assert.AreEqual(0, exitCode);
-
-            var expectedPath = Path.Combine(tempDir, ".claude", "skills", "dotsider", "SKILL.md");
+            var expectedPath = Path.Combine(tempDir, "SKILL.md");
             Assert.IsTrue(File.Exists(expectedPath), $"Expected file at {expectedPath}");
+            Assert.Contains($"Created: {expectedPath}", stdout);
+            Assert.Contains("name: dotsider", File.ReadAllText(expectedPath));
         }
         finally
         {
             if (Directory.Exists(tempDir))
                 CleanupTempDir(tempDir);
         }
-    }
-
-    /// <summary>
-    /// Verifies agent init no args shows usage error.
-    /// </summary>
-    [TestMethod]
-    public async Task Agent_Init_NoArgs_ShowsUsageError()
-    {
-        var (exitCode, _, stderr) = await RunDotsiderAsync(
-            "agent", "init");
-
-        Assert.AreNotEqual(0, exitCode);
-        Assert.Contains("--ai", stderr);
-        Assert.Contains("--path", stderr);
-        Assert.Contains("--stdout", stderr);
     }
 
     /// <summary>


### PR DESCRIPTION
`dotsider agent init` now writes `SKILL.md` to the current directory when no output option is supplied. `--path` remains available for callers that need a specific location, while `--stdout` and `--force` keep their existing roles.

This removes the provider lookup and keeps dotsider independent of vendor directory conventions. The CLI help, JSON output, tests, README files, and reference docs now describe the same behavior.

Fixes: #258