### PR TITLE
Add a reproducible development container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/base:noble
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clang \
+        llvm \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,34 @@
+# Development container
+
+Open the repository in Visual Studio Code and run **Dev Containers: Reopen in
+Container**. The first creation restores the .NET and documentation dependencies
+and installs the Hex1b CLI.
+
+The container includes the .NET 10 SDK, Native AOT prerequisites, the
+`wasm-tools` workload, Node.js, pnpm, GitHub CLI, LLVM, and an isolated Docker
+daemon. The Hex1b CLI is installed at the version used by dotsider and is
+available through the `hex1b` command.
+
+Docker-in-Docker requires the development container to run privileged. It uses
+its own Docker storage and does not mount the host Docker socket.
+
+MSBuild outputs use `bin/devcontainer` and `obj/devcontainer`, while test
+fixtures use dedicated container configurations. Windows and Linux builds do
+not share generated files, and existing host build outputs are left alone.
+
+The normal build and test workflow is unchanged:
+
+```console
+dotnet build
+dotnet test
+```
+
+Run the deployment integration tests explicitly:
+
+```console
+DOTSIDER_RUN_DEPLOY_INTEGRATION=1 dotnet test tests/Dotsider.Deploy.Tests/Dotsider.Deploy.Tests.csproj
+```
+
+The container provides the Linux development environment. Windows-specific,
+macOS-specific, and cross-platform release coverage remains in CI. CI also
+scans the built container image for secrets with Picket.

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:4": {
+      "version": "4.0.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",
+      "integrity": "sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5"
+    },
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "2.5.0",
+      "resolved": "ghcr.io/devcontainers/features/dotnet@sha256:0fc16547ed4db6d7ff2a9f5981d2b93eb314e568affb9958029ad794f1f9a093",
+      "integrity": "sha256:0fc16547ed4db6d7ff2a9f5981d2b93eb314e568affb9958029ad794f1f9a093"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "2.1.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857",
+      "integrity": "sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,63 @@
+{
+  "name": "dotsider",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "10.0.302",
+      "workloads": "wasm-tools"
+    },
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "22",
+      "pnpmVersion": "10.28.0"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:4": {
+      "dockerDashComposeVersion": "none"
+    }
+  },
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "64gb"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "astro-build.astro-vscode",
+        "github.vscode-github-actions",
+        "ms-dotnettools.csdevkit"
+      ],
+      "settings": {
+        "dotnet.defaultSolution": "Dotsider.slnx",
+        "dotnet.preferVisualStudioCodeFileSystemWatcher": true
+      }
+    }
+  },
+  "forwardPorts": [
+    4321,
+    5174
+  ],
+  "portsAttributes": {
+    "4321": {
+      "label": "Documentation"
+    },
+    "5174": {
+      "label": "Website"
+    }
+  },
+  "remoteEnv": {
+    "Demo__SampleAssembly": "${containerWorkspaceFolder}/samples/RichLibrary/bin/devcontainer/Debug/net10.0/RichLibrary.dll",
+    "DOTSIDER_DEV_CONTAINER": "1",
+    "PATH": "${containerWorkspaceFolder}/src/Dotsider/bin/devcontainer/Debug/net10.0:/home/vscode/.dotnet/tools:${containerEnv:PATH}"
+  },
+  "postCreateCommand": [
+    "dotnet",
+    "run",
+    "--file",
+    "./scripts/Initialize-DevContainer.cs"
+  ],
+  "waitFor": "postCreateCommand",
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/picket-image.ignore
+++ b/.devcontainer/picket-image.ignore
@@ -1,0 +1,2 @@
+# GNU Privacy Guard manual included by the base image.
+sha256:03aebbff795f9aedefa7c850889fa674e55d5a43b8b1bb8fc711e1cdd6bb3582

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
+* text=auto
+
 scripts/*.cs text eol=lf
 scripts/**/*.cs text eol=lf
+.devcontainer/* text eol=lf
 deploy/Caddyfile text eol=lf
 deploy/*.json text eol=lf
 deploy/*.service text eol=lf

--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -15,6 +15,8 @@ on:
       - 'scripts/Directory.Build.props'
       - 'scripts/Initialize-DevContainer.cs'
       - 'scripts/ScriptSupport.cs'
+      - 'tests/Dotsider.Deploy.Tests/**'
+      - 'tests/deploy/**'
   pull_request:
     branches: [main]
     paths:
@@ -29,6 +31,8 @@ on:
       - 'scripts/Directory.Build.props'
       - 'scripts/Initialize-DevContainer.cs'
       - 'scripts/ScriptSupport.cs'
+      - 'tests/Dotsider.Deploy.Tests/**'
+      - 'tests/deploy/**'
   schedule:
     - cron: '23 9 * * 1'
   workflow_dispatch:
@@ -55,6 +59,7 @@ jobs:
             dotnet clean
             dotnet build --no-restore
             dotnet test --no-build
+            DOTSIDER_RUN_DEPLOY_INTEGRATION=1 dotnet test tests/Dotsider.Deploy.Tests/Dotsider.Deploy.Tests.csproj --no-build
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -52,6 +52,7 @@ jobs:
           imageTag: ci
           push: never
           runCmd: |
+            dotnet clean
             dotnet build --no-restore
             dotnet test --no-build
 

--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -1,0 +1,90 @@
+name: Dev container
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.devcontainer/**'
+      - '.github/workflows/dev-container.yml'
+      - '.gitattributes'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
+      - 'global.json'
+      - 'docs/package.json'
+      - 'docs/pnpm-lock.yaml'
+      - 'scripts/Directory.Build.props'
+      - 'scripts/Initialize-DevContainer.cs'
+      - 'scripts/ScriptSupport.cs'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.devcontainer/**'
+      - '.github/workflows/dev-container.yml'
+      - '.gitattributes'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
+      - 'global.json'
+      - 'docs/package.json'
+      - 'docs/pnpm-lock.yaml'
+      - 'scripts/Directory.Build.props'
+      - 'scripts/Initialize-DevContainer.cs'
+      - 'scripts/ScriptSupport.cs'
+  schedule:
+    - cron: '23 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Build and validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build the development container
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: dotsider-devcontainer
+          imageTag: ci
+          push: never
+          runCmd: dotnet build --no-restore
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.302'
+
+      - name: Install Picket
+        run: dotnet tool install --global Picket --version 0.2.9
+
+      - name: Save the development container image
+        run: docker save dotsider-devcontainer:ci --output ${{ runner.temp }}/dotsider-devcontainer.tar
+
+      - name: Scan the development container for secrets
+        run: >-
+          picket scan
+          --docker-archive ${{ runner.temp }}/dotsider-devcontainer.tar
+          --ignore-path .devcontainer/picket-image.ignore
+          --report-format sarif
+          --report-path ${{ runner.temp }}/dotsider-devcontainer.picket.sarif
+          --redact 100
+          --max-target-megabytes 64
+          --max-archive-depth 2
+          --max-archive-entries 100000
+          --max-archive-megabytes 8192
+          --max-archive-ratio 1000
+          --timeout 900
+          --exit-code 1
+          --no-banner
+
+      - name: Upload Picket report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: dev-container-picket
+          path: ${{ runner.temp }}/dotsider-devcontainer.picket.sarif
+          if-no-files-found: warn

--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -51,7 +51,9 @@ jobs:
           imageName: dotsider-devcontainer
           imageTag: ci
           push: never
-          runCmd: dotnet build --no-restore
+          runCmd: |
+            dotnet build --no-restore
+            dotnet test --no-build
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,14 @@ dotnet test
 
 First test run is slower — the test setup prepares the 38-project sample matrix and restores its NuGet packages. Platform-specific fixtures are built where supported, and subsequent runs use cache.
 
+### Development container
+
+The checked-in development container provides the complete Linux toolchain,
+including Native AOT prerequisites, documentation tools, Docker, and the Hex1b
+CLI. Open the repository in Visual Studio Code and run **Dev Containers: Reopen
+in Container**. See [`.devcontainer/README.md`](.devcontainer/README.md) for the
+included tools and Docker security model.
+
 ## Project layout
 
 The README covers the full structure. The short version:
@@ -30,6 +38,7 @@ The README covers the full structure. The short version:
 - `tests/Dotsider.Mcp.Tests/` — MCP tool and prompt tests.
 - `tests/Dotsider.Deploy.Tests/` — deployment unit and Debian container tests.
 - `benchmarks/Dotsider.Benchmarks/` — BenchmarkDotNet harness for the core analyzers.
+- `.devcontainer/` — reproducible Linux contributor environment.
 
 ## Code conventions
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,4 +5,33 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <_DotsiderDevelopmentContainerBuild
+      Condition="'$(DOTSIDER_DEV_CONTAINER)' == '1' and '$(DOTSIDER_FIXTURE_BUILD)' != '1' and '$(FileBasedProgram)' != 'true'">true</_DotsiderDevelopmentContainerBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(_DotsiderDevelopmentContainerBuild)' == 'true' and '$(MSBuildProjectName)' != 'NativeAotArtifactsConsole'">
+    <BaseOutputPath>bin/devcontainer/</BaseOutputPath>
+    <BaseIntermediateOutputPath>obj/devcontainer/</BaseIntermediateOutputPath>
+    <DefaultItemExcludes>$(DefaultItemExcludes);obj/**;bin/**;artifacts/**</DefaultItemExcludes>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(_DotsiderDevelopmentContainerBuild)' == 'true' and '$(MSBuildProjectName)' == 'NativeAotArtifactsConsole'">
+    <ArtifactsPath>$(MSBuildProjectDirectory)/artifacts/devcontainer</ArtifactsPath>
+    <DefaultItemExcludes>$(DefaultItemExcludes);obj/**;bin/**;artifacts/**</DefaultItemExcludes>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'DevContainerDebug'">
+    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'DevContainerRelease'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ tests/Dotsider.Deploy.Tests/
 
 tests/Shared/                 Shared MSTest settings, assertions, and socket identifiers
 scripts/                      Test, deployment, and native-disassembly utilities
+.devcontainer/                Reproducible Linux contributor environment
 benchmarks/Dotsider.Benchmarks/ BenchmarkDotNet performance suite
 docs/                         Starlight documentation site
 deploy/                       Hosted-demo deployment and monitoring configuration

--- a/benchmarks/Dotsider.Benchmarks/BenchmarkHelpers.cs
+++ b/benchmarks/Dotsider.Benchmarks/BenchmarkHelpers.cs
@@ -12,6 +12,13 @@ namespace Dotsider.Benchmarks;
 internal static class BenchmarkHelpers
 {
     private static readonly ConcurrentDictionary<string, string> BuildCache = new();
+    private static readonly string s_buildOutputRoot =
+        string.Equals(
+            Environment.GetEnvironmentVariable("DOTSIDER_DEV_CONTAINER"),
+            "1",
+            StringComparison.Ordinal)
+            ? Path.Combine("bin", "devcontainer")
+            : "bin";
     private static string? _repoRoot;
 
     /// <summary>
@@ -100,7 +107,7 @@ internal static class BenchmarkHelpers
     internal static string GetPublishPath(string relativePath, string assemblyName)
     {
         var rid = RuntimeInformation.RuntimeIdentifier;
-        return Path.Combine(GetRepoRoot(), relativePath, "bin", "Release", "net10.0", rid, "publish",
+        return Path.Combine(GetRepoRoot(), relativePath, s_buildOutputRoot, "Release", "net10.0", rid, "publish",
             assemblyName + ApphostExtension);
     }
 
@@ -108,7 +115,7 @@ internal static class BenchmarkHelpers
     /// Computes the Debug build output path for a sample.
     /// </summary>
     internal static string GetBuildPath(string relativePath, string fileName)
-        => Path.Combine(GetRepoRoot(), relativePath, "bin", "Debug", "net10.0", fileName);
+        => Path.Combine(GetRepoRoot(), relativePath, s_buildOutputRoot, "Debug", "net10.0", fileName);
 
     private static void RunDotNet(string workingDirectory, string arguments)
     {

--- a/build/Dotsider.TraceHost.targets
+++ b/build/Dotsider.TraceHost.targets
@@ -41,6 +41,11 @@
 
   </Target>
 
+  <Target Name="CleanDotsiderTraceHostBuild"
+          BeforeTargets="Clean">
+    <RemoveDir Directories="$(_DotsiderTraceHostBuildDirectory)" />
+  </Target>
+
   <Target Name="CopyDotsiderTraceHostToOutput"
           AfterTargets="Build"
           DependsOnTargets="_PublishDotsiderTraceHost"

--- a/build/Dotsider.TraceHost.targets
+++ b/build/Dotsider.TraceHost.targets
@@ -3,8 +3,11 @@
     <_DotsiderTraceHostRoot>$(MSBuildThisFileDirectory)..\</_DotsiderTraceHostRoot>
     <_DotsiderTraceHostProjectRelativePath>src\Dotsider.TraceHost\Dotsider.TraceHost.csproj</_DotsiderTraceHostProjectRelativePath>
     <_DotsiderTraceHostProject>$([System.IO.Path]::GetFullPath('$(_DotsiderTraceHostRoot)$(_DotsiderTraceHostProjectRelativePath)'))</_DotsiderTraceHostProject>
-    <_DotsiderTraceHostPublishRelativePath>$(BaseIntermediateOutputPath)tracehost\$(MSBuildProjectName)\$(Configuration)\</_DotsiderTraceHostPublishRelativePath>
-    <_DotsiderTraceHostPublishDirectory>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\$(_DotsiderTraceHostPublishRelativePath)'))</_DotsiderTraceHostPublishDirectory>
+    <_DotsiderTraceHostBuildRelativePath>$(BaseIntermediateOutputPath)tracehost\$(MSBuildProjectName)\$(Configuration)\</_DotsiderTraceHostBuildRelativePath>
+    <_DotsiderTraceHostBuildDirectory>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\$(_DotsiderTraceHostBuildRelativePath)'))</_DotsiderTraceHostBuildDirectory>
+    <_DotsiderTraceHostOutputDirectory>$(_DotsiderTraceHostBuildDirectory)bin\</_DotsiderTraceHostOutputDirectory>
+    <_DotsiderTraceHostIntermediateDirectory>$(_DotsiderTraceHostBuildDirectory)obj\</_DotsiderTraceHostIntermediateDirectory>
+    <_DotsiderTraceHostPublishDirectory>$(_DotsiderTraceHostBuildDirectory)publish\</_DotsiderTraceHostPublishDirectory>
 
     <_DotsiderTraceHostPropertiesToRemove>RuntimeIdentifier;RuntimeIdentifiers;SelfContained</_DotsiderTraceHostPropertiesToRemove>
     <_DotsiderTraceHostPropertiesToRemove>$(_DotsiderTraceHostPropertiesToRemove);PublishAot;PublishSingleFile;PublishTrimmed</_DotsiderTraceHostPropertiesToRemove>
@@ -18,6 +21,8 @@
     <_DotsiderTraceHostPublishProperties>$(_DotsiderTraceHostPublishProperties);PublishAot=false;SelfContained=false</_DotsiderTraceHostPublishProperties>
     <_DotsiderTraceHostPublishProperties>$(_DotsiderTraceHostPublishProperties);PublishSingleFile=false;PublishTrimmed=false</_DotsiderTraceHostPublishProperties>
     <_DotsiderTraceHostPublishProperties>$(_DotsiderTraceHostPublishProperties);PublishReadyToRun=false;UseAppHost=false</_DotsiderTraceHostPublishProperties>
+    <_DotsiderTraceHostPublishProperties>$(_DotsiderTraceHostPublishProperties);OutputPath=$(_DotsiderTraceHostOutputDirectory)</_DotsiderTraceHostPublishProperties>
+    <_DotsiderTraceHostPublishProperties>$(_DotsiderTraceHostPublishProperties);IntermediateOutputPath=$(_DotsiderTraceHostIntermediateDirectory)</_DotsiderTraceHostPublishProperties>
     <_DotsiderTraceHostPublishProperties>$(_DotsiderTraceHostPublishProperties);PublishDir=$(_DotsiderTraceHostPublishDirectory)</_DotsiderTraceHostPublishProperties>
 
     <_DotsiderTraceHostExcludedFiles>$(_DotsiderTraceHostPublishDirectory)**\*.pdb</_DotsiderTraceHostExcludedFiles>

--- a/samples/NetFxBindingRedirects.Clr2/NetFxBindingRedirects.Clr2.csproj
+++ b/samples/NetFxBindingRedirects.Clr2/NetFxBindingRedirects.Clr2.csproj
@@ -77,21 +77,21 @@
     <MakeDir Directories="$(OutDir)external" />
     <MakeDir Directories="$(OutDir)fr" />
 
-    <Copy SourceFiles="..\NetFxBindingRedirects.Clr2.PrivatePathLib\bin\$(Configuration)\net35\NetFxBindingRedirects.Clr2.PrivatePathLib.dll"
+    <Copy SourceFiles="..\NetFxBindingRedirects.Clr2.PrivatePathLib\$(BaseOutputPath)$(Configuration)\net35\NetFxBindingRedirects.Clr2.PrivatePathLib.dll"
           DestinationFolder="$(OutDir)lib" />
-    <Copy SourceFiles="..\NetFxBindingRedirects.Clr2.CodeBaseLib\bin\$(Configuration)\net35\NetFxBindingRedirects.Clr2.CodeBaseLib.dll"
+    <Copy SourceFiles="..\NetFxBindingRedirects.Clr2.CodeBaseLib\$(BaseOutputPath)$(Configuration)\net35\NetFxBindingRedirects.Clr2.CodeBaseLib.dll"
           DestinationFolder="$(OutDir)external" />
-    <Copy SourceFiles="..\NetFxBindingRedirects.Clr2.CulturedLib\bin\$(Configuration)\net35\NetFxBindingRedirects.Clr2.CulturedLib.dll"
+    <Copy SourceFiles="..\NetFxBindingRedirects.Clr2.CulturedLib\$(BaseOutputPath)$(Configuration)\net35\NetFxBindingRedirects.Clr2.CulturedLib.dll"
           DestinationFolder="$(OutDir)" />
     <!-- The fr satellite is produced by CulturedLib's BuildFrSatellite target, which skips on
          hosts without the v3.5 framework csc.exe (Linux/macOS, Windows-without-.NET-3.5). The
          live-runtime CLR 2 tests are gated on Clr2RuntimePresent and skip cleanly on those
          hosts, so leave this copy conditional on the satellite actually existing. -->
-    <Copy SourceFiles="..\NetFxBindingRedirects.Clr2.CulturedLib\bin\$(Configuration)\net35\fr\NetFxBindingRedirects.Clr2.CulturedLib.resources.dll"
+    <Copy SourceFiles="..\NetFxBindingRedirects.Clr2.CulturedLib\$(BaseOutputPath)$(Configuration)\net35\fr\NetFxBindingRedirects.Clr2.CulturedLib.resources.dll"
           DestinationFolder="$(OutDir)fr"
-          Condition="Exists('..\NetFxBindingRedirects.Clr2.CulturedLib\bin\$(Configuration)\net35\fr\NetFxBindingRedirects.Clr2.CulturedLib.resources.dll')" />
+          Condition="Exists('..\NetFxBindingRedirects.Clr2.CulturedLib\$(BaseOutputPath)$(Configuration)\net35\fr\NetFxBindingRedirects.Clr2.CulturedLib.resources.dll')" />
     <!-- Stage SharedDep V2 (the redirect target) app-local. -->
-    <Copy SourceFiles="..\NetFxBindingRedirects.Clr2.SharedDep.V2\bin\$(Configuration)\net35\NetFxBindingRedirects.Clr2.SharedDep.dll"
+    <Copy SourceFiles="..\NetFxBindingRedirects.Clr2.SharedDep.V2\$(BaseOutputPath)$(Configuration)\net35\NetFxBindingRedirects.Clr2.SharedDep.dll"
           DestinationFolder="$(OutDir)" />
   </Target>
 </Project>

--- a/samples/NetFxBindingRedirects/NetFxBindingRedirects.csproj
+++ b/samples/NetFxBindingRedirects/NetFxBindingRedirects.csproj
@@ -53,9 +53,9 @@
     <MakeDir Directories="$(OutDir)external" />
     <MakeDir Directories="$(OutDir)fr" />
 
-    <Copy SourceFiles="..\NetFxBindingRedirects.PrivatePathLib\bin\$(Configuration)\net48\NetFxBindingRedirects.PrivatePathLib.dll" DestinationFolder="$(OutDir)lib" />
-    <Copy SourceFiles="..\NetFxBindingRedirects.CodeBaseLib\bin\$(Configuration)\net48\NetFxBindingRedirects.CodeBaseLib.dll" DestinationFolder="$(OutDir)external" />
-    <Copy SourceFiles="..\NetFxBindingRedirects.CulturedLib\bin\$(Configuration)\net48\CulturedLib.dll" DestinationFolder="$(OutDir)" />
-    <Copy SourceFiles="..\NetFxBindingRedirects.CulturedLib\bin\$(Configuration)\net48\fr\CulturedLib.resources.dll" DestinationFolder="$(OutDir)fr" />
+    <Copy SourceFiles="..\NetFxBindingRedirects.PrivatePathLib\$(BaseOutputPath)$(Configuration)\net48\NetFxBindingRedirects.PrivatePathLib.dll" DestinationFolder="$(OutDir)lib" />
+    <Copy SourceFiles="..\NetFxBindingRedirects.CodeBaseLib\$(BaseOutputPath)$(Configuration)\net48\NetFxBindingRedirects.CodeBaseLib.dll" DestinationFolder="$(OutDir)external" />
+    <Copy SourceFiles="..\NetFxBindingRedirects.CulturedLib\$(BaseOutputPath)$(Configuration)\net48\CulturedLib.dll" DestinationFolder="$(OutDir)" />
+    <Copy SourceFiles="..\NetFxBindingRedirects.CulturedLib\$(BaseOutputPath)$(Configuration)\net48\fr\CulturedLib.resources.dll" DestinationFolder="$(OutDir)fr" />
   </Target>
 </Project>

--- a/scripts/Initialize-DevContainer.cs
+++ b/scripts/Initialize-DevContainer.cs
@@ -1,0 +1,234 @@
+#!/usr/bin/env -S dotnet --
+#:property TargetFramework=net10.0
+#:property PackAsTool=false
+#:include ScriptSupport.cs
+
+using System.Diagnostics;
+using System.Xml.Linq;
+
+const string cliPackageId = "Hex1b.Tool";
+
+if (args.Length == 1 && IsHelpArgument(args[0]))
+{
+    Console.WriteLine("Initializes the dotsider development container.");
+    Console.WriteLine("Restores repository dependencies and installs Hex1b.Tool.");
+    return 0;
+}
+
+if (args.Length != 0)
+{
+    Console.Error.WriteLine($"Unexpected argument '{args[0]}'. Use --help for usage.");
+    return 2;
+}
+
+if (!OperatingSystem.IsLinux()
+    || !string.Equals(
+        Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"),
+        "true",
+        StringComparison.OrdinalIgnoreCase))
+{
+    Console.Error.WriteLine("This utility must run inside the dotsider development container.");
+    return 1;
+}
+
+try
+{
+    string repositoryRoot = ScriptSupport.FindRepositoryRoot();
+    string hex1bVersion = ReadHex1bVersion(repositoryRoot);
+
+    ConfigureGitSafeDirectory(repositoryRoot);
+    InstallOrUpdateGlobalTool(repositoryRoot, cliPackageId, hex1bVersion);
+
+    RunCommand("dotnet", ["restore", "Dotsider.slnx"], repositoryRoot);
+    RestoreFileApps(repositoryRoot);
+    RunCommand(
+        "pnpm",
+        ["install", "--frozen-lockfile"],
+        Path.Combine(repositoryRoot, "docs"),
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["CI"] = "true",
+        });
+
+    VerifyCommand("dotnet", ["--version"], repositoryRoot);
+    VerifyCommand("node", ["--version"], repositoryRoot);
+    VerifyCommand("pnpm", ["--version"], repositoryRoot);
+    VerifyCommand("clang", ["--version"], repositoryRoot);
+    VerifyCommand("llvm-objdump", ["--version"], repositoryRoot);
+    VerifyCommand("docker", ["version", "--format", "{{.Server.Version}}"], repositoryRoot);
+    VerifyGlobalToolVersion(ReadGlobalTools(repositoryRoot), cliPackageId, hex1bVersion);
+
+    Console.WriteLine();
+    Console.WriteLine("Development container initialization completed.");
+    return 0;
+}
+catch (Exception ex) when (ex is FileNotFoundException or InvalidOperationException or IOException or UnauthorizedAccessException)
+{
+    Console.Error.WriteLine(ex.Message);
+    return 1;
+}
+
+static bool IsHelpArgument(string argument)
+{
+    return argument is "--help" or "-h" or "-Help" or "-?";
+}
+
+static void ConfigureGitSafeDirectory(string repositoryRoot)
+{
+    (int exitCode, string stdout, string stderr, _, _, _) = ScriptSupport.RunProcess(
+        "git",
+        ["config", "--global", "--get-all", "safe.directory"],
+        repositoryRoot);
+    if (exitCode is not 0 and not 1)
+    {
+        throw new InvalidOperationException(
+            $"git config failed with exit code {exitCode}.{Environment.NewLine}{stderr}");
+    }
+
+    bool isConfigured = stdout
+        .Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries)
+        .Contains(repositoryRoot, StringComparer.Ordinal);
+    if (!isConfigured)
+    {
+        RunCommand(
+            "git",
+            ["config", "--global", "--add", "safe.directory", repositoryRoot],
+            repositoryRoot);
+    }
+}
+
+static string ReadHex1bVersion(string repositoryRoot)
+{
+    string packageFile = Path.Combine(repositoryRoot, "Directory.Packages.props");
+    XDocument document = XDocument.Load(packageFile, LoadOptions.None);
+    XElement? packageVersion = document
+        .Descendants()
+        .SingleOrDefault(element =>
+            element.Name.LocalName == "PackageVersion"
+            && string.Equals(
+                element.Attribute("Include")?.Value,
+                "Hex1b",
+                StringComparison.OrdinalIgnoreCase));
+    string? version = packageVersion?.Attribute("Version")?.Value;
+    return !string.IsNullOrWhiteSpace(version)
+        ? version
+        : throw new InvalidOperationException($"Hex1b does not have a version in '{packageFile}'.");
+}
+
+static void RestoreFileApps(string repositoryRoot)
+{
+    string[] fileApps =
+    [
+        "scripts/Capture-DisasmOracle.cs",
+        "scripts/Deploy-Website.cs",
+        "scripts/Run-Tests.cs",
+        "scripts/Verify-NativeAot.cs",
+    ];
+    foreach (string fileApp in fileApps)
+    {
+        RunCommand(
+            "dotnet",
+            ["restore", fileApp, "--nologo", "--verbosity", "quiet"],
+            repositoryRoot);
+    }
+}
+
+static void InstallOrUpdateGlobalTool(string repositoryRoot, string packageId, string version)
+{
+    Dictionary<string, string> installedTools = ReadGlobalTools(repositoryRoot);
+    string verb = installedTools.ContainsKey(packageId) ? "update" : "install";
+    var arguments = new List<string>
+    {
+        "tool",
+        verb,
+        "--global",
+        packageId,
+        "--version",
+        version,
+    };
+    if (verb == "update")
+    {
+        arguments.Add("--allow-downgrade");
+    }
+
+    RunCommand("dotnet", arguments, repositoryRoot);
+}
+
+static void VerifyGlobalToolVersion(
+    IReadOnlyDictionary<string, string> installedTools,
+    string packageId,
+    string expectedVersion)
+{
+    if (!installedTools.TryGetValue(packageId, out string? actualVersion)
+        || !string.Equals(actualVersion, expectedVersion, StringComparison.Ordinal))
+    {
+        throw new InvalidOperationException(
+            $"Expected global tool {packageId} {expectedVersion}, but found {actualVersion ?? "nothing"}.");
+    }
+}
+
+static Dictionary<string, string> ReadGlobalTools(string repositoryRoot)
+{
+    (int exitCode, string stdout, string stderr, _, _, _) = ScriptSupport.RunProcess(
+        "dotnet",
+        ["tool", "list", "--global"],
+        repositoryRoot);
+    if (exitCode != 0)
+    {
+        throw new InvalidOperationException(
+            $"dotnet tool list --global failed with exit code {exitCode}.{Environment.NewLine}{stderr}");
+    }
+
+    var tools = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    foreach (string line in stdout.Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries))
+    {
+        string[] columns = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (columns.Length >= 2 && Version.TryParse(columns[1], out _))
+        {
+            tools[columns[0]] = columns[1];
+        }
+    }
+
+    return tools;
+}
+
+static void VerifyCommand(string fileName, IReadOnlyList<string> arguments, string workingDirectory)
+{
+    Console.WriteLine();
+    Console.WriteLine($"Verifying {fileName}...");
+    RunCommand(fileName, arguments, workingDirectory);
+}
+
+static void RunCommand(
+    string fileName,
+    IReadOnlyList<string> arguments,
+    string workingDirectory,
+    IReadOnlyDictionary<string, string>? environment = null)
+{
+    var startInfo = new ProcessStartInfo(fileName)
+    {
+        UseShellExecute = false,
+        WorkingDirectory = workingDirectory,
+    };
+    foreach (string argument in arguments)
+    {
+        startInfo.ArgumentList.Add(argument);
+    }
+
+    if (environment is not null)
+    {
+        foreach ((string name, string value) in environment)
+        {
+            startInfo.Environment[name] = value;
+        }
+    }
+
+    using Process process = Process.Start(startInfo)
+        ?? throw new InvalidOperationException($"Failed to start {fileName}.");
+    process.WaitForExit();
+    if (process.ExitCode != 0)
+    {
+        throw new InvalidOperationException(
+            $"{fileName} exited with code {process.ExitCode} in '{workingDirectory}'.");
+    }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,7 @@ Run a utility with `dotnet run --file`:
 
 ```powershell
 dotnet run --file ./scripts/Run-Tests.cs
+dotnet run --file ./scripts/Initialize-DevContainer.cs
 dotnet run --file ./scripts/Deploy-Website.cs -- -Mode Package -DeployHost publish/deploy-host/dotsider-deploy-host
 dotnet run --file ./scripts/Capture-DisasmOracle.cs -- -Architecture riscv64 -Fixture path/to/blob.bin -OraclePath llvm-objdump -OutputDirectory artifacts/oracles/disasm -RuntimeRoot path/to/runtime -- -D -b binary -m riscv:rv64 path/to/blob.bin
 dotnet run --file ./scripts/Verify-NativeAot.cs -- -Mode CI -Rid linux-x64 -Version 0.0.0-ci
@@ -39,6 +40,7 @@ Current utilities:
 | --- | --- |
 | `Capture-DisasmOracle.cs` | Capture external native-disassembly oracle output and metadata. |
 | `Deploy-Website.cs` | Package, provision, preflight, or deploy the dotsider.dev website. |
+| `Initialize-DevContainer.cs` | Restore dependencies and install the Hex1b CLI in the development container. |
 | `Run-Tests.cs` | Run `dotnet test` once or repeatedly with forwarded test arguments. |
 | `Verify-NativeAot.cs` | Publish, package, and smoke-test Native AOT CI and release payloads. |
 

--- a/scripts/Run-Tests.cs
+++ b/scripts/Run-Tests.cs
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S dotnet --
 #:property TargetFramework=net10.0
 #:property PackAsTool=false
-#:package System.CommandLine@2.0.9
+#:package System.CommandLine
 #:include ScriptSupport.cs
 
 using System.CommandLine;

--- a/scripts/Verify-NativeAot.cs
+++ b/scripts/Verify-NativeAot.cs
@@ -179,16 +179,25 @@ internal static class NativeAotVerificationApp
         string symbolRoot = Path.Combine(outputRoot, "symbols");
         string packageRoot = Path.Combine(outputRoot, "packages");
         string smokeOutput = Path.Combine(outputRoot, "runtime-tracing");
+        string traceTargetOutput = Path.Combine(outputRoot, "runtime-tracing-target");
 
         RecreateDirectory(repositoryRoot, outputRoot);
         Directory.CreateDirectory(nativeRoot);
         Directory.CreateDirectory(symbolRoot);
         Directory.CreateDirectory(packageRoot);
         Directory.CreateDirectory(smokeOutput);
+        Directory.CreateDirectory(traceTargetOutput);
 
         RunDotnetChecked(
             repositoryRoot,
-            ["build", "samples/HelloWorld/HelloWorld.csproj", "--configuration", "Release"]);
+            [
+                "build",
+                "samples/HelloWorld/HelloWorld.csproj",
+                "--configuration",
+                "Release",
+                "--output",
+                traceTargetOutput,
+            ]);
 
         foreach ((string name, string project, string packageId) in s_products)
         {
@@ -271,14 +280,7 @@ internal static class NativeAotVerificationApp
                 smokeOutput,
             ]);
 
-        string traceTarget = Path.Combine(
-            repositoryRoot,
-            "samples",
-            "HelloWorld",
-            "bin",
-            "Release",
-            "net10.0",
-            "HelloWorld.dll");
+        string traceTarget = Path.Combine(traceTargetOutput, "HelloWorld.dll");
         string smokeExecutable = Path.Combine(
             smokeOutput,
             "Dotsider.NativeAotSmoke" + executableExtension);

--- a/src/Dotsider.TraceHost/Dotsider.TraceHost.csproj
+++ b/src/Dotsider.TraceHost/Dotsider.TraceHost.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../Dotsider.Core/Dotsider.Core.csproj"
-                      GlobalPropertiesToRemove="PublishAot;PublishDir;PublishReadyToRun;PublishSingleFile;PublishTrimmed;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;UseAppHost" />
+                      GlobalPropertiesToRemove="IntermediateOutputPath;OutputPath;PublishAot;PublishDir;PublishReadyToRun;PublishSingleFile;PublishTrimmed;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;UseAppHost" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dotsider.TraceHost/Dotsider.TraceHost.csproj
+++ b/src/Dotsider.TraceHost/Dotsider.TraceHost.csproj
@@ -18,7 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Dotsider.Core/Dotsider.Core.csproj" />
+    <ProjectReference Include="../Dotsider.Core/Dotsider.Core.csproj"
+                      GlobalPropertiesToRemove="PublishAot;PublishDir;PublishReadyToRun;PublishSingleFile;PublishTrimmed;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;UseAppHost" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dotsider.Deploy.Tests/DockerDeployFixture.cs
+++ b/tests/Dotsider.Deploy.Tests/DockerDeployFixture.cs
@@ -12,8 +12,10 @@ internal sealed class DockerDeployFixture : IDisposable
     private const int OutputLimit = 512 * 1024;
     private readonly string _repositoryRoot;
     private readonly string _dockerConfig;
+    private readonly string _builderName = "dotsider-deploy-builder-" + Guid.NewGuid().ToString("N");
     private readonly string _imageName = "dotsider-deploy-tests:" + Guid.NewGuid().ToString("N");
     private readonly string _containerName = "dotsider-deploy-tests-" + Guid.NewGuid().ToString("N");
+    private bool _builderCreated;
     private bool _containerCreated;
 
     /// <summary>
@@ -32,7 +34,7 @@ internal sealed class DockerDeployFixture : IDisposable
 
     /// <summary>
     /// Publishes Linux artifacts, starts Debian with systemd, and provisions the host.
-    /// The real website and sample are installed before activation and health verification.
+    /// A dedicated BuildKit builder isolates the image build from the default builder cache.
     /// Completion leaves the full deployment ready for independent assertions.
     /// </summary>
     internal void Initialize()
@@ -91,7 +93,32 @@ internal sealed class DockerDeployFixture : IDisposable
             ]);
         RunRequired(
             "docker",
-            ["build", "--pull", "--no-cache", "-t", _imageName, "-f", "tests/deploy/Dockerfile", "."]);
+            ["buildx", "create", "--name", _builderName, "--driver", "docker-container"]);
+        _builderCreated = true;
+        try
+        {
+            RunRequired(
+                "docker",
+                [
+                    "buildx",
+                    "build",
+                    "--builder",
+                    _builderName,
+                    "--load",
+                    "--pull",
+                    "--no-cache",
+                    "-t",
+                    _imageName,
+                    "-f",
+                    "tests/deploy/Dockerfile",
+                    ".",
+                ]);
+        }
+        finally
+        {
+            RemoveBuilder();
+        }
+
         RunRequired(
             "docker",
             ["run", "-d", "--privileged", "--name", _containerName, _imageName]);
@@ -133,7 +160,7 @@ internal sealed class DockerDeployFixture : IDisposable
     }
 
     /// <summary>
-    /// Stops and removes the container, image, and isolated Docker configuration.
+    /// Stops and removes the builder, container, image, and isolated Docker configuration.
     /// Cleanup accepts already-removed resources and never mutates the user's Docker files.
     /// Repository artifacts are retained for test diagnostics.
     /// </summary>
@@ -145,6 +172,7 @@ internal sealed class DockerDeployFixture : IDisposable
         }
 
         _ = Run("docker", ["image", "rm", "-f", _imageName]);
+        RemoveBuilder();
         if (Directory.Exists(_dockerConfig))
         {
             Directory.Delete(_dockerConfig, recursive: true);
@@ -176,6 +204,17 @@ internal sealed class DockerDeployFixture : IDisposable
             throw new InvalidOperationException(
                 $"Container command '{arguments[0]}' failed with exit code {result.ExitCode}: {result.StandardError.Trim()}");
         }
+    }
+
+    private void RemoveBuilder()
+    {
+        if (!_builderCreated)
+        {
+            return;
+        }
+
+        DockerResult result = Run("docker", ["buildx", "rm", "--force", _builderName]);
+        _builderCreated = result.ExitCode != 0;
     }
 
     private void RunRequired(string fileName, IReadOnlyList<string> arguments)

--- a/tests/Dotsider.Mcp.Tests/McpCliTests.cs
+++ b/tests/Dotsider.Mcp.Tests/McpCliTests.cs
@@ -15,7 +15,7 @@ public partial class McpCliTests
     private static readonly string s_projectPath = Path.Combine(
         FindRepoRoot(), "src", "Dotsider.Mcp");
 
-    private static readonly string s_buildConfig = DetectBuildConfig();
+    private static readonly string s_buildConfig = TestProcessEnvironment.CurrentBuildConfiguration;
 
     /// <summary>
     /// --help prints usage text identifying the binary and exits with success.
@@ -53,7 +53,11 @@ public partial class McpCliTests
         // Launch the built DLL directly instead of going through `dotnet run`
         // which has project resolution overhead that can exceed the timeout.
         var dllPath = Path.Combine(
-            FindRepoRoot(), "src", "Dotsider.Mcp", "bin", s_buildConfig, "net10.0", "dotsider-mcp.dll");
+            TestProcessEnvironment.GetProjectOutputDirectory(
+                s_projectPath,
+                s_buildConfig,
+                "net10.0"),
+            "dotsider-mcp.dll");
         Assert.IsTrue(File.Exists(dllPath), $"dotsider-mcp.dll not found: {dllPath}");
 
         await using var client = await McpClient.CreateAsync(
@@ -105,9 +109,15 @@ public partial class McpCliTests
     {
         var repoRoot = FindRepoRoot();
         var dotsiderExe = Path.Combine(
-            repoRoot, "src", "Dotsider", "bin", s_buildConfig, "net10.0", "dotsider");
-        var mcpDir = Path.Combine(
-            repoRoot, "src", "Dotsider.Mcp", "bin", s_buildConfig, "net10.0");
+            TestProcessEnvironment.GetProjectOutputDirectory(
+                Path.Combine(repoRoot, "src", "Dotsider"),
+                s_buildConfig,
+                "net10.0"),
+            "dotsider");
+        var mcpDir = TestProcessEnvironment.GetProjectOutputDirectory(
+            Path.Combine(repoRoot, "src", "Dotsider.Mcp"),
+            s_buildConfig,
+            "net10.0");
 
         Assert.IsTrue(File.Exists(dotsiderExe), $"dotsider not found: {dotsiderExe}");
         Assert.IsTrue(File.Exists(Path.Combine(mcpDir, "dotsider-mcp")),
@@ -197,19 +207,6 @@ public partial class McpCliTests
         while (dir is not null && !Directory.Exists(Path.Combine(dir, ".git")))
             dir = Path.GetDirectoryName(dir);
         return dir ?? throw new InvalidOperationException("Could not find repo root");
-    }
-
-    private static string DetectBuildConfig()
-    {
-        // BaseDirectory is e.g. .../bin/MyConfig/net10.0/ — extract the config segment
-        var parts = AppContext.BaseDirectory.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        for (var i = 0; i < parts.Length - 1; i++)
-        {
-            if (parts[i].Equals("bin", StringComparison.OrdinalIgnoreCase))
-                return parts[i + 1];
-        }
-
-        return "Debug";
     }
 
     [GeneratedRegex(@"\e\[[^@-~]*[@-~]")]

--- a/tests/Dotsider.Mcp.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Mcp.Tests/SampleAssemblyFixture.cs
@@ -147,7 +147,8 @@ internal class SampleAssemblyFixture : IAsyncDisposable
         await PublishWasmProject("samples/ReadyToRunConsole");
         await PublishWasmProject("samples/WasmConsole");
 
-        const string config = "Debug";
+        string config = TestProcessEnvironment.DebugBuildConfiguration;
+        string releaseConfig = TestProcessEnvironment.ReleaseBuildConfiguration;
         const string tfm = "net10.0";
         var apphostExt = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
 
@@ -169,22 +170,22 @@ internal class SampleAssemblyFixture : IAsyncDisposable
 
         var rid = RuntimeInformation.RuntimeIdentifier;
         SelfContainedConsoleExe = Path.Combine(_repoRoot, "samples", "SelfContainedConsole",
-            "bin", "Release", tfm, rid, "publish", $"SelfContainedConsole{apphostExt}");
+            "bin", releaseConfig, tfm, rid, "publish", $"SelfContainedConsole{apphostExt}");
 
         NativeAotConsoleExe = Path.Combine(_repoRoot, "samples", "NativeAotConsole",
-            "bin", "Release", tfm, rid, "publish", $"NativeAotConsole{apphostExt}");
+            "bin", releaseConfig, tfm, rid, "publish", $"NativeAotConsole{apphostExt}");
 
         var r2rConsoleDll = Path.Combine(_repoRoot, "samples", "ReadyToRunConsole",
-            "bin", "Release", tfm, rid, "publish", "ReadyToRunConsole.dll");
+            "bin", releaseConfig, tfm, rid, "publish", "ReadyToRunConsole.dll");
         ReadyToRunConsoleDll = File.Exists(r2rConsoleDll) ? r2rConsoleDll : null;
         var wasmNative = Path.Combine(_repoRoot, "samples", "ReadyToRunConsole",
-            "bin", "Release", tfm, "browser-wasm", "publish", "dotnet.native.wasm");
+            "bin", releaseConfig, tfm, "browser-wasm", "publish", "dotnet.native.wasm");
         ReadyToRunConsoleWasmNativeWasm = File.Exists(wasmNative) ? wasmNative : null;
         var wasmConsoleNative = Path.Combine(_repoRoot, "samples", "WasmConsole",
-            "bin", "Release", tfm, "browser-wasm", "publish", "dotnet.native.wasm");
+            "bin", releaseConfig, tfm, "browser-wasm", "publish", "dotnet.native.wasm");
         WasmConsoleNativeWasm = File.Exists(wasmConsoleNative) ? wasmConsoleNative : null;
         var wasmConsoleWebcil = Path.Combine(_repoRoot, "samples", "WasmConsole",
-            "bin", "Release", tfm, "browser-wasm", "AppBundle", "_framework", "WasmConsole.wasm");
+            "bin", releaseConfig, tfm, "browser-wasm", "AppBundle", "_framework", "WasmConsole.wasm");
         WasmConsoleWebcilWasm = File.Exists(wasmConsoleWebcil) ? wasmConsoleWebcil : null;
 
         Assert.IsTrue(File.Exists(HelloWorldDll), $"HelloWorld.dll not found at {HelloWorldDll}");
@@ -212,7 +213,7 @@ internal class SampleAssemblyFixture : IAsyncDisposable
                 : null;
 
             var aotObjDir = Path.Combine(_repoRoot, "samples", "NativeAotConsole",
-                "obj", "Release", tfm, rid);
+                "obj", releaseConfig, tfm, rid);
             var managedDll = Path.Combine(aotObjDir, "NativeAotConsole.dll");
             NativeAotConsoleManagedDll = File.Exists(managedDll) ? managedDll : null;
         }
@@ -220,7 +221,7 @@ internal class SampleAssemblyFixture : IAsyncDisposable
         // V2 of the AOT sample: same AssemblyName, so the publish output is also named
         // NativeAotConsole — the project folder is what tells the two builds apart.
         var aotV2PublishDir = Path.Combine(_repoRoot, "samples", "NativeAotConsoleV2",
-            "bin", "Release", tfm, rid, "publish");
+            "bin", releaseConfig, tfm, rid, "publish");
         var v2Exe = Path.Combine(aotV2PublishDir, $"NativeAotConsole{apphostExt}");
         NativeAotConsoleV2Exe = File.Exists(v2Exe) ? v2Exe : null;
         var v2Mstat = Path.Combine(aotV2PublishDir, "NativeAotConsole.mstat");
@@ -248,8 +249,9 @@ internal class SampleAssemblyFixture : IAsyncDisposable
     {
         // Skip if Dotsider.Tests already built this sample
         var projectName = Path.GetFileName(relativePath);
+        var configuration = TestProcessEnvironment.DebugBuildConfiguration;
         var expectedDll = Path.Combine(_repoRoot, relativePath,
-            "bin", "Debug", "net10.0", $"{projectName}.dll");
+            "bin", configuration, "net10.0", $"{projectName}.dll");
         if (File.Exists(expectedDll))
             return;
 
@@ -283,13 +285,13 @@ internal class SampleAssemblyFixture : IAsyncDisposable
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = "build --no-restore -c Debug -v q",
+                Arguments = $"build --no-restore -c {configuration} -v q",
                 WorkingDirectory = projectDir,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
-            TestProcessEnvironment.RemoveCodeCoverageVariables(psi);
+            TestProcessEnvironment.ConfigureBuild(psi);
 
             var process = Process.Start(psi)!;
             var stdout = await process.StandardOutput.ReadToEndAsync();
@@ -309,9 +311,10 @@ internal class SampleAssemblyFixture : IAsyncDisposable
     private async Task PublishSelfContainedProject(string relativePath)
     {
         var rid = RuntimeInformation.RuntimeIdentifier;
+        var configuration = TestProcessEnvironment.ReleaseBuildConfiguration;
         var apphostExt = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
         var expectedOutput = Path.Combine(_repoRoot, relativePath,
-            "bin", "Release", "net10.0", rid, "publish",
+            "bin", configuration, "net10.0", rid, "publish",
             $"{Path.GetFileName(relativePath)}{apphostExt}");
 
         // Skip if Dotsider.Tests already published
@@ -348,11 +351,12 @@ internal class SampleAssemblyFixture : IAsyncDisposable
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = $"publish -c Release -r {rid} --self-contained -p:PublishSingleFile=true -v q",
+                Arguments = $"publish -c {configuration} -r {rid} --self-contained "
+                    + "-p:PublishSingleFile=true -v q",
                 WorkingDirectory = projectDir,
                 UseShellExecute = false,
             };
-            TestProcessEnvironment.RemoveCodeCoverageVariables(psi);
+            TestProcessEnvironment.ConfigureBuild(psi);
 
             var process = Process.Start(psi)!;
             await process.WaitForExitAsync();
@@ -370,8 +374,9 @@ internal class SampleAssemblyFixture : IAsyncDisposable
     private async Task PublishReadyToRunProject(string relativePath)
     {
         var rid = RuntimeInformation.RuntimeIdentifier;
+        var configuration = TestProcessEnvironment.ReleaseBuildConfiguration;
         var expectedOutput = Path.Combine(_repoRoot, relativePath,
-            "bin", "Release", "net10.0", rid, "publish", $"{Path.GetFileName(relativePath)}.dll");
+            "bin", configuration, "net10.0", rid, "publish", $"{Path.GetFileName(relativePath)}.dll");
 
         // Reuse the Dotsider.Tests publish when it already ran (framework-dependent crossgen).
         if (File.Exists(expectedOutput))
@@ -399,13 +404,13 @@ internal class SampleAssemblyFixture : IAsyncDisposable
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = $"publish -c Release -r {rid} --self-contained false -v q",
+                Arguments = $"publish -c {configuration} -r {rid} --self-contained false -v q",
                 WorkingDirectory = Path.Combine(_repoRoot, relativePath),
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
-            TestProcessEnvironment.RemoveCodeCoverageVariables(psi);
+            TestProcessEnvironment.ConfigureBuild(psi);
             var process = Process.Start(psi)!;
             _ = await process.StandardOutput.ReadToEndAsync();
             _ = await process.StandardError.ReadToEndAsync();
@@ -420,8 +425,9 @@ internal class SampleAssemblyFixture : IAsyncDisposable
 
     private async Task PublishWasmProject(string relativePath)
     {
+        var configuration = TestProcessEnvironment.ReleaseBuildConfiguration;
         var expectedOutput = Path.Combine(_repoRoot, relativePath,
-            "bin", "Release", "net10.0", "browser-wasm", "publish", "dotnet.native.wasm");
+            "bin", configuration, "net10.0", "browser-wasm", "publish", "dotnet.native.wasm");
 
         if (File.Exists(expectedOutput))
             return;
@@ -454,14 +460,14 @@ internal class SampleAssemblyFixture : IAsyncDisposable
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = "publish -c Release -r browser-wasm --self-contained true "
+                Arguments = $"publish -c {configuration} -r browser-wasm --self-contained true "
                     + "-p:PublishReadyToRun=false -v q",
                 WorkingDirectory = Path.Combine(_repoRoot, relativePath),
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
-            TestProcessEnvironment.RemoveCodeCoverageVariables(psi);
+            TestProcessEnvironment.ConfigureBuild(psi);
             var process = Process.Start(psi)!;
             _ = await process.StandardOutput.ReadToEndAsync();
             _ = await process.StandardError.ReadToEndAsync();
@@ -477,9 +483,10 @@ internal class SampleAssemblyFixture : IAsyncDisposable
     private async Task PublishNativeAotProject(string relativePath)
     {
         var rid = RuntimeInformation.RuntimeIdentifier;
+        var configuration = TestProcessEnvironment.ReleaseBuildConfiguration;
         var apphostExt = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
         var publishDir = Path.Combine(_repoRoot, relativePath,
-            "bin", "Release", "net10.0", rid, "publish");
+            "bin", configuration, "net10.0", rid, "publish");
         var expectedOutput = Path.Combine(publishDir,
             $"{Path.GetFileName(relativePath)}{apphostExt}");
         // The mstat sidecar joins the up-to-date check so a publish that predates sidecar
@@ -520,7 +527,7 @@ internal class SampleAssemblyFixture : IAsyncDisposable
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = $"publish -c Release -r {rid} -v q",
+                Arguments = $"publish -c {configuration} -r {rid} -v q",
                 WorkingDirectory = projectDir,
                 UseShellExecute = false,
             };
@@ -530,7 +537,7 @@ internal class SampleAssemblyFixture : IAsyncDisposable
             // is not resolved from the current directory inside FOR /F).
             // Clear it for this process only.
             psi.Environment.Remove("NoDefaultCurrentDirectoryInExePath");
-            TestProcessEnvironment.RemoveCodeCoverageVariables(psi);
+            TestProcessEnvironment.ConfigureBuild(psi);
 
             var process = Process.Start(psi)!;
             await process.WaitForExitAsync();

--- a/tests/Dotsider.Tests/AgentCliTests.cs
+++ b/tests/Dotsider.Tests/AgentCliTests.cs
@@ -11,19 +11,7 @@ public sealed class AgentCliTests
     private static readonly string s_projectPath = Path.Combine(
         TestHelpers.GetRepoRoot(), "src", "Dotsider");
 
-    private static readonly string s_buildConfig = DetectBuildConfig();
-
-    private static string DetectBuildConfig()
-    {
-        var parts = AppContext.BaseDirectory.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        for (var i = 0; i < parts.Length - 1; i++)
-        {
-            if (parts[i].Equals("bin", StringComparison.OrdinalIgnoreCase))
-                return parts[i + 1];
-        }
-
-        return "Debug";
-    }
+    private static readonly string s_buildConfig = TestProcessEnvironment.CurrentBuildConfiguration;
 
     /// <summary>
     /// Verifies agent init stdout writes skill content.

--- a/tests/Dotsider.Tests/Dotsider.Tests.csproj
+++ b/tests/Dotsider.Tests/Dotsider.Tests.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IncludeDotsiderTraceHostInOutput>true</IncludeDotsiderTraceHostInOutput>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,13 +20,6 @@
     <ProjectReference Include="../../samples/MultiModuleManifest/MultiModuleManifest.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <Target Name="CopyDotsiderTraceHostToTestOutput" AfterTargets="Build">
-    <ItemGroup>
-      <_DotsiderTraceHostTestFile Include="../../src/Dotsider/$(BaseOutputPath)$(Configuration)/net10.0/tracehost/**/*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(_DotsiderTraceHostTestFile)"
-          DestinationFiles="@(_DotsiderTraceHostTestFile->'$(OutDir)tracehost/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true" />
-  </Target>
+  <Import Project="../../build/Dotsider.TraceHost.targets" />
 
 </Project>

--- a/tests/Dotsider.Tests/Dotsider.Tests.csproj
+++ b/tests/Dotsider.Tests/Dotsider.Tests.csproj
@@ -21,7 +21,7 @@
 
   <Target Name="CopyDotsiderTraceHostToTestOutput" AfterTargets="Build">
     <ItemGroup>
-      <_DotsiderTraceHostTestFile Include="../../src/Dotsider/bin/$(Configuration)/net10.0/tracehost/**/*" />
+      <_DotsiderTraceHostTestFile Include="../../src/Dotsider/$(BaseOutputPath)$(Configuration)/net10.0/tracehost/**/*" />
     </ItemGroup>
     <Copy SourceFiles="@(_DotsiderTraceHostTestFile)"
           DestinationFiles="@(_DotsiderTraceHostTestFile->'$(OutDir)tracehost/%(RecursiveDir)%(Filename)%(Extension)')"

--- a/tests/Dotsider.Tests/DynamicYankIntegrationTests.cs
+++ b/tests/Dotsider.Tests/DynamicYankIntegrationTests.cs
@@ -469,43 +469,83 @@ public class DynamicYankIntegrationTests : IDisposable
     {
         var (terminal, app, ct) = Launch(Samples.MinimalApiDll);
         var runTask = app.RunAsync(ct);
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(15));
 
-        // Launch trace, wait for running, switch to Summary (via Counters)
-        await new Hex1bTerminalInputSequenceBuilder()
-            .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(10))
-            .WaitUntil(s => s.ContainsText("Assembly Name"), TimeSpan.FromSeconds(10))
-            .Key(Hex1bKey.D8)
-            .WaitUntil(s => s.ContainsText("EventPipe") || s.ContainsText("Launch"), TimeSpan.FromSeconds(10))
-            .Key(Hex1bKey.Enter)
-            .WaitUntil(_ => _state!.Tracer?.ProcessState == TraceProcessState.Running, TimeSpan.FromSeconds(30))
-            .Key(Hex1bKey.RightArrow)
-            .WaitUntil(_ => _state!.DynamicSubTab == DynamicSubTabId.Counters, TimeSpan.FromSeconds(5))
-            .WaitUntil(_ => IsFocusedOnEditor(), TimeSpan.FromSeconds(5))
-            .Build()
-            .ApplyAsync(terminal, ct);
+        await auto.WaitUntilAlternateScreenAsync(TimeSpan.FromSeconds(10));
+        await auto.WaitUntilTextAsync("Assembly Name", TimeSpan.FromSeconds(10));
+        await auto.KeyAsync(Hex1bKey.D8, ct);
+        await auto.WaitUntilAsync(
+            s => s.ContainsText("EventPipe") || s.ContainsText("Launch"),
+            TimeSpan.FromSeconds(10),
+            "dynamic trace controls to appear");
+        await auto.EnterAsync(ct);
+        await auto.WaitUntilAsync(
+            _ => _state!.Tracer?.ProcessState == TraceProcessState.Running,
+            TimeSpan.FromSeconds(30),
+            "trace process to start");
+        await auto.RightAsync(ct);
+        await auto.WaitUntilAsync(
+            _ => _state!.DynamicSubTab == DynamicSubTabId.Counters,
+            TimeSpan.FromSeconds(5),
+            "Counters sub-tab to become active");
+        await auto.WaitUntilAsync(
+            _ => IsFocusedOnEditor(_state!.DynamicCpuEditorState),
+            TimeSpan.FromSeconds(5),
+            "CPU editor to receive focus");
 
-        await TabOutOfCountersEditorsAsync(terminal, ct);
+        await auto.TabAsync(ct);
+        await auto.WaitUntilAsync(
+            _ => IsFocusedOnEditor(_state!.DynamicMemoryEditorState),
+            TimeSpan.FromSeconds(5),
+            "memory editor to receive focus");
+        await auto.TabAsync(ct);
+        await auto.WaitUntilAsync(
+            _ => IsFocusedOnEditor(_state!.DynamicGcEditorState),
+            TimeSpan.FromSeconds(5),
+            "GC editor to receive focus");
+        await auto.TabAsync(ct);
+        await auto.WaitUntilAsync(
+            _ => IsFocusedOnEditor(_state!.DynamicThreadingEditorState),
+            TimeSpan.FromSeconds(5),
+            "threading editor to receive focus");
+        await auto.TabAsync(ct);
+        await auto.WaitUntilAsync(
+            _ => !IsFocusedOnEditor(),
+            TimeSpan.FromSeconds(5),
+            "Counters editors to release focus");
 
-        await NavigateFromCountersToSummary()
-            .Build()
-            .ApplyAsync(terminal, ct);
-
-        Assert.IsTrue(IsFocusedOnEditor());
+        await auto.RightAsync(ct);
+        await auto.WaitUntilAsync(
+            _ => _state!.DynamicSubTab == DynamicSubTabId.Output,
+            TimeSpan.FromSeconds(5),
+            "Output sub-tab to become active");
+        await auto.RightAsync(ct);
+        await auto.WaitUntilAsync(
+            _ => _state!.DynamicSubTab == DynamicSubTabId.Summary,
+            TimeSpan.FromSeconds(5),
+            "Summary sub-tab to become active");
+        await auto.WaitUntilAsync(
+            _ => IsFocusedOnEditor(_state!.DynamicSummaryEditorState),
+            TimeSpan.FromSeconds(5),
+            "summary editor to receive focus");
 
         // Capture the frozen EditorState reference while the process is running.
         // The freeze mechanism keeps this exact instance alive while focused+running.
         var frozenState = _state!.DynamicSummaryEditorState;
+        Assert.IsNotNull(frozenState);
 
         // Wait for the tracer to accumulate some data so Duration differs from the frozen snapshot
-        await new Hex1bTerminalInputSequenceBuilder()
-            .WaitUntil(_ => true, TimeSpan.FromSeconds(3))
-            .Build()
-            .ApplyAsync(terminal, ct);
+        await auto.WaitAsync(TimeSpan.FromSeconds(3), ct);
+        await auto.WaitUntilAsync(
+            _ => _state.Tracer?.ProcessState == TraceProcessState.Running
+                && IsFocusedOnEditor(frozenState)
+                && ReferenceEquals(_state.DynamicSummaryEditorState, frozenState),
+            TimeSpan.FromSeconds(5),
+            "summary editor to remain frozen while focused");
 
         // Stop the tracer via Ctrl+K (through the UI, which naturally triggers a
         // render) rather than calling Stop() directly. Direct Stop() can race with
         // the render loop's snapshot polling.
-        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(15));
         await auto.Ctrl().KeyAsync(Hex1bKey.K, ct);
         await auto.WaitUntilTextAsync("Exited");
         await auto.WaitUntilAsync(_ => _state.DynamicSummaryEditorState != frozenState,

--- a/tests/Dotsider.Tests/IlEditorLifecycleTests.cs
+++ b/tests/Dotsider.Tests/IlEditorLifecycleTests.cs
@@ -313,6 +313,9 @@ public class IlEditorLifecycleTests : IDisposable
 
         // Switch back to original method
         SelectMethodForRender(methodA);
+        await auto.WaitUntilAsync(
+            _ => _state.IlEditorMethod?.Token == methodA.Token,
+            description: "method A loaded");
         RequestEditorFocusForRender();
         EditorNode? restoredEditorNode = null;
         await auto.WaitUntilAsync(

--- a/tests/Dotsider.Tests/MultiModuleResolutionTests.cs
+++ b/tests/Dotsider.Tests/MultiModuleResolutionTests.cs
@@ -22,14 +22,13 @@ public sealed class MultiModuleResolutionTests
     [Timeout(30_000, CooperativeCancellation = true)]
     public void Resolve_CompilerBuiltModule_PushesCompleteAnalyzer()
     {
-        var configuration = new DirectoryInfo(AppContext.BaseDirectory).Parent?.Name
-            ?? throw new InvalidOperationException("Could not determine the test build configuration.");
-        var outputDirectory = Path.Combine(
+        var projectDirectory = Path.Combine(
             TestHelpers.GetRepoRoot(),
             "samples",
-            "MultiModuleManifest",
-            "bin",
-            configuration,
+            "MultiModuleManifest");
+        var outputDirectory = TestProcessEnvironment.GetProjectOutputDirectory(
+            projectDirectory,
+            TestProcessEnvironment.CurrentBuildConfiguration,
             "net10.0");
         var manifestPath = Path.Combine(outputDirectory, "MultiModuleManifest.dll");
         var modulePath = Path.Combine(outputDirectory, "MultiModulePart.netmodule");

--- a/tests/Dotsider.Tests/NetFxBinderClr2Tests.cs
+++ b/tests/Dotsider.Tests/NetFxBinderClr2Tests.cs
@@ -356,10 +356,11 @@ public sealed class NetFxBinderClr2Tests
     private static string SignedSampleDll()
     {
         // Use the CodeBaseLib.dll the fixture builds — it's strong-named with a known PKT
-        // and lives under samples/NetFxBindingRedirects.Clr2.CodeBaseLib/bin/Debug/net35.
+        // and lives under the fixture's isolated Debug-equivalent output directory.
         var repoRoot = TestHelpers.GetRepoRoot();
         var dll = Path.Combine(repoRoot, "samples", "NetFxBindingRedirects.Clr2.CodeBaseLib",
-            "bin", "Debug", "net35", "NetFxBindingRedirects.Clr2.CodeBaseLib.dll");
+            "bin", TestProcessEnvironment.DebugBuildConfiguration, "net35",
+            "NetFxBindingRedirects.Clr2.CodeBaseLib.dll");
         Assert.IsTrue(File.Exists(dll), $"Signed sample DLL not built at {dll}");
         return dll;
     }

--- a/tests/Dotsider.Tests/PreIlcSidecarDetectorTests.cs
+++ b/tests/Dotsider.Tests/PreIlcSidecarDetectorTests.cs
@@ -523,7 +523,9 @@ public class PreIlcSidecarDetectorTests : IDisposable
         Assert.IsEmpty(result.UnresolvedReferencePaths);
     }
 
-    /// <summary>Verifies the real artifacts-layout publish maps publish→obj with obj-only sidecars.</summary>
+    /// <summary>
+    /// Verifies the real artifacts-layout publish maps publish to obj with obj-only sidecars.
+    /// </summary>
     [TestMethod]
     [Timeout(30_000, CooperativeCancellation = true)]
     public void Find_ArtifactsFixture_FindsObjSidecarsWithNoSiblings()
@@ -534,7 +536,10 @@ public class PreIlcSidecarDetectorTests : IDisposable
 
         Assert.IsNotNull(result);
         Assert.IsTrue(result!.HasAttachableCompanion);
-        Assert.Contains(Path.Combine("artifacts", "obj"), result.ManagedAssemblyPath!, StringComparison.OrdinalIgnoreCase);
+        var artifactsObj = TestProcessEnvironment.IsDevelopmentContainer
+            ? Path.Combine("artifacts", "devcontainer", "obj")
+            : Path.Combine("artifacts", "obj");
+        Assert.Contains(artifactsObj, result.ManagedAssemblyPath!, StringComparison.OrdinalIgnoreCase);
         Assert.IsNotNull(result.MstatPath);
         Assert.IsNotNull(result.CodegenDgmlPath);
 

--- a/tests/Dotsider.Tests/ReadyToRunRoutingTests.cs
+++ b/tests/Dotsider.Tests/ReadyToRunRoutingTests.cs
@@ -18,7 +18,7 @@ public class ReadyToRunRoutingTests
     private static readonly string s_projectPath = Path.Combine(
         TestHelpers.GetRepoRoot(), "src", "Dotsider");
 
-    private static readonly string s_buildConfig = DetectBuildConfig();
+    private static readonly string s_buildConfig = TestProcessEnvironment.CurrentBuildConfiguration;
 
     /// <summary>Bare <c>--r2r-correlate</c> prints the ReadyToRun stats over the image.</summary>
     [TestMethod]
@@ -83,15 +83,6 @@ public class ReadyToRunRoutingTests
         Assert.AreEqual(0, exit);
         // The import resolver names the indirect call; the multi-range body shows a funclet/cold block.
         Assert.Contains("Console.WriteLine", stdout);
-    }
-
-    private static string DetectBuildConfig()
-    {
-        var parts = AppContext.BaseDirectory.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        for (var i = 0; i < parts.Length - 1; i++)
-            if (parts[i].Equals("bin", StringComparison.OrdinalIgnoreCase))
-                return parts[i + 1];
-        return "Debug";
     }
 
     private static async Task<(int ExitCode, string Stdout, string Stderr)> RunDotsiderAsync(

--- a/tests/Dotsider.Tests/ReleaseWorkflowTests.cs
+++ b/tests/Dotsider.Tests/ReleaseWorkflowTests.cs
@@ -57,6 +57,26 @@ public class ReleaseWorkflowTests
         Assert.Contains(
             "<_DotsiderTraceHostPublishDirectory>$(_DotsiderTraceHostBuildDirectory)publish\\",
             targets);
+        Assert.Contains(
+            "<Target Name=\"CleanDotsiderTraceHostBuild\"",
+            targets);
+        Assert.Contains(
+            "<RemoveDir Directories=\"$(_DotsiderTraceHostBuildDirectory)\" />",
+            targets);
+
+        string testProject = File.ReadAllText(Path.Combine(
+            TestHelpers.GetRepoRoot(),
+            "tests",
+            "Dotsider.Tests",
+            "Dotsider.Tests.csproj"));
+
+        Assert.Contains(
+            "<IncludeDotsiderTraceHostInOutput>true</IncludeDotsiderTraceHostInOutput>",
+            testProject);
+        Assert.Contains(
+            "<Import Project=\"../../build/Dotsider.TraceHost.targets\" />",
+            testProject);
+        Assert.DoesNotContain("CopyDotsiderTraceHostToTestOutput", testProject);
     }
 
     /// <summary>

--- a/tests/Dotsider.Tests/ReleaseWorkflowTests.cs
+++ b/tests/Dotsider.Tests/ReleaseWorkflowTests.cs
@@ -21,6 +21,8 @@ public class ReleaseWorkflowTests
             "Dotsider.TraceHost.csproj"));
 
         Assert.Contains("GlobalPropertiesToRemove=", project);
+        Assert.Contains("IntermediateOutputPath", project);
+        Assert.Contains("OutputPath", project);
         Assert.Contains("PublishAot", project);
         Assert.Contains("PublishDir", project);
         Assert.Contains("PublishReadyToRun", project);
@@ -30,6 +32,31 @@ public class ReleaseWorkflowTests
         Assert.Contains("RuntimeIdentifiers", project);
         Assert.Contains("SelfContained", project);
         Assert.Contains("UseAppHost", project);
+    }
+
+    /// <summary>
+    /// Verifies each bundled trace-host publish uses consumer-specific build directories.
+    /// Parallel solution builds must not share TraceHost intermediate or output files.
+    /// This prevents concurrent GenerateDepsFile tasks from writing the same dependency file.
+    /// </summary>
+    [TestMethod]
+    public void TraceHostPublish_UsesConsumerSpecificBuildDirectories()
+    {
+        string targets = File.ReadAllText(Path.Combine(
+            TestHelpers.GetRepoRoot(),
+            "build",
+            "Dotsider.TraceHost.targets"));
+
+        Assert.Contains(
+            "$(BaseIntermediateOutputPath)tracehost\\$(MSBuildProjectName)\\$(Configuration)\\",
+            targets);
+        Assert.Contains(
+            "IntermediateOutputPath=$(_DotsiderTraceHostIntermediateDirectory)",
+            targets);
+        Assert.Contains("OutputPath=$(_DotsiderTraceHostOutputDirectory)", targets);
+        Assert.Contains(
+            "<_DotsiderTraceHostPublishDirectory>$(_DotsiderTraceHostBuildDirectory)publish\\",
+            targets);
     }
 
     /// <summary>

--- a/tests/Dotsider.Tests/ReleaseWorkflowTests.cs
+++ b/tests/Dotsider.Tests/ReleaseWorkflowTests.cs
@@ -7,6 +7,32 @@ namespace Dotsider.Tests;
 public class ReleaseWorkflowTests
 {
     /// <summary>
+    /// Verifies trace-host publish settings do not flow into the Core project reference.
+    /// Multiple bundled trace-host publishes must share one Core project build.
+    /// This prevents concurrent builds from writing the same Core output file.
+    /// </summary>
+    [TestMethod]
+    public void TraceHostProjectReference_RemovesPublishGlobalProperties()
+    {
+        string project = File.ReadAllText(Path.Combine(
+            TestHelpers.GetRepoRoot(),
+            "src",
+            "Dotsider.TraceHost",
+            "Dotsider.TraceHost.csproj"));
+
+        Assert.Contains("GlobalPropertiesToRemove=", project);
+        Assert.Contains("PublishAot", project);
+        Assert.Contains("PublishDir", project);
+        Assert.Contains("PublishReadyToRun", project);
+        Assert.Contains("PublishSingleFile", project);
+        Assert.Contains("PublishTrimmed", project);
+        Assert.Contains("RuntimeIdentifier", project);
+        Assert.Contains("RuntimeIdentifiers", project);
+        Assert.Contains("SelfContained", project);
+        Assert.Contains("UseAppHost", project);
+    }
+
+    /// <summary>
     /// Verifies generated winget branch commits suppress fork-side push workflows without
     /// leaking the marker into user-facing winget pull request titles.
     /// </summary>

--- a/tests/Dotsider.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Tests/SampleAssemblyFixture.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 
@@ -384,7 +385,8 @@ internal class SampleAssemblyFixture
         await Task.WhenAll(builds);
         await PublishWasmProject("samples/WasmConsole", runAotCompilation: true);
 
-        var config = "Debug";
+        var config = TestProcessEnvironment.DebugBuildConfiguration;
+        var releaseConfig = TestProcessEnvironment.ReleaseBuildConfiguration;
         var tfm = "net10.0";
         var apphostExt = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
 
@@ -438,7 +440,7 @@ internal class SampleAssemblyFixture
 
         var rid = RuntimeInformation.RuntimeIdentifier;
         NativeAotConsoleExe = Path.Combine(_repoRoot, "samples", "NativeAotConsole",
-            "bin", "Release", tfm, rid, "publish", $"NativeAotConsole{apphostExt}");
+            "bin", releaseConfig, tfm, rid, "publish", $"NativeAotConsole{apphostExt}");
 
         // ILC sidecars copied next to the exe by the sample's publish target. Null when the
         // toolchain did not produce them, so sidecar tests skip rather than fail.
@@ -460,7 +462,7 @@ internal class SampleAssemblyFixture
 
         // The pre-ILC inputs stay in the intermediate tree — the sidecar probe's territory.
         var aotObjDir = Path.Combine(_repoRoot, "samples", "NativeAotConsole",
-            "obj", "Release", tfm, rid);
+            "obj", releaseConfig, tfm, rid);
         NativeAotConsoleManagedDll = ExistingPathOrNull(Path.Combine(aotObjDir, "NativeAotConsole.dll"));
         NativeAotConsoleManagedPdb = ExistingPathOrNull(Path.Combine(aotObjDir, "NativeAotConsole.pdb"));
         NativeAotConsoleIlcRsp = ExistingPathOrNull(
@@ -469,7 +471,7 @@ internal class SampleAssemblyFixture
         // V2 of the AOT sample: same AssemblyName, so the publish output is also named
         // NativeAotConsole — the project folder is what tells the two builds apart.
         var aotV2PublishDir = Path.Combine(_repoRoot, "samples", "NativeAotConsoleV2",
-            "bin", "Release", tfm, rid, "publish");
+            "bin", releaseConfig, tfm, rid, "publish");
         NativeAotConsoleV2Exe = ExistingPathOrNull(
             Path.Combine(aotV2PublishDir, $"NativeAotConsole{apphostExt}"));
         NativeAotConsoleV2Mstat = ExistingPathOrNull(
@@ -483,45 +485,55 @@ internal class SampleAssemblyFixture
             "NativeAotArtifactsConsole", $"NativeAotArtifactsConsole{apphostExt}");
 
         var libPublishDir = Path.Combine(_repoRoot, "samples", "NativeAotLibrary",
-            "bin", "Release", tfm, rid, "publish");
+            "bin", releaseConfig, tfm, rid, "publish");
         NativeAotLibraryBinary =
             ExistingPathOrNull(Path.Combine(libPublishDir, "NativeAotLibrary.dll"))
             ?? ExistingPathOrNull(Path.Combine(libPublishDir, "NativeAotLibrary.so"))
             ?? ExistingPathOrNull(Path.Combine(libPublishDir, "NativeAotLibrary.dylib"));
 
         HardwareIntrinsicsExe = ExistingPathOrNull(Path.Combine(_repoRoot, "samples", "HardwareIntrinsics",
-            "bin", "Release", tfm, rid, "publish", $"HardwareIntrinsics{apphostExt}"));
+            "bin", releaseConfig, tfm, rid, "publish", $"HardwareIntrinsics{apphostExt}"));
 
         SelfContainedConsoleExe = Path.Combine(_repoRoot, "samples", "SelfContainedConsole",
-            "bin", "Release", tfm, rid, "publish", $"SelfContainedConsole{apphostExt}");
+            "bin", releaseConfig, tfm, rid, "publish", $"SelfContainedConsole{apphostExt}");
 
         // ReadyToRun publish outputs. Null when crossgen2 did not run for this RID, so R2R tests skip.
         var r2rConsoleDir = Path.Combine(_repoRoot, "samples", "ReadyToRunConsole",
-            "bin", "Release", tfm, rid, "publish");
-        ReadyToRunConsoleDll = ExistingPathOrNull(Path.Combine(r2rConsoleDir, "ReadyToRunConsole.dll"));
+            "bin", releaseConfig, tfm, rid, "publish");
+        ReadyToRunConsoleDll = ExistingReadyToRunPathOrNull(
+            Path.Combine(r2rConsoleDir, "ReadyToRunConsole.dll"));
         ReadyToRunConsoleExe = ExistingPathOrNull(Path.Combine(r2rConsoleDir, $"ReadyToRunConsole{apphostExt}"));
-        ReadyToRunConsoleX86Dll = ExistingPathOrNull(Path.Combine(_repoRoot, "samples", "ReadyToRunConsole",
-            "bin", "Release", tfm, "win-x86", "publish", "ReadyToRunConsole.dll"));
-        ReadyToRunConsoleArm32Dll = ExistingPathOrNull(Path.Combine(_repoRoot, "samples", "ReadyToRunConsole",
-            "bin", "Release", tfm, "linux-arm", "publish", "ReadyToRunConsole.dll"));
-        ReadyToRunConsoleRiscV64Dll = ExistingPathOrNull(Path.Combine(_repoRoot, "samples", "ReadyToRunConsole",
-            "bin", "Release", tfm, "linux-riscv64", "publish", "ReadyToRunConsole.dll"));
-        ReadyToRunConsoleLoongArch64Dll = ExistingPathOrNull(Path.Combine(_repoRoot, "samples", "ReadyToRunConsole",
-            "bin", "Release", tfm, "linux-loongarch64", "publish", "ReadyToRunConsole.dll"));
+        ReadyToRunConsoleX86Dll = ExistingReadyToRunPathOrNull(Path.Combine(
+            _repoRoot, "samples", "ReadyToRunConsole", "bin", releaseConfig,
+            tfm, "win-x86", "publish", "ReadyToRunConsole.dll"));
+        ReadyToRunConsoleArm32Dll = ExistingReadyToRunPathOrNull(Path.Combine(
+            _repoRoot, "samples", "ReadyToRunConsole", "bin", releaseConfig,
+            tfm, "linux-arm", "publish", "ReadyToRunConsole.dll"));
+        ReadyToRunConsoleRiscV64Dll = ExistingReadyToRunPathOrNull(Path.Combine(
+            _repoRoot, "samples", "ReadyToRunConsole", "bin", releaseConfig,
+            tfm, "linux-riscv64", "publish", "ReadyToRunConsole.dll"));
+        ReadyToRunConsoleLoongArch64Dll = ExistingReadyToRunPathOrNull(Path.Combine(
+            _repoRoot, "samples", "ReadyToRunConsole", "bin", releaseConfig,
+            tfm, "linux-loongarch64", "publish", "ReadyToRunConsole.dll"));
         ReadyToRunConsoleWasmNativeWasm = ExistingPathOrNull(Path.Combine(_repoRoot, "samples", "ReadyToRunConsole",
-            "bin", "Release", tfm, "browser-wasm", "publish", "dotnet.native.wasm"));
+            "bin", releaseConfig, tfm, "browser-wasm", "publish", "dotnet.native.wasm"));
         WasmConsoleNativeWasm = ExistingPathOrNull(Path.Combine(_repoRoot, "samples", "WasmConsole",
-            "bin", "Release", tfm, "browser-wasm", "publish", "dotnet.native.wasm"));
+            "bin", releaseConfig, tfm, "browser-wasm", "publish", "dotnet.native.wasm"));
         WasmConsoleAotNativeWasm = ExistingPathOrNull(Path.Combine(_repoRoot, "samples", "WasmConsole",
-            "bin", "Release", tfm, "browser-wasm-aot", "publish", "dotnet.native.wasm"));
+            "bin", releaseConfig, tfm, "browser-wasm-aot", "publish", "dotnet.native.wasm"));
         WasmConsoleWebcilWasm = ExistingPathOrNull(Path.Combine(_repoRoot, "samples", "WasmConsole",
-            "bin", "Release", tfm, "browser-wasm", "AppBundle", "_framework", "WasmConsole.wasm"));
+            "bin", releaseConfig, tfm, "browser-wasm", "AppBundle", "_framework", "WasmConsole.wasm"));
 
         var r2rCompositeDir = Path.Combine(_repoRoot, "samples", "ReadyToRunComposite",
-            "bin", "Release", tfm, rid, "publish");
-        ReadyToRunCompositeImage = ExistingPathOrNull(Path.Combine(r2rCompositeDir, "ReadyToRunComposite.r2r.dll"));
-        ReadyToRunCompositeComponent = ExistingPathOrNull(Path.Combine(r2rCompositeDir, "ReadyToRunComposite.dll"));
-        ReadyToRunComponentLibDll = ExistingPathOrNull(Path.Combine(r2rCompositeDir, "ReadyToRunComponentLib.dll"));
+            "bin", releaseConfig, tfm, rid, "publish");
+        ReadyToRunCompositeImage = ExistingReadyToRunPathOrNull(
+            Path.Combine(r2rCompositeDir, "ReadyToRunComposite.r2r.dll"));
+        ReadyToRunCompositeComponent = ReadyToRunCompositeImage is null
+            ? null
+            : ExistingReadyToRunPathOrNull(Path.Combine(r2rCompositeDir, "ReadyToRunComposite.dll"));
+        ReadyToRunComponentLibDll = ReadyToRunCompositeImage is null
+            ? null
+            : ExistingReadyToRunPathOrNull(Path.Combine(r2rCompositeDir, "ReadyToRunComponentLib.dll"));
         if (ReadyToRunCompositeComponent is not null)
             ReadyToRunCompositeComponentMvid = ReadModuleMvid(ReadyToRunCompositeComponent);
         if (ReadyToRunComponentLibDll is not null)
@@ -614,8 +626,11 @@ internal class SampleAssemblyFixture
 
     private string? FindArtifactsPublishOutput(string project, string fileName)
     {
+        var artifactsDirectory = TestProcessEnvironment.IsDevelopmentContainer
+            ? Path.Combine("artifacts", "devcontainer")
+            : "artifacts";
         var publishRoot = Path.Combine(
-            _repoRoot, "samples", project, "artifacts", "publish", project);
+            _repoRoot, "samples", project, artifactsDirectory, "publish", project);
         if (!Directory.Exists(publishRoot)) return null;
 
         foreach (var pivotDir in Directory.GetDirectories(publishRoot))
@@ -632,6 +647,31 @@ internal class SampleAssemblyFixture
 
     private static string? ExistingPathOrNull(string path)
         => File.Exists(path) ? path : null;
+
+    /// <summary>
+    /// Returns an existing readable PE path and rejects partial publish outputs.
+    /// </summary>
+    internal static string? ExistingReadyToRunPathOrNull(string path)
+    {
+        if (!File.Exists(path))
+            return null;
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var reader = new PEReader(stream);
+            _ = reader.HasMetadata;
+            return path;
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
 
     private static string? ExistingDirOrNull(string path)
         => Directory.Exists(path) ? path : null;
@@ -661,7 +701,8 @@ internal class SampleAssemblyFixture
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = $"publish -c Release -r {RuntimeInformation.RuntimeIdentifier} -v q",
+                Arguments = $"publish -c {TestProcessEnvironment.ReleaseBuildConfiguration} "
+                    + $"-r {RuntimeInformation.RuntimeIdentifier} -v q",
                 WorkingDirectory = projectDir,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
@@ -673,7 +714,14 @@ internal class SampleAssemblyFixture
             // is not resolved from the current directory inside FOR /F).
             // Clear it for this process only.
             psi.Environment.Remove("NoDefaultCurrentDirectoryInExePath");
-            TestProcessEnvironment.RemoveCodeCoverageVariables(psi);
+            if (relativePath.EndsWith("NativeAotArtifactsConsole", StringComparison.Ordinal))
+            {
+                TestProcessEnvironment.ConfigureArtifactsBuild(psi);
+            }
+            else
+            {
+                TestProcessEnvironment.ConfigureBuild(psi);
+            }
 
             var process = Process.Start(psi)!;
             var stdout = await process.StandardOutput.ReadToEndAsync();
@@ -719,22 +767,39 @@ internal class SampleAssemblyFixture
         try
         {
             var projectDir = Path.Combine(_repoRoot, relativePath);
+            var projectName = Path.GetFileName(projectDir);
+            var imageName = projectName.Equals("ReadyToRunComposite", StringComparison.Ordinal)
+                ? $"{projectName}.r2r.dll"
+                : $"{projectName}.dll";
+            var imagePath = Path.Combine(
+                projectDir,
+                "bin",
+                TestProcessEnvironment.ReleaseBuildConfiguration,
+                "net10.0",
+                rid,
+                "publish",
+                imageName);
+            if (File.Exists(imagePath) && ExistingReadyToRunPathOrNull(imagePath) is null)
+                File.Delete(imagePath);
+
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = $"publish -c Release -r {rid} "
+                Arguments = $"publish -c {TestProcessEnvironment.ReleaseBuildConfiguration} -r {rid} "
                     + $"--self-contained {(selfContained ? "true" : "false")} -v q",
                 WorkingDirectory = projectDir,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
-            TestProcessEnvironment.RemoveCodeCoverageVariables(psi);
+            TestProcessEnvironment.ConfigureBuild(psi);
 
             var process = Process.Start(psi)!;
             _ = await process.StandardOutput.ReadToEndAsync();
             _ = await process.StandardError.ReadToEndAsync();
             await process.WaitForExitAsync();
+            if (File.Exists(imagePath) && ExistingReadyToRunPathOrNull(imagePath) is null)
+                File.Delete(imagePath);
             // A non-zero exit means crossgen2 is unavailable for this RID; leave the outputs absent.
         }
         finally
@@ -751,8 +816,9 @@ internal class SampleAssemblyFixture
     private async Task PublishWasmProject(string relativePath, bool runAotCompilation = false)
     {
         var wasmRid = runAotCompilation ? "browser-wasm-aot" : "browser-wasm";
+        var configuration = TestProcessEnvironment.ReleaseBuildConfiguration;
         var expectedOutput = Path.Combine(_repoRoot, relativePath,
-            "bin", "Release", "net10.0", wasmRid, "publish", "dotnet.native.wasm");
+            "bin", configuration, "net10.0", wasmRid, "publish", "dotnet.native.wasm");
         if (File.Exists(expectedOutput))
             return;
 
@@ -776,13 +842,13 @@ internal class SampleAssemblyFixture
         try
         {
             var projectDir = Path.Combine(_repoRoot, relativePath);
-            var arguments = "publish -c Release -r browser-wasm --self-contained true "
+            var arguments = $"publish -c {configuration} -r browser-wasm --self-contained true "
                 + "-p:PublishReadyToRun=false -p:WasmEmitSymbolMap=true ";
             if (runAotCompilation)
             {
                 arguments += "-p:RunAOTCompilation=true "
-                    + "-p:WasmAppDir=bin\\Release\\net10.0\\browser-wasm-aot\\AppBundle "
-                    + "-p:PublishDir=bin\\Release\\net10.0\\browser-wasm-aot\\publish\\ ";
+                    + $"-p:WasmAppDir=bin\\{configuration}\\net10.0\\browser-wasm-aot\\AppBundle "
+                    + $"-p:PublishDir=bin\\{configuration}\\net10.0\\browser-wasm-aot\\publish\\ ";
             }
 
             var psi = new ProcessStartInfo
@@ -794,7 +860,7 @@ internal class SampleAssemblyFixture
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
-            TestProcessEnvironment.RemoveCodeCoverageVariables(psi);
+            TestProcessEnvironment.ConfigureBuild(psi);
 
             var process = Process.Start(psi)!;
             _ = await process.StandardOutput.ReadToEndAsync();
@@ -840,13 +906,15 @@ internal class SampleAssemblyFixture
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = $"publish -c Release -r {RuntimeInformation.RuntimeIdentifier} --self-contained -p:PublishSingleFile=true -v q",
+                Arguments = $"publish -c {TestProcessEnvironment.ReleaseBuildConfiguration} "
+                    + $"-r {RuntimeInformation.RuntimeIdentifier} --self-contained "
+                    + "-p:PublishSingleFile=true -v q",
                 WorkingDirectory = projectDir,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
-            TestProcessEnvironment.RemoveCodeCoverageVariables(psi);
+            TestProcessEnvironment.ConfigureBuild(psi);
 
             var process = Process.Start(psi)!;
             var stdout = await process.StandardOutput.ReadToEndAsync();
@@ -891,13 +959,13 @@ internal class SampleAssemblyFixture
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = "build --no-restore -c Debug -v q",
+                Arguments = $"build --no-restore -c {TestProcessEnvironment.DebugBuildConfiguration} -v q",
                 WorkingDirectory = projectDir,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
-            TestProcessEnvironment.RemoveCodeCoverageVariables(psi);
+            TestProcessEnvironment.ConfigureBuild(psi);
 
             var process = Process.Start(psi)!;
             var stdout = await process.StandardOutput.ReadToEndAsync();

--- a/tests/Dotsider.Tests/SampleAssemblyFixtureTests.cs
+++ b/tests/Dotsider.Tests/SampleAssemblyFixtureTests.cs
@@ -1,0 +1,35 @@
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Verifies sample fixture artifact validation and recovery behavior.
+/// </summary>
+[TestClass]
+public class SampleAssemblyFixtureTests
+{
+    private static SampleAssemblyFixture Samples => SampleAssemblyHost.Instance;
+
+    /// <summary>
+    /// Verifies a truncated ReadyToRun publish output is not reused as a fixture.
+    /// </summary>
+    [TestMethod]
+    public void ExistingReadyToRunPathOrNull_TruncatedImage_ReturnsNull()
+    {
+        TestSkip.When(
+            Samples.ReadyToRunCompositeImage is null,
+            "ReadyToRun composite publish did not run on this leg.");
+
+        var directory = Directory.CreateTempSubdirectory("dotsider-r2r-");
+        try
+        {
+            var path = Path.Combine(directory.FullName, "partial.r2r.dll");
+            var image = File.ReadAllBytes(Samples.ReadyToRunCompositeImage!);
+            File.WriteAllBytes(path, image.AsSpan(0, Math.Min(image.Length, 4096)));
+
+            Assert.IsNull(SampleAssemblyFixture.ExistingReadyToRunPathOrNull(path));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+}

--- a/tests/Dotsider.Tests/ScriptConventionTests.cs
+++ b/tests/Dotsider.Tests/ScriptConventionTests.cs
@@ -117,6 +117,7 @@ public sealed partial class ScriptConventionTests : IDisposable
         Assert.Contains("safe.directory", initializer);
         Assert.Contains("[\"CI\"] = \"true\"", initializer);
         Assert.Contains("devcontainers/ci@v0.3", workflow);
+        Assert.Contains("dotnet clean", workflow);
         Assert.Contains("dotnet build --no-restore", workflow);
         Assert.Contains("dotnet test --no-build", workflow);
         Assert.Contains("imageName: dotsider-devcontainer", workflow);

--- a/tests/Dotsider.Tests/ScriptConventionTests.cs
+++ b/tests/Dotsider.Tests/ScriptConventionTests.cs
@@ -14,6 +14,7 @@ namespace Dotsider.Tests;
 public sealed partial class ScriptConventionTests : IDisposable
 {
     private static readonly ConcurrentDictionary<string, Lazy<bool>> s_builtFileApps = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly Lock s_fileAppExecutionLock = new();
 
     private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "dotsider-script-tests", Guid.NewGuid().ToString("N"));
 
@@ -41,6 +42,7 @@ public sealed partial class ScriptConventionTests : IDisposable
         string attributes = File.ReadAllText(Path.Combine(root, ".gitattributes"));
 
         Assert.Contains("dotnet run --file ./scripts/Capture-DisasmOracle.cs", readme);
+        Assert.Contains("dotnet run --file ./scripts/Initialize-DevContainer.cs", readme);
         Assert.Contains("dotnet run --file ./scripts/Run-Tests.cs", readme);
         Assert.Contains("dotnet run --file ./scripts/Verify-NativeAot.cs", readme);
         Assert.Contains("FullyQualifiedName~", runTestsScript);
@@ -48,8 +50,102 @@ public sealed partial class ScriptConventionTests : IDisposable
         Assert.Contains("#!/usr/bin/env -S dotnet --", readme);
         Assert.Contains("Current utilities", readme);
         Assert.Contains("-RuntimeRoot path/to/runtime", readme);
+        Assert.Contains("* text=auto", attributes);
         Assert.Contains("scripts/*.cs text eol=lf", attributes);
         Assert.Contains("scripts/**/*.cs text eol=lf", attributes);
+        Assert.Contains("#:package System.CommandLine", runTestsScript);
+        Assert.DoesNotContain("#:package System.CommandLine@", runTestsScript);
+    }
+
+    /// <summary>
+    /// Verifies the development container pins the repository toolchain and uses the initializer app.
+    /// Native tools, documentation dependencies, Docker isolation, and the Hex1b CLI stay reproducible.
+    /// The validation workflow catches upstream image or feature changes before contributors do.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void DevContainerConfiguration_ProvidesCompleteLinuxEnvironment()
+    {
+        string root = FindRepositoryRoot();
+        string configuration = File.ReadAllText(Path.Combine(root, ".devcontainer", "devcontainer.json"));
+        string dockerfile = File.ReadAllText(Path.Combine(root, ".devcontainer", "Dockerfile"));
+        string picketIgnore = File.ReadAllText(Path.Combine(root, ".devcontainer", "picket-image.ignore"));
+        string initializer = File.ReadAllText(Path.Combine(root, "scripts", "Initialize-DevContainer.cs"));
+        string workflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "dev-container.yml"));
+
+        Assert.Contains("mcr.microsoft.com/devcontainers/base:noble", dockerfile);
+        Assert.Contains("clang", dockerfile);
+        Assert.Contains("llvm", dockerfile);
+        Assert.Contains("zlib1g-dev", dockerfile);
+        Assert.Contains("\"version\": \"10.0.302\"", configuration);
+        Assert.Contains("\"workloads\": \"wasm-tools\"", configuration);
+        Assert.Contains("\"version\": \"22\"", configuration);
+        Assert.Contains("\"pnpmVersion\": \"10.28.0\"", configuration);
+        Assert.Contains("docker-in-docker:4", configuration);
+        Assert.DoesNotContain("docker-outside-of-docker", configuration);
+        Assert.Contains("Demo__SampleAssembly", configuration);
+        Assert.Contains("\"DOTSIDER_DEV_CONTAINER\": \"1\"", configuration);
+        string buildProperties = File.ReadAllText(Path.Combine(root, "Directory.Build.props"));
+        Assert.Contains("<BaseOutputPath>bin/devcontainer/</BaseOutputPath>", buildProperties);
+        Assert.Contains("<BaseIntermediateOutputPath>obj/devcontainer/</BaseIntermediateOutputPath>", buildProperties);
+        Assert.Contains(
+            "$(MSBuildProjectDirectory)/artifacts/devcontainer",
+            buildProperties);
+        Assert.Contains(
+            "<DefaultItemExcludes>$(DefaultItemExcludes);obj/**;bin/**;artifacts/**</DefaultItemExcludes>",
+            buildProperties);
+        Assert.Contains("'$(DOTSIDER_FIXTURE_BUILD)' != '1'", buildProperties);
+        Assert.Contains("'$(FileBasedProgram)' != 'true'", buildProperties);
+        Assert.Contains("'$(Configuration)' == 'DevContainerDebug'", buildProperties);
+        Assert.Contains("'$(Configuration)' == 'DevContainerRelease'", buildProperties);
+        Assert.Contains("<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>", buildProperties);
+        Assert.Contains("<Optimize>false</Optimize>", buildProperties);
+        Assert.Contains("<Optimize>true</Optimize>", buildProperties);
+        Assert.Contains("Initialize-DevContainer.cs", configuration);
+        Assert.Contains("\"waitFor\": \"postCreateCommand\"", configuration);
+        Assert.Contains("\"dotnet.preferVisualStudioCodeFileSystemWatcher\": true", configuration);
+        Assert.Contains("Directory.Packages.props", initializer);
+        Assert.Contains("RestoreFileApps(repositoryRoot)", initializer);
+        Assert.Contains("[\"restore\", fileApp, \"--nologo\", \"--verbosity\", \"quiet\"]", initializer);
+        Assert.DoesNotContain("[\"build\", fileApp", initializer);
+        Assert.Contains("Capture-DisasmOracle.cs", initializer);
+        Assert.Contains("Deploy-Website.cs", initializer);
+        Assert.Contains("Hex1b.Tool", initializer);
+        Assert.DoesNotContain("Hex1b.McpServer", initializer);
+        Assert.Contains("Run-Tests.cs", initializer);
+        Assert.Contains("Verify-NativeAot.cs", initializer);
+        Assert.Contains("safe.directory", initializer);
+        Assert.Contains("[\"CI\"] = \"true\"", initializer);
+        Assert.Contains("devcontainers/ci@v0.3", workflow);
+        Assert.Contains("dotnet build --no-restore", workflow);
+        Assert.Contains("imageName: dotsider-devcontainer", workflow);
+        Assert.Contains("imageTag: ci", workflow);
+        Assert.Contains("Picket --version 0.2.9", workflow);
+        Assert.Contains("--docker-archive ${{ runner.temp }}/dotsider-devcontainer.tar", workflow);
+        Assert.Contains("--ignore-path .devcontainer/picket-image.ignore", workflow);
+        Assert.Contains("--redact 100", workflow);
+        Assert.Contains("--exit-code 1", workflow);
+        Assert.Contains("actions/upload-artifact@v7", workflow);
+        Assert.Contains("sha256:03aebbff795f9aedefa7c850889fa674e55d5a43b8b1bb8fc711e1cdd6bb3582", picketIgnore);
+    }
+
+    /// <summary>
+    /// Verifies the development container initializer builds and exposes safe usage text.
+    /// Help must not restore dependencies or change the developer's global tool installation.
+    /// The real initialization path is exercised when CI creates the development container.
+    /// </summary>
+    [TestMethod]
+    public void InitializeDevContainer_BuildsAndPrintsHelp()
+    {
+        string root = FindRepositoryRoot();
+        string scriptPath = Path.Combine(root, "scripts", "Initialize-DevContainer.cs");
+
+        var (exitCode, stdout, _) = RunFileApp(root, scriptPath, "--help");
+
+        Assert.AreEqual(0, exitCode);
+        Assert.Contains("development container", stdout);
+        Assert.Contains("Hex1b.Tool", stdout);
+        Assert.DoesNotContain("Hex1b.McpServer", stdout);
     }
 
     /// <summary>
@@ -229,7 +325,7 @@ public sealed partial class ScriptConventionTests : IDisposable
     public void RunTests_BuildsAndPrintsHelp()
     {
         string root = FindRepositoryRoot();
-        string scriptPath = CopyRunTestsApp(root);
+        string scriptPath = Path.Combine(root, "scripts", "Run-Tests.cs");
 
         var (runExitCode, stdout, _) = RunFileApp(root, scriptPath, "-Help");
         Assert.AreEqual(0, runExitCode);
@@ -305,6 +401,8 @@ public sealed partial class ScriptConventionTests : IDisposable
 
         Assert.Contains("mcr.microsoft.com/dotnet/sdk:10.0.302-alpine3.23", script);
         Assert.Contains("OperatingSystem.IsWindows() ? \".cmd\" : \"\"", script);
+        Assert.Contains("runtime-tracing-target", script);
+        Assert.Contains("\"--output\"", script);
     }
 
     /// <summary>
@@ -373,7 +471,7 @@ public sealed partial class ScriptConventionTests : IDisposable
         {
             startInfo.ArgumentList.Add(argument);
         }
-        TestProcessEnvironment.RemoveCodeCoverageVariables(startInfo);
+        TestProcessEnvironment.ConfigureFileApp(startInfo);
 
         using Process process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start dotnet.");
         string stdout = process.StandardOutput.ReadToEnd();
@@ -387,33 +485,23 @@ public sealed partial class ScriptConventionTests : IDisposable
         return (process.ExitCode, stdout, stderr);
     }
 
-    private string CopyRunTestsApp(string root)
-    {
-        string scriptsRoot = Path.Combine(_tempRoot, "run-tests-app", "scripts");
-        Directory.CreateDirectory(scriptsRoot);
-
-        File.Copy(
-            Path.Combine(root, "scripts", "ScriptSupport.cs"),
-            Path.Combine(scriptsRoot, "ScriptSupport.cs"));
-        string scriptPath = Path.Combine(scriptsRoot, "Run-Tests.cs");
-        File.Copy(Path.Combine(root, "scripts", "Run-Tests.cs"), scriptPath);
-        return scriptPath;
-    }
-
     private static (int ExitCode, string Stdout, string Stderr) RunFileApp(string workingDirectory, string scriptPath, params string[] arguments)
     {
-        EnsureFileAppBuilt(workingDirectory, scriptPath);
-
-        var dotnetArguments = new List<string>
+        lock (s_fileAppExecutionLock)
         {
-            "run",
-            "--file",
-            scriptPath,
-            "--no-build",
-            "--",
-        };
-        dotnetArguments.AddRange(arguments);
-        return RunDotnet(workingDirectory, [.. dotnetArguments]);
+            EnsureFileAppBuilt(workingDirectory, scriptPath);
+
+            var dotnetArguments = new List<string>
+            {
+                "run",
+                "--file",
+                scriptPath,
+                "--no-build",
+                "--",
+            };
+            dotnetArguments.AddRange(arguments);
+            return RunDotnet(workingDirectory, [.. dotnetArguments]);
+        }
     }
 
     private static void EnsureFileAppBuilt(string workingDirectory, string scriptPath)
@@ -423,7 +511,14 @@ public sealed partial class ScriptConventionTests : IDisposable
             fullPath,
             path => new Lazy<bool>(() =>
             {
-                var (exitCode, _, _) = RunDotnet(workingDirectory, "build", path, "--nologo", "--verbosity", "quiet");
+                var (exitCode, _, _) = RunDotnet(
+                    workingDirectory,
+                    "build",
+                    path,
+                    "--no-incremental",
+                    "--nologo",
+                    "--verbosity",
+                    "quiet");
                 Assert.AreEqual(0, exitCode);
                 return true;
             }));

--- a/tests/Dotsider.Tests/ScriptConventionTests.cs
+++ b/tests/Dotsider.Tests/ScriptConventionTests.cs
@@ -120,6 +120,9 @@ public sealed partial class ScriptConventionTests : IDisposable
         Assert.Contains("dotnet clean", workflow);
         Assert.Contains("dotnet build --no-restore", workflow);
         Assert.Contains("dotnet test --no-build", workflow);
+        Assert.Contains(
+            "DOTSIDER_RUN_DEPLOY_INTEGRATION=1 dotnet test tests/Dotsider.Deploy.Tests/Dotsider.Deploy.Tests.csproj --no-build",
+            workflow);
         Assert.Contains("imageName: dotsider-devcontainer", workflow);
         Assert.Contains("imageTag: ci", workflow);
         Assert.Contains("Picket --version 0.2.9", workflow);

--- a/tests/Dotsider.Tests/ScriptConventionTests.cs
+++ b/tests/Dotsider.Tests/ScriptConventionTests.cs
@@ -118,6 +118,7 @@ public sealed partial class ScriptConventionTests : IDisposable
         Assert.Contains("[\"CI\"] = \"true\"", initializer);
         Assert.Contains("devcontainers/ci@v0.3", workflow);
         Assert.Contains("dotnet build --no-restore", workflow);
+        Assert.Contains("dotnet test --no-build", workflow);
         Assert.Contains("imageName: dotsider-devcontainer", workflow);
         Assert.Contains("imageTag: ci", workflow);
         Assert.Contains("Picket --version 0.2.9", workflow);

--- a/tests/Dotsider.Tests/SessionCliTests.cs
+++ b/tests/Dotsider.Tests/SessionCliTests.cs
@@ -13,24 +13,12 @@ public sealed class SessionCliTests
     private static readonly string s_projectPath = Path.Combine(
         TestHelpers.GetRepoRoot(), "src", "Dotsider");
 
-    private static readonly string s_buildConfig = DetectBuildConfig();
+    private static readonly string s_buildConfig = TestProcessEnvironment.CurrentBuildConfiguration;
 
     private int _testPid;
     private TestDotsiderSocket _dotsiderSocket = null!;
     private TestRawJsonSocket _hex1bSocket = null!;
     private string[]? _lastTraceArguments;
-
-    private static string DetectBuildConfig()
-    {
-        var parts = AppContext.BaseDirectory.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        for (var i = 0; i < parts.Length - 1; i++)
-        {
-            if (parts[i].Equals("bin", StringComparison.OrdinalIgnoreCase))
-                return parts[i + 1];
-        }
-
-        return "Debug";
-    }
 
     /// <summary>
     /// Prepares the fixture state before tests execute.

--- a/tests/Dotsider.Tests/SessionDiffModeTests.cs
+++ b/tests/Dotsider.Tests/SessionDiffModeTests.cs
@@ -20,7 +20,7 @@ public class SessionDiffModeTests
     private static readonly string s_projectPath = Path.Combine(
         TestHelpers.GetRepoRoot(), "src", "Dotsider");
 
-    private static readonly string s_buildConfig = DetectBuildConfig();
+    private static readonly string s_buildConfig = TestProcessEnvironment.CurrentBuildConfiguration;
 
     private readonly SampleAssemblyFixture _samples = Samples;
     private int _diffPid;
@@ -32,19 +32,6 @@ public class SessionDiffModeTests
     private AssemblyAnalyzer _leftAnalyzer = null!;
     private AssemblyAnalyzer _rightAnalyzer = null!;
     private DotsiderDiagnosticsListener _listener = null!;
-
-    private static string DetectBuildConfig()
-    {
-        var parts = AppContext.BaseDirectory.Split(
-            Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        for (var i = 0; i < parts.Length - 1; i++)
-        {
-            if (parts[i].Equals("bin", StringComparison.OrdinalIgnoreCase))
-                return parts[i + 1];
-        }
-
-        return "Debug";
-    }
 
     /// <summary>
     /// Prepares the fixture state before tests execute.

--- a/tests/Dotsider.Tests/SessionNugetModeTests.cs
+++ b/tests/Dotsider.Tests/SessionNugetModeTests.cs
@@ -20,7 +20,7 @@ public class SessionNugetModeTests
     private static readonly string s_projectPath = Path.Combine(
         TestHelpers.GetRepoRoot(), "src", "Dotsider");
 
-    private static readonly string s_buildConfig = DetectBuildConfig();
+    private static readonly string s_buildConfig = TestProcessEnvironment.CurrentBuildConfiguration;
 
     private readonly SampleAssemblyFixture _samples = Samples;
     private int _nugetPid;
@@ -32,20 +32,6 @@ public class SessionNugetModeTests
 
     private NuGetPackageAnalyzer _packageAnalyzer = null!;
     private DotsiderDiagnosticsListener _listener = null!;
-
-    private static string DetectBuildConfig()
-    {
-        var parts = AppContext.BaseDirectory.Split(
-            Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-        for (var i = 0; i < parts.Length - 1; i++)
-        {
-            if (parts[i].Equals("bin", StringComparison.OrdinalIgnoreCase))
-                return parts[i + 1];
-        }
-
-        return "Debug";
-    }
 
     /// <summary>
     /// Prepares the fixture state before tests execute.

--- a/tests/Dotsider.Tests/TestHelpers.cs
+++ b/tests/Dotsider.Tests/TestHelpers.cs
@@ -59,19 +59,7 @@ internal static class TestHelpers
         throw new InvalidOperationException("Could not find repo root (Dotsider.slnx)");
     }
 
-    private static readonly string s_dotsiderBuildConfig = DetectBuildConfig();
-
-    private static string DetectBuildConfig()
-    {
-        var parts = AppContext.BaseDirectory.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        for (var i = 0; i < parts.Length - 1; i++)
-        {
-            if (parts[i].Equals("bin", StringComparison.OrdinalIgnoreCase))
-                return parts[i + 1];
-        }
-
-        return "Debug";
-    }
+    private static readonly string s_dotsiderBuildConfig = TestProcessEnvironment.CurrentBuildConfiguration;
 
     /// <summary>
     /// Runs the real dotsider CLI as a subprocess (via <c>dotnet run --no-build</c>) and

--- a/tests/Dotsider.Tests/TestProcessEnvironmentTests.cs
+++ b/tests/Dotsider.Tests/TestProcessEnvironmentTests.cs
@@ -9,6 +9,29 @@ namespace Dotsider.Tests;
 public class TestProcessEnvironmentTests
 {
     /// <summary>
+    /// Conventional and development-container output paths expose the actual configuration.
+    /// </summary>
+    /// <param name="useDevelopmentContainerLayout">Whether to include the isolated path segment.</param>
+    /// <param name="configuration">The expected and embedded configuration.</param>
+    [TestMethod]
+    [DataRow(false, "Debug")]
+    [DataRow(false, "Release")]
+    [DataRow(true, "Debug")]
+    [DataRow(true, "Release")]
+    public void GetBuildConfiguration_KnownOutputLayout_ReturnsConfiguration(
+        bool useDevelopmentContainerLayout,
+        string configuration)
+    {
+        string baseDirectory = useDevelopmentContainerLayout
+            ? Path.Combine("root", "bin", "devcontainer", configuration, "net10.0")
+            : Path.Combine("root", "bin", configuration, "net10.0");
+
+        string actual = TestProcessEnvironment.GetBuildConfiguration(baseDirectory);
+
+        Assert.AreEqual(configuration, actual);
+    }
+
+    /// <summary>
     /// Code-coverage profiler variables are removed without disturbing unrelated environment variables.
     /// </summary>
     [TestMethod]
@@ -27,5 +50,34 @@ public class TestProcessEnvironmentTests
         Assert.IsFalse(startInfo.Environment.ContainsKey("CORECLR_ENABLE_PROFILING"));
         Assert.IsFalse(startInfo.Environment.ContainsKey("CORECLR_PROFILER"));
         Assert.AreEqual("1", startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"]);
+    }
+
+    /// <summary>
+    /// Artifact-layout fixture builds use a container-only artifacts root.
+    /// </summary>
+    [TestMethod]
+    public void ConfigureArtifactsBuild_UsesContainerArtifactsRootOnlyInContainer()
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            UseShellExecute = false,
+        };
+
+        TestProcessEnvironment.ConfigureArtifactsBuild(startInfo);
+
+        if (TestProcessEnvironment.IsDevelopmentContainer)
+        {
+            Assert.AreEqual("artifacts/devcontainer/", startInfo.Environment["ArtifactsPath"]);
+            Assert.AreEqual(
+                "obj/**;bin/**;artifacts/**",
+                startInfo.Environment["DefaultItemExcludes"]);
+            Assert.AreEqual("1", startInfo.Environment["DOTSIDER_FIXTURE_BUILD"]);
+        }
+        else
+        {
+            Assert.IsFalse(startInfo.Environment.ContainsKey("ArtifactsPath"));
+            Assert.IsFalse(startInfo.Environment.ContainsKey("DefaultItemExcludes"));
+            Assert.IsFalse(startInfo.Environment.ContainsKey("DOTSIDER_FIXTURE_BUILD"));
+        }
     }
 }

--- a/tests/Dotsider.Website.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Website.Tests/SampleAssemblyFixture.cs
@@ -60,10 +60,14 @@ internal class SampleAssemblyFixture : IAsyncDisposable
     private async Task PublishWebsite()
     {
         var rid = RuntimeInformation.RuntimeIdentifier;
+        var configuration = TestProcessEnvironment.ReleaseBuildConfiguration;
         var apphostExt = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
+        var publishDirectoryName = TestProcessEnvironment.IsDevelopmentContainer
+            ? "website-publish-devcontainer"
+            : "website-publish";
 
         WebsitePublishedDir = Path.Combine(_repoRoot, "tests", "Dotsider.Website.Tests",
-            "bin", "website-publish");
+            "bin", publishDirectoryName);
         WebsitePublishedExe = Path.Combine(WebsitePublishedDir, $"Dotsider.Website{apphostExt}");
 
         var lockPath = Path.Combine(Path.GetTempPath(), "dotsider-build-website-publish.lock");
@@ -83,11 +87,13 @@ internal class SampleAssemblyFixture : IAsyncDisposable
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = $"publish src/Dotsider.Website/Dotsider.Website.csproj -c Release -r {rid} --self-contained -p:PublishSingleFile=true -o {WebsitePublishedDir} -v q",
+                Arguments = $"publish src/Dotsider.Website/Dotsider.Website.csproj -c {configuration} "
+                    + $"-r {rid} --self-contained -p:PublishSingleFile=true "
+                    + $"-o {WebsitePublishedDir} -v q",
                 WorkingDirectory = _repoRoot,
                 UseShellExecute = false,
             };
-            TestProcessEnvironment.RemoveCodeCoverageVariables(psi);
+            TestProcessEnvironment.ConfigureBuild(psi);
 
             var process = Process.Start(psi)!;
             await process.WaitForExitAsync();
@@ -110,6 +116,7 @@ internal class SampleAssemblyFixture : IAsyncDisposable
         // a unit. Place it under the website publish dir at sample/ to match the
         // deploy layout exactly; tests then exercise the same shape production runs.
         var rid = RuntimeInformation.RuntimeIdentifier;
+        var configuration = TestProcessEnvironment.ReleaseBuildConfiguration;
         SamplePublishedDir = Path.Combine(WebsitePublishedDir, "sample");
         RichLibraryDll = Path.Combine(SamplePublishedDir, "RichLibrary.dll");
 
@@ -138,13 +145,14 @@ internal class SampleAssemblyFixture : IAsyncDisposable
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = $"publish samples/RichLibrary/RichLibrary.csproj -c Release -r {rid} -o {SamplePublishedDir} -v q",
+                Arguments = $"publish samples/RichLibrary/RichLibrary.csproj -c {configuration} "
+                    + $"-r {rid} -o {SamplePublishedDir} -v q",
                 WorkingDirectory = _repoRoot,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
-            TestProcessEnvironment.RemoveCodeCoverageVariables(psi);
+            TestProcessEnvironment.ConfigureBuild(psi);
 
             var process = Process.Start(psi)!;
             var stdout = await process.StandardOutput.ReadToEndAsync();

--- a/tests/Shared/TestProcessEnvironment.cs
+++ b/tests/Shared/TestProcessEnvironment.cs
@@ -28,6 +28,67 @@ internal static class TestProcessEnvironment
     };
 
     /// <summary>
+    /// Gets the isolated configuration used for fixture Debug builds in the development container.
+    /// </summary>
+    internal static string DebugBuildConfiguration => IsDevelopmentContainer ? "DevContainerDebug" : "Debug";
+
+    /// <summary>
+    /// Gets the isolated configuration used for fixture Release builds in the development container.
+    /// </summary>
+    internal static string ReleaseBuildConfiguration => IsDevelopmentContainer ? "DevContainerRelease" : "Release";
+
+    /// <summary>
+    /// Gets the configuration containing the currently executing test assembly.
+    /// </summary>
+    internal static string CurrentBuildConfiguration
+        => GetBuildConfiguration(AppContext.BaseDirectory);
+
+    /// <summary>
+    /// Extracts the configuration from a conventional or development-container output path.
+    /// </summary>
+    /// <param name="baseDirectory">The application base directory.</param>
+    /// <returns>The detected configuration, or Debug when no output segment is present.</returns>
+    internal static string GetBuildConfiguration(string baseDirectory)
+    {
+        string[] parts = baseDirectory.Split(
+            Path.DirectorySeparatorChar,
+            Path.AltDirectorySeparatorChar);
+        for (var index = 0; index < parts.Length - 1; index++)
+        {
+            if (!parts[index].Equals("bin", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            return parts[index + 1].Equals("devcontainer", StringComparison.OrdinalIgnoreCase)
+                && index + 2 < parts.Length
+                ? parts[index + 2]
+                : parts[index + 1];
+        }
+
+        return "Debug";
+    }
+
+    /// <summary>
+    /// Gets whether the current test process is running inside the dotsider development container.
+    /// </summary>
+    internal static bool IsDevelopmentContainer =>
+        string.Equals(Environment.GetEnvironmentVariable("DOTSIDER_DEV_CONTAINER"), "1", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Resolves a project's build output directory for the active host or development container.
+    /// </summary>
+    /// <param name="projectDirectory">The project directory.</param>
+    /// <param name="configuration">The build configuration.</param>
+    /// <param name="targetFramework">The target framework directory.</param>
+    /// <returns>The absolute project output directory.</returns>
+    internal static string GetProjectOutputDirectory(
+        string projectDirectory,
+        string configuration,
+        string targetFramework) =>
+        IsDevelopmentContainer
+            ? Path.Combine(projectDirectory, "bin", "devcontainer", configuration, targetFramework)
+            : Path.Combine(projectDirectory, "bin", configuration, targetFramework);
+
+    /// <summary>
     /// Removes inherited code-coverage profiler variables from <paramref name="startInfo"/>.
     /// </summary>
     /// <param name="startInfo">The child process start info to sanitize.</param>
@@ -35,6 +96,52 @@ internal static class TestProcessEnvironment
     {
         foreach (var variable in CodeCoverageEnvironmentVariables)
             startInfo.Environment.Remove(variable);
+    }
+
+    /// <summary>
+    /// Removes profiler variables and gives fixture builds an isolated, conventional intermediate layout.
+    /// </summary>
+    /// <param name="startInfo">The child build process start info to configure.</param>
+    internal static void ConfigureBuild(ProcessStartInfo startInfo)
+    {
+        RemoveCodeCoverageVariables(startInfo);
+        if (!IsDevelopmentContainer)
+            return;
+
+        startInfo.Environment["BaseIntermediateOutputPath"] = "obj/";
+        startInfo.Environment["MSBuildProjectExtensionsPath"] = "obj/devcontainer/";
+        startInfo.Environment["DOTSIDER_FIXTURE_BUILD"] = "1";
+        startInfo.Environment.Remove("DefaultItemExcludes");
+    }
+
+    /// <summary>
+    /// Removes repository build overrides so file-based apps retain their SDK-managed cache layout.
+    /// </summary>
+    /// <param name="startInfo">The file-based app process start info to configure.</param>
+    internal static void ConfigureFileApp(ProcessStartInfo startInfo)
+    {
+        RemoveCodeCoverageVariables(startInfo);
+        if (!IsDevelopmentContainer)
+            return;
+
+        startInfo.Environment.Remove("BaseIntermediateOutputPath");
+        startInfo.Environment.Remove("DefaultItemExcludes");
+        startInfo.Environment.Remove("MSBuildProjectExtensionsPath");
+    }
+
+    /// <summary>
+    /// Removes repository overrides so UseArtifactsOutput can own the fixture's isolated layout.
+    /// </summary>
+    /// <param name="startInfo">The artifacts-layout build process start info to configure.</param>
+    internal static void ConfigureArtifactsBuild(ProcessStartInfo startInfo)
+    {
+        ConfigureFileApp(startInfo);
+        if (IsDevelopmentContainer)
+        {
+            startInfo.Environment["ArtifactsPath"] = "artifacts/devcontainer/";
+            startInfo.Environment["DefaultItemExcludes"] = "obj/**;bin/**;artifacts/**";
+            startInfo.Environment["DOTSIDER_FIXTURE_BUILD"] = "1";
+        }
     }
 
     /// <summary>

--- a/tests/deploy/README.md
+++ b/tests/deploy/README.md
@@ -12,9 +12,11 @@ dotnet test tests/Dotsider.Deploy.Tests/Dotsider.Deploy.Tests.csproj
 
 Set `DOTSIDER_RUN_DEPLOY_INTEGRATION` to `1` to run the complete Debian 13
 fixture. Docker must be available and support privileged Linux containers.
+Docker Buildx must also be installed.
 The fixture publishes the Native AOT helper and website beneath `artifacts/`,
 starts systemd as PID 1, provisions the real Caddy and Prometheus services, and
 then exercises preflight, reporting, and integrity recovery.
 
-Docker uses an isolated temporary configuration directory. The tests never
-read or rewrite the user's Docker credential configuration.
+Docker uses an isolated temporary configuration and a dedicated BuildKit
+builder. The tests never read or rewrite the user's Docker credential
+configuration or default builder cache.


### PR DESCRIPTION
Adds a pinned VS Code development container with the .NET 10 toolchain, Native AOT dependencies, Docker, and the Hex1b CLI. Container builds use isolated outputs so Windows and Linux worktrees stay clean, while CI builds and scans the image with Picket. Tests cover initialization, fixture recovery, workflow configuration, and concurrent Hex1b automation.