### PR TITLE
Fix ARM64 development container tests

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -23,6 +23,9 @@ dotnet build
 dotnet test
 ```
 
+Integrated terminals limit .NET to four processors and disable reusable MSBuild
+nodes so full builds and tests fit within the container's 8 GB memory budget.
+
 Run the deployment integration tests explicitly:
 
 ```console

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,11 @@
       ],
       "settings": {
         "dotnet.defaultSolution": "Dotsider.slnx",
-        "dotnet.preferVisualStudioCodeFileSystemWatcher": true
+        "dotnet.preferVisualStudioCodeFileSystemWatcher": true,
+        "terminal.integrated.env.linux": {
+          "DOTNET_PROCESSOR_COUNT": "4",
+          "MSBUILDDISABLENODEREUSE": "1"
+        }
       }
     }
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-26]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-26]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/src/Dotsider.Core/Analysis/NoFollowFileReader.cs
+++ b/src/Dotsider.Core/Analysis/NoFollowFileReader.cs
@@ -16,6 +16,10 @@ internal static partial class NoFollowFileReader
     private const uint GenericRead = 0x8000_0000;
     private const uint OpenExisting = 3;
     private const int FileAttributeTagInfo = 9;
+    private const int LinuxOpenCloseOnExec = 0x0008_0000;
+    private const int LinuxOpenNoFollowArm = 0x0000_8000;
+    private const int LinuxOpenNoFollowGeneric = 0x0002_0000;
+    private const int LinuxOpenNonBlocking = 0x0000_0800;
 
     /// <summary>
     /// Reads all bytes from <paramref name="path"/> without following a link at the final path
@@ -94,10 +98,10 @@ internal static partial class NoFollowFileReader
         int flags;
         if (OperatingSystem.IsLinux())
         {
-            const int openCloseOnExec = 0x0008_0000;
-            const int openNoFollow = 0x0002_0000;
-            const int openNonBlocking = 0x0000_0800;
-            flags = openCloseOnExec | openNoFollow | openNonBlocking;
+            if (!TryGetLinuxOpenFlags(RuntimeInformation.ProcessArchitecture, out flags))
+            {
+                return null;
+            }
         }
         else if (OperatingSystem.IsMacOS())
         {
@@ -115,6 +119,32 @@ internal static partial class NoFollowFileReader
         return descriptor < 0
             ? null
             : new SafeFileHandle((IntPtr)descriptor, ownsHandle: true);
+    }
+
+    /// <summary>
+    /// Gets Linux open flags for an architecture whose ABI values are known.
+    /// Unknown architectures fail closed instead of opening a path without link protection.
+    /// </summary>
+    internal static bool TryGetLinuxOpenFlags(Architecture architecture, out int flags)
+    {
+        int openNoFollow = architecture switch
+        {
+            Architecture.Arm or
+            Architecture.Arm64 or
+            Architecture.Armv6 or
+            Architecture.Ppc64le => LinuxOpenNoFollowArm,
+            Architecture.LoongArch64 or
+            Architecture.RiscV64 or
+            Architecture.S390x or
+            Architecture.X64 or
+            Architecture.X86 => LinuxOpenNoFollowGeneric,
+            _ => 0,
+        };
+
+        flags = openNoFollow == 0
+            ? 0
+            : LinuxOpenCloseOnExec | openNoFollow | LinuxOpenNonBlocking;
+        return flags != 0;
     }
 
     [LibraryImport("kernel32.dll", EntryPoint = "CreateFileW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]

--- a/tests/Dotsider.Mcp.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Mcp.Tests/SampleAssemblyFixture.cs
@@ -247,13 +247,13 @@ internal class SampleAssemblyFixture : IAsyncDisposable
 
     private async Task BuildProject(string relativePath)
     {
-        // Skip if Dotsider.Tests already built this sample
         var projectName = Path.GetFileName(relativePath);
         var configuration = TestProcessEnvironment.DebugBuildConfiguration;
+        var assemblyName = projectName.Equals("RichLibraryV2", StringComparison.Ordinal)
+            ? "RichLibrary"
+            : projectName;
         var expectedDll = Path.Combine(_repoRoot, relativePath,
-            "bin", configuration, "net10.0", $"{projectName}.dll");
-        if (File.Exists(expectedDll))
-            return;
+            "bin", configuration, "net10.0", $"{assemblyName}.dll");
 
         var lockName = "dotsider-build-" + relativePath.Replace('/', '-').Replace('\\', '-') + ".lock";
         var lockPath = Path.Combine(Path.GetTempPath(), lockName);
@@ -275,18 +275,20 @@ internal class SampleAssemblyFixture : IAsyncDisposable
         try
         {
             // Re-check after acquiring lock
-            if (File.Exists(expectedDll))
+            var projectDirectory = Path.Combine(_repoRoot, relativePath);
+            if (TestProcessEnvironment.IsFixtureOutputCurrent(
+                expectedDll,
+                projectDirectory,
+                _repoRoot))
             {
-                lockFile.Dispose();
                 return;
             }
 
-            var projectDir = Path.Combine(_repoRoot, relativePath);
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
                 Arguments = $"build --no-restore -c {configuration} -v q",
-                WorkingDirectory = projectDir,
+                WorkingDirectory = projectDirectory,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -317,10 +319,6 @@ internal class SampleAssemblyFixture : IAsyncDisposable
             "bin", configuration, "net10.0", rid, "publish",
             $"{Path.GetFileName(relativePath)}{apphostExt}");
 
-        // Skip if Dotsider.Tests already published
-        if (File.Exists(expectedOutput))
-            return;
-
         var lockName = "dotsider-build-" + relativePath.Replace('/', '-').Replace('\\', '-') + ".lock";
         var lockPath = Path.Combine(Path.GetTempPath(), lockName);
 
@@ -341,19 +339,22 @@ internal class SampleAssemblyFixture : IAsyncDisposable
         try
         {
             // Re-check after acquiring lock
-            if (File.Exists(expectedOutput))
+            var projectDirectory = Path.Combine(_repoRoot, relativePath);
+            if (Dotsider.Core.Analysis.SingleFileBundleReader.IsBundle(expectedOutput, out _) &&
+                TestProcessEnvironment.IsFixtureOutputCurrent(
+                    expectedOutput,
+                    projectDirectory,
+                    _repoRoot))
             {
-                lockFile.Dispose();
                 return;
             }
 
-            var projectDir = Path.Combine(_repoRoot, relativePath);
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
                 Arguments = $"publish -c {configuration} -r {rid} --self-contained "
                     + "-p:PublishSingleFile=true -v q",
-                WorkingDirectory = projectDir,
+                WorkingDirectory = projectDirectory,
                 UseShellExecute = false,
             };
             TestProcessEnvironment.ConfigureBuild(psi);
@@ -378,10 +379,6 @@ internal class SampleAssemblyFixture : IAsyncDisposable
         var expectedOutput = Path.Combine(_repoRoot, relativePath,
             "bin", configuration, "net10.0", rid, "publish", $"{Path.GetFileName(relativePath)}.dll");
 
-        // Reuse the Dotsider.Tests publish when it already ran (framework-dependent crossgen).
-        if (File.Exists(expectedOutput))
-            return;
-
         var lockName = "dotsider-build-" + relativePath.Replace('/', '-').Replace('\\', '-') + ".lock";
         var lockPath = Path.Combine(Path.GetTempPath(), lockName);
         FileStream lockFile;
@@ -400,12 +397,19 @@ internal class SampleAssemblyFixture : IAsyncDisposable
 
         try
         {
-            if (File.Exists(expectedOutput)) { lockFile.Dispose(); return; }
+            var projectDirectory = Path.Combine(_repoRoot, relativePath);
+            if (TestProcessEnvironment.IsFixtureOutputCurrent(
+                expectedOutput,
+                projectDirectory,
+                _repoRoot))
+            {
+                return;
+            }
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
                 Arguments = $"publish -c {configuration} -r {rid} --self-contained false -v q",
-                WorkingDirectory = Path.Combine(_repoRoot, relativePath),
+                WorkingDirectory = projectDirectory,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -429,9 +433,6 @@ internal class SampleAssemblyFixture : IAsyncDisposable
         var expectedOutput = Path.Combine(_repoRoot, relativePath,
             "bin", configuration, "net10.0", "browser-wasm", "publish", "dotnet.native.wasm");
 
-        if (File.Exists(expectedOutput))
-            return;
-
         var lockName = "dotsider-build-" + relativePath.Replace('/', '-').Replace('\\', '-') + "-browser-wasm.lock";
         var lockPath = Path.Combine(Path.GetTempPath(), lockName);
 
@@ -451,9 +452,12 @@ internal class SampleAssemblyFixture : IAsyncDisposable
 
         try
         {
-            if (File.Exists(expectedOutput))
+            var projectDirectory = Path.Combine(_repoRoot, relativePath);
+            if (TestProcessEnvironment.IsFixtureOutputCurrent(
+                expectedOutput,
+                projectDirectory,
+                _repoRoot))
             {
-                lockFile.Dispose();
                 return;
             }
 
@@ -462,7 +466,7 @@ internal class SampleAssemblyFixture : IAsyncDisposable
                 FileName = "dotnet",
                 Arguments = $"publish -c {configuration} -r browser-wasm --self-contained true "
                     + "-p:PublishReadyToRun=false -v q",
-                WorkingDirectory = Path.Combine(_repoRoot, relativePath),
+                WorkingDirectory = projectDirectory,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -487,15 +491,14 @@ internal class SampleAssemblyFixture : IAsyncDisposable
         var apphostExt = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
         var publishDir = Path.Combine(_repoRoot, relativePath,
             "bin", configuration, "net10.0", rid, "publish");
-        var expectedOutput = Path.Combine(publishDir,
-            $"{Path.GetFileName(relativePath)}{apphostExt}");
+        var projectName = Path.GetFileName(relativePath);
+        var assemblyName = projectName.Equals("NativeAotConsoleV2", StringComparison.Ordinal)
+            ? "NativeAotConsole"
+            : projectName;
+        var expectedOutput = Path.Combine(publishDir, $"{assemblyName}{apphostExt}");
         // The mstat sidecar joins the up-to-date check so a publish that predates sidecar
         // emission republishes once instead of leaving sidecar tests skipping forever.
-        var expectedMstat = Path.Combine(publishDir, $"{Path.GetFileName(relativePath)}.mstat");
-
-        // Skip if Dotsider.Tests already published
-        if (File.Exists(expectedOutput) && File.Exists(expectedMstat))
-            return;
+        var expectedMstat = Path.Combine(publishDir, $"{assemblyName}.mstat");
 
         var lockName = "dotsider-build-" + relativePath.Replace('/', '-').Replace('\\', '-') + ".lock";
         var lockPath = Path.Combine(Path.GetTempPath(), lockName);
@@ -517,18 +520,24 @@ internal class SampleAssemblyFixture : IAsyncDisposable
         try
         {
             // Re-check after acquiring lock
-            if (File.Exists(expectedOutput) && File.Exists(expectedMstat))
+            var projectDirectory = Path.Combine(_repoRoot, relativePath);
+            if (TestProcessEnvironment.IsFixtureOutputCurrent(
+                    expectedOutput,
+                    projectDirectory,
+                    _repoRoot) &&
+                TestProcessEnvironment.IsFixtureOutputCurrent(
+                    expectedMstat,
+                    projectDirectory,
+                    _repoRoot))
             {
-                lockFile.Dispose();
                 return;
             }
 
-            var projectDir = Path.Combine(_repoRoot, relativePath);
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
                 Arguments = $"publish -c {configuration} -r {rid} -v q",
-                WorkingDirectory = projectDir,
+                WorkingDirectory = projectDirectory,
                 UseShellExecute = false,
             };
 

--- a/tests/Dotsider.Tests/NoFollowFileReaderTests.cs
+++ b/tests/Dotsider.Tests/NoFollowFileReaderTests.cs
@@ -1,0 +1,53 @@
+using Dotsider.Core.Analysis;
+using System.Runtime.InteropServices;
+
+namespace Dotsider.Tests;
+
+/// <summary>
+/// Verifies Linux no-follow opens use the ABI constants for each architecture.
+/// The mapping prevents final-path symbolic links from being followed during analysis.
+/// Unknown architectures must fail closed.
+/// </summary>
+[TestClass]
+public sealed class NoFollowFileReaderTests
+{
+    /// <summary>
+    /// Verifies every supported Linux architecture gets its ABI-specific no-follow value.
+    /// Close-on-exec and non-blocking flags remain present on every architecture.
+    /// </summary>
+    [TestMethod]
+    [DataRow(Architecture.Arm, 0x0000_8000)]
+    [DataRow(Architecture.Arm64, 0x0000_8000)]
+    [DataRow(Architecture.Armv6, 0x0000_8000)]
+    [DataRow(Architecture.Ppc64le, 0x0000_8000)]
+    [DataRow(Architecture.LoongArch64, 0x0002_0000)]
+    [DataRow(Architecture.RiscV64, 0x0002_0000)]
+    [DataRow(Architecture.S390x, 0x0002_0000)]
+    [DataRow(Architecture.X64, 0x0002_0000)]
+    [DataRow(Architecture.X86, 0x0002_0000)]
+    public void TryGetLinuxOpenFlags_KnownArchitecture_UsesExpectedNoFollowFlag(
+        Architecture architecture,
+        int expectedNoFollowFlag)
+    {
+        const int openCloseOnExec = 0x0008_0000;
+        const int openNonBlocking = 0x0000_0800;
+
+        bool supported = NoFollowFileReader.TryGetLinuxOpenFlags(architecture, out int flags);
+
+        Assert.IsTrue(supported);
+        Assert.AreEqual(openCloseOnExec | expectedNoFollowFlag | openNonBlocking, flags);
+    }
+
+    /// <summary>
+    /// Verifies an architecture without known Linux ABI constants cannot open a path.
+    /// The returned flags remain empty so callers cannot accidentally perform an unsafe fallback.
+    /// </summary>
+    [TestMethod]
+    public void TryGetLinuxOpenFlags_UnknownArchitecture_FailsClosed()
+    {
+        bool supported = NoFollowFileReader.TryGetLinuxOpenFlags(Architecture.Wasm, out int flags);
+
+        Assert.IsFalse(supported);
+        Assert.AreEqual(0, flags);
+    }
+}

--- a/tests/Dotsider.Tests/SampleAssemblyFixture.cs
+++ b/tests/Dotsider.Tests/SampleAssemblyFixture.cs
@@ -678,6 +678,21 @@ internal class SampleAssemblyFixture
 
     private async Task PublishNativeAotProject(string relativePath)
     {
+        var projectName = Path.GetFileName(relativePath);
+        var assemblyName = projectName.Equals("NativeAotConsoleV2", StringComparison.Ordinal)
+            ? "NativeAotConsole"
+            : projectName;
+        var publishDirectory = Path.Combine(
+            _repoRoot,
+            relativePath,
+            "bin",
+            TestProcessEnvironment.ReleaseBuildConfiguration,
+            "net10.0",
+            RuntimeInformation.RuntimeIdentifier,
+            "publish");
+        var apphostExtension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
+        var expectedOutput = Path.Combine(publishDirectory, $"{assemblyName}{apphostExtension}");
+        var expectedMstat = Path.Combine(publishDirectory, $"{assemblyName}.mstat");
         var lockName = "dotsider-build-" + relativePath.Replace('/', '-').Replace('\\', '-') + ".lock";
         var lockPath = Path.Combine(Path.GetTempPath(), lockName);
 
@@ -697,13 +712,29 @@ internal class SampleAssemblyFixture
 
         try
         {
-            var projectDir = Path.Combine(_repoRoot, relativePath);
+            var sharesOutputWithMcpTests =
+                projectName.Equals("NativeAotConsole", StringComparison.Ordinal) ||
+                projectName.Equals("NativeAotConsoleV2", StringComparison.Ordinal);
+            var projectDirectory = Path.Combine(_repoRoot, relativePath);
+            if (sharesOutputWithMcpTests &&
+                TestProcessEnvironment.IsFixtureOutputCurrent(
+                    expectedOutput,
+                    projectDirectory,
+                    _repoRoot) &&
+                TestProcessEnvironment.IsFixtureOutputCurrent(
+                    expectedMstat,
+                    projectDirectory,
+                    _repoRoot))
+            {
+                return;
+            }
+
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
                 Arguments = $"publish -c {TestProcessEnvironment.ReleaseBuildConfiguration} "
                     + $"-r {RuntimeInformation.RuntimeIdentifier} -v q",
-                WorkingDirectory = projectDir,
+                WorkingDirectory = projectDirectory,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -779,7 +810,13 @@ internal class SampleAssemblyFixture
                 rid,
                 "publish",
                 imageName);
-            if (File.Exists(imagePath) && ExistingReadyToRunPathOrNull(imagePath) is null)
+            if (ExistingReadyToRunPathOrNull(imagePath) is not null &&
+                TestProcessEnvironment.IsFixtureOutputCurrent(imagePath, projectDir, _repoRoot))
+            {
+                return;
+            }
+
+            if (File.Exists(imagePath))
                 File.Delete(imagePath);
 
             var psi = new ProcessStartInfo
@@ -819,9 +856,6 @@ internal class SampleAssemblyFixture
         var configuration = TestProcessEnvironment.ReleaseBuildConfiguration;
         var expectedOutput = Path.Combine(_repoRoot, relativePath,
             "bin", configuration, "net10.0", wasmRid, "publish", "dotnet.native.wasm");
-        if (File.Exists(expectedOutput))
-            return;
-
         var lockName = "dotsider-build-" + relativePath.Replace('/', '-').Replace('\\', '-') + $"-{wasmRid}.lock";
         var lockPath = Path.Combine(Path.GetTempPath(), lockName);
 
@@ -841,7 +875,15 @@ internal class SampleAssemblyFixture
 
         try
         {
-            var projectDir = Path.Combine(_repoRoot, relativePath);
+            var projectDirectory = Path.Combine(_repoRoot, relativePath);
+            if (TestProcessEnvironment.IsFixtureOutputCurrent(
+                expectedOutput,
+                projectDirectory,
+                _repoRoot))
+            {
+                return;
+            }
+
             var arguments = $"publish -c {configuration} -r browser-wasm --self-contained true "
                 + "-p:PublishReadyToRun=false -p:WasmEmitSymbolMap=true ";
             if (runAotCompilation)
@@ -855,7 +897,7 @@ internal class SampleAssemblyFixture
             {
                 FileName = "dotnet",
                 Arguments = arguments + "-v q",
-                WorkingDirectory = projectDir,
+                WorkingDirectory = projectDirectory,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -883,6 +925,17 @@ internal class SampleAssemblyFixture
 
     private async Task PublishSelfContainedProject(string relativePath)
     {
+        var projectName = Path.GetFileName(relativePath);
+        var apphostExtension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
+        var expectedOutput = Path.Combine(
+            _repoRoot,
+            relativePath,
+            "bin",
+            TestProcessEnvironment.ReleaseBuildConfiguration,
+            "net10.0",
+            RuntimeInformation.RuntimeIdentifier,
+            "publish",
+            $"{projectName}{apphostExtension}");
         var lockName = "dotsider-build-" + relativePath.Replace('/', '-').Replace('\\', '-') + ".lock";
         var lockPath = Path.Combine(Path.GetTempPath(), lockName);
 
@@ -902,14 +955,23 @@ internal class SampleAssemblyFixture
 
         try
         {
-            var projectDir = Path.Combine(_repoRoot, relativePath);
+            var projectDirectory = Path.Combine(_repoRoot, relativePath);
+            if (Dotsider.Core.Analysis.SingleFileBundleReader.IsBundle(expectedOutput, out _) &&
+                TestProcessEnvironment.IsFixtureOutputCurrent(
+                    expectedOutput,
+                    projectDirectory,
+                    _repoRoot))
+            {
+                return;
+            }
+
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
                 Arguments = $"publish -c {TestProcessEnvironment.ReleaseBuildConfiguration} "
                     + $"-r {RuntimeInformation.RuntimeIdentifier} --self-contained "
                     + "-p:PublishSingleFile=true -v q",
-                WorkingDirectory = projectDir,
+                WorkingDirectory = projectDirectory,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -956,6 +1018,24 @@ internal class SampleAssemblyFixture
         try
         {
             var projectDir = Path.Combine(_repoRoot, relativePath);
+            var projectName = Path.GetFileName(projectDir);
+            var assemblyName = projectName.Equals("RichLibraryV2", StringComparison.Ordinal)
+                ? "RichLibrary"
+                : projectName;
+            var expectedOutput = Path.Combine(
+                projectDir,
+                "bin",
+                TestProcessEnvironment.DebugBuildConfiguration,
+                "net10.0",
+                $"{assemblyName}.dll");
+            if (TestProcessEnvironment.IsFixtureOutputCurrent(
+                expectedOutput,
+                projectDir,
+                _repoRoot))
+            {
+                return;
+            }
+
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",

--- a/tests/Dotsider.Tests/ScriptConventionTests.cs
+++ b/tests/Dotsider.Tests/ScriptConventionTests.cs
@@ -72,6 +72,12 @@ public sealed partial class ScriptConventionTests : IDisposable
         string picketIgnore = File.ReadAllText(Path.Combine(root, ".devcontainer", "picket-image.ignore"));
         string initializer = File.ReadAllText(Path.Combine(root, "scripts", "Initialize-DevContainer.cs"));
         string workflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "dev-container.yml"));
+        using JsonDocument configurationDocument = JsonDocument.Parse(configuration);
+        JsonElement terminalEnvironment = configurationDocument.RootElement
+            .GetProperty("customizations")
+            .GetProperty("vscode")
+            .GetProperty("settings")
+            .GetProperty("terminal.integrated.env.linux");
 
         Assert.Contains("mcr.microsoft.com/devcontainers/base:noble", dockerfile);
         Assert.Contains("clang", dockerfile);
@@ -104,6 +110,8 @@ public sealed partial class ScriptConventionTests : IDisposable
         Assert.Contains("Initialize-DevContainer.cs", configuration);
         Assert.Contains("\"waitFor\": \"postCreateCommand\"", configuration);
         Assert.Contains("\"dotnet.preferVisualStudioCodeFileSystemWatcher\": true", configuration);
+        Assert.AreEqual("4", terminalEnvironment.GetProperty("DOTNET_PROCESSOR_COUNT").GetString());
+        Assert.AreEqual("1", terminalEnvironment.GetProperty("MSBUILDDISABLENODEREUSE").GetString());
         Assert.Contains("Directory.Packages.props", initializer);
         Assert.Contains("RestoreFileApps(repositoryRoot)", initializer);
         Assert.Contains("[\"restore\", fileApp, \"--nologo\", \"--verbosity\", \"quiet\"]", initializer);
@@ -132,6 +140,21 @@ public sealed partial class ScriptConventionTests : IDisposable
         Assert.Contains("--exit-code 1", workflow);
         Assert.Contains("actions/upload-artifact@v7", workflow);
         Assert.Contains("sha256:03aebbff795f9aedefa7c850889fa674e55d5a43b8b1bb8fc711e1cdd6bb3582", picketIgnore);
+    }
+
+    /// <summary>
+    /// Keeps Linux ARM64 in the full build-and-test matrix so architecture-specific behavior
+    /// is exercised on every pull request.
+    /// </summary>
+    [TestMethod]
+    public void ContinuousIntegration_RunsFullSuiteOnLinuxArm64()
+    {
+        string root = FindRepositoryRoot();
+        string workflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "ci.yml"));
+
+        Assert.Contains(
+            "os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-26]",
+            workflow);
     }
 
     /// <summary>

--- a/tests/Dotsider.Tests/TestProcessEnvironmentTests.cs
+++ b/tests/Dotsider.Tests/TestProcessEnvironmentTests.cs
@@ -53,6 +53,52 @@ public class TestProcessEnvironmentTests
     }
 
     /// <summary>
+    /// Fixture outputs are reused only while they are newer than relevant project inputs.
+    /// Generated build directories do not invalidate a completed fixture.
+    /// </summary>
+    [TestMethod]
+    public void IsFixtureOutputCurrent_SourceAndBuildArtifacts_DistinguishesInputs()
+    {
+        string repositoryRoot = Path.Combine(Path.GetTempPath(), $"dotsider-fixture-{Guid.NewGuid():N}");
+        string projectDirectory = Path.Combine(repositoryRoot, "sample");
+        string outputDirectory = Path.Combine(projectDirectory, "bin");
+        string generatedDirectory = Path.Combine(projectDirectory, "obj");
+        Directory.CreateDirectory(outputDirectory);
+        Directory.CreateDirectory(generatedDirectory);
+
+        try
+        {
+            string sourcePath = Path.Combine(projectDirectory, "Program.cs");
+            string outputPath = Path.Combine(outputDirectory, "sample.dll");
+            string generatedPath = Path.Combine(generatedDirectory, "generated.cs");
+            File.WriteAllText(sourcePath, "source");
+            File.WriteAllText(outputPath, "output");
+            File.WriteAllText(generatedPath, "generated");
+
+            DateTime baseline = DateTime.UtcNow.AddMinutes(-5);
+            File.SetLastWriteTimeUtc(sourcePath, baseline);
+            File.SetLastWriteTimeUtc(outputPath, baseline.AddMinutes(1));
+            File.SetLastWriteTimeUtc(generatedPath, baseline.AddMinutes(2));
+
+            Assert.IsTrue(TestProcessEnvironment.IsFixtureOutputCurrent(
+                outputPath,
+                projectDirectory,
+                repositoryRoot));
+
+            File.SetLastWriteTimeUtc(sourcePath, baseline.AddMinutes(2));
+
+            Assert.IsFalse(TestProcessEnvironment.IsFixtureOutputCurrent(
+                outputPath,
+                projectDirectory,
+                repositoryRoot));
+        }
+        finally
+        {
+            Directory.Delete(repositoryRoot, recursive: true);
+        }
+    }
+
+    /// <summary>
     /// Artifact-layout fixture builds use a container-only artifacts root.
     /// </summary>
     [TestMethod]

--- a/tests/Shared/TestProcessEnvironment.cs
+++ b/tests/Shared/TestProcessEnvironment.cs
@@ -89,6 +89,77 @@ internal static class TestProcessEnvironment
             : Path.Combine(projectDirectory, "bin", configuration, targetFramework);
 
     /// <summary>
+    /// Determines whether a fixture output is newer than the source project and shared build inputs.
+    /// </summary>
+    /// <param name="outputPath">The output that represents a completed fixture build.</param>
+    /// <param name="projectDirectory">The sample project directory.</param>
+    /// <param name="repositoryRoot">The repository root containing shared build inputs.</param>
+    /// <returns><see langword="true"/> when the existing output can be reused safely.</returns>
+    internal static bool IsFixtureOutputCurrent(
+        string outputPath,
+        string projectDirectory,
+        string repositoryRoot)
+    {
+        if (!File.Exists(outputPath))
+            return false;
+
+        try
+        {
+            DateTime outputWriteTime = File.GetLastWriteTimeUtc(outputPath);
+            foreach (string inputPath in EnumerateFixtureInputs(projectDirectory, repositoryRoot))
+            {
+                if (File.GetLastWriteTimeUtc(inputPath) > outputWriteTime)
+                    return false;
+            }
+
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static IEnumerable<string> EnumerateFixtureInputs(
+        string projectDirectory,
+        string repositoryRoot)
+    {
+        foreach (string path in Directory.EnumerateFiles(projectDirectory, "*", SearchOption.AllDirectories))
+        {
+            string relativePath = Path.GetRelativePath(projectDirectory, path);
+            string firstSegment = relativePath.Split(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar)[0];
+            if (firstSegment.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
+                firstSegment.Equals("obj", StringComparison.OrdinalIgnoreCase) ||
+                firstSegment.Equals("artifacts", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            yield return path;
+        }
+
+        string[] sharedInputNames =
+        [
+            "Directory.Build.props",
+            "Directory.Packages.props",
+            "global.json",
+            "NuGet.config",
+        ];
+        foreach (string inputName in sharedInputNames)
+        {
+            string inputPath = Path.Combine(repositoryRoot, inputName);
+            if (File.Exists(inputPath))
+                yield return inputPath;
+        }
+    }
+
+    /// <summary>
     /// Removes inherited code-coverage profiler variables from <paramref name="startInfo"/>.
     /// </summary>
     /// <param name="startInfo">The child process start info to sanitize.</param>


### PR DESCRIPTION
Fixes Linux ARM64 no-follow file opens, keeps development-container test runs within the container memory limit, and prevents parallel test fixtures from reading incomplete publishes. Adds an ARM64 Linux CI leg to keep the behavior covered.