### PR TITLE
Automate size-check baselines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,9 @@ jobs:
 
   size-check-integrations:
     name: Size check integration (${{ matrix.rid }})
+    permissions:
+      actions: read
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -342,7 +345,10 @@ jobs:
         uses: ./
         with:
           target: ${{ steps.integration-assets.outputs.target }}
-          budgets: max=1gb
+          baseline-key: first-run-${{ matrix.rid }}-${{ github.run_id }}
+          budgets: |
+            max=1gb
+            growth=1%
           dotsider-path: ${{ steps.integration-assets.outputs.exe }}
           report-directory: ${{ runner.temp }}/dotsider-absolute
           upload-reports: 'false'
@@ -350,11 +356,14 @@ jobs:
       - name: Assert absolute-budget action output
         shell: pwsh
         run: |
-          if ('${{ steps.absolute.outputs.result }}' -ne 'passed') { throw 'Expected absolute budget to pass.' }
+          if ('${{ steps.absolute.outputs.result }}' -ne 'passed-with-warnings') { throw 'Expected deferred growth warning.' }
           if ('${{ steps.absolute.outputs.exit-code }}' -ne '0') { throw 'Expected absolute budget exit code 0.' }
+          if ('${{ steps.absolute.outputs.baseline-status }}' -ne 'not-found') { throw 'Expected a first-run baseline status.' }
           if (-not [string]::IsNullOrWhiteSpace('${{ steps.absolute.outputs.baseline-total }}')) { throw 'Expected no baseline total.' }
           if (-not (Test-Path -LiteralPath '${{ steps.absolute.outputs.json-report-path }}')) { throw 'Missing absolute JSON report.' }
           if (-not (Test-Path -LiteralPath '${{ steps.absolute.outputs.markdown-report-path }}')) { throw 'Missing absolute Markdown report.' }
+          $report = Get-Content -Raw -LiteralPath '${{ steps.absolute.outputs.json-report-path }}' | ConvertFrom-Json
+          if (-not $report.budgets.hasDeferred) { throw 'Expected growth budgets to be deferred.' }
 
       - name: Test shared runtime and Azure handler on Node.js 24
         run: pnpm --dir integrations/size-check test:integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -582,7 +582,7 @@ jobs:
           if ('${{ steps.released.outputs.exit-code }}' -ne '0') { throw 'Released action returned a nonzero exit code.' }
           if ('${{ steps.released.outputs.dotsider-version }}' -ne $version) { throw 'Released action resolved the wrong version.' }
           $report = Get-Content -LiteralPath '${{ steps.released.outputs.json-report-path }}' -Raw | ConvertFrom-Json
-          if ($report.schemaVersion -ne 1) { throw 'Released action returned an unsupported report schema.' }
+          if ($report.schemaVersion -ne 2) { throw 'Released action returned an unsupported report schema.' }
 
       - name: Reuse the resolved Dotsider tool
         uses: ./

--- a/README.md
+++ b/README.md
@@ -148,15 +148,18 @@ dotsider size-check out/pr/app --baseline baseline/app.mstat \
 dotsider size-check out/pr/app --budget max=25mb                        # absolute cap, no baseline
 ```
 
-Most projects should start with an absolute cap. This catches unexpected growth without any
-baseline build or artifact:
+Run the action or task on pull requests and the target branch. The first successful branch
+run enforces absolute limits and stores a managed baseline; later pull requests compare with
+the newest successful target-branch run:
 
 ```yaml
 - name: Check NativeAOT size
   uses: willibrandon/dotsider@v0
   with:
     target: out/pr/App
-    budgets: max=25mb
+    budgets: |
+      max=25mb
+      growth=1%
 ```
 
 Azure Pipelines provides the same contract through `DotsiderSizeCheck@1`:
@@ -168,11 +171,11 @@ Azure Pipelines provides the same contract through `DotsiderSizeCheck@1`:
     budgets: max=25mb
 ```
 
-To gate the change from one build to another, also pass `baseline` and use `growth=` budgets.
-For pull requests, build the base commit and the current commit in the same job so both use
-the same SDK, runtime identifier, and runner. See the
+When no baseline exists yet, absolute limits run and growth limits are clearly deferred; a
+successful branch build establishes it. Set `baseline` only as an explicit override. See the
 [size-regression guide](https://dotsider.dev/usage/size-regression/) for that workflow,
-stable outputs, and the offline `dotsider-path` option.
+stable provenance outputs, optional `/aot-size` reports, and the offline `dotsider-path`
+option.
 
 Budgets: `[scope:]limit(,limit)*` — scope `total` / `ns=<Namespace>` (covers sub-namespaces) /
 `asm=<Assembly>`; limits `max=SIZE` and `growth=SIZE|PERCENT` (`25mb`, `10kb`, `1%`).

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,10 @@ inputs:
     description: NativeAOT binary or .mstat report to check.
     required: true
   baseline:
-    description: Optional NativeAOT binary or .mstat report to compare with the target.
+    description: Optional explicit baseline override. By default, successful branch artifacts are managed automatically.
+    required: false
+  baseline-key:
+    description: Stable logical target key when the target path is temporary or otherwise changes between runs.
     required: false
   budgets:
     description: Size budget expressions, one per line.
@@ -75,6 +78,21 @@ outputs:
   violation-count:
     description: Number of budget violations.
     value: ${{ steps.run.outputs.violation-count }}
+  baseline-status:
+    description: explicit, restored, or not-found.
+    value: ${{ steps.run.outputs.baseline-status }}
+  baseline-source-id:
+    description: Provider run or build ID used as the baseline.
+    value: ${{ steps.run.outputs.baseline-source-id }}
+  baseline-source-commit:
+    description: Commit used as the baseline.
+    value: ${{ steps.run.outputs.baseline-source-commit }}
+  baseline-source-url:
+    description: Provider URL for the baseline run or build.
+    value: ${{ steps.run.outputs.baseline-source-url }}
+  baseline-artifact-name:
+    description: Managed baseline artifact name.
+    value: ${{ steps.run.outputs.baseline-artifact-name }}
 runs:
   using: composite
   steps:
@@ -99,6 +117,38 @@ runs:
         path: ${{ steps.prepare.outputs.cache-directory }}
         key: ${{ runner.os }}-${{ steps.prepare.outputs.cache-key }}
 
+    - name: Find Dotsider baseline
+      id: baseline
+      if: steps.prepare.outcome == 'success'
+      shell: bash
+      env:
+        DOTSIDER_INPUT_TARGET: ${{ inputs.target }}
+        DOTSIDER_INPUT_BASELINE: ${{ inputs.baseline }}
+        DOTSIDER_INPUT_BASELINE_KEY: ${{ inputs.baseline-key }}
+        DOTSIDER_INPUT_BUDGETS: ${{ inputs.budgets }}
+        DOTSIDER_INPUT_BUDGET_FILE: ${{ inputs.budget-file }}
+        DOTSIDER_INPUT_TOP: ${{ inputs.top }}
+        DOTSIDER_INPUT_WHY: ${{ inputs.why }}
+        DOTSIDER_INPUT_VERSION: ${{ inputs.dotsider-version }}
+        DOTSIDER_INPUT_PATH: ${{ inputs.dotsider-path }}
+        DOTSIDER_INPUT_REPORT_DIRECTORY: ${{ inputs.report-directory }}
+        DOTSIDER_INPUT_PUBLISH_SUMMARY: ${{ inputs.publish-summary }}
+        DOTSIDER_INPUT_PUBLISH_REPORTS: ${{ inputs.upload-reports }}
+        DOTSIDER_INPUT_ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        DOTSIDER_PREPARED_RID: ${{ steps.prepare.outputs.rid }}
+        GITHUB_TOKEN: ${{ github.token }}
+      run: node "${{ github.action_path }}/integrations/size-check/dist/github.js" discover
+
+    - name: Restore managed Dotsider baseline
+      if: steps.baseline.outputs.status == 'restored'
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ steps.baseline.outputs.artifact-name }}
+        path: ${{ steps.baseline.outputs.download-directory }}
+        github-token: ${{ github.token }}
+        repository: ${{ github.repository }}
+        run-id: ${{ steps.baseline.outputs.run-id }}
+
     - name: Run Dotsider size check
       id: run
       if: always()
@@ -106,6 +156,7 @@ runs:
       env:
         DOTSIDER_INPUT_TARGET: ${{ inputs.target }}
         DOTSIDER_INPUT_BASELINE: ${{ inputs.baseline }}
+        DOTSIDER_INPUT_BASELINE_KEY: ${{ inputs.baseline-key }}
         DOTSIDER_INPUT_BUDGETS: ${{ inputs.budgets }}
         DOTSIDER_INPUT_BUDGET_FILE: ${{ inputs.budget-file }}
         DOTSIDER_INPUT_TOP: ${{ inputs.top }}
@@ -122,6 +173,11 @@ runs:
         DOTSIDER_PREPARED_EXECUTABLE_PATH: ${{ steps.prepare.outputs.executable-path }}
         DOTSIDER_PREPARED_CACHE_KEY: ${{ steps.prepare.outputs.cache-key }}
         DOTSIDER_PREPARED_EXPLICIT: ${{ steps.prepare.outputs.explicit }}
+        DOTSIDER_BASELINE_SOURCE: ${{ steps.baseline.outputs.source }}
+        DOTSIDER_BASELINE_IDENTITY: ${{ steps.baseline.outputs.identity }}
+        DOTSIDER_BASELINE_ARTIFACT_NAME: ${{ steps.baseline.outputs.artifact-name }}
+        DOTSIDER_BASELINE_DOWNLOAD_DIRECTORY: ${{ steps.baseline.outputs.download-directory }}
+        DOTSIDER_BASELINE_PUBLISH: ${{ steps.baseline.outputs.publish }}
         GITHUB_TOKEN: ${{ github.token }}
       run: node "${{ github.action_path }}/integrations/size-check/dist/github.js" run
 
@@ -134,6 +190,15 @@ runs:
           ${{ steps.run.outputs.json-report-path }}
           ${{ steps.run.outputs.markdown-report-path }}
         if-no-files-found: error
+
+    - name: Publish managed Dotsider baseline
+      if: steps.run.outputs.publish-baseline == 'true'
+      uses: actions/upload-artifact@v7.0.1
+      with:
+        name: ${{ steps.run.outputs.baseline-artifact-name }}
+        path: ${{ steps.run.outputs.baseline-upload-path }}
+        if-no-files-found: error
+        include-hidden-files: true
 
     - name: Enforce Dotsider result
       if: always()

--- a/azure-devops/CHANGELOG.md
+++ b/azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.25.0
+
+- Discover matching successful branch baselines automatically and retain passing branch builds for later comparisons.
+- Defer growth budgets on a genuine first run while continuing to enforce absolute limits.
+- Report the source build, commit, URL, artifact identity, and resolved size sidecars.
+
 ## 0.24.9
 
 - Align the size-check verdict with the rest of the report in GitHub and Azure Pipelines summaries.

--- a/azure-devops/PRIVACY.md
+++ b/azure-devops/PRIVACY.md
@@ -2,4 +2,6 @@
 
 The Dotsider Azure Pipelines extension analyzes files selected by the pipeline and writes reports into the agent workspace. It does not send application contents or reports to Dotsider services.
 
-Unless `dotsiderPath` is supplied, the task contacts GitHub to resolve or download an official Dotsider release and its checksum. Azure Pipelines handles any reports published as build artifacts according to the project's retention and access settings.
+Unless `dotsiderPath` is supplied, the task contacts GitHub to resolve or download an official Dotsider release and its checksum. To manage baselines, it uses the pipeline's short-lived SystemVssConnection token to read successful builds and artifacts from the current Azure DevOps project. The token is removed from the environment before Dotsider runs and is never written to reports or logs.
+
+Azure Pipelines handles size reports and managed baseline artifacts according to the project's retention and access settings. Dotsider does not send their contents to an external service.

--- a/azure-devops/README.md
+++ b/azure-devops/README.md
@@ -2,7 +2,8 @@
 
 `DotsiderSizeCheck@1` enforces NativeAOT size budgets and publishes the same JSON and Markdown reports as `dotsider size-check`.
 
-Publish the application with NativeAOT size sidecars, then start with an absolute limit:
+Publish the application with NativeAOT size sidecars, then invoke the task on pull requests
+and on the target branch:
 
 ```yaml
 - task: DotsiderSizeCheck@1
@@ -11,23 +12,33 @@ Publish the application with NativeAOT size sidecars, then start with an absolut
     budgets: max=25mb
 ```
 
-The task downloads the matching released Dotsider binary, verifies its published SHA-256 checksum, and caches it by version and runtime identifier. Set `dotsiderPath` to use an existing installation without network access.
+The first successful branch build enforces absolute limits and stores a managed baseline.
+Later branch builds compare with the preceding successful build, and pull requests compare
+with the newest successful build of their target branch. The task downloads the matching
+released Dotsider binary, verifies its published SHA-256 checksum, and caches it by version
+and runtime identifier. Set `dotsiderPath` to use an existing installation without network
+access.
 
 Exit code 2 means an error-severity budget was exceeded. Reports and the pipeline summary are published before the task fails. Exit code 1 means the command or its inputs were invalid.
 
-When the pipeline builds both revisions, pass the older binary as `baseline` and add growth budgets:
+Add growth budgets immediately. When no stored baseline exists, they are reported as deferred
+while absolute limits still run; the successful branch build establishes the baseline:
 
 ```yaml
 - task: DotsiderSizeCheck@1
   inputs:
     target: '$(Build.ArtifactStagingDirectory)/current/myapp'
-    baseline: '$(Agent.TempDirectory)/base/myapp'
     budgets: |
+      total:max=25mb
       total:growth=50kb
       ns=MyApp.Serialization:growth=10kb
     why: true
 ```
 
-No setting needs to change between these uses. An omitted baseline measures the current build and supports `max=` budgets. A supplied baseline enables the comparison and `growth=` budgets. A growth budget without a baseline is an input error.
+No setting changes between the first run and later comparisons. Set `baseline` only to
+override the managed lifecycle with an explicit file; automatic discovery and publication
+are disabled for that invocation. Use `baselineKey` only when the target path is unstable.
 
-Application publishing stays explicit because the project chooses its target framework, runtime identifier, and publish options. For pull requests, build the base and current revisions in the same job instead of relying on a retained artifact from a different toolchain.
+Application publishing stays explicit because the project chooses its target framework,
+runtime identifier, and publish options. Managed artifacts are isolated by pipeline
+definition, job, logical target, and RID, and only wholly successful builds are eligible.

--- a/azure-devops/tasks/DotsiderSizeCheckV1/runtime/azure-baseline.js
+++ b/azure-devops/tasks/DotsiderSizeCheckV1/runtime/azure-baseline.js
@@ -1,0 +1,323 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.discoverAzureBaseline = discoverAzureBaseline;
+exports.takeAccessToken = takeAccessToken;
+exports.extractZipArchive = extractZipArchive;
+const node_zlib_1 = require("node:zlib");
+const fs = __importStar(require("node:fs/promises"));
+const path = __importStar(require("node:path"));
+const baseline_1 = require("./baseline");
+const maximumArchiveBytes = 1024 * 1024 * 1024;
+async function discoverAzureBaseline(inputs, preparedRid, environment = process.env) {
+    const targetRid = await (0, baseline_1.detectTargetRid)(inputs.target, preparedRid);
+    if (inputs.baseline) {
+        const identity = (0, baseline_1.createBaselineIdentity)("azure-pipelines", "explicit", "explicit", inputs.target, targetRid, inputs.baselineKey, environment.PIPELINE_WORKSPACE || environment.BUILD_SOURCESDIRECTORY, environment.AGENT_TEMPDIRECTORY);
+        const artifactName = (0, baseline_1.baselineArtifactName)(identity);
+        return {
+            identity,
+            artifactName,
+            source: { status: "explicit", path: inputs.baseline, artifactName },
+            publish: false,
+        };
+    }
+    const project = required(environment.SYSTEM_TEAMPROJECTID || environment.SYSTEM_TEAMPROJECT, "project");
+    const definition = required(environment.SYSTEM_DEFINITIONID, "pipeline definition");
+    const job = required(environment.SYSTEM_JOBNAME, "job");
+    const collection = required(environment.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI, "collection URI").replace(/\/$/u, "");
+    const identity = (0, baseline_1.createBaselineIdentity)("azure-pipelines", `${project}/${definition}`, job, inputs.target, targetRid, inputs.baselineKey, environment.PIPELINE_WORKSPACE || environment.BUILD_SOURCESDIRECTORY, environment.AGENT_TEMPDIRECTORY);
+    const artifactName = (0, baseline_1.baselineArtifactName)(identity);
+    const branch = targetBranch(environment);
+    const publish = environment.BUILD_REASON !== "PullRequest" && branch !== undefined;
+    if (!branch) {
+        return {
+            identity,
+            artifactName,
+            source: { status: "not-found", provider: "azure-pipelines", artifactName },
+            publish: false,
+        };
+    }
+    const token = takeAccessToken(environment);
+    const apiRoot = `${collection}/${encodeURIComponent(project)}/_apis/build`;
+    const buildsUrl = `${apiRoot}/builds?definitions=${encodeURIComponent(definition)}`
+        + `&branchName=${encodeURIComponent(branch)}&statusFilter=completed&resultFilter=succeeded`
+        + "&queryOrder=queueTimeDescending&$top=100&api-version=7.1";
+    const builds = await azureJson(buildsUrl, token);
+    const currentBuild = Number(environment.BUILD_BUILDID || "0");
+    for (const build of builds.value ?? []) {
+        if (build.id === currentBuild || build.result.toLowerCase() !== "succeeded" || build.sourceBranch !== branch) {
+            continue;
+        }
+        const artifactUrl = `${apiRoot}/builds/${build.id}/artifacts?artifactName=${encodeURIComponent(artifactName)}`
+            + "&api-version=7.1";
+        const artifact = await tryAzureArtifact(artifactUrl, token);
+        if (!artifact || artifact.name !== artifactName)
+            continue;
+        const downloadDirectory = path.join(environment.AGENT_TEMPDIRECTORY || process.cwd(), "dotsider-baseline", artifactName);
+        const baselineRoot = await downloadAndExtractZip(artifactUrl, token, downloadDirectory, collection);
+        const source = {
+            status: "restored",
+            provider: "azure-pipelines",
+            branch,
+            commit: build.sourceVersion,
+            id: String(build.id),
+            number: build.buildNumber,
+            url: build._links?.web?.href,
+            artifactName,
+        };
+        return { identity, artifactName, source, downloadDirectory: baselineRoot, publish };
+    }
+    return {
+        identity,
+        artifactName,
+        source: { status: "not-found", provider: "azure-pipelines", branch, artifactName },
+        publish,
+    };
+}
+function takeAccessToken(environment = process.env) {
+    const name = "ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN";
+    const token = environment[name]?.trim();
+    delete environment[name];
+    if (!token) {
+        throw new Error("Azure baseline discovery could not access the job token supplied to agent tasks. "
+            + "Run DotsiderSizeCheck in an agent job with access to the current project.");
+    }
+    return token;
+}
+async function extractZipArchive(buffer, destination) {
+    if (buffer.length > maximumArchiveBytes)
+        throw new Error("The Dotsider baseline archive exceeds 1 GiB.");
+    const eocd = findEndOfCentralDirectory(buffer);
+    const entryCount = buffer.readUInt16LE(eocd + 10);
+    const centralOffset = buffer.readUInt32LE(eocd + 16);
+    if (entryCount === 0xffff || centralOffset === 0xffffffff || entryCount > 20) {
+        throw new Error("The Dotsider baseline archive uses an unsupported ZIP layout.");
+    }
+    await fs.rm(destination, { recursive: true, force: true });
+    await fs.mkdir(destination, { recursive: true });
+    let offset = centralOffset;
+    let extractedBytes = 0;
+    for (let index = 0; index < entryCount; index++) {
+        requireSignature(buffer, offset, 0x02014b50, "central directory");
+        const flags = buffer.readUInt16LE(offset + 8);
+        const compression = buffer.readUInt16LE(offset + 10);
+        const crc = buffer.readUInt32LE(offset + 16);
+        const compressedBytes = buffer.readUInt32LE(offset + 20);
+        const uncompressedBytes = buffer.readUInt32LE(offset + 24);
+        const nameLength = buffer.readUInt16LE(offset + 28);
+        const extraLength = buffer.readUInt16LE(offset + 30);
+        const commentLength = buffer.readUInt16LE(offset + 32);
+        const externalAttributes = buffer.readUInt32LE(offset + 38);
+        const localOffset = buffer.readUInt32LE(offset + 42);
+        const name = buffer.toString("utf8", offset + 46, offset + 46 + nameLength);
+        offset += 46 + nameLength + extraLength + commentLength;
+        if ((flags & 1) !== 0 || ![0, 8].includes(compression)) {
+            throw new Error(`The Dotsider baseline archive entry '${name}' is encrypted or uses unsupported compression.`);
+        }
+        const unixMode = externalAttributes >>> 16;
+        if ((unixMode & 0xf000) === 0xa000)
+            throw new Error(`The Dotsider baseline archive contains symlink '${name}'.`);
+        if (name.endsWith("/"))
+            continue;
+        const destinationPath = safeZipPath(destination, name);
+        requireSignature(buffer, localOffset, 0x04034b50, "local entry");
+        const localNameLength = buffer.readUInt16LE(localOffset + 26);
+        const localExtraLength = buffer.readUInt16LE(localOffset + 28);
+        const dataOffset = localOffset + 30 + localNameLength + localExtraLength;
+        if (dataOffset + compressedBytes > buffer.length)
+            throw new Error(`ZIP entry '${name}' is truncated.`);
+        const compressed = buffer.subarray(dataOffset, dataOffset + compressedBytes);
+        if (uncompressedBytes > maximumArchiveBytes - extractedBytes) {
+            throw new Error("The Dotsider baseline archive expands beyond 1 GiB.");
+        }
+        const contents = compression === 0
+            ? Buffer.from(compressed)
+            : (0, node_zlib_1.inflateRawSync)(compressed, { maxOutputLength: Math.max(1, uncompressedBytes) });
+        if (contents.length !== uncompressedBytes || crc32(contents) !== crc) {
+            throw new Error(`ZIP entry '${name}' failed size or CRC validation.`);
+        }
+        extractedBytes += contents.length;
+        if (extractedBytes > maximumArchiveBytes)
+            throw new Error("The Dotsider baseline archive expands beyond 1 GiB.");
+        await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+        await fs.writeFile(destinationPath, contents, { flag: "wx" });
+    }
+}
+async function downloadAndExtractZip(url, token, destination, trustedCollection) {
+    const trustedOrigin = new URL(trustedCollection).origin;
+    let current = new URL(url);
+    let response;
+    for (let redirect = 0; redirect <= 5; redirect++) {
+        response = await fetch(current, {
+            redirect: "manual",
+            headers: {
+                Accept: "application/zip",
+                ...(current.origin === trustedOrigin ? { Authorization: `Bearer ${token}` } : {}),
+            },
+        });
+        if (![301, 302, 303, 307, 308].includes(response.status))
+            break;
+        const location = response.headers.get("location");
+        if (!location)
+            throw new Error("Azure baseline artifact download returned an invalid redirect.");
+        current = new URL(location, current);
+    }
+    if (!response)
+        throw new Error("Azure baseline artifact download did not return a response.");
+    if (!response.ok) {
+        const permission = response.status === 401 || response.status === 403
+            ? " Grant the project Build Service permission to read builds and artifacts."
+            : "";
+        throw new Error(`Azure baseline artifact download failed with HTTP ${response.status}.${permission}`);
+    }
+    await extractZipArchive(await readBoundedBody(response), destination);
+    return await locateBaselineRoot(destination);
+}
+async function readBoundedBody(response) {
+    const declaredLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(declaredLength) && declaredLength > maximumArchiveBytes) {
+        throw new Error("The Dotsider baseline archive exceeds 1 GiB.");
+    }
+    if (!response.body)
+        throw new Error("Azure baseline artifact download returned no content.");
+    const chunks = [];
+    let bytes = 0;
+    const reader = response.body.getReader();
+    while (true) {
+        const next = await reader.read();
+        if (next.done)
+            break;
+        bytes += next.value.byteLength;
+        if (bytes > maximumArchiveBytes) {
+            await reader.cancel();
+            throw new Error("The Dotsider baseline archive exceeds 1 GiB.");
+        }
+        chunks.push(Buffer.from(next.value));
+    }
+    return Buffer.concat(chunks, bytes);
+}
+async function locateBaselineRoot(directory) {
+    if (await isFile(path.join(directory, "dotsider-baseline.json")))
+        return directory;
+    const candidates = [];
+    for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+            const candidate = path.join(directory, entry.name);
+            if (await isFile(path.join(candidate, "dotsider-baseline.json")))
+                candidates.push(candidate);
+        }
+    }
+    if (candidates.length !== 1) {
+        throw new Error("The Azure baseline artifact does not contain one baseline manifest at its root.");
+    }
+    return candidates[0];
+}
+async function isFile(filePath) {
+    try {
+        return (await fs.stat(filePath)).isFile();
+    }
+    catch {
+        return false;
+    }
+}
+async function azureJson(url, token) {
+    const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    if (!response.ok) {
+        const permission = response.status === 401 || response.status === 403
+            ? " Grant the project Build Service permission to read builds and artifacts."
+            : "";
+        throw new Error(`Azure baseline discovery failed with HTTP ${response.status}.${permission}`);
+    }
+    return await response.json();
+}
+async function tryAzureArtifact(url, token) {
+    const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    if (response.status === 404)
+        return undefined;
+    if (!response.ok) {
+        const permission = response.status === 401 || response.status === 403
+            ? " Grant the project Build Service permission to read builds and artifacts."
+            : "";
+        throw new Error(`Azure baseline discovery failed with HTTP ${response.status}.${permission}`);
+    }
+    return await response.json();
+}
+function targetBranch(environment) {
+    const value = environment.BUILD_REASON === "PullRequest"
+        ? environment.SYSTEM_PULLREQUEST_TARGETBRANCH
+        : environment.BUILD_SOURCEBRANCH;
+    return value?.startsWith("refs/heads/") ? value : undefined;
+}
+function findEndOfCentralDirectory(buffer) {
+    const lowerBound = Math.max(0, buffer.length - 65_557);
+    for (let offset = buffer.length - 22; offset >= lowerBound; offset--) {
+        if (buffer.readUInt32LE(offset) === 0x06054b50)
+            return offset;
+    }
+    throw new Error("The Dotsider baseline artifact is not a supported ZIP archive.");
+}
+function requireSignature(buffer, offset, signature, name) {
+    if (offset < 0 || offset + 4 > buffer.length || buffer.readUInt32LE(offset) !== signature) {
+        throw new Error(`The Dotsider baseline ZIP ${name} is invalid.`);
+    }
+}
+function safeZipPath(root, entry) {
+    if (!entry || path.isAbsolute(entry) || entry.includes("\\"))
+        throw new Error(`Unsafe ZIP path '${entry}'.`);
+    const normalized = path.posix.normalize(entry);
+    if (normalized === ".." || normalized.startsWith("../") || normalized.includes("/../")) {
+        throw new Error(`Unsafe ZIP path '${entry}'.`);
+    }
+    const resolvedRoot = path.resolve(root);
+    const resolved = path.resolve(root, ...normalized.split("/"));
+    if (!resolved.startsWith(`${resolvedRoot}${path.sep}`))
+        throw new Error(`Unsafe ZIP path '${entry}'.`);
+    return resolved;
+}
+function crc32(buffer) {
+    let crc = 0xffffffff;
+    for (const byte of buffer) {
+        crc ^= byte;
+        for (let bit = 0; bit < 8; bit++)
+            crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+    return (crc ^ 0xffffffff) >>> 0;
+}
+function required(value, name) {
+    const candidate = value?.trim();
+    if (!candidate)
+        throw new Error(`Unable to determine the Azure Pipelines ${name}.`);
+    return candidate;
+}

--- a/azure-devops/tasks/DotsiderSizeCheckV1/runtime/azure.js
+++ b/azure-devops/tasks/DotsiderSizeCheckV1/runtime/azure.js
@@ -40,6 +40,8 @@ const fs = __importStar(require("node:fs/promises"));
 const os = __importStar(require("node:os"));
 const path = __importStar(require("node:path"));
 const acquisition_1 = require("./acquisition");
+const azure_baseline_1 = require("./azure-baseline");
+const baseline_1 = require("./baseline");
 const input_1 = require("./input");
 const process_1 = require("./process");
 const report_1 = require("./report");
@@ -54,9 +56,10 @@ async function main() {
         const defaultRoot = process.env.BUILD_ARTIFACTSTAGINGDIRECTORY
             || process.env.AGENT_TEMPDIRECTORY
             || os.tmpdir();
-        const inputs = (0, input_1.createInputs)({
+        let inputs = (0, input_1.createInputs)({
             target: getInput("target"),
             baseline: getInput("baseline"),
+            baselineKey: getInput("baselineKey"),
             budgets: getInput("budgets"),
             budgetFile: getInput("budgetFile"),
             top: getInput("top"),
@@ -72,8 +75,16 @@ async function main() {
         const tool = await (0, acquisition_1.prepareTool)(inputs.dotsiderVersion, inputs.dotsiderPath);
         dotsiderVersion = tool.version;
         const executable = await (0, acquisition_1.acquireTool)(tool);
-        const execution = await (0, process_1.executeSizeCheck)(executable, inputs);
-        const outputs = (0, report_1.createStableOutputs)(execution, inputs.artifactName, tool.version);
+        const discovery = await (0, azure_baseline_1.discoverAzureBaseline)(inputs, tool.rid);
+        if (discovery.source.status === "restored") {
+            const restored = await (0, baseline_1.restoreBaseline)(discovery.downloadDirectory || "", discovery.identity, discovery.source);
+            inputs = { ...inputs, baseline: restored.targetPath };
+        }
+        const execution = await (0, process_1.executeSizeCheck)(executable, inputs, discovery.source.status === "not-found");
+        if (execution.report && await fileExists(execution.markdownReportPath)) {
+            execution.report = await (0, baseline_1.enrichReports)(execution.jsonReportPath, execution.markdownReportPath, discovery.source);
+        }
+        const outputs = (0, report_1.createStableOutputs)(execution, inputs.artifactName, tool.version, discovery.source);
         errorOutputs = { ...outputs, result: "error", exitCode: "1" };
         writeStableOutputs(outputs);
         const summary = (0, report_1.formatSizeCheckSummary)(outputs);
@@ -87,6 +98,12 @@ async function main() {
             && await fileExists(execution.jsonReportPath)
             && await fileExists(execution.markdownReportPath)) {
             vso("artifact.upload", { artifactname: inputs.artifactName }, inputs.reportDirectory);
+        }
+        if (discovery.publish && execution.report
+            && (execution.result === "passed" || execution.result === "passed-with-warnings")) {
+            const baselineDirectory = path.join(process.env.AGENT_TEMPDIRECTORY || os.tmpdir(), "dotsider-baseline-upload", discovery.artifactName);
+            await (0, baseline_1.stageBaseline)(execution.report, discovery.identity, currentAzureSource(discovery.artifactName), baselineDirectory);
+            vso("artifact.upload", { artifactname: discovery.artifactName }, baselineDirectory);
         }
         if (execution.exitCode === 0) {
             complete("Succeeded", execution.result === "passed-with-warnings"
@@ -110,6 +127,23 @@ async function main() {
         complete("Failed", error instanceof Error ? error.message : String(error));
         process.exitCode = 1;
     }
+}
+function currentAzureSource(artifactName) {
+    const collection = (process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI || "").replace(/\/$/u, "");
+    const project = process.env.SYSTEM_TEAMPROJECT || process.env.SYSTEM_TEAMPROJECTID || "";
+    const buildId = process.env.BUILD_BUILDID || "";
+    return {
+        status: "restored",
+        provider: "azure-pipelines",
+        branch: process.env.BUILD_SOURCEBRANCH,
+        commit: process.env.BUILD_SOURCEVERSION,
+        id: buildId,
+        number: process.env.BUILD_BUILDNUMBER,
+        url: collection && project && buildId
+            ? `${collection}/${encodeURIComponent(project)}/_build/results?buildId=${buildId}`
+            : undefined,
+        artifactName,
+    };
 }
 function getInput(name) {
     const variants = [

--- a/azure-devops/tasks/DotsiderSizeCheckV1/runtime/baseline.js
+++ b/azure-devops/tasks/DotsiderSizeCheckV1/runtime/baseline.js
@@ -1,0 +1,316 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createBaselineIdentity = createBaselineIdentity;
+exports.baselineArtifactName = baselineArtifactName;
+exports.detectTargetRid = detectTargetRid;
+exports.detectRidFromHeader = detectRidFromHeader;
+exports.stageBaseline = stageBaseline;
+exports.restoreBaseline = restoreBaseline;
+exports.enrichReports = enrichReports;
+const node_crypto_1 = require("node:crypto");
+const node_fs_1 = require("node:fs");
+const fs = __importStar(require("node:fs/promises"));
+const path = __importStar(require("node:path"));
+const manifestFileName = "dotsider-baseline.json";
+const manifestSchemaVersion = 1;
+const maximumFileBytes = 1024 * 1024 * 1024;
+function createBaselineIdentity(provider, scope, job, targetPath, rid, baselineKey, workspace, temporaryDirectory) {
+    return {
+        provider,
+        scope: requiredIdentityPart(scope, "provider scope"),
+        job: requiredIdentityPart(job, "job"),
+        target: baselineKey?.trim() || logicalTarget(targetPath, workspace, temporaryDirectory),
+        rid: requiredIdentityPart(rid, "target RID"),
+    };
+}
+function baselineArtifactName(identity) {
+    const digest = (0, node_crypto_1.createHash)("sha256").update(canonicalIdentity(identity)).digest("hex").slice(0, 20);
+    const rid = sanitize(identity.rid).slice(0, 32) || "unknown";
+    return `dotsider-baseline-${rid}-${digest}`;
+}
+async function detectTargetRid(targetPath, fallbackRid) {
+    if (targetPath.toLowerCase().endsWith(".mstat")) {
+        return fallbackRid;
+    }
+    const handle = await fs.open(targetPath, "r");
+    try {
+        // The ELF program interpreter is not guaranteed to appear in the first page.
+        // Reading 64 KiB is still bounded while covering normal program-header layouts.
+        const buffer = Buffer.alloc(64 * 1024);
+        const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+        return detectRidFromHeader(buffer.subarray(0, bytesRead), fallbackRid);
+    }
+    finally {
+        await handle.close();
+    }
+}
+function detectRidFromHeader(bytes, fallbackRid) {
+    if (bytes.length >= 64 && bytes[0] === 0x7f && bytes.toString("ascii", 1, 4) === "ELF") {
+        const littleEndian = bytes[5] === 1;
+        const machine = littleEndian ? bytes.readUInt16LE(18) : bytes.readUInt16BE(18);
+        const architecture = machine === 0x3e ? "x64"
+            : machine === 0xb7 ? "arm64"
+                : machine === 0x03 ? "x86"
+                    : machine === 0x28 ? "arm"
+                        : undefined;
+        if (architecture) {
+            const musl = bytes.includes(Buffer.from("ld-musl-"));
+            return `linux-${musl ? "musl-" : ""}${architecture}`;
+        }
+    }
+    if (bytes.length >= 64 && bytes[0] === 0x4d && bytes[1] === 0x5a) {
+        const peOffset = bytes.readUInt32LE(0x3c);
+        if (peOffset + 6 <= bytes.length && bytes.toString("ascii", peOffset, peOffset + 4) === "PE\0\0") {
+            const machine = bytes.readUInt16LE(peOffset + 4);
+            const architecture = machine === 0x8664 ? "x64"
+                : machine === 0xaa64 ? "arm64"
+                    : machine === 0x014c ? "x86"
+                        : machine === 0x01c4 ? "arm"
+                            : undefined;
+            if (architecture)
+                return `win-${architecture}`;
+        }
+    }
+    if (bytes.length >= 8) {
+        const magic = bytes.readUInt32BE(0);
+        const littleEndian = magic === 0xcefaedfe || magic === 0xcffaedfe;
+        if (magic === 0xfeedface || magic === 0xfeedfacf || littleEndian) {
+            const cpu = littleEndian ? bytes.readUInt32LE(4) : bytes.readUInt32BE(4);
+            if (cpu === 0x01000007)
+                return "osx-x64";
+            if (cpu === 0x0100000c)
+                return "osx-arm64";
+        }
+    }
+    return fallbackRid;
+}
+async function stageBaseline(report, identity, source, directory) {
+    await fs.rm(directory, { recursive: true, force: true });
+    const filesDirectory = path.join(directory, "files");
+    await fs.mkdir(filesDirectory, { recursive: true });
+    const artifacts = report.targetArtifacts;
+    const candidates = [
+        ["binary", artifacts.binaryPath],
+        ["mstat", artifacts.mstatPath],
+        ["dgml", artifacts.dgmlPath],
+    ];
+    const manifestFiles = [];
+    let targetRelativePath;
+    for (const [role, sourcePath] of candidates) {
+        if (!sourcePath)
+            continue;
+        const extension = role === "binary" ? path.extname(sourcePath) : role === "mstat" ? ".mstat" : ".dgml.xml";
+        const relativePath = path.posix.join("files", `target${extension}`);
+        const destination = path.join(directory, ...relativePath.split("/"));
+        const stat = await fs.lstat(sourcePath);
+        if (!stat.isFile() || stat.isSymbolicLink()) {
+            throw new Error(`Baseline source '${sourcePath}' is not a regular file.`);
+        }
+        if (stat.size > maximumFileBytes) {
+            throw new Error(`Baseline source '${sourcePath}' exceeds the 1 GiB file limit.`);
+        }
+        await fs.copyFile(sourcePath, destination);
+        manifestFiles.push({ role, path: relativePath, bytes: stat.size, sha256: await sha256File(destination) });
+        if (role === (artifacts.binaryPath ? "binary" : "mstat"))
+            targetRelativePath = relativePath;
+    }
+    if (!targetRelativePath || !manifestFiles.some(file => file.role === "mstat")) {
+        throw new Error("Dotsider did not report the files required to create a baseline artifact.");
+    }
+    const manifest = {
+        schemaVersion: manifestSchemaVersion,
+        identity,
+        source,
+        targetPath: targetRelativePath,
+        files: manifestFiles,
+    };
+    await fs.writeFile(path.join(directory, manifestFileName), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    return directory;
+}
+async function restoreBaseline(directory, expected, expectedSource) {
+    const manifestPath = path.join(directory, manifestFileName);
+    const manifest = parseManifest(JSON.parse(await fs.readFile(manifestPath, "utf8")));
+    if (canonicalIdentity(manifest.identity) !== canonicalIdentity(expected)) {
+        throw new Error("The stored Dotsider baseline does not match this workflow, job, target, and RID.");
+    }
+    if (expectedSource?.status === "restored"
+        && (manifest.source.status !== "restored"
+            || manifest.source.provider !== expectedSource.provider
+            || manifest.source.branch !== expectedSource.branch
+            || manifest.source.id !== expectedSource.id
+            || manifest.source.commit !== expectedSource.commit
+            || manifest.source.artifactName !== expectedSource.artifactName)) {
+        throw new Error("The stored Dotsider baseline provenance does not match its provider build.");
+    }
+    if (manifest.files.length === 0 || manifest.files.length > 3) {
+        throw new Error("The stored Dotsider baseline manifest has an invalid file count.");
+    }
+    const paths = new Set();
+    const roles = new Set();
+    for (const file of manifest.files) {
+        if (paths.has(file.path) || roles.has(file.role)) {
+            throw new Error("The stored Dotsider baseline manifest contains duplicate files or roles.");
+        }
+        paths.add(file.path);
+        roles.add(file.role);
+        const resolved = safeArtifactPath(directory, file.path);
+        const stat = await fs.lstat(resolved);
+        if (!stat.isFile() || stat.isSymbolicLink() || stat.size !== file.bytes || stat.size > maximumFileBytes) {
+            throw new Error(`Stored Dotsider baseline file '${file.path}' failed validation.`);
+        }
+        if (await sha256File(resolved) !== file.sha256) {
+            throw new Error(`Stored Dotsider baseline file '${file.path}' failed SHA-256 validation.`);
+        }
+    }
+    if (!roles.has("mstat")
+        || !manifest.files.some(file => file.path === manifest.targetPath
+            && (file.role === "binary" || file.role === "mstat"))) {
+        throw new Error("The stored Dotsider baseline manifest does not identify a verified target and mstat file.");
+    }
+    return {
+        targetPath: safeArtifactPath(directory, manifest.targetPath),
+        source: manifest.source,
+    };
+}
+async function enrichReports(jsonPath, markdownPath, source) {
+    const report = JSON.parse(await fs.readFile(jsonPath, "utf8"));
+    report.baselineSource = source;
+    await fs.writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+    const markdown = await fs.readFile(markdownPath, "utf8");
+    const baselineLine = formatBaselineSource(source);
+    const firstSection = /\r?\n---\r?\n/u.exec(markdown);
+    const newline = markdown.includes("\r\n") ? "\r\n" : "\n";
+    const enriched = firstSection?.index !== undefined
+        ? `${markdown.slice(0, firstSection.index).trimEnd()}${newline}${newline}${baselineLine}${newline}`
+            + markdown.slice(firstSection.index)
+        : `${markdown.trimEnd()}${newline}${newline}${baselineLine}${newline}`;
+    await fs.writeFile(markdownPath, enriched, "utf8");
+    return report;
+}
+function formatBaselineSource(source) {
+    if (source.status === "explicit") {
+        return `**Baseline:** Explicit file ${markdownCodeSpan(source.path ?? "unknown")}.`;
+    }
+    if (source.status === "not-found") {
+        const branch = source.branch ? ` for ${markdownCodeSpan(source.branch)}` : "";
+        return `**Baseline:** No stored baseline was found${branch}; absolute budgets were evaluated and growth budgets were deferred.`;
+    }
+    const label = source.number ? `run ${source.number}` : `run ${source.id ?? "unknown"}`;
+    const linked = source.url ? `[${label}](${source.url})` : label;
+    const commit = source.commit ? ` at ${markdownCodeSpan(source.commit.slice(0, 12))}` : "";
+    const branch = source.branch ? ` on ${markdownCodeSpan(source.branch)}` : "";
+    return `**Baseline:** Restored from ${linked}${commit}${branch}.`;
+}
+function markdownCodeSpan(value) {
+    const longestRun = Math.max(0, ...[...value.matchAll(/`+/gu)].map(match => match[0].length));
+    const delimiter = "`".repeat(longestRun + 1);
+    const padding = value.startsWith("`") || value.startsWith(" ")
+        || value.endsWith("`") || value.endsWith(" ")
+        ? " "
+        : "";
+    return `${delimiter}${padding}${value}${padding}${delimiter}`;
+}
+function parseManifest(value) {
+    if (!value || typeof value !== "object")
+        throw new Error("The stored Dotsider baseline manifest is invalid.");
+    const manifest = value;
+    if (manifest.schemaVersion !== manifestSchemaVersion || !manifest.identity || !manifest.source
+        || typeof manifest.targetPath !== "string" || !Array.isArray(manifest.files)) {
+        throw new Error("The stored Dotsider baseline manifest is unsupported or incomplete.");
+    }
+    for (const file of manifest.files) {
+        if (!file || typeof file.path !== "string" || typeof file.sha256 !== "string"
+            || typeof file.bytes !== "number" || !["binary", "mstat", "dgml"].includes(file.role)) {
+            throw new Error("The stored Dotsider baseline manifest contains an invalid file entry.");
+        }
+    }
+    return manifest;
+}
+function safeArtifactPath(root, relativePath) {
+    if (!relativePath || path.isAbsolute(relativePath) || relativePath.includes("\\")) {
+        throw new Error(`Stored Dotsider baseline path '${relativePath}' is unsafe.`);
+    }
+    const normalized = path.posix.normalize(relativePath);
+    if (normalized === ".." || normalized.startsWith("../") || normalized.includes("/../")) {
+        throw new Error(`Stored Dotsider baseline path '${relativePath}' is unsafe.`);
+    }
+    const resolvedRoot = path.resolve(root);
+    const resolved = path.resolve(root, ...normalized.split("/"));
+    if (resolved !== resolvedRoot && !resolved.startsWith(`${resolvedRoot}${path.sep}`)) {
+        throw new Error(`Stored Dotsider baseline path '${relativePath}' escapes its artifact.`);
+    }
+    return resolved;
+}
+async function sha256File(filePath) {
+    const hash = (0, node_crypto_1.createHash)("sha256");
+    await new Promise((resolve, reject) => {
+        const stream = (0, node_fs_1.createReadStream)(filePath);
+        stream.on("data", chunk => hash.update(chunk));
+        stream.on("error", reject);
+        stream.on("end", resolve);
+    });
+    return hash.digest("hex");
+}
+function canonicalIdentity(identity) {
+    return JSON.stringify({
+        provider: identity.provider,
+        scope: identity.scope,
+        job: identity.job,
+        target: identity.target,
+        rid: identity.rid,
+    });
+}
+function logicalTarget(targetPath, workspace, temporaryDirectory) {
+    const absolute = path.resolve(targetPath);
+    for (const [label, root] of [["workspace", workspace], ["temp", temporaryDirectory]]) {
+        if (!root)
+            continue;
+        const relative = path.relative(path.resolve(root), absolute);
+        if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+            return `${label}/${relative.replaceAll(path.sep, "/")}`;
+        }
+    }
+    return `file/${path.basename(absolute)}`;
+}
+function requiredIdentityPart(value, name) {
+    const candidate = value.trim();
+    if (!candidate)
+        throw new Error(`Unable to determine the Dotsider baseline ${name}.`);
+    return candidate;
+}
+function sanitize(value) {
+    return value.toLowerCase().replace(/[^a-z0-9_.-]+/gu, "-").replace(/^-+|-+$/gu, "");
+}

--- a/azure-devops/tasks/DotsiderSizeCheckV1/runtime/input.js
+++ b/azure-devops/tasks/DotsiderSizeCheckV1/runtime/input.js
@@ -82,6 +82,7 @@ function createInputs(values, defaultReportRoot) {
     return {
         target: path.resolve(target),
         baseline,
+        baselineKey: optional(values.baselineKey),
         budgets: parseBudgets(values.budgets),
         budgetFile: optionalPath(values.budgetFile),
         top: parseTop(values.top),
@@ -103,4 +104,8 @@ function required(value, name) {
 function optionalPath(value) {
     const candidate = value?.trim();
     return candidate ? path.resolve(candidate) : undefined;
+}
+function optional(value) {
+    const candidate = value?.trim();
+    return candidate || undefined;
 }

--- a/azure-devops/tasks/DotsiderSizeCheckV1/runtime/process.js
+++ b/azure-devops/tasks/DotsiderSizeCheckV1/runtime/process.js
@@ -45,6 +45,7 @@ async function runProcess(fileName, args) {
             shell: false,
             windowsHide: true,
             stdio: ["ignore", "pipe", "pipe"],
+            env: sanitizedChildEnvironment(),
         });
         let stdout = "";
         let stderr = "";
@@ -68,7 +69,7 @@ async function runProcess(fileName, args) {
         });
     });
 }
-async function executeSizeCheck(executablePath, inputs) {
+async function executeSizeCheck(executablePath, inputs, baselineNotFound = false) {
     await fs.mkdir(inputs.reportDirectory, { recursive: true });
     const jsonReportPath = path.join(inputs.reportDirectory, "dotsider-size-check.json");
     const markdownReportPath = path.join(inputs.reportDirectory, "dotsider-size-check.md");
@@ -77,7 +78,22 @@ async function executeSizeCheck(executablePath, inputs) {
         fs.rm(markdownReportPath, { force: true }),
     ]);
     const args = (0, report_1.buildSizeCheckArguments)(inputs.target, inputs.baseline, inputs.budgets, inputs.budgetFile, inputs.top, inputs.why, jsonReportPath, markdownReportPath);
-    const processResult = await runProcess(executablePath, args);
+    const previous = process.env.DOTSIDER_SIZE_CHECK_BASELINE_NOT_FOUND;
+    if (baselineNotFound) {
+        process.env.DOTSIDER_SIZE_CHECK_BASELINE_NOT_FOUND = "1";
+    }
+    let processResult;
+    try {
+        processResult = await runProcess(executablePath, args);
+    }
+    finally {
+        if (previous === undefined) {
+            delete process.env.DOTSIDER_SIZE_CHECK_BASELINE_NOT_FOUND;
+        }
+        else {
+            process.env.DOTSIDER_SIZE_CHECK_BASELINE_NOT_FOUND = previous;
+        }
+    }
     let report;
     try {
         report = await (0, report_1.readSizeReport)(jsonReportPath);
@@ -102,4 +118,19 @@ async function executeSizeCheck(executablePath, inputs) {
         report,
         stderr: processResult.stderr,
     };
+}
+function sanitizedChildEnvironment() {
+    const environment = { ...process.env };
+    for (const name of [
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "ACTIONS_RUNTIME_TOKEN",
+        "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+        "ACTIONS_ID_TOKEN_REQUEST_URL",
+        "ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN",
+        "SYSTEM_ACCESSTOKEN",
+    ]) {
+        delete environment[name];
+    }
+    return environment;
 }

--- a/azure-devops/tasks/DotsiderSizeCheckV1/runtime/report.js
+++ b/azure-devops/tasks/DotsiderSizeCheckV1/runtime/report.js
@@ -81,8 +81,10 @@ function isSizeReport(value) {
         return false;
     }
     const report = value;
-    return report.schemaVersion === 1
+    return report.schemaVersion === 2
         && typeof report.target === "string"
+        && !!report.targetArtifacts
+        && typeof report.targetArtifacts.mstatPath === "string"
         && typeof report.totalBasis === "string"
         && typeof report.rightTotal === "number"
         && !!report.summary
@@ -95,12 +97,12 @@ function classifyResult(exitCode, report) {
     if (exitCode !== 0 || report === undefined) {
         return "error";
     }
-    if (report.budgets?.hasWarnings === true) {
+    if (report.budgets?.hasWarnings === true || report.budgets?.hasDeferred === true) {
         return "passed-with-warnings";
     }
     return "passed";
 }
-function createStableOutputs(execution, artifactName, dotsiderVersion) {
+function createStableOutputs(execution, artifactName, dotsiderVersion, baselineSource) {
     const report = execution.report;
     const evaluations = report?.budgets?.evaluations ?? [];
     const violationCount = evaluations.reduce((count, evaluation) => count + (evaluation.violations?.length ?? 0), 0);
@@ -116,6 +118,11 @@ function createStableOutputs(execution, artifactName, dotsiderVersion) {
         currentTotal: numberOutput(report?.rightTotal),
         delta: numberOutput(report?.summary.delta),
         violationCount: String(violationCount),
+        baselineStatus: baselineSource?.status ?? "",
+        baselineSourceId: baselineSource?.id ?? "",
+        baselineSourceCommit: baselineSource?.commit ?? "",
+        baselineSourceUrl: baselineSource?.url ?? "",
+        baselineArtifactName: baselineSource?.artifactName ?? "",
     };
 }
 function createErrorOutputs(artifactName, dotsiderVersion) {
@@ -131,6 +138,11 @@ function createErrorOutputs(artifactName, dotsiderVersion) {
         currentTotal: "",
         delta: "",
         violationCount: "0",
+        baselineStatus: "",
+        baselineSourceId: "",
+        baselineSourceCommit: "",
+        baselineSourceUrl: "",
+        baselineArtifactName: "",
     };
 }
 function formatSizeCheckSummary(outputs) {

--- a/azure-devops/tasks/DotsiderSizeCheckV1/task.json
+++ b/azure-devops/tasks/DotsiderSizeCheckV1/task.json
@@ -4,7 +4,7 @@
   "name": "DotsiderSizeCheck",
   "friendlyName": "Dotsider size check",
   "description": "Enforce NativeAOT size budgets and publish JSON and Markdown reports.",
-  "helpMarkDown": "Runs Dotsider against an application published with NativeAOT size sidecars. Omit the baseline for absolute budgets or supply one to compare builds.",
+  "helpMarkDown": "Runs Dotsider against an application published with NativeAOT size sidecars. Successful branch builds are retained automatically and pull requests compare with their target branch.",
   "category": "Build",
   "author": "willibrandon",
   "version": {
@@ -30,6 +30,14 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "Optional NativeAOT binary or .mstat report to compare with the target."
+    },
+    {
+      "name": "baselineKey",
+      "type": "string",
+      "label": "Baseline key",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Stable logical target key when the target path is temporary or otherwise changes between builds."
     },
     {
       "name": "budgets",
@@ -156,6 +164,26 @@
     {
       "name": "violationCount",
       "description": "Number of budget violations."
+    },
+    {
+      "name": "baselineStatus",
+      "description": "explicit, restored, or not-found."
+    },
+    {
+      "name": "baselineSourceId",
+      "description": "Provider build ID used as the baseline."
+    },
+    {
+      "name": "baselineSourceCommit",
+      "description": "Commit used as the baseline."
+    },
+    {
+      "name": "baselineSourceUrl",
+      "description": "Provider URL for the baseline build."
+    },
+    {
+      "name": "baselineArtifactName",
+      "description": "Managed baseline artifact name."
     }
   ],
   "execution": {
@@ -179,7 +207,12 @@
         "baselineTotal",
         "currentTotal",
         "delta",
-        "violationCount"
+        "violationCount",
+        "baselineStatus",
+        "baselineSourceId",
+        "baselineSourceCommit",
+        "baselineSourceUrl",
+        "baselineArtifactName"
       ]
     }
   }

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SizeBudgetEvaluation.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SizeBudgetEvaluation.md
@@ -95,6 +95,17 @@ The budget that was evaluated.
 public SizeBudget Budget { get; init; }
 ```
 
+### DeferredMetrics
+
+Growth limits that could not be evaluated because no baseline exists. Absolute limits
+in the same budget are still evaluated normally.
+
+**Returns:** [IReadOnlyList\<SizeBudgetMetric\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1)
+
+```csharp
+public IReadOnlyList<SizeBudgetMetric> DeferredMetrics { get; init; }
+```
+
 ### Passed
 
 True when no limit was breached.

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SizeBudgetReport.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-Models-SizeBudgetReport.md
@@ -61,6 +61,16 @@ One outcome per budget, in input order.
 public IReadOnlyList<SizeBudgetEvaluation> Evaluations { get; init; }
 ```
 
+### HasDeferred
+
+True when one or more growth limits were deferred because no baseline exists.
+
+**Returns:** [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)
+
+```csharp
+public bool HasDeferred { get; init; }
+```
+
 ### HasWarnings
 
 True when at least one warning-severity budget breached.

--- a/docs/src/content/docs/api/Dotsider-Core-Analysis-SizeBudgetEvaluator.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Analysis-SizeBudgetEvaluator.md
@@ -26,6 +26,27 @@ public static class SizeBudgetEvaluator
 
 ## Methods
 
+### Evaluate(IReadOnlyList\<SizeBudget\>, MstatDiffResult, SizeBasis, long, long?, int, bool)
+
+Evaluates budgets while deferring growth limits when a provider has established that no
+baseline artifact exists. Absolute limits continue to be enforced.
+
+**Parameters:**
+
+- `budgets` ([IReadOnlyList\<SizeBudget\>](https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1))
+- `diff` ([MstatDiffResult](/api/dotsider.core.analysis.models.mstatdiffresult/))
+- `totalBasis` ([SizeBasis](/api/dotsider.core.analysis.models.sizebasis/))
+- `currentTotalBytes` ([Int64](https://learn.microsoft.com/dotnet/api/system.int64))
+- `baselineTotalBytes` ([Nullable\<Int64\>](https://learn.microsoft.com/dotnet/api/system.nullable-1))
+- `defaultTopN` ([Int32](https://learn.microsoft.com/dotnet/api/system.int32))
+- `deferGrowthWithoutBaseline` ([Boolean](https://learn.microsoft.com/dotnet/api/system.boolean))
+
+**Returns:** [SizeBudgetReport](/api/dotsider.core.analysis.models.sizebudgetreport/)
+
+```csharp
+public static SizeBudgetReport Evaluate(IReadOnlyList<SizeBudget> budgets, MstatDiffResult diff, SizeBasis totalBasis, long currentTotalBytes, long? baselineTotalBytes, int defaultTopN, bool deferGrowthWithoutBaseline)
+```
+
 ### Evaluate(IReadOnlyList\<SizeBudget\>, MstatDiffResult, SizeBasis, long, long?, int)
 
 Evaluates budgets against a diff.
@@ -45,7 +66,7 @@ The report, failing only on error-severity breaches.
 
 **Exceptions:**
 
-- [ArgumentException](https://learn.microsoft.com/dotnet/api/system.argumentexception): A total-scope growth budget was supplied without a baseline; callers reject that combination before evaluating.
+- [ArgumentException](https://learn.microsoft.com/dotnet/api/system.argumentexception): A growth budget was supplied without a baseline.
 
 ```csharp
 public static SizeBudgetReport Evaluate(IReadOnlyList<SizeBudget> budgets, MstatDiffResult diff, SizeBasis totalBasis, long currentTotalBytes, long? baselineTotalBytes, int defaultTopN = 10)

--- a/docs/src/content/docs/api/Dotsider-Core-Protocol-DotsiderJsonContext.md
+++ b/docs/src/content/docs/api/Dotsider-Core-Protocol-DotsiderJsonContext.md
@@ -970,6 +970,16 @@ Defines the source generated JSON serialization contract metadata for a given ty
 public JsonTypeInfo<IReadOnlyList<SizeBudgetEvaluation>> IReadOnlyListSizeBudgetEvaluation { get; }
 ```
 
+### IReadOnlyListSizeBudgetMetric
+
+Defines the source generated JSON serialization contract metadata for a given type.
+
+**Returns:** [JsonTypeInfo\<SizeBudgetMetric\>\>](https://learn.microsoft.com/dotnet/api/system.text.json.serialization.metadata.jsontypeinfo-1)
+
+```csharp
+public JsonTypeInfo<IReadOnlyList<SizeBudgetMetric>> IReadOnlyListSizeBudgetMetric { get; }
+```
+
 ### IReadOnlyListSizeBudgetViolation
 
 Defines the source generated JSON serialization contract metadata for a given type.

--- a/docs/src/content/docs/reference/ci-integrations.md
+++ b/docs/src/content/docs/reference/ci-integrations.md
@@ -4,13 +4,16 @@ description: GitHub Actions and Azure Pipelines contracts for NativeAOT size che
 ---
 
 Dotsider publishes a composite GitHub Action and `DotsiderSizeCheck@1` Azure Pipelines task.
-Both run the existing `dotsider size-check` command, preserve its exit codes, and publish the
-CLI-generated JSON and Markdown reports before failing a budget gate.
+Both run the existing `dotsider size-check` command, preserve its exit codes, publish the
+CLI-generated JSON and Markdown reports before failing a budget gate, and manage matching
+branch baselines without project-specific artifact queries.
 
-## Start with an absolute limit
+## Automatic branch baselines
 
-An absolute limit needs only the NativeAOT build you already publish. It is the simplest
-useful guardrail and does not require a baseline:
+Run the integration after the NativeAOT publish on pull requests and on the target branch.
+The first successful branch run enforces absolute limits and stores the binary plus its
+resolved `.mstat` and optional DGML sidecars. Later branch runs compare with the preceding
+successful run; pull requests compare with the newest successful run of their target branch.
 
 ```yaml
 - uses: willibrandon/dotsider@v0
@@ -18,6 +21,14 @@ useful guardrail and does not require a baseline:
   with:
     target: out/current/App
     budgets: max=25mb
+```
+
+The job needs read access to earlier workflow artifacts:
+
+```yaml
+permissions:
+  actions: read
+  contents: read
 ```
 
 The equivalent Azure Pipelines task is:
@@ -30,13 +41,19 @@ The equivalent Azure Pipelines task is:
     budgets: max=25mb
 ```
 
-Choose the initial cap from a known-good build and leave enough room for ordinary compiler
-and dependency changes. Tighten it once the application has a stable size envelope.
+The Azure task uses the current pipeline's Build Service identity to read successful builds
+and artifacts from the same pipeline definition. No PAT is required. If access was removed,
+grant that identity read access to builds and artifacts.
 
-## Compare two builds
+When no matching baseline exists, `max=` limits still run and `growth=` limits are named as
+deferred in the summary and JSON report. A successful branch run then establishes the first
+baseline. Network, authentication, corrupt-artifact, and manifest-validation failures are
+errors; they never masquerade as a first run.
 
-Add `baseline` when the job already has an older build to compare. This enables `growth=`
-budgets and changes the report from current-build totals to a before-and-after comparison:
+## Explicit baseline override
+
+Set `baseline` when the job deliberately owns both inputs. That disables automatic discovery
+and publication for this invocation:
 
 ```yaml
 - uses: willibrandon/dotsider@v0
@@ -60,14 +77,22 @@ budgets and changes the report from current-build totals to a before-and-after c
     why: true
 ```
 
-For pull requests, build the base commit and current commit in the same job. That keeps the
-SDK, NativeAOT toolchain, runtime identifier, and runner constant, so the report measures the
-code change instead of a toolchain change. The [size-regression guide](/usage/size-regression/)
-contains complete GitHub Actions and Azure Pipelines examples.
+This remains useful for release-to-release checks or pipelines that intentionally rebuild
+the base revision with the current toolchain. The [size-regression guide](/usage/size-regression/)
+contains complete examples.
 
-Dotsider does not search workflow history or manage baseline artifacts. Projects vary too
-widely in runtime identifiers, publish properties, retention, permissions, and generated
-inputs for that behavior to be reliable inside a size-check action.
+## On-demand pull-request reports
+
+Projects that do not want to run the comparison on every pull request can publish the binary
+and sidecars from their normal build, then add a trusted `/aot-size` comment workflow. The
+command works in the pull-request conversation and in review comments. It
+downloads the successful PR and base-branch input artifacts, runs Dotsider with an explicit
+baseline, and updates one PR comment. The analysis job never checks out or executes PR code
+with a write-capable token, and the Dotsider child process does not inherit provider tokens.
+
+Copy the [on-demand workflow template](https://github.com/willibrandon/dotsider/blob/main/integrations/size-check/examples/github-aot-size.yml),
+then change its build workflow, artifact name, target path, and budgets. It also supports a
+manual `workflow_dispatch` with a pull-request number.
 
 ## Inputs
 
@@ -75,6 +100,7 @@ inputs for that behavior to be reliable inside a size-check action.
 | --- | --- | --- |
 | `target` | `target` | Required NativeAOT binary or `.mstat` report |
 | `baseline` | `baseline` | Optional older binary or `.mstat`; enables comparison and `growth=` budgets |
+| `baseline-key` | `baselineKey` | Stable logical target key when a temporary target path changes between runs |
 | `budgets` | `budgets` | Budget expressions, one per line |
 | `budget-file` | `budgetFile` | JSON budget document |
 | `top` | `top` | Contributors per section; default 10 |
@@ -86,20 +112,29 @@ inputs for that behavior to be reliable inside a size-check action.
 | `upload-reports` | `publishReports` | Publish both reports as an artifact |
 | `artifact-name` | `artifactName` | Report artifact name |
 
-Without `baseline`, use absolute `max=` budgets. With `baseline`, both `max=` and `growth=`
-budgets are valid. A growth budget without a baseline fails as an input error instead of
-silently skipping the check.
+An automatically missing baseline defers growth limits only after provider discovery proves
+that no matching artifact exists. Direct CLI use remains strict: growth budgets require
+`--baseline`.
 
 ## Outputs
 
 Both integrations expose `result`, `exitCode`, `jsonReportPath`, `markdownReportPath`,
 `artifactName`, `dotsiderVersion`, `totalBasis`, `baselineTotal`, `currentTotal`, `delta`, and
-`violationCount`. GitHub spells multiword outputs with hyphens; Azure uses camel case.
-`baselineTotal` is empty when no baseline was supplied.
+`violationCount`, `baselineStatus`, `baselineSourceId`, `baselineSourceCommit`,
+`baselineSourceUrl`, and `baselineArtifactName`. GitHub spells multiword outputs with
+hyphens; Azure uses camel case.
+`baselineStatus` is `restored`, `explicit`, or `not-found`; `baselineTotal` is empty on a
+first run.
 
 `result` is `passed`, `passed-with-warnings`, `budget-failed`, or `error`. A budget failure
 retains the raw exit code 2 and an input or execution error retains exit code 1. JSON reports
-carry `schemaVersion: 1` so consumers can reject an incompatible future shape explicitly.
+carry `schemaVersion: 2`, resolved target-side artifact paths, baseline provenance, and
+deferred budget metrics so consumers can reject an incompatible future shape explicitly.
+
+Managed artifact names are derived from the workflow or pipeline definition, stable job,
+logical target, and detected RID. Discovery searches only successful runs of the exact base
+branch. Pull-request artifacts are never eligible as baselines. `baseline-key` is normally
+unnecessary; use it when a randomized temporary target path would otherwise change identity.
 
 ## Acquisition and compatibility
 

--- a/docs/src/content/docs/usage/size-regression.md
+++ b/docs/src/content/docs/usage/size-regression.md
@@ -131,8 +131,8 @@ target's DGML sidecar): the root kept X, X kept Y, down to the new entry.
 
 ### GitHub Actions
 
-Start with an absolute cap. This workflow has one NativeAOT build and no baseline to store or
-retrieve:
+Run the same job on pull requests and the target branch. The action keeps its own matching
+successful branch baseline:
 
 ```yaml
 - uses: actions/checkout@v6
@@ -146,58 +146,56 @@ retrieve:
   uses: willibrandon/dotsider@v0
   with:
     target: out/current/App
-    budgets: max=25mb
+    budgets: |
+      max=25mb
+      growth=1%
 ```
 
 The action selects the release for the runner's OS and architecture, verifies its SHA-256
 sidecar, and caches the result. It writes the Markdown report to the job summary and uploads
 the Markdown and schema-versioned JSON reports before enforcing a budget failure. Set
 `dotsider-version` to an exact release for reproducibility, or set `dotsider-path` to an
-existing executable for an offline or custom installation.
+existing executable for an offline or custom installation. Give the job `actions: read` and
+`contents: read` permissions so it can find earlier successful artifacts.
 
-When an absolute cap is too coarse, build the pull request's base commit in a detached
-worktree and pass that output as `baseline`. Both builds happen on the same runner with the
-same SDK and NativeAOT toolchain; users do not change the workflow between runs:
+On the first branch run, absolute limits are evaluated and growth limits are named as
+deferred. If the job succeeds, Dotsider uploads the binary, resolved `.mstat`, optional DGML,
+and a hashed manifest as the baseline. Later branch runs compare with their preceding
+successful run; pull requests compare with the newest successful run of their target branch.
+The artifact identity includes the workflow, job, logical target, and detected RID. Set
+`baseline-key` only when the target lives under a randomized temporary path.
+
+Supplying `baseline` remains an explicit override for release-to-release comparisons. It
+disables automatic discovery and retention for that action invocation.
+
+#### Manual and `/aot-size` reports
+
+An on-demand report uses artifacts emitted by the normal build; it does not check out or run
+pull-request code in the comment workflow. Add this to the normal PR and branch build after
+publishing:
 
 ```yaml
-- uses: actions/checkout@v6
+- name: Upload NativeAOT size input
+  uses: actions/upload-artifact@v7.0.1
   with:
-    fetch-depth: 0
-
-- name: Publish base revision
-  shell: bash
-  env:
-    BASE_SHA: ${{ github.event.pull_request.base.sha }}
-  run: |
-    git worktree add --detach "$RUNNER_TEMP/dotsider-base" "$BASE_SHA"
-    dotnet publish "$RUNNER_TEMP/dotsider-base/src/App/App.csproj" \
-      -c Release -r linux-x64 -p:PublishAot=true \
-      -p:IlcGenerateMstatFile=true -o "$RUNNER_TEMP/dotsider-base-publish"
-
-- name: Publish pull request revision
-  run: >-
-    dotnet publish src/App/App.csproj -c Release -r linux-x64
-    -p:PublishAot=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true
-    -o out/current
-
-- name: Size comparison
-  uses: willibrandon/dotsider@v0
-  with:
-    target: out/current/App
-    baseline: ${{ runner.temp }}/dotsider-base-publish/App
-    budgets: |
-      total:max=25mb,growth=1%
-      ns=MyApp.Generated:growth=10kb
-    why: true
+    name: nativeaot-size-linux-x64
+    path: |
+      out/current/App
+      out/current/App.mstat
+      out/current/App.codegen.dgml.xml
+    if-no-files-found: error
 ```
 
-The project-specific publish commands remain in the workflow because the application owns
-its target framework, runtime identifier, conditional properties, and generated inputs.
-Dotsider does not search earlier workflow runs or silently replace a baseline.
+Then copy the [`workflow_dispatch` and `/aot-size` template](https://github.com/willibrandon/dotsider/blob/main/integrations/size-check/examples/github-aot-size.yml).
+It accepts `/aot-size` in the pull-request conversation or a review comment, verifies that
+the author has write access, resolves the PR through GitHub's API,
+downloads the successful PR and base-branch input artifacts, runs Dotsider, and updates a
+single PR comment. Change the template's build workflow, artifact name, target path, and
+budgets to match the project.
 
 ### Azure DevOps
 
-The basic Azure Pipelines setup is the same one-build absolute check:
+Run the task after the NativeAOT publish on both pull requests and the target branch:
 
 ```yaml
 - checkout: self
@@ -211,47 +209,18 @@ The basic Azure Pipelines setup is the same one-build absolute check:
 - task: DotsiderSizeCheck@1
   inputs:
     target: '$(Build.ArtifactStagingDirectory)/current/App'
-    budgets: max=25mb
-```
-
-For a pull-request comparison, fetch the target branch and publish it in a worktree before
-publishing the checked-out revision:
-
-```yaml
-- checkout: self
-  fetchDepth: 0
-
-- pwsh: |
-    $branch = '$(System.PullRequest.TargetBranch)' -replace '^refs/heads/', ''
-    $base = '$(Agent.TempDirectory)/dotsider-base'
-    git fetch origin $branch
-    git worktree add --detach $base "origin/$branch"
-    dotnet publish "$base/src/App/App.csproj" -c Release -r linux-x64 `
-      -p:PublishAot=true -p:IlcGenerateMstatFile=true `
-      -o '$(Agent.TempDirectory)/dotsider-base-publish'
-  displayName: Publish base revision
-
-- pwsh: >-
-    dotnet publish src/App/App.csproj -c Release -r linux-x64
-    -p:PublishAot=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true
-    -o $(Build.ArtifactStagingDirectory)/current
-  displayName: Publish pull request revision
-
-- task: DotsiderSizeCheck@1
-  inputs:
-    target: '$(Build.ArtifactStagingDirectory)/current/App'
-    baseline: '$(Agent.TempDirectory)/dotsider-base-publish/App'
     budgets: |
-      total:max=25mb,growth=1%
-      ns=MyApp.Generated:growth=10kb
-    why: true
+      max=25mb
+      growth=1%
 ```
 
 Install the public **Dotsider** extension from the Azure DevOps Marketplace. The task uses
 Node 24 on current agents and retains a Node 20 handler for older supported agents. Its tool
-selection, checksum verification, reports, summary, exit meanings, and typed outputs match
-the GitHub Action. Supplying `baseline` enables the comparison; omitting it keeps the task on
-the absolute current-build path. A `growth=` budget without a baseline is an input error.
+selection, checksum verification, reports, summary, exit meanings, baseline lifecycle, and
+typed outputs match the GitHub Action. It uses the pipeline's short-lived OAuth token to read
+successful builds and artifacts from the same pipeline definition, then removes that token
+before Dotsider runs. A missing artifact is a first run; authentication, network, and corrupt
+artifact failures remain errors. Set `baseline` only for an explicit override.
 
 See [CI integrations](/reference/ci-integrations/) for every input and output, platform
 compatibility, report lifetime, and release policy.

--- a/integrations/size-check/README.md
+++ b/integrations/size-check/README.md
@@ -35,4 +35,11 @@ dotnet run --file ./scripts/Validate-CiIntegrations.cs -- -Vsix artifacts/azure-
 ```
 
 CI repeats the real adapter suite on Windows, Linux, and macOS for x64 and ARM64.
-It also runs the Azure handler under Node.js 20 to verify the fallback handler.
+It also runs the Azure handler under Node.js 20 to verify the fallback handler. Baseline
+lifecycle tests use local provider API servers and real files: they exercise successful-run
+selection, first-run deferral, manifest hashing, provenance, token removal, and safe ZIP
+extraction without substituting a Dotsider executable or size report.
+
+`examples/github-aot-size.yml` is the reference on-demand workflow. It consumes NativeAOT
+size-input artifacts from a normal build and supports both manual dispatch and trusted
+`/aot-size` pull-request comments.

--- a/integrations/size-check/dist/baseline.js
+++ b/integrations/size-check/dist/baseline.js
@@ -1,0 +1,316 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createBaselineIdentity = createBaselineIdentity;
+exports.baselineArtifactName = baselineArtifactName;
+exports.detectTargetRid = detectTargetRid;
+exports.detectRidFromHeader = detectRidFromHeader;
+exports.stageBaseline = stageBaseline;
+exports.restoreBaseline = restoreBaseline;
+exports.enrichReports = enrichReports;
+const node_crypto_1 = require("node:crypto");
+const node_fs_1 = require("node:fs");
+const fs = __importStar(require("node:fs/promises"));
+const path = __importStar(require("node:path"));
+const manifestFileName = "dotsider-baseline.json";
+const manifestSchemaVersion = 1;
+const maximumFileBytes = 1024 * 1024 * 1024;
+function createBaselineIdentity(provider, scope, job, targetPath, rid, baselineKey, workspace, temporaryDirectory) {
+    return {
+        provider,
+        scope: requiredIdentityPart(scope, "provider scope"),
+        job: requiredIdentityPart(job, "job"),
+        target: baselineKey?.trim() || logicalTarget(targetPath, workspace, temporaryDirectory),
+        rid: requiredIdentityPart(rid, "target RID"),
+    };
+}
+function baselineArtifactName(identity) {
+    const digest = (0, node_crypto_1.createHash)("sha256").update(canonicalIdentity(identity)).digest("hex").slice(0, 20);
+    const rid = sanitize(identity.rid).slice(0, 32) || "unknown";
+    return `dotsider-baseline-${rid}-${digest}`;
+}
+async function detectTargetRid(targetPath, fallbackRid) {
+    if (targetPath.toLowerCase().endsWith(".mstat")) {
+        return fallbackRid;
+    }
+    const handle = await fs.open(targetPath, "r");
+    try {
+        // The ELF program interpreter is not guaranteed to appear in the first page.
+        // Reading 64 KiB is still bounded while covering normal program-header layouts.
+        const buffer = Buffer.alloc(64 * 1024);
+        const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+        return detectRidFromHeader(buffer.subarray(0, bytesRead), fallbackRid);
+    }
+    finally {
+        await handle.close();
+    }
+}
+function detectRidFromHeader(bytes, fallbackRid) {
+    if (bytes.length >= 64 && bytes[0] === 0x7f && bytes.toString("ascii", 1, 4) === "ELF") {
+        const littleEndian = bytes[5] === 1;
+        const machine = littleEndian ? bytes.readUInt16LE(18) : bytes.readUInt16BE(18);
+        const architecture = machine === 0x3e ? "x64"
+            : machine === 0xb7 ? "arm64"
+                : machine === 0x03 ? "x86"
+                    : machine === 0x28 ? "arm"
+                        : undefined;
+        if (architecture) {
+            const musl = bytes.includes(Buffer.from("ld-musl-"));
+            return `linux-${musl ? "musl-" : ""}${architecture}`;
+        }
+    }
+    if (bytes.length >= 64 && bytes[0] === 0x4d && bytes[1] === 0x5a) {
+        const peOffset = bytes.readUInt32LE(0x3c);
+        if (peOffset + 6 <= bytes.length && bytes.toString("ascii", peOffset, peOffset + 4) === "PE\0\0") {
+            const machine = bytes.readUInt16LE(peOffset + 4);
+            const architecture = machine === 0x8664 ? "x64"
+                : machine === 0xaa64 ? "arm64"
+                    : machine === 0x014c ? "x86"
+                        : machine === 0x01c4 ? "arm"
+                            : undefined;
+            if (architecture)
+                return `win-${architecture}`;
+        }
+    }
+    if (bytes.length >= 8) {
+        const magic = bytes.readUInt32BE(0);
+        const littleEndian = magic === 0xcefaedfe || magic === 0xcffaedfe;
+        if (magic === 0xfeedface || magic === 0xfeedfacf || littleEndian) {
+            const cpu = littleEndian ? bytes.readUInt32LE(4) : bytes.readUInt32BE(4);
+            if (cpu === 0x01000007)
+                return "osx-x64";
+            if (cpu === 0x0100000c)
+                return "osx-arm64";
+        }
+    }
+    return fallbackRid;
+}
+async function stageBaseline(report, identity, source, directory) {
+    await fs.rm(directory, { recursive: true, force: true });
+    const filesDirectory = path.join(directory, "files");
+    await fs.mkdir(filesDirectory, { recursive: true });
+    const artifacts = report.targetArtifacts;
+    const candidates = [
+        ["binary", artifacts.binaryPath],
+        ["mstat", artifacts.mstatPath],
+        ["dgml", artifacts.dgmlPath],
+    ];
+    const manifestFiles = [];
+    let targetRelativePath;
+    for (const [role, sourcePath] of candidates) {
+        if (!sourcePath)
+            continue;
+        const extension = role === "binary" ? path.extname(sourcePath) : role === "mstat" ? ".mstat" : ".dgml.xml";
+        const relativePath = path.posix.join("files", `target${extension}`);
+        const destination = path.join(directory, ...relativePath.split("/"));
+        const stat = await fs.lstat(sourcePath);
+        if (!stat.isFile() || stat.isSymbolicLink()) {
+            throw new Error(`Baseline source '${sourcePath}' is not a regular file.`);
+        }
+        if (stat.size > maximumFileBytes) {
+            throw new Error(`Baseline source '${sourcePath}' exceeds the 1 GiB file limit.`);
+        }
+        await fs.copyFile(sourcePath, destination);
+        manifestFiles.push({ role, path: relativePath, bytes: stat.size, sha256: await sha256File(destination) });
+        if (role === (artifacts.binaryPath ? "binary" : "mstat"))
+            targetRelativePath = relativePath;
+    }
+    if (!targetRelativePath || !manifestFiles.some(file => file.role === "mstat")) {
+        throw new Error("Dotsider did not report the files required to create a baseline artifact.");
+    }
+    const manifest = {
+        schemaVersion: manifestSchemaVersion,
+        identity,
+        source,
+        targetPath: targetRelativePath,
+        files: manifestFiles,
+    };
+    await fs.writeFile(path.join(directory, manifestFileName), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    return directory;
+}
+async function restoreBaseline(directory, expected, expectedSource) {
+    const manifestPath = path.join(directory, manifestFileName);
+    const manifest = parseManifest(JSON.parse(await fs.readFile(manifestPath, "utf8")));
+    if (canonicalIdentity(manifest.identity) !== canonicalIdentity(expected)) {
+        throw new Error("The stored Dotsider baseline does not match this workflow, job, target, and RID.");
+    }
+    if (expectedSource?.status === "restored"
+        && (manifest.source.status !== "restored"
+            || manifest.source.provider !== expectedSource.provider
+            || manifest.source.branch !== expectedSource.branch
+            || manifest.source.id !== expectedSource.id
+            || manifest.source.commit !== expectedSource.commit
+            || manifest.source.artifactName !== expectedSource.artifactName)) {
+        throw new Error("The stored Dotsider baseline provenance does not match its provider build.");
+    }
+    if (manifest.files.length === 0 || manifest.files.length > 3) {
+        throw new Error("The stored Dotsider baseline manifest has an invalid file count.");
+    }
+    const paths = new Set();
+    const roles = new Set();
+    for (const file of manifest.files) {
+        if (paths.has(file.path) || roles.has(file.role)) {
+            throw new Error("The stored Dotsider baseline manifest contains duplicate files or roles.");
+        }
+        paths.add(file.path);
+        roles.add(file.role);
+        const resolved = safeArtifactPath(directory, file.path);
+        const stat = await fs.lstat(resolved);
+        if (!stat.isFile() || stat.isSymbolicLink() || stat.size !== file.bytes || stat.size > maximumFileBytes) {
+            throw new Error(`Stored Dotsider baseline file '${file.path}' failed validation.`);
+        }
+        if (await sha256File(resolved) !== file.sha256) {
+            throw new Error(`Stored Dotsider baseline file '${file.path}' failed SHA-256 validation.`);
+        }
+    }
+    if (!roles.has("mstat")
+        || !manifest.files.some(file => file.path === manifest.targetPath
+            && (file.role === "binary" || file.role === "mstat"))) {
+        throw new Error("The stored Dotsider baseline manifest does not identify a verified target and mstat file.");
+    }
+    return {
+        targetPath: safeArtifactPath(directory, manifest.targetPath),
+        source: manifest.source,
+    };
+}
+async function enrichReports(jsonPath, markdownPath, source) {
+    const report = JSON.parse(await fs.readFile(jsonPath, "utf8"));
+    report.baselineSource = source;
+    await fs.writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+    const markdown = await fs.readFile(markdownPath, "utf8");
+    const baselineLine = formatBaselineSource(source);
+    const firstSection = /\r?\n---\r?\n/u.exec(markdown);
+    const newline = markdown.includes("\r\n") ? "\r\n" : "\n";
+    const enriched = firstSection?.index !== undefined
+        ? `${markdown.slice(0, firstSection.index).trimEnd()}${newline}${newline}${baselineLine}${newline}`
+            + markdown.slice(firstSection.index)
+        : `${markdown.trimEnd()}${newline}${newline}${baselineLine}${newline}`;
+    await fs.writeFile(markdownPath, enriched, "utf8");
+    return report;
+}
+function formatBaselineSource(source) {
+    if (source.status === "explicit") {
+        return `**Baseline:** Explicit file ${markdownCodeSpan(source.path ?? "unknown")}.`;
+    }
+    if (source.status === "not-found") {
+        const branch = source.branch ? ` for ${markdownCodeSpan(source.branch)}` : "";
+        return `**Baseline:** No stored baseline was found${branch}; absolute budgets were evaluated and growth budgets were deferred.`;
+    }
+    const label = source.number ? `run ${source.number}` : `run ${source.id ?? "unknown"}`;
+    const linked = source.url ? `[${label}](${source.url})` : label;
+    const commit = source.commit ? ` at ${markdownCodeSpan(source.commit.slice(0, 12))}` : "";
+    const branch = source.branch ? ` on ${markdownCodeSpan(source.branch)}` : "";
+    return `**Baseline:** Restored from ${linked}${commit}${branch}.`;
+}
+function markdownCodeSpan(value) {
+    const longestRun = Math.max(0, ...[...value.matchAll(/`+/gu)].map(match => match[0].length));
+    const delimiter = "`".repeat(longestRun + 1);
+    const padding = value.startsWith("`") || value.startsWith(" ")
+        || value.endsWith("`") || value.endsWith(" ")
+        ? " "
+        : "";
+    return `${delimiter}${padding}${value}${padding}${delimiter}`;
+}
+function parseManifest(value) {
+    if (!value || typeof value !== "object")
+        throw new Error("The stored Dotsider baseline manifest is invalid.");
+    const manifest = value;
+    if (manifest.schemaVersion !== manifestSchemaVersion || !manifest.identity || !manifest.source
+        || typeof manifest.targetPath !== "string" || !Array.isArray(manifest.files)) {
+        throw new Error("The stored Dotsider baseline manifest is unsupported or incomplete.");
+    }
+    for (const file of manifest.files) {
+        if (!file || typeof file.path !== "string" || typeof file.sha256 !== "string"
+            || typeof file.bytes !== "number" || !["binary", "mstat", "dgml"].includes(file.role)) {
+            throw new Error("The stored Dotsider baseline manifest contains an invalid file entry.");
+        }
+    }
+    return manifest;
+}
+function safeArtifactPath(root, relativePath) {
+    if (!relativePath || path.isAbsolute(relativePath) || relativePath.includes("\\")) {
+        throw new Error(`Stored Dotsider baseline path '${relativePath}' is unsafe.`);
+    }
+    const normalized = path.posix.normalize(relativePath);
+    if (normalized === ".." || normalized.startsWith("../") || normalized.includes("/../")) {
+        throw new Error(`Stored Dotsider baseline path '${relativePath}' is unsafe.`);
+    }
+    const resolvedRoot = path.resolve(root);
+    const resolved = path.resolve(root, ...normalized.split("/"));
+    if (resolved !== resolvedRoot && !resolved.startsWith(`${resolvedRoot}${path.sep}`)) {
+        throw new Error(`Stored Dotsider baseline path '${relativePath}' escapes its artifact.`);
+    }
+    return resolved;
+}
+async function sha256File(filePath) {
+    const hash = (0, node_crypto_1.createHash)("sha256");
+    await new Promise((resolve, reject) => {
+        const stream = (0, node_fs_1.createReadStream)(filePath);
+        stream.on("data", chunk => hash.update(chunk));
+        stream.on("error", reject);
+        stream.on("end", resolve);
+    });
+    return hash.digest("hex");
+}
+function canonicalIdentity(identity) {
+    return JSON.stringify({
+        provider: identity.provider,
+        scope: identity.scope,
+        job: identity.job,
+        target: identity.target,
+        rid: identity.rid,
+    });
+}
+function logicalTarget(targetPath, workspace, temporaryDirectory) {
+    const absolute = path.resolve(targetPath);
+    for (const [label, root] of [["workspace", workspace], ["temp", temporaryDirectory]]) {
+        if (!root)
+            continue;
+        const relative = path.relative(path.resolve(root), absolute);
+        if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+            return `${label}/${relative.replaceAll(path.sep, "/")}`;
+        }
+    }
+    return `file/${path.basename(absolute)}`;
+}
+function requiredIdentityPart(value, name) {
+    const candidate = value.trim();
+    if (!candidate)
+        throw new Error(`Unable to determine the Dotsider baseline ${name}.`);
+    return candidate;
+}
+function sanitize(value) {
+    return value.toLowerCase().replace(/[^a-z0-9_.-]+/gu, "-").replace(/^-+|-+$/gu, "");
+}

--- a/integrations/size-check/dist/github-baseline.js
+++ b/integrations/size-check/dist/github-baseline.js
@@ -1,0 +1,214 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.discoverGithubBaseline = discoverGithubBaseline;
+const fs = __importStar(require("node:fs/promises"));
+const path = __importStar(require("node:path"));
+const baseline_1 = require("./baseline");
+async function discoverGithubBaseline(inputs, preparedRid, environment = process.env) {
+    const targetRid = await (0, baseline_1.detectTargetRid)(inputs.target, preparedRid);
+    if (inputs.baseline) {
+        const identity = (0, baseline_1.createBaselineIdentity)("github-actions", "explicit", "explicit", inputs.target, targetRid, inputs.baselineKey, environment.GITHUB_WORKSPACE, environment.RUNNER_TEMP);
+        const artifactName = (0, baseline_1.baselineArtifactName)(identity);
+        return {
+            identity,
+            artifactName,
+            source: { status: "explicit", path: inputs.baseline, artifactName },
+            publish: false,
+        };
+    }
+    const repository = required(environment.GITHUB_REPOSITORY, "GITHUB_REPOSITORY");
+    const workflow = workflowFile(required(environment.GITHUB_WORKFLOW_REF, "GITHUB_WORKFLOW_REF"));
+    const job = required(environment.GITHUB_JOB, "GITHUB_JOB");
+    const identity = (0, baseline_1.createBaselineIdentity)("github-actions", `${repository}/${workflow}`, job, inputs.target, targetRid, inputs.baselineKey, environment.GITHUB_WORKSPACE, environment.RUNNER_TEMP);
+    const artifactName = (0, baseline_1.baselineArtifactName)(identity);
+    const apiUrl = (environment.GITHUB_API_URL || "https://api.github.com").replace(/\/$/u, "");
+    const token = required(environment.GITHUB_TOKEN, "GITHUB_TOKEN");
+    const context = await resolveContext(apiUrl, repository, token, environment);
+    if (!context.branch) {
+        return {
+            identity,
+            artifactName,
+            source: { status: "not-found", provider: "github-actions", artifactName },
+            publish: false,
+        };
+    }
+    const artifacts = await githubJson(`${apiUrl}/repos/${repository}/actions/artifacts?name=${encodeURIComponent(artifactName)}&per_page=100`, token);
+    const artifactRunIds = new Set((artifacts.artifacts ?? [])
+        .filter(artifact => artifact.name === artifactName && !artifact.expired && artifact.workflow_run)
+        .map(artifact => artifact.workflow_run.id));
+    if (artifactRunIds.size === 0) {
+        return {
+            identity,
+            artifactName,
+            source: {
+                status: "not-found",
+                provider: "github-actions",
+                branch: context.branch,
+                artifactName,
+            },
+            publish: context.publish,
+        };
+    }
+    const runsUrl = `${apiUrl}/repos/${repository}/actions/workflows/${encodeURIComponent(workflow)}/runs`
+        + `?branch=${encodeURIComponent(context.branch)}&status=success&exclude_pull_requests=true&per_page=100`;
+    const runs = await githubJson(runsUrl, token);
+    const currentRunId = Number(environment.GITHUB_RUN_ID || "0");
+    for (const run of runs.workflow_runs ?? []) {
+        if (run.id === currentRunId || run.conclusion !== "success" || run.head_branch !== context.branch
+            || run.event === "pull_request" || run.event === "pull_request_target"
+            || !artifactRunIds.has(run.id)) {
+            continue;
+        }
+        const source = {
+            status: "restored",
+            provider: "github-actions",
+            branch: context.branch,
+            commit: run.head_sha,
+            id: String(run.id),
+            number: String(run.run_number),
+            url: run.html_url,
+            artifactName,
+        };
+        return {
+            identity,
+            artifactName,
+            source,
+            runId: String(run.id),
+            downloadDirectory: path.join(environment.RUNNER_TEMP || process.cwd(), "dotsider-baseline", artifactName),
+            publish: context.publish,
+        };
+    }
+    return {
+        identity,
+        artifactName,
+        source: {
+            status: "not-found",
+            provider: "github-actions",
+            branch: context.branch,
+            artifactName,
+        },
+        publish: context.publish,
+    };
+}
+async function resolveContext(apiUrl, repository, token, environment) {
+    const eventName = environment.GITHUB_EVENT_NAME || "";
+    const event = await readEvent(environment.GITHUB_EVENT_PATH);
+    if (eventName === "pull_request" || eventName === "pull_request_target") {
+        return { branch: objectString(event, "pull_request", "base", "ref"), publish: false };
+    }
+    if (eventName === "issue_comment" || eventName === "pull_request_review_comment") {
+        const number = eventName === "issue_comment"
+            ? objectNumber(event, "issue", "number")
+            : objectNumber(event, "pull_request", "number");
+        const pull = await githubJson(`${apiUrl}/repos/${repository}/pulls/${number}`, token);
+        return { branch: pull.base.ref, publish: false };
+    }
+    if (eventName === "workflow_dispatch") {
+        const dispatchNumber = objectOptionalNumber(event, "inputs", "pr_number");
+        if (dispatchNumber !== undefined) {
+            const pull = await githubJson(`${apiUrl}/repos/${repository}/pulls/${dispatchNumber}`, token);
+            return { branch: pull.base.ref, publish: false };
+        }
+    }
+    const ref = environment.GITHUB_REF || "";
+    const branch = ref.startsWith("refs/heads/")
+        ? ref.slice("refs/heads/".length)
+        : environment.GITHUB_REF_TYPE === "branch" ? environment.GITHUB_REF_NAME : undefined;
+    return { branch, publish: branch !== undefined };
+}
+async function githubJson(url, token) {
+    const response = await fetch(url, {
+        headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${token}`,
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "dotsider-size-check",
+        },
+    });
+    if (!response.ok) {
+        const permission = response.status === 401 || response.status === 403
+            ? " Grant the job 'actions: read' permission."
+            : "";
+        throw new Error(`GitHub baseline discovery failed with HTTP ${response.status}.${permission}`);
+    }
+    return await response.json();
+}
+async function readEvent(eventPath) {
+    if (!eventPath)
+        return {};
+    return JSON.parse(await fs.readFile(eventPath, "utf8"));
+}
+function objectString(value, ...keys) {
+    let current = value;
+    for (const key of keys) {
+        if (!current || typeof current !== "object")
+            throw new Error("The GitHub event payload is incomplete.");
+        current = current[key];
+    }
+    if (typeof current !== "string" || !current)
+        throw new Error("The GitHub event payload is incomplete.");
+    return current;
+}
+function objectNumber(value, ...keys) {
+    const result = objectOptionalNumber(value, ...keys);
+    if (result === undefined)
+        throw new Error("The GitHub event payload does not identify a pull request.");
+    return result;
+}
+function objectOptionalNumber(value, ...keys) {
+    let current = value;
+    for (const key of keys) {
+        if (!current || typeof current !== "object")
+            return undefined;
+        current = current[key];
+    }
+    const parsed = typeof current === "number" ? current : typeof current === "string" ? Number(current) : NaN;
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+function workflowFile(reference) {
+    const beforeRef = reference.split("@")[0] ?? reference;
+    const marker = "/.github/workflows/";
+    const index = beforeRef.indexOf(marker);
+    if (index < 0)
+        throw new Error(`Unable to determine the workflow file from GITHUB_WORKFLOW_REF '${reference}'.`);
+    return beforeRef.slice(index + marker.length);
+}
+function required(value, name) {
+    const candidate = value?.trim();
+    if (!candidate)
+        throw new Error(`Required environment variable ${name} was not provided.`);
+    return candidate;
+}

--- a/integrations/size-check/dist/github.js
+++ b/integrations/size-check/dist/github.js
@@ -35,7 +35,10 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = __importStar(require("node:fs/promises"));
 const os = __importStar(require("node:os"));
+const path = __importStar(require("node:path"));
 const acquisition_1 = require("./acquisition");
+const baseline_1 = require("./baseline");
+const github_baseline_1 = require("./github-baseline");
 const input_1 = require("./input");
 const process_1 = require("./process");
 const report_1 = require("./report");
@@ -53,11 +56,14 @@ async function main() {
                     errorOutputs = { ...outputs, result: "error", exitCode: "1" };
                 });
                 break;
+            case "discover":
+                await discover();
+                break;
             case "enforce":
                 enforce();
                 break;
             default:
-                throw new Error("Expected a GitHub adapter command: prepare, run, or enforce.");
+                throw new Error("Expected a GitHub adapter command: prepare, discover, run, or enforce.");
         }
     }
     catch (error) {
@@ -68,6 +74,19 @@ async function main() {
         command("error", {}, message);
         process.exitCode = 1;
     }
+}
+async function discover() {
+    const inputs = githubInputs();
+    const discovery = await (0, github_baseline_1.discoverGithubBaseline)(inputs, requiredEnvironment("DOTSIDER_PREPARED_RID"));
+    writeOutputs({
+        status: discovery.source.status,
+        "artifact-name": discovery.artifactName,
+        "run-id": discovery.runId ?? "",
+        "download-directory": discovery.downloadDirectory ?? "",
+        publish: String(discovery.publish),
+        identity: JSON.stringify(discovery.identity),
+        source: JSON.stringify(discovery.source),
+    });
 }
 async function prepare() {
     const tool = await (0, acquisition_1.prepareTool)(process.env.DOTSIDER_INPUT_VERSION || "latest", optional(process.env.DOTSIDER_INPUT_PATH));
@@ -81,26 +100,37 @@ async function prepare() {
     });
 }
 async function run(onOutputs) {
-    const inputs = (0, input_1.createInputs)({
-        target: process.env.DOTSIDER_INPUT_TARGET,
-        baseline: process.env.DOTSIDER_INPUT_BASELINE,
-        budgets: process.env.DOTSIDER_INPUT_BUDGETS,
-        budgetFile: process.env.DOTSIDER_INPUT_BUDGET_FILE,
-        top: process.env.DOTSIDER_INPUT_TOP,
-        why: process.env.DOTSIDER_INPUT_WHY,
-        dotsiderVersion: process.env.DOTSIDER_INPUT_VERSION,
-        dotsiderPath: process.env.DOTSIDER_INPUT_PATH,
-        reportDirectory: process.env.DOTSIDER_INPUT_REPORT_DIRECTORY,
-        publishSummary: process.env.DOTSIDER_INPUT_PUBLISH_SUMMARY,
-        publishReports: process.env.DOTSIDER_INPUT_PUBLISH_REPORTS,
-        artifactName: process.env.DOTSIDER_INPUT_ARTIFACT_NAME,
-    }, process.env.RUNNER_TEMP || os.tmpdir());
+    let inputs = githubInputs();
     const tool = preparedTool();
     const executable = await (0, acquisition_1.acquireTool)(tool);
-    const execution = await (0, process_1.executeSizeCheck)(executable, inputs);
-    const outputs = (0, report_1.createStableOutputs)(execution, inputs.artifactName, tool.version);
+    const discovery = process.env.DOTSIDER_BASELINE_SOURCE
+        ? preparedDiscovery()
+        : await (0, github_baseline_1.discoverGithubBaseline)(inputs, tool.rid);
+    let source = discovery.source;
+    if (source.status === "restored") {
+        const directory = requiredEnvironment("DOTSIDER_BASELINE_DOWNLOAD_DIRECTORY");
+        const restored = await (0, baseline_1.restoreBaseline)(directory, discovery.identity, source);
+        inputs = { ...inputs, baseline: restored.targetPath };
+    }
+    const execution = await (0, process_1.executeSizeCheck)(executable, inputs, source.status === "not-found");
+    if (execution.report && await fileExists(execution.markdownReportPath)) {
+        execution.report = await (0, baseline_1.enrichReports)(execution.jsonReportPath, execution.markdownReportPath, source);
+    }
+    const outputs = (0, report_1.createStableOutputs)(execution, inputs.artifactName, tool.version, source);
     onOutputs(outputs);
     writeStableOutputs(outputs);
+    let baselineUploadPath = "";
+    let publishBaseline = false;
+    if (discovery.publish && execution.report
+        && (execution.result === "passed" || execution.result === "passed-with-warnings")) {
+        source = currentGithubSource(discovery.artifactName);
+        baselineUploadPath = await (0, baseline_1.stageBaseline)(execution.report, discovery.identity, source, pathForBaseline(inputs.reportDirectory));
+        publishBaseline = true;
+    }
+    writeOutputs({
+        "baseline-upload-path": baselineUploadPath,
+        "publish-baseline": String(publishBaseline),
+    });
     const summary = (0, report_1.formatSizeCheckSummary)(outputs);
     if (summary) {
         process.stdout.write(`Dotsider size check: ${summary}.\n`);
@@ -112,6 +142,49 @@ async function run(onOutputs) {
             await fs.appendFile(summaryPath, `${markdown.trimEnd()}\n`);
         }
     }
+}
+function githubInputs() {
+    return (0, input_1.createInputs)({
+        target: process.env.DOTSIDER_INPUT_TARGET,
+        baseline: process.env.DOTSIDER_INPUT_BASELINE,
+        baselineKey: process.env.DOTSIDER_INPUT_BASELINE_KEY,
+        budgets: process.env.DOTSIDER_INPUT_BUDGETS,
+        budgetFile: process.env.DOTSIDER_INPUT_BUDGET_FILE,
+        top: process.env.DOTSIDER_INPUT_TOP,
+        why: process.env.DOTSIDER_INPUT_WHY,
+        dotsiderVersion: process.env.DOTSIDER_INPUT_VERSION,
+        dotsiderPath: process.env.DOTSIDER_INPUT_PATH,
+        reportDirectory: process.env.DOTSIDER_INPUT_REPORT_DIRECTORY,
+        publishSummary: process.env.DOTSIDER_INPUT_PUBLISH_SUMMARY,
+        publishReports: process.env.DOTSIDER_INPUT_PUBLISH_REPORTS,
+        artifactName: process.env.DOTSIDER_INPUT_ARTIFACT_NAME,
+    }, process.env.RUNNER_TEMP || os.tmpdir());
+}
+function preparedDiscovery() {
+    return {
+        source: JSON.parse(requiredEnvironment("DOTSIDER_BASELINE_SOURCE")),
+        identity: JSON.parse(requiredEnvironment("DOTSIDER_BASELINE_IDENTITY")),
+        artifactName: requiredEnvironment("DOTSIDER_BASELINE_ARTIFACT_NAME"),
+        downloadDirectory: optional(process.env.DOTSIDER_BASELINE_DOWNLOAD_DIRECTORY),
+        publish: process.env.DOTSIDER_BASELINE_PUBLISH === "true",
+    };
+}
+function currentGithubSource(artifactName) {
+    const repository = requiredEnvironment("GITHUB_REPOSITORY");
+    const runId = requiredEnvironment("GITHUB_RUN_ID");
+    return {
+        status: "restored",
+        provider: "github-actions",
+        branch: process.env.GITHUB_REF_NAME,
+        commit: process.env.GITHUB_SHA,
+        id: runId,
+        number: process.env.GITHUB_RUN_NUMBER,
+        url: `${process.env.GITHUB_SERVER_URL || "https://github.com"}/${repository}/actions/runs/${runId}`,
+        artifactName,
+    };
+}
+function pathForBaseline(reportDirectory) {
+    return path.join(reportDirectory, ".baseline");
 }
 function enforce() {
     const exitCode = Number.parseInt(process.env.DOTSIDER_EXIT_CODE || "1", 10);
@@ -162,6 +235,11 @@ function writeStableOutputs(outputs) {
         "current-total": outputs.currentTotal,
         delta: outputs.delta,
         "violation-count": outputs.violationCount,
+        "baseline-status": outputs.baselineStatus,
+        "baseline-source-id": outputs.baselineSourceId,
+        "baseline-source-commit": outputs.baselineSourceCommit,
+        "baseline-source-url": outputs.baselineSourceUrl,
+        "baseline-artifact-name": outputs.baselineArtifactName,
     });
 }
 function writeOutputs(outputs) {

--- a/integrations/size-check/dist/input.js
+++ b/integrations/size-check/dist/input.js
@@ -82,6 +82,7 @@ function createInputs(values, defaultReportRoot) {
     return {
         target: path.resolve(target),
         baseline,
+        baselineKey: optional(values.baselineKey),
         budgets: parseBudgets(values.budgets),
         budgetFile: optionalPath(values.budgetFile),
         top: parseTop(values.top),
@@ -103,4 +104,8 @@ function required(value, name) {
 function optionalPath(value) {
     const candidate = value?.trim();
     return candidate ? path.resolve(candidate) : undefined;
+}
+function optional(value) {
+    const candidate = value?.trim();
+    return candidate || undefined;
 }

--- a/integrations/size-check/dist/process.js
+++ b/integrations/size-check/dist/process.js
@@ -45,6 +45,7 @@ async function runProcess(fileName, args) {
             shell: false,
             windowsHide: true,
             stdio: ["ignore", "pipe", "pipe"],
+            env: sanitizedChildEnvironment(),
         });
         let stdout = "";
         let stderr = "";
@@ -68,7 +69,7 @@ async function runProcess(fileName, args) {
         });
     });
 }
-async function executeSizeCheck(executablePath, inputs) {
+async function executeSizeCheck(executablePath, inputs, baselineNotFound = false) {
     await fs.mkdir(inputs.reportDirectory, { recursive: true });
     const jsonReportPath = path.join(inputs.reportDirectory, "dotsider-size-check.json");
     const markdownReportPath = path.join(inputs.reportDirectory, "dotsider-size-check.md");
@@ -77,7 +78,22 @@ async function executeSizeCheck(executablePath, inputs) {
         fs.rm(markdownReportPath, { force: true }),
     ]);
     const args = (0, report_1.buildSizeCheckArguments)(inputs.target, inputs.baseline, inputs.budgets, inputs.budgetFile, inputs.top, inputs.why, jsonReportPath, markdownReportPath);
-    const processResult = await runProcess(executablePath, args);
+    const previous = process.env.DOTSIDER_SIZE_CHECK_BASELINE_NOT_FOUND;
+    if (baselineNotFound) {
+        process.env.DOTSIDER_SIZE_CHECK_BASELINE_NOT_FOUND = "1";
+    }
+    let processResult;
+    try {
+        processResult = await runProcess(executablePath, args);
+    }
+    finally {
+        if (previous === undefined) {
+            delete process.env.DOTSIDER_SIZE_CHECK_BASELINE_NOT_FOUND;
+        }
+        else {
+            process.env.DOTSIDER_SIZE_CHECK_BASELINE_NOT_FOUND = previous;
+        }
+    }
     let report;
     try {
         report = await (0, report_1.readSizeReport)(jsonReportPath);
@@ -102,4 +118,19 @@ async function executeSizeCheck(executablePath, inputs) {
         report,
         stderr: processResult.stderr,
     };
+}
+function sanitizedChildEnvironment() {
+    const environment = { ...process.env };
+    for (const name of [
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "ACTIONS_RUNTIME_TOKEN",
+        "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+        "ACTIONS_ID_TOKEN_REQUEST_URL",
+        "ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN",
+        "SYSTEM_ACCESSTOKEN",
+    ]) {
+        delete environment[name];
+    }
+    return environment;
 }

--- a/integrations/size-check/dist/report.js
+++ b/integrations/size-check/dist/report.js
@@ -81,8 +81,10 @@ function isSizeReport(value) {
         return false;
     }
     const report = value;
-    return report.schemaVersion === 1
+    return report.schemaVersion === 2
         && typeof report.target === "string"
+        && !!report.targetArtifacts
+        && typeof report.targetArtifacts.mstatPath === "string"
         && typeof report.totalBasis === "string"
         && typeof report.rightTotal === "number"
         && !!report.summary
@@ -95,12 +97,12 @@ function classifyResult(exitCode, report) {
     if (exitCode !== 0 || report === undefined) {
         return "error";
     }
-    if (report.budgets?.hasWarnings === true) {
+    if (report.budgets?.hasWarnings === true || report.budgets?.hasDeferred === true) {
         return "passed-with-warnings";
     }
     return "passed";
 }
-function createStableOutputs(execution, artifactName, dotsiderVersion) {
+function createStableOutputs(execution, artifactName, dotsiderVersion, baselineSource) {
     const report = execution.report;
     const evaluations = report?.budgets?.evaluations ?? [];
     const violationCount = evaluations.reduce((count, evaluation) => count + (evaluation.violations?.length ?? 0), 0);
@@ -116,6 +118,11 @@ function createStableOutputs(execution, artifactName, dotsiderVersion) {
         currentTotal: numberOutput(report?.rightTotal),
         delta: numberOutput(report?.summary.delta),
         violationCount: String(violationCount),
+        baselineStatus: baselineSource?.status ?? "",
+        baselineSourceId: baselineSource?.id ?? "",
+        baselineSourceCommit: baselineSource?.commit ?? "",
+        baselineSourceUrl: baselineSource?.url ?? "",
+        baselineArtifactName: baselineSource?.artifactName ?? "",
     };
 }
 function createErrorOutputs(artifactName, dotsiderVersion) {
@@ -131,6 +138,11 @@ function createErrorOutputs(artifactName, dotsiderVersion) {
         currentTotal: "",
         delta: "",
         violationCount: "0",
+        baselineStatus: "",
+        baselineSourceId: "",
+        baselineSourceCommit: "",
+        baselineSourceUrl: "",
+        baselineArtifactName: "",
     };
 }
 function formatSizeCheckSummary(outputs) {

--- a/integrations/size-check/examples/github-aot-size.yml
+++ b/integrations/size-check/examples/github-aot-size.yml
@@ -1,0 +1,231 @@
+name: NativeAOT size report
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to analyze
+        required: true
+        type: number
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions: read-all
+
+jobs:
+  authorize:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
+      github.event_name == 'pull_request_review_comment'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    outputs:
+      should-run: ${{ steps.resolve.outputs.should-run }}
+      pr-number: ${{ steps.resolve.outputs.pr-number }}
+      head-sha: ${{ steps.resolve.outputs.head-sha }}
+      base-branch: ${{ steps.resolve.outputs.base-branch }}
+    steps:
+      - name: Authorize and resolve request
+        id: resolve
+        uses: actions/github-script@v8
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          DISPATCH_PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const isComment = context.eventName === 'issue_comment'
+              || context.eventName === 'pull_request_review_comment';
+            if (isComment) {
+              const command = (process.env.COMMENT_BODY || '').trim().toLowerCase();
+              if (!command.startsWith('/aot-size')) {
+                core.setOutput('should-run', 'false');
+                return;
+              }
+              const username = context.payload.comment?.user?.login;
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username });
+              if (!['admin', 'write'].includes(data.permission)) {
+                throw new Error('Only collaborators with write access may run /aot-size.');
+              }
+              if (context.eventName === 'pull_request_review_comment') {
+                await github.rest.reactions.createForPullRequestReviewComment({
+                  owner, repo, comment_id: context.payload.comment.id, content: 'eyes'
+                });
+              } else {
+                await github.rest.reactions.createForIssueComment({
+                  owner, repo, comment_id: context.payload.comment.id, content: 'eyes'
+                });
+              }
+            }
+
+            const prNumber = context.eventName === 'workflow_dispatch'
+              ? Number(process.env.DISPATCH_PR_NUMBER)
+              : context.eventName === 'pull_request_review_comment'
+                ? context.payload.pull_request.number
+                : context.payload.issue.number;
+            const { data: pull } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            core.setOutput('should-run', 'true');
+            core.setOutput('pr-number', String(pull.number));
+            core.setOutput('head-sha', pull.head.sha);
+            core.setOutput('base-branch', pull.base.ref);
+
+  analyze:
+    needs: authorize
+    if: needs.authorize.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    env:
+      # Change these three values to match the normal build workflow's uploaded input artifact.
+      BUILD_WORKFLOW: ci.yml
+      SIZE_INPUT_ARTIFACT: nativeaot-size-linux-x64
+      SIZE_TARGET: App
+    steps:
+      - name: Find pull-request and base artifacts
+        id: artifacts
+        uses: actions/github-script@v8
+        env:
+          HEAD_SHA: ${{ needs.authorize.outputs.head-sha }}
+          BASE_BRANCH: ${{ needs.authorize.outputs.base-branch }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr-number }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const find = async (parameters, acceptRun) => {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: process.env.BUILD_WORKFLOW,
+                status: 'success', per_page: 100, ...parameters
+              });
+              for (const run of data.workflow_runs) {
+                if (!acceptRun(run)) continue;
+                const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                  owner, repo, run_id: run.id, per_page: 100
+                });
+                if (artifacts.some(artifact => artifact.name === process.env.SIZE_INPUT_ARTIFACT && !artifact.expired)) {
+                  return run.id;
+                }
+              }
+              throw new Error(`No successful ${process.env.SIZE_INPUT_ARTIFACT} artifact was found.`);
+            };
+            const prNumber = Number(process.env.PR_NUMBER);
+            const currentRun = await find(
+              { head_sha: process.env.HEAD_SHA },
+              run => run.event === 'pull_request'
+                && run.pull_requests?.some(pull => pull.number === prNumber)
+            );
+            const baseRun = await find(
+              { branch: process.env.BASE_BRANCH },
+              run => run.event !== 'pull_request' && run.event !== 'pull_request_target'
+            );
+            core.setOutput('current-run', String(currentRun));
+            core.setOutput('base-run', String(baseRun));
+
+      - name: Download pull-request size input
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.SIZE_INPUT_ARTIFACT }}
+          path: ${{ runner.temp }}/current
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.artifacts.outputs.current-run }}
+
+      - name: Download base-branch size input
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.SIZE_INPUT_ARTIFACT }}
+          path: ${{ runner.temp }}/baseline
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.artifacts.outputs.base-run }}
+
+      - name: Compare NativeAOT size
+        id: size
+        continue-on-error: true
+        uses: willibrandon/dotsider@v0
+        with:
+          target: ${{ runner.temp }}/current/${{ env.SIZE_TARGET }}
+          baseline: ${{ runner.temp }}/baseline/${{ env.SIZE_TARGET }}
+          budgets: |
+            max=25mb
+            growth=1%
+          why: true
+          publish-summary: false
+          artifact-name: dotsider-size-report
+
+      - name: Prepare pull-request report
+        if: always()
+        shell: bash
+        env:
+          REPORT_PATH: ${{ steps.size.outputs.markdown-report-path }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          output="$RUNNER_TEMP/dotsider-aot-size-comment.md"
+          printf '%s\n' '<!-- dotsider-aot-size -->' > "$output"
+          if [[ -n "$REPORT_PATH" && -f "$REPORT_PATH" ]]; then
+            cat "$REPORT_PATH" >> "$output"
+          else
+            printf 'Dotsider size analysis failed. [Open the workflow run](%s).\n' "$RUN_URL" >> "$output"
+          fi
+
+      - name: Upload pull-request report
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: dotsider-aot-size-comment-${{ github.run_id }}
+          path: ${{ runner.temp }}/dotsider-aot-size-comment.md
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Enforce result
+        if: steps.size.outcome == 'failure'
+        shell: bash
+        run: exit 1
+
+  comment:
+    needs: [authorize, analyze]
+    if: always() && needs.authorize.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Download pull-request report
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: dotsider-aot-size-comment-${{ github.run_id }}
+          path: ${{ runner.temp }}/comment
+
+      - name: Update pull-request report
+        if: always()
+        uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ needs.authorize.outputs.pr-number }}
+          REPORT_PATH: ${{ runner.temp }}/comment/dotsider-aot-size-comment.md
+        with:
+          script: |
+            const fs = require('node:fs');
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const marker = '<!-- dotsider-aot-size -->';
+            const body = fs.existsSync(process.env.REPORT_PATH)
+              ? fs.readFileSync(process.env.REPORT_PATH, 'utf8')
+              : `${marker}\nDotsider size analysis failed. [Open the workflow run](${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}).`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100
+            });
+            const existing = comments.find(comment => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/integrations/size-check/scripts/validate-generated.mjs
+++ b/integrations/size-check/scripts/validate-generated.mjs
@@ -9,8 +9,14 @@ const roots = [
   path.join(repositoryRoot, "azure-devops/tasks/DotsiderSizeCheckV1/runtime"),
 ];
 const expectedByRoot = new Map([
-  [roots[0], new Set(["acquisition.js", "github.js", "input.js", "process.js", "report.js", "types.js"])],
-  [roots[1], new Set(["acquisition.js", "azure.js", "input.js", "process.js", "report.js", "types.js"])],
+  [roots[0], new Set([
+    "acquisition.js", "baseline.js", "github-baseline.js", "github.js",
+    "input.js", "process.js", "report.js", "types.js",
+  ])],
+  [roots[1], new Set([
+    "acquisition.js", "azure-baseline.js", "azure.js", "baseline.js",
+    "input.js", "process.js", "report.js", "types.js",
+  ])],
 ]);
 const bundleMarkers = ["__webpack_require__", "webpackBootstrap", "parcelRequire", "__commonJS("];
 let totalBytes = 0;
@@ -46,8 +52,8 @@ for (const root of roots) {
 if (totalBytes > 150 * 1024) {
   throw new Error(`Generated JavaScript totals ${totalBytes} bytes; the combined limit is 150 KiB.`);
 }
-if (totalLines > 2_000) {
-  throw new Error(`Generated JavaScript totals ${totalLines} lines; the combined limit is 2,000 lines.`);
+if (totalLines > 3_500) {
+  throw new Error(`Generated JavaScript totals ${totalLines} lines; the combined limit is 3,500 lines.`);
 }
 
 process.stdout.write(`Validated ${totalBytes} bytes and ${totalLines} lines of plain tsc output.\n`);

--- a/integrations/size-check/src/azure-baseline.ts
+++ b/integrations/size-check/src/azure-baseline.ts
@@ -1,0 +1,336 @@
+import { inflateRawSync } from "node:zlib";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { baselineArtifactName, createBaselineIdentity, detectTargetRid } from "./baseline";
+import { BaselineDiscovery, BaselineSource, SizeCheckInputs } from "./types";
+
+const maximumArchiveBytes = 1024 * 1024 * 1024;
+
+interface AzureBuild {
+  id: number;
+  buildNumber: string;
+  sourceBranch: string;
+  sourceVersion: string;
+  result: string;
+  _links?: { web?: { href?: string } };
+}
+
+interface AzureArtifact {
+  name: string;
+}
+
+export async function discoverAzureBaseline(
+  inputs: SizeCheckInputs,
+  preparedRid: string,
+  environment: NodeJS.ProcessEnv = process.env,
+): Promise<BaselineDiscovery> {
+  const targetRid = await detectTargetRid(inputs.target, preparedRid);
+  if (inputs.baseline) {
+    const identity = createBaselineIdentity(
+      "azure-pipelines", "explicit", "explicit", inputs.target, targetRid, inputs.baselineKey,
+      environment.PIPELINE_WORKSPACE || environment.BUILD_SOURCESDIRECTORY,
+      environment.AGENT_TEMPDIRECTORY,
+    );
+    const artifactName = baselineArtifactName(identity);
+    return {
+      identity,
+      artifactName,
+      source: { status: "explicit", path: inputs.baseline, artifactName },
+      publish: false,
+    };
+  }
+
+  const project = required(environment.SYSTEM_TEAMPROJECTID || environment.SYSTEM_TEAMPROJECT, "project");
+  const definition = required(environment.SYSTEM_DEFINITIONID, "pipeline definition");
+  const job = required(environment.SYSTEM_JOBNAME, "job");
+  const collection = required(environment.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI, "collection URI").replace(/\/$/u, "");
+  const identity = createBaselineIdentity(
+    "azure-pipelines",
+    `${project}/${definition}`,
+    job,
+    inputs.target,
+    targetRid,
+    inputs.baselineKey,
+    environment.PIPELINE_WORKSPACE || environment.BUILD_SOURCESDIRECTORY,
+    environment.AGENT_TEMPDIRECTORY,
+  );
+  const artifactName = baselineArtifactName(identity);
+
+  const branch = targetBranch(environment);
+  const publish = environment.BUILD_REASON !== "PullRequest" && branch !== undefined;
+  if (!branch) {
+    return {
+      identity,
+      artifactName,
+      source: { status: "not-found", provider: "azure-pipelines", artifactName },
+      publish: false,
+    };
+  }
+
+  const token = takeAccessToken(environment);
+  const apiRoot = `${collection}/${encodeURIComponent(project)}/_apis/build`;
+  const buildsUrl = `${apiRoot}/builds?definitions=${encodeURIComponent(definition)}`
+    + `&branchName=${encodeURIComponent(branch)}&statusFilter=completed&resultFilter=succeeded`
+    + "&queryOrder=queueTimeDescending&$top=100&api-version=7.1";
+  const builds = await azureJson<{ value?: AzureBuild[] }>(buildsUrl, token);
+  const currentBuild = Number(environment.BUILD_BUILDID || "0");
+  for (const build of builds.value ?? []) {
+    if (build.id === currentBuild || build.result.toLowerCase() !== "succeeded" || build.sourceBranch !== branch) {
+      continue;
+    }
+    const artifactUrl = `${apiRoot}/builds/${build.id}/artifacts?artifactName=${encodeURIComponent(artifactName)}`
+      + "&api-version=7.1";
+    const artifact = await tryAzureArtifact(artifactUrl, token);
+    if (!artifact || artifact.name !== artifactName) continue;
+
+    const downloadDirectory = path.join(
+      environment.AGENT_TEMPDIRECTORY || process.cwd(),
+      "dotsider-baseline",
+      artifactName,
+    );
+    const baselineRoot = await downloadAndExtractZip(
+      artifactUrl,
+      token,
+      downloadDirectory,
+      collection,
+    );
+    const source: BaselineSource = {
+      status: "restored",
+      provider: "azure-pipelines",
+      branch,
+      commit: build.sourceVersion,
+      id: String(build.id),
+      number: build.buildNumber,
+      url: build._links?.web?.href,
+      artifactName,
+    };
+    return { identity, artifactName, source, downloadDirectory: baselineRoot, publish };
+  }
+
+  return {
+    identity,
+    artifactName,
+    source: { status: "not-found", provider: "azure-pipelines", branch, artifactName },
+    publish,
+  };
+}
+
+export function takeAccessToken(environment: NodeJS.ProcessEnv = process.env): string {
+  const name = "ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN";
+  const token = environment[name]?.trim();
+  delete environment[name];
+  if (!token) {
+    throw new Error(
+      "Azure baseline discovery could not access the job token supplied to agent tasks. "
+      + "Run DotsiderSizeCheck in an agent job with access to the current project.",
+    );
+  }
+  return token;
+}
+
+export async function extractZipArchive(buffer: Buffer, destination: string): Promise<void> {
+  if (buffer.length > maximumArchiveBytes) throw new Error("The Dotsider baseline archive exceeds 1 GiB.");
+  const eocd = findEndOfCentralDirectory(buffer);
+  const entryCount = buffer.readUInt16LE(eocd + 10);
+  const centralOffset = buffer.readUInt32LE(eocd + 16);
+  if (entryCount === 0xffff || centralOffset === 0xffffffff || entryCount > 20) {
+    throw new Error("The Dotsider baseline archive uses an unsupported ZIP layout.");
+  }
+
+  await fs.rm(destination, { recursive: true, force: true });
+  await fs.mkdir(destination, { recursive: true });
+  let offset = centralOffset;
+  let extractedBytes = 0;
+  for (let index = 0; index < entryCount; index++) {
+    requireSignature(buffer, offset, 0x02014b50, "central directory");
+    const flags = buffer.readUInt16LE(offset + 8);
+    const compression = buffer.readUInt16LE(offset + 10);
+    const crc = buffer.readUInt32LE(offset + 16);
+    const compressedBytes = buffer.readUInt32LE(offset + 20);
+    const uncompressedBytes = buffer.readUInt32LE(offset + 24);
+    const nameLength = buffer.readUInt16LE(offset + 28);
+    const extraLength = buffer.readUInt16LE(offset + 30);
+    const commentLength = buffer.readUInt16LE(offset + 32);
+    const externalAttributes = buffer.readUInt32LE(offset + 38);
+    const localOffset = buffer.readUInt32LE(offset + 42);
+    const name = buffer.toString("utf8", offset + 46, offset + 46 + nameLength);
+    offset += 46 + nameLength + extraLength + commentLength;
+
+    if ((flags & 1) !== 0 || ![0, 8].includes(compression)) {
+      throw new Error(`The Dotsider baseline archive entry '${name}' is encrypted or uses unsupported compression.`);
+    }
+    const unixMode = externalAttributes >>> 16;
+    if ((unixMode & 0xf000) === 0xa000) throw new Error(`The Dotsider baseline archive contains symlink '${name}'.`);
+    if (name.endsWith("/")) continue;
+    const destinationPath = safeZipPath(destination, name);
+    requireSignature(buffer, localOffset, 0x04034b50, "local entry");
+    const localNameLength = buffer.readUInt16LE(localOffset + 26);
+    const localExtraLength = buffer.readUInt16LE(localOffset + 28);
+    const dataOffset = localOffset + 30 + localNameLength + localExtraLength;
+    if (dataOffset + compressedBytes > buffer.length) throw new Error(`ZIP entry '${name}' is truncated.`);
+    const compressed = buffer.subarray(dataOffset, dataOffset + compressedBytes);
+    if (uncompressedBytes > maximumArchiveBytes - extractedBytes) {
+      throw new Error("The Dotsider baseline archive expands beyond 1 GiB.");
+    }
+    const contents = compression === 0
+      ? Buffer.from(compressed)
+      : inflateRawSync(compressed, { maxOutputLength: Math.max(1, uncompressedBytes) });
+    if (contents.length !== uncompressedBytes || crc32(contents) !== crc) {
+      throw new Error(`ZIP entry '${name}' failed size or CRC validation.`);
+    }
+    extractedBytes += contents.length;
+    if (extractedBytes > maximumArchiveBytes) throw new Error("The Dotsider baseline archive expands beyond 1 GiB.");
+    await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+    await fs.writeFile(destinationPath, contents, { flag: "wx" });
+  }
+}
+
+async function downloadAndExtractZip(
+  url: string,
+  token: string,
+  destination: string,
+  trustedCollection: string,
+): Promise<string> {
+  const trustedOrigin = new URL(trustedCollection).origin;
+  let current = new URL(url);
+  let response: Response | undefined;
+  for (let redirect = 0; redirect <= 5; redirect++) {
+    response = await fetch(current, {
+      redirect: "manual",
+      headers: {
+        Accept: "application/zip",
+        ...(current.origin === trustedOrigin ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+    if (![301, 302, 303, 307, 308].includes(response.status)) break;
+    const location = response.headers.get("location");
+    if (!location) throw new Error("Azure baseline artifact download returned an invalid redirect.");
+    current = new URL(location, current);
+  }
+  if (!response) throw new Error("Azure baseline artifact download did not return a response.");
+  if (!response.ok) {
+    const permission = response.status === 401 || response.status === 403
+      ? " Grant the project Build Service permission to read builds and artifacts."
+      : "";
+    throw new Error(`Azure baseline artifact download failed with HTTP ${response.status}.${permission}`);
+  }
+  await extractZipArchive(await readBoundedBody(response), destination);
+  return await locateBaselineRoot(destination);
+}
+
+async function readBoundedBody(response: Response): Promise<Buffer> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > maximumArchiveBytes) {
+    throw new Error("The Dotsider baseline archive exceeds 1 GiB.");
+  }
+  if (!response.body) throw new Error("Azure baseline artifact download returned no content.");
+
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  const reader = response.body.getReader();
+  while (true) {
+    const next = await reader.read();
+    if (next.done) break;
+    bytes += next.value.byteLength;
+    if (bytes > maximumArchiveBytes) {
+      await reader.cancel();
+      throw new Error("The Dotsider baseline archive exceeds 1 GiB.");
+    }
+    chunks.push(Buffer.from(next.value));
+  }
+  return Buffer.concat(chunks, bytes);
+}
+
+async function locateBaselineRoot(directory: string): Promise<string> {
+  if (await isFile(path.join(directory, "dotsider-baseline.json"))) return directory;
+  const candidates: string[] = [];
+  for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      const candidate = path.join(directory, entry.name);
+      if (await isFile(path.join(candidate, "dotsider-baseline.json"))) candidates.push(candidate);
+    }
+  }
+  if (candidates.length !== 1) {
+    throw new Error("The Azure baseline artifact does not contain one baseline manifest at its root.");
+  }
+  return candidates[0]!;
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    return (await fs.stat(filePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function azureJson<T>(url: string, token: string): Promise<T> {
+  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!response.ok) {
+    const permission = response.status === 401 || response.status === 403
+      ? " Grant the project Build Service permission to read builds and artifacts."
+      : "";
+    throw new Error(`Azure baseline discovery failed with HTTP ${response.status}.${permission}`);
+  }
+  return await response.json() as T;
+}
+
+async function tryAzureArtifact(url: string, token: string): Promise<AzureArtifact | undefined> {
+  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (response.status === 404) return undefined;
+  if (!response.ok) {
+    const permission = response.status === 401 || response.status === 403
+      ? " Grant the project Build Service permission to read builds and artifacts."
+      : "";
+    throw new Error(`Azure baseline discovery failed with HTTP ${response.status}.${permission}`);
+  }
+  return await response.json() as AzureArtifact;
+}
+
+function targetBranch(environment: NodeJS.ProcessEnv): string | undefined {
+  const value = environment.BUILD_REASON === "PullRequest"
+    ? environment.SYSTEM_PULLREQUEST_TARGETBRANCH
+    : environment.BUILD_SOURCEBRANCH;
+  return value?.startsWith("refs/heads/") ? value : undefined;
+}
+
+function findEndOfCentralDirectory(buffer: Buffer): number {
+  const lowerBound = Math.max(0, buffer.length - 65_557);
+  for (let offset = buffer.length - 22; offset >= lowerBound; offset--) {
+    if (buffer.readUInt32LE(offset) === 0x06054b50) return offset;
+  }
+  throw new Error("The Dotsider baseline artifact is not a supported ZIP archive.");
+}
+
+function requireSignature(buffer: Buffer, offset: number, signature: number, name: string): void {
+  if (offset < 0 || offset + 4 > buffer.length || buffer.readUInt32LE(offset) !== signature) {
+    throw new Error(`The Dotsider baseline ZIP ${name} is invalid.`);
+  }
+}
+
+function safeZipPath(root: string, entry: string): string {
+  if (!entry || path.isAbsolute(entry) || entry.includes("\\")) throw new Error(`Unsafe ZIP path '${entry}'.`);
+  const normalized = path.posix.normalize(entry);
+  if (normalized === ".." || normalized.startsWith("../") || normalized.includes("/../")) {
+    throw new Error(`Unsafe ZIP path '${entry}'.`);
+  }
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(root, ...normalized.split("/"));
+  if (!resolved.startsWith(`${resolvedRoot}${path.sep}`)) throw new Error(`Unsafe ZIP path '${entry}'.`);
+  return resolved;
+}
+
+function crc32(buffer: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function required(value: string | undefined, name: string): string {
+  const candidate = value?.trim();
+  if (!candidate) throw new Error(`Unable to determine the Azure Pipelines ${name}.`);
+  return candidate;
+}

--- a/integrations/size-check/src/azure.ts
+++ b/integrations/size-check/src/azure.ts
@@ -2,10 +2,12 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { acquireTool, prepareTool } from "./acquisition";
+import { discoverAzureBaseline } from "./azure-baseline";
+import { enrichReports, restoreBaseline, stageBaseline } from "./baseline";
 import { createInputs } from "./input";
 import { executeSizeCheck } from "./process";
 import { createErrorOutputs, createStableOutputs, formatSizeCheckSummary } from "./report";
-import { StableOutputs } from "./types";
+import { BaselineSource, StableOutputs } from "./types";
 
 if (require.main === module) {
   void main();
@@ -19,9 +21,10 @@ async function main(): Promise<void> {
     const defaultRoot = process.env.BUILD_ARTIFACTSTAGINGDIRECTORY
       || process.env.AGENT_TEMPDIRECTORY
       || os.tmpdir();
-    const inputs = createInputs({
+    let inputs = createInputs({
       target: getInput("target"),
       baseline: getInput("baseline"),
+      baselineKey: getInput("baselineKey"),
       budgets: getInput("budgets"),
       budgetFile: getInput("budgetFile"),
       top: getInput("top"),
@@ -38,8 +41,33 @@ async function main(): Promise<void> {
     const tool = await prepareTool(inputs.dotsiderVersion, inputs.dotsiderPath);
     dotsiderVersion = tool.version;
     const executable = await acquireTool(tool);
-    const execution = await executeSizeCheck(executable, inputs);
-    const outputs = createStableOutputs(execution, inputs.artifactName, tool.version);
+    const discovery = await discoverAzureBaseline(inputs, tool.rid);
+    if (discovery.source.status === "restored") {
+      const restored = await restoreBaseline(
+        discovery.downloadDirectory || "",
+        discovery.identity,
+        discovery.source,
+      );
+      inputs = { ...inputs, baseline: restored.targetPath };
+    }
+    const execution = await executeSizeCheck(
+      executable,
+      inputs,
+      discovery.source.status === "not-found",
+    );
+    if (execution.report && await fileExists(execution.markdownReportPath)) {
+      execution.report = await enrichReports(
+        execution.jsonReportPath,
+        execution.markdownReportPath,
+        discovery.source,
+      );
+    }
+    const outputs = createStableOutputs(
+      execution,
+      inputs.artifactName,
+      tool.version,
+      discovery.source,
+    );
     errorOutputs = { ...outputs, result: "error", exitCode: "1" };
     writeStableOutputs(outputs);
     const summary = formatSizeCheckSummary(outputs);
@@ -54,6 +82,21 @@ async function main(): Promise<void> {
       && await fileExists(execution.jsonReportPath)
       && await fileExists(execution.markdownReportPath)) {
       vso("artifact.upload", { artifactname: inputs.artifactName }, inputs.reportDirectory);
+    }
+    if (discovery.publish && execution.report
+      && (execution.result === "passed" || execution.result === "passed-with-warnings")) {
+      const baselineDirectory = path.join(
+        process.env.AGENT_TEMPDIRECTORY || os.tmpdir(),
+        "dotsider-baseline-upload",
+        discovery.artifactName,
+      );
+      await stageBaseline(
+        execution.report,
+        discovery.identity,
+        currentAzureSource(discovery.artifactName),
+        baselineDirectory,
+      );
+      vso("artifact.upload", { artifactname: discovery.artifactName }, baselineDirectory);
     }
 
     if (execution.exitCode === 0) {
@@ -76,6 +119,24 @@ async function main(): Promise<void> {
     complete("Failed", error instanceof Error ? error.message : String(error));
     process.exitCode = 1;
   }
+}
+
+function currentAzureSource(artifactName: string): BaselineSource {
+  const collection = (process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI || "").replace(/\/$/u, "");
+  const project = process.env.SYSTEM_TEAMPROJECT || process.env.SYSTEM_TEAMPROJECTID || "";
+  const buildId = process.env.BUILD_BUILDID || "";
+  return {
+    status: "restored",
+    provider: "azure-pipelines",
+    branch: process.env.BUILD_SOURCEBRANCH,
+    commit: process.env.BUILD_SOURCEVERSION,
+    id: buildId,
+    number: process.env.BUILD_BUILDNUMBER,
+    url: collection && project && buildId
+      ? `${collection}/${encodeURIComponent(project)}/_build/results?buildId=${buildId}`
+      : undefined,
+    artifactName,
+  };
 }
 
 export function getInput(name: string): string | undefined {

--- a/integrations/size-check/src/baseline.ts
+++ b/integrations/size-check/src/baseline.ts
@@ -1,0 +1,337 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+  BaselineIdentity,
+  BaselineSource,
+  SizeReport,
+} from "./types";
+
+const manifestFileName = "dotsider-baseline.json";
+const manifestSchemaVersion = 1;
+const maximumFileBytes = 1024 * 1024 * 1024;
+
+interface BaselineManifestFile {
+  role: "binary" | "mstat" | "dgml";
+  path: string;
+  bytes: number;
+  sha256: string;
+}
+
+interface BaselineManifest {
+  schemaVersion: number;
+  identity: BaselineIdentity;
+  source: BaselineSource;
+  targetPath: string;
+  files: readonly BaselineManifestFile[];
+}
+
+export function createBaselineIdentity(
+  provider: BaselineIdentity["provider"],
+  scope: string,
+  job: string,
+  targetPath: string,
+  rid: string,
+  baselineKey: string | undefined,
+  workspace: string | undefined,
+  temporaryDirectory: string | undefined,
+): BaselineIdentity {
+  return {
+    provider,
+    scope: requiredIdentityPart(scope, "provider scope"),
+    job: requiredIdentityPart(job, "job"),
+    target: baselineKey?.trim() || logicalTarget(targetPath, workspace, temporaryDirectory),
+    rid: requiredIdentityPart(rid, "target RID"),
+  };
+}
+
+export function baselineArtifactName(identity: BaselineIdentity): string {
+  const digest = createHash("sha256").update(canonicalIdentity(identity)).digest("hex").slice(0, 20);
+  const rid = sanitize(identity.rid).slice(0, 32) || "unknown";
+  return `dotsider-baseline-${rid}-${digest}`;
+}
+
+export async function detectTargetRid(targetPath: string, fallbackRid: string): Promise<string> {
+  if (targetPath.toLowerCase().endsWith(".mstat")) {
+    return fallbackRid;
+  }
+
+  const handle = await fs.open(targetPath, "r");
+  try {
+    // The ELF program interpreter is not guaranteed to appear in the first page.
+    // Reading 64 KiB is still bounded while covering normal program-header layouts.
+    const buffer = Buffer.alloc(64 * 1024);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    return detectRidFromHeader(buffer.subarray(0, bytesRead), fallbackRid);
+  } finally {
+    await handle.close();
+  }
+}
+
+export function detectRidFromHeader(bytes: Buffer, fallbackRid: string): string {
+  if (bytes.length >= 64 && bytes[0] === 0x7f && bytes.toString("ascii", 1, 4) === "ELF") {
+    const littleEndian = bytes[5] === 1;
+    const machine = littleEndian ? bytes.readUInt16LE(18) : bytes.readUInt16BE(18);
+    const architecture = machine === 0x3e ? "x64"
+      : machine === 0xb7 ? "arm64"
+        : machine === 0x03 ? "x86"
+          : machine === 0x28 ? "arm"
+            : undefined;
+    if (architecture) {
+      const musl = bytes.includes(Buffer.from("ld-musl-"));
+      return `linux-${musl ? "musl-" : ""}${architecture}`;
+    }
+  }
+
+  if (bytes.length >= 64 && bytes[0] === 0x4d && bytes[1] === 0x5a) {
+    const peOffset = bytes.readUInt32LE(0x3c);
+    if (peOffset + 6 <= bytes.length && bytes.toString("ascii", peOffset, peOffset + 4) === "PE\0\0") {
+      const machine = bytes.readUInt16LE(peOffset + 4);
+      const architecture = machine === 0x8664 ? "x64"
+        : machine === 0xaa64 ? "arm64"
+          : machine === 0x014c ? "x86"
+            : machine === 0x01c4 ? "arm"
+              : undefined;
+      if (architecture) return `win-${architecture}`;
+    }
+  }
+
+  if (bytes.length >= 8) {
+    const magic = bytes.readUInt32BE(0);
+    const littleEndian = magic === 0xcefaedfe || magic === 0xcffaedfe;
+    if (magic === 0xfeedface || magic === 0xfeedfacf || littleEndian) {
+      const cpu = littleEndian ? bytes.readUInt32LE(4) : bytes.readUInt32BE(4);
+      if (cpu === 0x01000007) return "osx-x64";
+      if (cpu === 0x0100000c) return "osx-arm64";
+    }
+  }
+
+  return fallbackRid;
+}
+
+export async function stageBaseline(
+  report: SizeReport,
+  identity: BaselineIdentity,
+  source: BaselineSource,
+  directory: string,
+): Promise<string> {
+  await fs.rm(directory, { recursive: true, force: true });
+  const filesDirectory = path.join(directory, "files");
+  await fs.mkdir(filesDirectory, { recursive: true });
+
+  const artifacts = report.targetArtifacts;
+  const candidates: readonly [BaselineManifestFile["role"], string | null | undefined][] = [
+    ["binary", artifacts.binaryPath],
+    ["mstat", artifacts.mstatPath],
+    ["dgml", artifacts.dgmlPath],
+  ];
+  const manifestFiles: BaselineManifestFile[] = [];
+  let targetRelativePath: string | undefined;
+  for (const [role, sourcePath] of candidates) {
+    if (!sourcePath) continue;
+    const extension = role === "binary" ? path.extname(sourcePath) : role === "mstat" ? ".mstat" : ".dgml.xml";
+    const relativePath = path.posix.join("files", `target${extension}`);
+    const destination = path.join(directory, ...relativePath.split("/"));
+    const stat = await fs.lstat(sourcePath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`Baseline source '${sourcePath}' is not a regular file.`);
+    }
+    if (stat.size > maximumFileBytes) {
+      throw new Error(`Baseline source '${sourcePath}' exceeds the 1 GiB file limit.`);
+    }
+    await fs.copyFile(sourcePath, destination);
+    manifestFiles.push({ role, path: relativePath, bytes: stat.size, sha256: await sha256File(destination) });
+    if (role === (artifacts.binaryPath ? "binary" : "mstat")) targetRelativePath = relativePath;
+  }
+
+  if (!targetRelativePath || !manifestFiles.some(file => file.role === "mstat")) {
+    throw new Error("Dotsider did not report the files required to create a baseline artifact.");
+  }
+
+  const manifest: BaselineManifest = {
+    schemaVersion: manifestSchemaVersion,
+    identity,
+    source,
+    targetPath: targetRelativePath,
+    files: manifestFiles,
+  };
+  await fs.writeFile(path.join(directory, manifestFileName), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  return directory;
+}
+
+export async function restoreBaseline(
+  directory: string,
+  expected: BaselineIdentity,
+  expectedSource?: BaselineSource,
+): Promise<{
+  targetPath: string;
+  source: BaselineSource;
+}> {
+  const manifestPath = path.join(directory, manifestFileName);
+  const manifest = parseManifest(JSON.parse(await fs.readFile(manifestPath, "utf8")));
+  if (canonicalIdentity(manifest.identity) !== canonicalIdentity(expected)) {
+    throw new Error("The stored Dotsider baseline does not match this workflow, job, target, and RID.");
+  }
+  if (expectedSource?.status === "restored"
+      && (manifest.source.status !== "restored"
+        || manifest.source.provider !== expectedSource.provider
+        || manifest.source.branch !== expectedSource.branch
+        || manifest.source.id !== expectedSource.id
+        || manifest.source.commit !== expectedSource.commit
+        || manifest.source.artifactName !== expectedSource.artifactName)) {
+    throw new Error("The stored Dotsider baseline provenance does not match its provider build.");
+  }
+
+  if (manifest.files.length === 0 || manifest.files.length > 3) {
+    throw new Error("The stored Dotsider baseline manifest has an invalid file count.");
+  }
+  const paths = new Set<string>();
+  const roles = new Set<string>();
+  for (const file of manifest.files) {
+    if (paths.has(file.path) || roles.has(file.role)) {
+      throw new Error("The stored Dotsider baseline manifest contains duplicate files or roles.");
+    }
+    paths.add(file.path);
+    roles.add(file.role);
+    const resolved = safeArtifactPath(directory, file.path);
+    const stat = await fs.lstat(resolved);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size !== file.bytes || stat.size > maximumFileBytes) {
+      throw new Error(`Stored Dotsider baseline file '${file.path}' failed validation.`);
+    }
+    if (await sha256File(resolved) !== file.sha256) {
+      throw new Error(`Stored Dotsider baseline file '${file.path}' failed SHA-256 validation.`);
+    }
+  }
+  if (!roles.has("mstat")
+      || !manifest.files.some(file => file.path === manifest.targetPath
+        && (file.role === "binary" || file.role === "mstat"))) {
+    throw new Error("The stored Dotsider baseline manifest does not identify a verified target and mstat file.");
+  }
+
+  return {
+    targetPath: safeArtifactPath(directory, manifest.targetPath),
+    source: manifest.source,
+  };
+}
+
+export async function enrichReports(
+  jsonPath: string,
+  markdownPath: string,
+  source: BaselineSource,
+): Promise<SizeReport> {
+  const report = JSON.parse(await fs.readFile(jsonPath, "utf8")) as SizeReport;
+  report.baselineSource = source;
+  await fs.writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+
+  const markdown = await fs.readFile(markdownPath, "utf8");
+  const baselineLine = formatBaselineSource(source);
+  const firstSection = /\r?\n---\r?\n/u.exec(markdown);
+  const newline = markdown.includes("\r\n") ? "\r\n" : "\n";
+  const enriched = firstSection?.index !== undefined
+    ? `${markdown.slice(0, firstSection.index).trimEnd()}${newline}${newline}${baselineLine}${newline}`
+      + markdown.slice(firstSection.index)
+    : `${markdown.trimEnd()}${newline}${newline}${baselineLine}${newline}`;
+  await fs.writeFile(markdownPath, enriched, "utf8");
+  return report;
+}
+
+function formatBaselineSource(source: BaselineSource): string {
+  if (source.status === "explicit") {
+    return `**Baseline:** Explicit file ${markdownCodeSpan(source.path ?? "unknown")}.`;
+  }
+  if (source.status === "not-found") {
+    const branch = source.branch ? ` for ${markdownCodeSpan(source.branch)}` : "";
+    return `**Baseline:** No stored baseline was found${branch}; absolute budgets were evaluated and growth budgets were deferred.`;
+  }
+  const label = source.number ? `run ${source.number}` : `run ${source.id ?? "unknown"}`;
+  const linked = source.url ? `[${label}](${source.url})` : label;
+  const commit = source.commit ? ` at ${markdownCodeSpan(source.commit.slice(0, 12))}` : "";
+  const branch = source.branch ? ` on ${markdownCodeSpan(source.branch)}` : "";
+  return `**Baseline:** Restored from ${linked}${commit}${branch}.`;
+}
+
+function markdownCodeSpan(value: string): string {
+  const longestRun = Math.max(0, ...[...value.matchAll(/`+/gu)].map(match => match[0].length));
+  const delimiter = "`".repeat(longestRun + 1);
+  const padding = value.startsWith("`") || value.startsWith(" ")
+      || value.endsWith("`") || value.endsWith(" ")
+    ? " "
+    : "";
+  return `${delimiter}${padding}${value}${padding}${delimiter}`;
+}
+
+function parseManifest(value: unknown): BaselineManifest {
+  if (!value || typeof value !== "object") throw new Error("The stored Dotsider baseline manifest is invalid.");
+  const manifest = value as Partial<BaselineManifest>;
+  if (manifest.schemaVersion !== manifestSchemaVersion || !manifest.identity || !manifest.source
+      || typeof manifest.targetPath !== "string" || !Array.isArray(manifest.files)) {
+    throw new Error("The stored Dotsider baseline manifest is unsupported or incomplete.");
+  }
+  for (const file of manifest.files) {
+    if (!file || typeof file.path !== "string" || typeof file.sha256 !== "string"
+        || typeof file.bytes !== "number" || !["binary", "mstat", "dgml"].includes(file.role)) {
+      throw new Error("The stored Dotsider baseline manifest contains an invalid file entry.");
+    }
+  }
+  return manifest as BaselineManifest;
+}
+
+function safeArtifactPath(root: string, relativePath: string): string {
+  if (!relativePath || path.isAbsolute(relativePath) || relativePath.includes("\\")) {
+    throw new Error(`Stored Dotsider baseline path '${relativePath}' is unsafe.`);
+  }
+  const normalized = path.posix.normalize(relativePath);
+  if (normalized === ".." || normalized.startsWith("../") || normalized.includes("/../")) {
+    throw new Error(`Stored Dotsider baseline path '${relativePath}' is unsafe.`);
+  }
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(root, ...normalized.split("/"));
+  if (resolved !== resolvedRoot && !resolved.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error(`Stored Dotsider baseline path '${relativePath}' escapes its artifact.`);
+  }
+  return resolved;
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const hash = createHash("sha256");
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(filePath);
+    stream.on("data", chunk => hash.update(chunk));
+    stream.on("error", reject);
+    stream.on("end", resolve);
+  });
+  return hash.digest("hex");
+}
+
+function canonicalIdentity(identity: BaselineIdentity): string {
+  return JSON.stringify({
+    provider: identity.provider,
+    scope: identity.scope,
+    job: identity.job,
+    target: identity.target,
+    rid: identity.rid,
+  });
+}
+
+function logicalTarget(targetPath: string, workspace: string | undefined, temporaryDirectory: string | undefined): string {
+  const absolute = path.resolve(targetPath);
+  for (const [label, root] of [["workspace", workspace], ["temp", temporaryDirectory]] as const) {
+    if (!root) continue;
+    const relative = path.relative(path.resolve(root), absolute);
+    if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+      return `${label}/${relative.replaceAll(path.sep, "/")}`;
+    }
+  }
+  return `file/${path.basename(absolute)}`;
+}
+
+function requiredIdentityPart(value: string, name: string): string {
+  const candidate = value.trim();
+  if (!candidate) throw new Error(`Unable to determine the Dotsider baseline ${name}.`);
+  return candidate;
+}
+
+function sanitize(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9_.-]+/gu, "-").replace(/^-+|-+$/gu, "");
+}

--- a/integrations/size-check/src/github-baseline.ts
+++ b/integrations/size-check/src/github-baseline.ts
@@ -1,0 +1,237 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { baselineArtifactName, createBaselineIdentity, detectTargetRid } from "./baseline";
+import { BaselineDiscovery, BaselineSource, SizeCheckInputs } from "./types";
+
+interface GitHubRun {
+  id: number;
+  run_number: number;
+  head_branch: string | null;
+  head_sha: string;
+  html_url: string;
+  event: string;
+  conclusion: string | null;
+}
+
+interface GitHubArtifact {
+  id: number;
+  name: string;
+  expired: boolean;
+  workflow_run?: { id: number } | null;
+}
+
+interface PullRequestData {
+  number: number;
+  base: { ref: string };
+  head: { sha: string };
+}
+
+export async function discoverGithubBaseline(
+  inputs: SizeCheckInputs,
+  preparedRid: string,
+  environment: NodeJS.ProcessEnv = process.env,
+): Promise<BaselineDiscovery> {
+  const targetRid = await detectTargetRid(inputs.target, preparedRid);
+  if (inputs.baseline) {
+    const identity = createBaselineIdentity(
+      "github-actions", "explicit", "explicit", inputs.target, targetRid, inputs.baselineKey,
+      environment.GITHUB_WORKSPACE, environment.RUNNER_TEMP,
+    );
+    const artifactName = baselineArtifactName(identity);
+    return {
+      identity,
+      artifactName,
+      source: { status: "explicit", path: inputs.baseline, artifactName },
+      publish: false,
+    };
+  }
+
+  const repository = required(environment.GITHUB_REPOSITORY, "GITHUB_REPOSITORY");
+  const workflow = workflowFile(required(environment.GITHUB_WORKFLOW_REF, "GITHUB_WORKFLOW_REF"));
+  const job = required(environment.GITHUB_JOB, "GITHUB_JOB");
+  const identity = createBaselineIdentity(
+    "github-actions",
+    `${repository}/${workflow}`,
+    job,
+    inputs.target,
+    targetRid,
+    inputs.baselineKey,
+    environment.GITHUB_WORKSPACE,
+    environment.RUNNER_TEMP,
+  );
+  const artifactName = baselineArtifactName(identity);
+
+  const apiUrl = (environment.GITHUB_API_URL || "https://api.github.com").replace(/\/$/u, "");
+  const token = required(environment.GITHUB_TOKEN, "GITHUB_TOKEN");
+  const context = await resolveContext(apiUrl, repository, token, environment);
+  if (!context.branch) {
+    return {
+      identity,
+      artifactName,
+      source: { status: "not-found", provider: "github-actions", artifactName },
+      publish: false,
+    };
+  }
+
+  const artifacts = await githubJson<{ artifacts?: GitHubArtifact[] }>(
+    `${apiUrl}/repos/${repository}/actions/artifacts?name=${encodeURIComponent(artifactName)}&per_page=100`,
+    token,
+  );
+  const artifactRunIds = new Set(
+    (artifacts.artifacts ?? [])
+      .filter(artifact => artifact.name === artifactName && !artifact.expired && artifact.workflow_run)
+      .map(artifact => artifact.workflow_run!.id),
+  );
+  if (artifactRunIds.size === 0) {
+    return {
+      identity,
+      artifactName,
+      source: {
+        status: "not-found",
+        provider: "github-actions",
+        branch: context.branch,
+        artifactName,
+      },
+      publish: context.publish,
+    };
+  }
+
+  const runsUrl = `${apiUrl}/repos/${repository}/actions/workflows/${encodeURIComponent(workflow)}/runs`
+    + `?branch=${encodeURIComponent(context.branch)}&status=success&exclude_pull_requests=true&per_page=100`;
+  const runs = await githubJson<{ workflow_runs?: GitHubRun[] }>(runsUrl, token);
+  const currentRunId = Number(environment.GITHUB_RUN_ID || "0");
+  for (const run of runs.workflow_runs ?? []) {
+    if (run.id === currentRunId || run.conclusion !== "success" || run.head_branch !== context.branch
+        || run.event === "pull_request" || run.event === "pull_request_target"
+        || !artifactRunIds.has(run.id)) {
+      continue;
+    }
+
+    const source: BaselineSource = {
+      status: "restored",
+      provider: "github-actions",
+      branch: context.branch,
+      commit: run.head_sha,
+      id: String(run.id),
+      number: String(run.run_number),
+      url: run.html_url,
+      artifactName,
+    };
+    return {
+      identity,
+      artifactName,
+      source,
+      runId: String(run.id),
+      downloadDirectory: path.join(environment.RUNNER_TEMP || process.cwd(), "dotsider-baseline", artifactName),
+      publish: context.publish,
+    };
+  }
+
+  return {
+    identity,
+    artifactName,
+    source: {
+      status: "not-found",
+      provider: "github-actions",
+      branch: context.branch,
+      artifactName,
+    },
+    publish: context.publish,
+  };
+}
+
+async function resolveContext(
+  apiUrl: string,
+  repository: string,
+  token: string,
+  environment: NodeJS.ProcessEnv,
+): Promise<{ branch?: string; publish: boolean }> {
+  const eventName = environment.GITHUB_EVENT_NAME || "";
+  const event = await readEvent(environment.GITHUB_EVENT_PATH);
+  if (eventName === "pull_request" || eventName === "pull_request_target") {
+    return { branch: objectString(event, "pull_request", "base", "ref"), publish: false };
+  }
+  if (eventName === "issue_comment" || eventName === "pull_request_review_comment") {
+    const number = eventName === "issue_comment"
+      ? objectNumber(event, "issue", "number")
+      : objectNumber(event, "pull_request", "number");
+    const pull = await githubJson<PullRequestData>(`${apiUrl}/repos/${repository}/pulls/${number}`, token);
+    return { branch: pull.base.ref, publish: false };
+  }
+  if (eventName === "workflow_dispatch") {
+    const dispatchNumber = objectOptionalNumber(event, "inputs", "pr_number");
+    if (dispatchNumber !== undefined) {
+      const pull = await githubJson<PullRequestData>(`${apiUrl}/repos/${repository}/pulls/${dispatchNumber}`, token);
+      return { branch: pull.base.ref, publish: false };
+    }
+  }
+
+  const ref = environment.GITHUB_REF || "";
+  const branch = ref.startsWith("refs/heads/")
+    ? ref.slice("refs/heads/".length)
+    : environment.GITHUB_REF_TYPE === "branch" ? environment.GITHUB_REF_NAME : undefined;
+  return { branch, publish: branch !== undefined };
+}
+
+async function githubJson<T>(url: string, token: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "dotsider-size-check",
+    },
+  });
+  if (!response.ok) {
+    const permission = response.status === 401 || response.status === 403
+      ? " Grant the job 'actions: read' permission."
+      : "";
+    throw new Error(`GitHub baseline discovery failed with HTTP ${response.status}.${permission}`);
+  }
+  return await response.json() as T;
+}
+
+async function readEvent(eventPath: string | undefined): Promise<Record<string, unknown>> {
+  if (!eventPath) return {};
+  return JSON.parse(await fs.readFile(eventPath, "utf8")) as Record<string, unknown>;
+}
+
+function objectString(value: unknown, ...keys: string[]): string {
+  let current = value;
+  for (const key of keys) {
+    if (!current || typeof current !== "object") throw new Error("The GitHub event payload is incomplete.");
+    current = (current as Record<string, unknown>)[key];
+  }
+  if (typeof current !== "string" || !current) throw new Error("The GitHub event payload is incomplete.");
+  return current;
+}
+
+function objectNumber(value: unknown, ...keys: string[]): number {
+  const result = objectOptionalNumber(value, ...keys);
+  if (result === undefined) throw new Error("The GitHub event payload does not identify a pull request.");
+  return result;
+}
+
+function objectOptionalNumber(value: unknown, ...keys: string[]): number | undefined {
+  let current = value;
+  for (const key of keys) {
+    if (!current || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  const parsed = typeof current === "number" ? current : typeof current === "string" ? Number(current) : NaN;
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function workflowFile(reference: string): string {
+  const beforeRef = reference.split("@")[0] ?? reference;
+  const marker = "/.github/workflows/";
+  const index = beforeRef.indexOf(marker);
+  if (index < 0) throw new Error(`Unable to determine the workflow file from GITHUB_WORKFLOW_REF '${reference}'.`);
+  return beforeRef.slice(index + marker.length);
+}
+
+function required(value: string | undefined, name: string): string {
+  const candidate = value?.trim();
+  if (!candidate) throw new Error(`Required environment variable ${name} was not provided.`);
+  return candidate;
+}

--- a/integrations/size-check/src/github.ts
+++ b/integrations/size-check/src/github.ts
@@ -1,10 +1,13 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
+import * as path from "node:path";
 import { acquireTool, prepareTool } from "./acquisition";
+import { enrichReports, restoreBaseline, stageBaseline } from "./baseline";
+import { discoverGithubBaseline } from "./github-baseline";
 import { createInputs } from "./input";
 import { executeSizeCheck } from "./process";
 import { createErrorOutputs, createStableOutputs, formatSizeCheckSummary } from "./report";
-import { PreparedTool, StableOutputs } from "./types";
+import { BaselineDiscovery, BaselineSource, PreparedTool, StableOutputs } from "./types";
 
 void main();
 
@@ -24,11 +27,14 @@ async function main(): Promise<void> {
           errorOutputs = { ...outputs, result: "error", exitCode: "1" };
         });
         break;
+      case "discover":
+        await discover();
+        break;
       case "enforce":
         enforce();
         break;
       default:
-        throw new Error("Expected a GitHub adapter command: prepare, run, or enforce.");
+        throw new Error("Expected a GitHub adapter command: prepare, discover, run, or enforce.");
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -38,6 +44,20 @@ async function main(): Promise<void> {
     command("error", {}, message);
     process.exitCode = 1;
   }
+}
+
+async function discover(): Promise<void> {
+  const inputs = githubInputs();
+  const discovery = await discoverGithubBaseline(inputs, requiredEnvironment("DOTSIDER_PREPARED_RID"));
+  writeOutputs({
+    status: discovery.source.status,
+    "artifact-name": discovery.artifactName,
+    "run-id": discovery.runId ?? "",
+    "download-directory": discovery.downloadDirectory ?? "",
+    publish: String(discovery.publish),
+    identity: JSON.stringify(discovery.identity),
+    source: JSON.stringify(discovery.source),
+  });
 }
 
 async function prepare(): Promise<void> {
@@ -56,27 +76,49 @@ async function prepare(): Promise<void> {
 }
 
 async function run(onOutputs: (outputs: StableOutputs) => void): Promise<void> {
-  const inputs = createInputs({
-    target: process.env.DOTSIDER_INPUT_TARGET,
-    baseline: process.env.DOTSIDER_INPUT_BASELINE,
-    budgets: process.env.DOTSIDER_INPUT_BUDGETS,
-    budgetFile: process.env.DOTSIDER_INPUT_BUDGET_FILE,
-    top: process.env.DOTSIDER_INPUT_TOP,
-    why: process.env.DOTSIDER_INPUT_WHY,
-    dotsiderVersion: process.env.DOTSIDER_INPUT_VERSION,
-    dotsiderPath: process.env.DOTSIDER_INPUT_PATH,
-    reportDirectory: process.env.DOTSIDER_INPUT_REPORT_DIRECTORY,
-    publishSummary: process.env.DOTSIDER_INPUT_PUBLISH_SUMMARY,
-    publishReports: process.env.DOTSIDER_INPUT_PUBLISH_REPORTS,
-    artifactName: process.env.DOTSIDER_INPUT_ARTIFACT_NAME,
-  }, process.env.RUNNER_TEMP || os.tmpdir());
+  let inputs = githubInputs();
 
   const tool = preparedTool();
   const executable = await acquireTool(tool);
-  const execution = await executeSizeCheck(executable, inputs);
-  const outputs = createStableOutputs(execution, inputs.artifactName, tool.version);
+  const discovery = process.env.DOTSIDER_BASELINE_SOURCE
+    ? preparedDiscovery()
+    : await discoverGithubBaseline(inputs, tool.rid);
+  let source = discovery.source;
+  if (source.status === "restored") {
+    const directory = requiredEnvironment("DOTSIDER_BASELINE_DOWNLOAD_DIRECTORY");
+    const restored = await restoreBaseline(directory, discovery.identity, source);
+    inputs = { ...inputs, baseline: restored.targetPath };
+  }
+
+  const execution = await executeSizeCheck(executable, inputs, source.status === "not-found");
+  if (execution.report && await fileExists(execution.markdownReportPath)) {
+    execution.report = await enrichReports(
+      execution.jsonReportPath,
+      execution.markdownReportPath,
+      source,
+    );
+  }
+  const outputs = createStableOutputs(execution, inputs.artifactName, tool.version, source);
   onOutputs(outputs);
   writeStableOutputs(outputs);
+
+  let baselineUploadPath = "";
+  let publishBaseline = false;
+  if (discovery.publish && execution.report
+      && (execution.result === "passed" || execution.result === "passed-with-warnings")) {
+    source = currentGithubSource(discovery.artifactName);
+    baselineUploadPath = await stageBaseline(
+      execution.report,
+      discovery.identity,
+      source,
+      pathForBaseline(inputs.reportDirectory),
+    );
+    publishBaseline = true;
+  }
+  writeOutputs({
+    "baseline-upload-path": baselineUploadPath,
+    "publish-baseline": String(publishBaseline),
+  });
   const summary = formatSizeCheckSummary(outputs);
   if (summary) {
     process.stdout.write(`Dotsider size check: ${summary}.\n`);
@@ -89,6 +131,53 @@ async function run(onOutputs: (outputs: StableOutputs) => void): Promise<void> {
       await fs.appendFile(summaryPath, `${markdown.trimEnd()}\n`);
     }
   }
+}
+
+function githubInputs() {
+  return createInputs({
+    target: process.env.DOTSIDER_INPUT_TARGET,
+    baseline: process.env.DOTSIDER_INPUT_BASELINE,
+    baselineKey: process.env.DOTSIDER_INPUT_BASELINE_KEY,
+    budgets: process.env.DOTSIDER_INPUT_BUDGETS,
+    budgetFile: process.env.DOTSIDER_INPUT_BUDGET_FILE,
+    top: process.env.DOTSIDER_INPUT_TOP,
+    why: process.env.DOTSIDER_INPUT_WHY,
+    dotsiderVersion: process.env.DOTSIDER_INPUT_VERSION,
+    dotsiderPath: process.env.DOTSIDER_INPUT_PATH,
+    reportDirectory: process.env.DOTSIDER_INPUT_REPORT_DIRECTORY,
+    publishSummary: process.env.DOTSIDER_INPUT_PUBLISH_SUMMARY,
+    publishReports: process.env.DOTSIDER_INPUT_PUBLISH_REPORTS,
+    artifactName: process.env.DOTSIDER_INPUT_ARTIFACT_NAME,
+  }, process.env.RUNNER_TEMP || os.tmpdir());
+}
+
+function preparedDiscovery(): BaselineDiscovery {
+  return {
+    source: JSON.parse(requiredEnvironment("DOTSIDER_BASELINE_SOURCE")) as BaselineSource,
+    identity: JSON.parse(requiredEnvironment("DOTSIDER_BASELINE_IDENTITY")) as BaselineDiscovery["identity"],
+    artifactName: requiredEnvironment("DOTSIDER_BASELINE_ARTIFACT_NAME"),
+    downloadDirectory: optional(process.env.DOTSIDER_BASELINE_DOWNLOAD_DIRECTORY),
+    publish: process.env.DOTSIDER_BASELINE_PUBLISH === "true",
+  };
+}
+
+function currentGithubSource(artifactName: string): BaselineSource {
+  const repository = requiredEnvironment("GITHUB_REPOSITORY");
+  const runId = requiredEnvironment("GITHUB_RUN_ID");
+  return {
+    status: "restored",
+    provider: "github-actions",
+    branch: process.env.GITHUB_REF_NAME,
+    commit: process.env.GITHUB_SHA,
+    id: runId,
+    number: process.env.GITHUB_RUN_NUMBER,
+    url: `${process.env.GITHUB_SERVER_URL || "https://github.com"}/${repository}/actions/runs/${runId}`,
+    artifactName,
+  };
+}
+
+function pathForBaseline(reportDirectory: string): string {
+  return path.join(reportDirectory, ".baseline");
 }
 
 function enforce(): void {
@@ -145,6 +234,11 @@ function writeStableOutputs(outputs: StableOutputs): void {
     "current-total": outputs.currentTotal,
     delta: outputs.delta,
     "violation-count": outputs.violationCount,
+    "baseline-status": outputs.baselineStatus,
+    "baseline-source-id": outputs.baselineSourceId,
+    "baseline-source-commit": outputs.baselineSourceCommit,
+    "baseline-source-url": outputs.baselineSourceUrl,
+    "baseline-artifact-name": outputs.baselineArtifactName,
   });
 }
 

--- a/integrations/size-check/src/input.ts
+++ b/integrations/size-check/src/input.ts
@@ -57,6 +57,7 @@ export function createInputs(
   return {
     target: path.resolve(target),
     baseline,
+    baselineKey: optional(values.baselineKey),
     budgets: parseBudgets(values.budgets),
     budgetFile: optionalPath(values.budgetFile),
     top: parseTop(values.top),
@@ -81,4 +82,9 @@ function required(value: string | undefined, name: string): string {
 function optionalPath(value: string | undefined): string | undefined {
   const candidate = value?.trim();
   return candidate ? path.resolve(candidate) : undefined;
+}
+
+function optional(value: string | undefined): string | undefined {
+  const candidate = value?.trim();
+  return candidate || undefined;
 }

--- a/integrations/size-check/src/process.ts
+++ b/integrations/size-check/src/process.ts
@@ -10,6 +10,7 @@ export async function runProcess(fileName: string, args: readonly string[]): Pro
       shell: false,
       windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
+      env: sanitizedChildEnvironment(),
     });
     let stdout = "";
     let stderr = "";
@@ -38,6 +39,7 @@ export async function runProcess(fileName: string, args: readonly string[]): Pro
 export async function executeSizeCheck(
   executablePath: string,
   inputs: SizeCheckInputs,
+  baselineNotFound = false,
 ): Promise<SizeCheckExecution> {
   await fs.mkdir(inputs.reportDirectory, { recursive: true });
   const jsonReportPath = path.join(inputs.reportDirectory, "dotsider-size-check.json");
@@ -57,7 +59,20 @@ export async function executeSizeCheck(
     jsonReportPath,
     markdownReportPath,
   );
-  const processResult = await runProcess(executablePath, args);
+  const previous = process.env.DOTSIDER_SIZE_CHECK_BASELINE_NOT_FOUND;
+  if (baselineNotFound) {
+    process.env.DOTSIDER_SIZE_CHECK_BASELINE_NOT_FOUND = "1";
+  }
+  let processResult: ProcessResult;
+  try {
+    processResult = await runProcess(executablePath, args);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.DOTSIDER_SIZE_CHECK_BASELINE_NOT_FOUND;
+    } else {
+      process.env.DOTSIDER_SIZE_CHECK_BASELINE_NOT_FOUND = previous;
+    }
+  }
 
   let report;
   try {
@@ -83,4 +98,20 @@ export async function executeSizeCheck(
     report,
     stderr: processResult.stderr,
   };
+}
+
+function sanitizedChildEnvironment(): NodeJS.ProcessEnv {
+  const environment = { ...process.env };
+  for (const name of [
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "ACTIONS_RUNTIME_TOKEN",
+    "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+    "ACTIONS_ID_TOKEN_REQUEST_URL",
+    "ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN",
+    "SYSTEM_ACCESSTOKEN",
+  ]) {
+    delete environment[name];
+  }
+  return environment;
 }

--- a/integrations/size-check/src/report.ts
+++ b/integrations/size-check/src/report.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { SizeCheckExecution, SizeReport, StableOutputs } from "./types";
+import { BaselineSource, SizeCheckExecution, SizeReport, StableOutputs } from "./types";
 
 type SizeCheckSummary = Pick<
   StableOutputs,
@@ -61,8 +61,10 @@ export function isSizeReport(value: unknown): value is SizeReport {
   }
 
   const report = value as Partial<SizeReport>;
-  return report.schemaVersion === 1
+  return report.schemaVersion === 2
     && typeof report.target === "string"
+    && !!report.targetArtifacts
+    && typeof report.targetArtifacts.mstatPath === "string"
     && typeof report.totalBasis === "string"
     && typeof report.rightTotal === "number"
     && !!report.summary
@@ -76,7 +78,7 @@ export function classifyResult(exitCode: number, report: SizeReport | undefined)
   if (exitCode !== 0 || report === undefined) {
     return "error";
   }
-  if (report.budgets?.hasWarnings === true) {
+  if (report.budgets?.hasWarnings === true || report.budgets?.hasDeferred === true) {
     return "passed-with-warnings";
   }
   return "passed";
@@ -86,6 +88,7 @@ export function createStableOutputs(
   execution: SizeCheckExecution,
   artifactName: string,
   dotsiderVersion: string,
+  baselineSource?: BaselineSource,
 ): StableOutputs {
   const report = execution.report;
   const evaluations = report?.budgets?.evaluations ?? [];
@@ -106,6 +109,11 @@ export function createStableOutputs(
     currentTotal: numberOutput(report?.rightTotal),
     delta: numberOutput(report?.summary.delta),
     violationCount: String(violationCount),
+    baselineStatus: baselineSource?.status ?? "",
+    baselineSourceId: baselineSource?.id ?? "",
+    baselineSourceCommit: baselineSource?.commit ?? "",
+    baselineSourceUrl: baselineSource?.url ?? "",
+    baselineArtifactName: baselineSource?.artifactName ?? "",
   };
 }
 
@@ -125,6 +133,11 @@ export function createErrorOutputs(
     currentTotal: "",
     delta: "",
     violationCount: "0",
+    baselineStatus: "",
+    baselineSourceId: "",
+    baselineSourceCommit: "",
+    baselineSourceUrl: "",
+    baselineArtifactName: "",
   };
 }
 

--- a/integrations/size-check/src/types.ts
+++ b/integrations/size-check/src/types.ts
@@ -1,6 +1,7 @@
 export interface SizeCheckInputs {
   target: string;
   baseline?: string;
+  baselineKey?: string;
   budgets: readonly string[];
   budgetFile?: string;
   top: number;
@@ -32,18 +33,45 @@ export type SizeCheckResult = "passed" | "passed-with-warnings" | "budget-failed
 
 export interface SizeBudgetEvaluation {
   violations?: readonly unknown[];
+  deferredMetrics?: readonly string[];
 }
 
 export interface SizeBudgetReport {
   passed?: boolean;
   hasWarnings?: boolean;
+  hasDeferred?: boolean;
   evaluations?: readonly SizeBudgetEvaluation[];
+}
+
+export interface SizeArtifactPaths {
+  inputPath: string;
+  mstatPath: string;
+  binaryPath?: string | null;
+  dgmlPath?: string | null;
+}
+
+export type BaselineStatus = "explicit" | "restored" | "not-found";
+export type BaselineProvider = "github-actions" | "azure-pipelines";
+
+export interface BaselineSource {
+  status: BaselineStatus;
+  provider?: BaselineProvider;
+  branch?: string;
+  commit?: string;
+  id?: string;
+  number?: string;
+  url?: string;
+  artifactName?: string;
+  path?: string;
 }
 
 export interface SizeReport {
   schemaVersion: number;
   target: string;
   baseline?: string | null;
+  targetArtifacts: SizeArtifactPaths;
+  baselineArtifacts?: SizeArtifactPaths | null;
+  baselineSource?: BaselineSource;
   totalBasis: string;
   leftTotal?: number | null;
   rightTotal: number;
@@ -74,4 +102,26 @@ export interface StableOutputs {
   currentTotal: string;
   delta: string;
   violationCount: string;
+  baselineStatus: BaselineStatus | "";
+  baselineSourceId: string;
+  baselineSourceCommit: string;
+  baselineSourceUrl: string;
+  baselineArtifactName: string;
+}
+
+export interface BaselineIdentity {
+  provider: BaselineProvider;
+  scope: string;
+  job: string;
+  target: string;
+  rid: string;
+}
+
+export interface BaselineDiscovery {
+  source: BaselineSource;
+  identity: BaselineIdentity;
+  artifactName: string;
+  runId?: string;
+  downloadDirectory?: string;
+  publish: boolean;
 }

--- a/integrations/size-check/test/adapters.unit.test.ts
+++ b/integrations/size-check/test/adapters.unit.test.ts
@@ -20,6 +20,11 @@ const stableGithubOutputs = [
   "current-total",
   "delta",
   "violation-count",
+  "baseline-status",
+  "baseline-source-id",
+  "baseline-source-commit",
+  "baseline-source-url",
+  "baseline-artifact-name",
 ];
 const stableAzureOutputs = [
   "result",
@@ -33,6 +38,11 @@ const stableAzureOutputs = [
   "currentTotal",
   "delta",
   "violationCount",
+  "baselineStatus",
+  "baselineSourceId",
+  "baselineSourceCommit",
+  "baselineSourceUrl",
+  "baselineArtifactName",
 ];
 
 test("GitHub adapter writes stable error outputs before returning an input error", async () => {
@@ -56,13 +66,15 @@ test("GitHub adapter writes stable error outputs before returning an input error
   assert.equal(outputs.get("violation-count"), "0");
 });
 
-test("GitHub Action exposes the baseline-driven contract", async () => {
+test("GitHub Action exposes automatic baseline discovery and retention", async () => {
   const action = await fs.readFile(path.join(repositoryRoot, "action.yml"), "utf8");
   assert.match(action, /inputs:\r?\n  target:\r?\n(?:.*\r?\n)*?    required: true/u);
   assert.match(action, /  baseline:\r?\n(?:.*\r?\n)*?    required: false/u);
   assert.doesNotMatch(action, /^  mode:/mu);
   assert.doesNotMatch(action, /DOTSIDER_(?:INPUT_)?MODE|steps\.run\.outputs\.mode/u);
-  assert.doesNotMatch(action, /actions\/download-artifact/u);
+  assert.match(action, /actions\/download-artifact@v8/u);
+  assert.match(action, /Find Dotsider baseline/u);
+  assert.match(action, /Publish managed Dotsider baseline/u);
 
   const uploadStart = action.indexOf("- name: Upload Dotsider reports");
   const enforceStart = action.indexOf("- name: Enforce Dotsider result");
@@ -70,7 +82,7 @@ test("GitHub Action exposes the baseline-driven contract", async () => {
   const uploadStep = action.slice(uploadStart, enforceStart);
   assert.match(uploadStep, /steps\.run\.outputs\.json-report-path/u);
   assert.match(uploadStep, /steps\.run\.outputs\.markdown-report-path/u);
-  assert.doesNotMatch(uploadStep, /baseline/u);
+  assert.match(uploadStep, /steps\.run\.outputs\.baseline-artifact-name/u);
 });
 
 test("GitHub enforcement identifies the measured size and retained report", async () => {
@@ -163,7 +175,7 @@ test("Azure task exposes the baseline-driven contract on its supported Node hand
   assert.equal(target.type, "filePath");
   assert.equal(target.required, true);
 
-  for (const name of ["baseline", "budgetFile", "dotsiderPath"]) {
+  for (const name of ["baseline", "baselineKey", "budgetFile", "dotsiderPath"]) {
     const input: {
       name?: string;
       type?: string;

--- a/integrations/size-check/test/azure.integration.test.ts
+++ b/integrations/size-check/test/azure.integration.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import * as fs from "node:fs/promises";
+import { createServer } from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
 import { test } from "node:test";
@@ -29,7 +30,7 @@ test("Azure handler emits outputs from a real comparison", async () => {
     leftTotal?: number;
     summary: { delta: number };
   };
-  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.schemaVersion, 2);
   assert.equal(report.baseline, path.resolve(baseline));
   assert.ok((report.leftTotal ?? 0) > 0);
   assert.notEqual(report.summary.delta, 0);
@@ -69,29 +70,39 @@ test("Azure handler accepts an absolute budget without a baseline", async () => 
     baseline?: string | null;
     rightTotal?: number;
   };
-  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.schemaVersion, 2);
   assert.equal(report.baseline ?? null, null);
   assert.ok((report.rightTotal ?? 0) > 0);
   assert.equal((await fs.stat(path.join(directory, "dotsider-size-check.md"))).isFile(), true);
 });
 
-test("Azure handler rejects a growth budget without a baseline", async () => {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-azure-growth-error-"));
+test("Azure handler defers growth on a confirmed first run", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-azure-growth-first-run-"));
   const result = await runAzure(directory, { budgets: "growth=1%" });
 
-  assert.equal(result.exitCode, 1);
-  assert.match(result.stderr, /limits growth, which needs --baseline/u);
-  assert.match(result.stdout, /variable=result;isOutput=true;\]error/u);
-  assert.match(result.stdout, /variable=exitCode;isOutput=true;\]1/u);
-  assert.doesNotMatch(result.stdout, /##vso\[artifact\.upload/u);
-  assert.equal(await fileExists(path.join(directory, "dotsider-size-check.json")), false);
-  assert.equal(await fileExists(path.join(directory, "dotsider-size-check.md")), false);
+  assert.equal(result.exitCode, 0, result.stderr);
+  assert.match(result.stdout, /variable=result;isOutput=true;\]passed-with-warnings/u);
+  assert.match(result.stdout, /variable=baselineStatus;isOutput=true;\]not-found/u);
+  const json = JSON.parse(await fs.readFile(path.join(directory, "dotsider-size-check.json"), "utf8")) as {
+    baselineSource?: { status?: string };
+    budgets?: { hasDeferred?: boolean };
+  };
+  assert.equal(json.baselineSource?.status, "not-found");
+  assert.equal(json.budgets?.hasDeferred, true);
+  assert.match(await fs.readFile(path.join(directory, "dotsider-size-check.md"), "utf8"), /DEFERRED/u);
 });
 
 async function runAzure(
   reportDirectory: string,
   options: { baseline?: string; budgets?: string },
 ): Promise<ChildResult> {
+  const server = createServer((_request, response) => {
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify({ value: [] }));
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
   return await new Promise<ChildResult>((resolve, reject) => {
     const child = spawn(process.execPath, [runtime], {
       shell: false,
@@ -109,6 +120,18 @@ async function runAzure(
         INPUT_PUBLISH_SUMMARY: "true",
         INPUT_PUBLISH_REPORTS: "true",
         INPUT_ARTIFACT_NAME: "dotsider-azure-test",
+        SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: `http://127.0.0.1:${address.port}`,
+        SYSTEM_TEAMPROJECTID: "project-id",
+        SYSTEM_TEAMPROJECT: "project",
+        SYSTEM_DEFINITIONID: "77",
+        SYSTEM_JOBNAME: "size-check",
+        BUILD_SOURCEBRANCH: "refs/heads/main",
+        BUILD_BUILDID: "100",
+        BUILD_BUILDNUMBER: "100",
+        BUILD_SOURCEVERSION: "current-sha",
+        BUILD_SOURCESDIRECTORY: path.dirname(target),
+        AGENT_TEMPDIRECTORY: reportDirectory,
+        ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN: "test-token",
       },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -118,8 +141,14 @@ async function runAzure(
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (value: string) => stdout += value);
     child.stderr.on("data", (value: string) => stderr += value);
-    child.on("error", reject);
-    child.on("close", exitCode => resolve({ exitCode: exitCode ?? 1, stdout, stderr }));
+    child.on("error", error => {
+      server.close();
+      reject(error);
+    });
+    child.on("close", exitCode => {
+      server.close();
+      resolve({ exitCode: exitCode ?? 1, stdout, stderr });
+    });
   });
 }
 

--- a/integrations/size-check/test/baseline.unit.test.ts
+++ b/integrations/size-check/test/baseline.unit.test.ts
@@ -1,0 +1,553 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { test } from "node:test";
+import { discoverAzureBaseline, extractZipArchive } from "../src/azure-baseline";
+import {
+  baselineArtifactName,
+  createBaselineIdentity,
+  detectRidFromHeader,
+  detectTargetRid,
+  enrichReports,
+  restoreBaseline,
+  stageBaseline,
+} from "../src/baseline";
+import { discoverGithubBaseline } from "../src/github-baseline";
+import { SizeCheckInputs, SizeReport } from "../src/types";
+
+test("baseline identity is stable and isolated by job, logical target, and RID", () => {
+  const first = createBaselineIdentity(
+    "github-actions", "owner/repo/ci.yml", "size-linux", "C:\\temp\\app.exe", "win-x64",
+    "picket", "C:\\src", "C:\\temp",
+  );
+  const same = { ...first };
+  const differentJob = { ...first, job: "size-windows" };
+
+  assert.equal(baselineArtifactName(first), baselineArtifactName(same));
+  assert.notEqual(baselineArtifactName(first), baselineArtifactName(differentJob));
+  assert.match(baselineArtifactName(first), /^dotsider-baseline-win-x64-[a-f0-9]{20}$/u);
+});
+
+test("target RID detection reads PE, ELF, and Mach-O architecture headers", () => {
+  const pe = Buffer.alloc(256);
+  pe.write("MZ");
+  pe.writeUInt32LE(128, 0x3c);
+  pe.write("PE\0\0", 128);
+  pe.writeUInt16LE(0xaa64, 132);
+  assert.equal(detectRidFromHeader(pe, "linux-x64"), "win-arm64");
+
+  const elf = Buffer.alloc(64);
+  elf.set([0x7f, 0x45, 0x4c, 0x46, 2, 1]);
+  elf.writeUInt16LE(0x3e, 18);
+  assert.equal(detectRidFromHeader(elf, "win-x64"), "linux-x64");
+
+  const macho = Buffer.alloc(16);
+  macho.writeUInt32BE(0xfeedfacf, 0);
+  macho.writeUInt32BE(0x0100000c, 4);
+  assert.equal(detectRidFromHeader(macho, "linux-x64"), "osx-arm64");
+});
+
+test("target RID detection finds a musl interpreter beyond the first ELF page", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-musl-target-"));
+  try {
+    const target = path.join(directory, "app");
+    const elf = Buffer.alloc(16 * 1024);
+    elf.set([0x7f, 0x45, 0x4c, 0x46, 2, 1]);
+    elf.writeUInt16LE(0x3e, 18);
+    elf.write("/lib/ld-musl-x86_64.so.1", 8 * 1024, "ascii");
+    await fs.writeFile(target, elf);
+
+    assert.equal(await detectTargetRid(target, "linux-x64"), "linux-musl-x64");
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("staged baselines verify identity, lengths, and SHA-256 before restoration", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-baseline-manifest-"));
+  try {
+    const binary = path.join(directory, "app");
+    const mstat = path.join(directory, "app.mstat");
+    const dgml = path.join(directory, "app.dgml.xml");
+    await Promise.all([
+      fs.writeFile(binary, "native binary"),
+      fs.writeFile(mstat, "real mstat bytes"),
+      fs.writeFile(dgml, "<DirectedGraph />"),
+    ]);
+    const identity = createBaselineIdentity(
+      "github-actions", "owner/repo/ci.yml", "size", binary, "linux-x64", "app", directory, directory,
+    );
+    const staged = path.join(directory, "artifact");
+    await stageBaseline(report(binary, mstat, dgml), identity, {
+      status: "restored", provider: "github-actions", id: "12", commit: "abc", artifactName: "baseline",
+    }, staged);
+
+    const restored = await restoreBaseline(staged, identity);
+    assert.equal(await fs.readFile(restored.targetPath, "utf8"), "native binary");
+    assert.equal(restored.source.id, "12");
+
+    await assert.rejects(
+      () => restoreBaseline(staged, { ...identity, job: "different-job" }),
+      /does not match/u,
+    );
+
+    const manifestPath = path.join(staged, "dotsider-baseline.json");
+    const manifestText = await fs.readFile(manifestPath, "utf8");
+    const manifest = JSON.parse(manifestText) as { targetPath: string };
+    manifest.targetPath = "files/unverified";
+    await fs.writeFile(path.join(staged, "files", "unverified"), "unverified bytes");
+    await fs.writeFile(manifestPath, JSON.stringify(manifest));
+    await assert.rejects(() => restoreBaseline(staged, identity), /verified target and mstat/u);
+    await fs.writeFile(manifestPath, manifestText);
+
+    await fs.writeFile(restored.targetPath, "forged binary");
+    await assert.rejects(() => restoreBaseline(staged, identity), /SHA-256 validation/u);
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("report enrichment records provenance and explains a genuine first run", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-baseline-report-"));
+  try {
+    const json = path.join(directory, "report.json");
+    const markdown = path.join(directory, "report.md");
+    await fs.writeFile(json, JSON.stringify(report("app", "app.mstat")), "utf8");
+    await fs.writeFile(markdown, "## Size check\n\n---\n\n### Overview\n", "utf8");
+
+    const enriched = await enrichReports(json, markdown, {
+      status: "not-found", provider: "github-actions", branch: "main", artifactName: "baseline",
+    });
+
+    assert.equal(enriched.baselineSource?.status, "not-found");
+    assert.match(await fs.readFile(markdown, "utf8"), /No stored baseline was found for `main`.*growth budgets were deferred/u);
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("report enrichment places provenance before the first CRLF report section", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-baseline-crlf-report-"));
+  try {
+    const json = path.join(directory, "report.json");
+    const markdown = path.join(directory, "report.md");
+    await fs.writeFile(json, JSON.stringify(report("app", "app.mstat")), "utf8");
+    await fs.writeFile(markdown, "## Size check\r\n\r\n---\r\n\r\n### Overview\r\n", "utf8");
+
+    await enrichReports(json, markdown, {
+      status: "restored",
+      provider: "github-actions",
+      id: "15",
+      number: "7",
+      branch: "main",
+      commit: "abcdef1234567890",
+      artifactName: "baseline",
+    });
+
+    const enriched = await fs.readFile(markdown, "utf8");
+    assert.match(enriched, /## Size check\r\n\r\n\*\*Baseline:\*\* Restored from run 7 at `abcdef123456` on `main`\.\r\n\r\n---\r\n/u);
+    assert.ok(enriched.indexOf("**Baseline:**") < enriched.indexOf("### Overview"));
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("GitHub discovery skips pull-request and expired artifacts before selecting the base-branch baseline", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-github-discovery-"));
+  const target = path.join(directory, "app.mstat");
+  const eventPath = path.join(directory, "event.json");
+  await fs.writeFile(target, "mstat");
+  await fs.writeFile(eventPath, JSON.stringify({ pull_request: { base: { ref: "main" } } }));
+  const server = createServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url?.includes("/actions/artifacts?")) {
+      response.end(JSON.stringify({ artifacts: [
+        { id: 8, name: expectedArtifact(target), expired: false, workflow_run: { id: 50 } },
+        { id: 7, name: expectedArtifact(target), expired: true, workflow_run: { id: 49 } },
+        { id: 6, name: expectedArtifact(target), expired: false, workflow_run: { id: 41 } },
+      ] }));
+    } else if (request.url?.includes("/runs?")) {
+      response.end(JSON.stringify({ workflow_runs: [
+        {
+          id: 50, run_number: 11, head_branch: "main", head_sha: "pr-sha",
+          html_url: "https://example.test/run/50", event: "pull_request", conclusion: "success",
+        },
+        {
+          id: 49, run_number: 10, head_branch: "main", head_sha: "expired-sha",
+          html_url: "https://example.test/run/49", event: "push", conclusion: "success",
+        },
+        {
+          id: 41, run_number: 9, head_branch: "main", head_sha: "base-sha",
+          html_url: "https://example.test/run/41", event: "push", conclusion: "success",
+        },
+      ] }));
+    } else {
+      response.statusCode = 404;
+      response.end(JSON.stringify({ message: "unexpected request" }));
+    }
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const discovery = await discoverGithubBaseline(inputs(target), "linux-x64", {
+      GITHUB_API_URL: `http://127.0.0.1:${address.port}`,
+      GITHUB_REPOSITORY: "owner/repo",
+      GITHUB_WORKFLOW_REF: "owner/repo/.github/workflows/ci.yml@refs/heads/feature",
+      GITHUB_JOB: "size",
+      GITHUB_EVENT_NAME: "pull_request",
+      GITHUB_EVENT_PATH: eventPath,
+      GITHUB_TOKEN: "token",
+      GITHUB_RUN_ID: "99",
+      GITHUB_WORKSPACE: directory,
+      RUNNER_TEMP: directory,
+    });
+    assert.equal(discovery.source.status, "restored");
+    assert.equal(discovery.source.id, "41");
+    assert.equal(discovery.source.branch, "main");
+    assert.equal(discovery.source.commit, "base-sha");
+    assert.equal(discovery.publish, false);
+  } finally {
+    server.close();
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("GitHub discovery reports the permission required for an authorization failure", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-github-permission-"));
+  const target = path.join(directory, "app.mstat");
+  await fs.writeFile(target, "mstat");
+  const server = createServer((_request, response) => {
+    response.statusCode = 403;
+    response.end("forbidden");
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    await assert.rejects(
+      () => discoverGithubBaseline(inputs(target), "linux-x64", {
+        GITHUB_API_URL: `http://127.0.0.1:${address.port}`,
+        GITHUB_REPOSITORY: "owner/repo",
+        GITHUB_WORKFLOW_REF: "owner/repo/.github/workflows/ci.yml@refs/heads/main",
+        GITHUB_JOB: "size",
+        GITHUB_EVENT_NAME: "push",
+        GITHUB_REF: "refs/heads/main",
+        GITHUB_TOKEN: "token",
+        GITHUB_WORKSPACE: directory,
+        RUNNER_TEMP: directory,
+      }),
+      /HTTP 403.*actions: read/u,
+    );
+  } finally {
+    server.close();
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("GitHub discovery proves a first run with one matching-artifact request", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-github-first-run-"));
+  const target = path.join(directory, "app.mstat");
+  await fs.writeFile(target, "mstat");
+  let requests = 0;
+  const server = createServer((_request, response) => {
+    requests++;
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify({ artifacts: [] }));
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const discovery = await discoverGithubBaseline(inputs(target), "linux-x64", {
+      GITHUB_API_URL: `http://127.0.0.1:${address.port}`,
+      GITHUB_REPOSITORY: "owner/repo",
+      GITHUB_WORKFLOW_REF: "owner/repo/.github/workflows/ci.yml@refs/heads/main",
+      GITHUB_JOB: "size",
+      GITHUB_EVENT_NAME: "push",
+      GITHUB_REF: "refs/heads/main",
+      GITHUB_REF_NAME: "main",
+      GITHUB_RUN_ID: "51",
+      GITHUB_TOKEN: "token",
+      GITHUB_WORKSPACE: directory,
+      RUNNER_TEMP: directory,
+    });
+
+    assert.equal(discovery.source.status, "not-found");
+    assert.equal(discovery.publish, true);
+    assert.equal(requests, 1);
+  } finally {
+    server.close();
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Azure discovery treats no successful artifact as first run and clears its token", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-azure-discovery-"));
+  const target = path.join(directory, "app.mstat");
+  await fs.writeFile(target, "mstat");
+  const server = createServer((_request, response) => {
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify({ value: [] }));
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const environment: NodeJS.ProcessEnv = {
+      SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: `http://127.0.0.1:${address.port}`,
+      SYSTEM_TEAMPROJECTID: "project",
+      SYSTEM_DEFINITIONID: "12",
+      SYSTEM_JOBNAME: "size",
+      BUILD_SOURCEBRANCH: "refs/heads/main",
+      BUILD_BUILDID: "99",
+      BUILD_SOURCESDIRECTORY: directory,
+      AGENT_TEMPDIRECTORY: directory,
+      ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN: "secret-token",
+    };
+    const discovery = await discoverAzureBaseline(inputs(target), "linux-x64", environment);
+    assert.equal(discovery.source.status, "not-found");
+    assert.equal(discovery.publish, true);
+    assert.equal(environment.ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN, undefined);
+  } finally {
+    server.close();
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Azure discovery downloads and verifies a real stored baseline archive", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-azure-restore-"));
+  const target = path.join(directory, "app.mstat");
+  await fs.writeFile(target, "real baseline mstat bytes");
+  const identity = createBaselineIdentity(
+    "azure-pipelines", "project/12", "size", target, "linux-x64", "app", directory, directory,
+  );
+  const artifactName = baselineArtifactName(identity);
+  const source = {
+    status: "restored" as const,
+    provider: "azure-pipelines" as const,
+    branch: "refs/heads/main",
+    commit: "base-sha",
+    id: "41",
+    number: "20260811.1",
+    artifactName,
+  };
+  const staged = path.join(directory, "staged");
+  await stageBaseline(report(target, target), identity, source, staged);
+  const archive = storedZip([
+    [`${artifactName}/dotsider-baseline.json`, await fs.readFile(path.join(staged, "dotsider-baseline.json"))],
+    [`${artifactName}/files/target.mstat`, await fs.readFile(path.join(staged, "files", "target.mstat"))],
+  ]);
+
+  let root = "";
+  const server = createServer((request, response) => {
+    if (request.headers.authorization !== "Bearer secret-token") {
+      response.statusCode = 401;
+      response.end("missing token");
+      return;
+    }
+    if (request.url?.includes("/_apis/build/builds?")) {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ value: [{
+        id: 41,
+        buildNumber: "20260811.1",
+        sourceBranch: "refs/heads/main",
+        sourceVersion: "base-sha",
+        result: "succeeded",
+      }] }));
+    } else if (request.url?.includes("/artifacts?")
+        && request.headers.accept === "application/zip") {
+      response.setHeader("content-type", "application/zip");
+      response.end(archive);
+    } else if (request.url?.includes("/artifacts?")) {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ name: artifactName }));
+    } else {
+      response.setHeader("content-type", "application/zip");
+      response.end(archive);
+    }
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    root = `http://127.0.0.1:${address.port}`;
+    const environment: NodeJS.ProcessEnv = {
+      SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: root,
+      SYSTEM_TEAMPROJECTID: "project",
+      SYSTEM_DEFINITIONID: "12",
+      SYSTEM_JOBNAME: "size",
+      BUILD_SOURCEBRANCH: "refs/heads/main",
+      BUILD_BUILDID: "99",
+      BUILD_SOURCESDIRECTORY: directory,
+      AGENT_TEMPDIRECTORY: directory,
+      ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN: "secret-token",
+    };
+
+    const discovery = await discoverAzureBaseline(inputs(target), "linux-x64", environment);
+    assert.equal(discovery.source.status, "restored");
+    assert.equal(discovery.source.id, "41");
+    assert.ok(discovery.downloadDirectory);
+    const restored = await restoreBaseline(discovery.downloadDirectory, identity, discovery.source);
+    assert.equal(await fs.readFile(restored.targetPath, "utf8"), "real baseline mstat bytes");
+    assert.equal(environment.ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN, undefined);
+  } finally {
+    server.close();
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Azure discovery reports Build Service permissions and clears a rejected token", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-azure-permission-"));
+  const target = path.join(directory, "app.mstat");
+  await fs.writeFile(target, "mstat");
+  const server = createServer((_request, response) => {
+    response.statusCode = 403;
+    response.end("forbidden");
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const environment: NodeJS.ProcessEnv = {
+      SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: `http://127.0.0.1:${address.port}`,
+      SYSTEM_TEAMPROJECTID: "project",
+      SYSTEM_DEFINITIONID: "12",
+      SYSTEM_JOBNAME: "size",
+      BUILD_SOURCEBRANCH: "refs/heads/main",
+      BUILD_BUILDID: "99",
+      BUILD_SOURCESDIRECTORY: directory,
+      AGENT_TEMPDIRECTORY: directory,
+      ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN: "secret-token",
+    };
+
+    await assert.rejects(
+      () => discoverAzureBaseline(inputs(target), "linux-x64", environment),
+      /HTTP 403.*Build Service permission/u,
+    );
+    assert.equal(environment.ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN, undefined);
+  } finally {
+    server.close();
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Azure ZIP extraction rejects parent traversal", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-zip-traversal-"));
+  try {
+    await assert.rejects(
+      () => extractZipArchive(storedZip([["../secret", Buffer.from("secret")]]), directory),
+      /Unsafe ZIP path/u,
+    );
+    await assert.rejects(() => fs.stat(path.join(directory, "..", "secret")));
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Azure ZIP extraction rejects an entry whose bytes do not match its CRC", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-zip-crc-"));
+  try {
+    const archive = storedZip([["baseline/file.mstat", Buffer.from("real bytes")]]);
+    const nameLength = archive.readUInt16LE(26);
+    archive[30 + nameLength] = archive[30 + nameLength]! ^ 0xff;
+    await assert.rejects(
+      () => extractZipArchive(archive, directory),
+      /CRC validation/u,
+    );
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+function inputs(target: string): SizeCheckInputs {
+  return {
+    target,
+    baselineKey: "app",
+    budgets: ["max=25mb"],
+    top: 10,
+    why: false,
+    dotsiderVersion: "latest",
+    reportDirectory: path.join(path.dirname(target), "report"),
+    publishSummary: true,
+    publishReports: true,
+    artifactName: "dotsider-size-check",
+  };
+}
+
+function expectedArtifact(target: string): string {
+  return baselineArtifactName(createBaselineIdentity(
+    "github-actions", "owner/repo/ci.yml", "size", target, "linux-x64", "app",
+    path.dirname(target), path.dirname(target),
+  ));
+}
+
+function report(binary: string, mstat: string, dgml?: string): SizeReport {
+  return {
+    schemaVersion: 2,
+    target: binary,
+    baseline: null,
+    targetArtifacts: {
+      inputPath: binary,
+      binaryPath: binary === mstat ? undefined : binary,
+      mstatPath: mstat,
+      dgmlPath: dgml,
+    },
+    totalBasis: "fileSize",
+    leftTotal: null,
+    rightTotal: 13,
+    summary: { delta: 13 },
+  };
+}
+
+function storedZip(entries: readonly (readonly [string, Buffer])[]): Buffer {
+  const localEntries: Buffer[] = [];
+  const centralEntries: Buffer[] = [];
+  let localOffset = 0;
+  for (const [name, contents] of entries) {
+    const nameBytes = Buffer.from(name);
+    const crc = crc32(contents);
+    const local = Buffer.alloc(30 + nameBytes.length + contents.length);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(contents.length, 18);
+    local.writeUInt32LE(contents.length, 22);
+    local.writeUInt16LE(nameBytes.length, 26);
+    nameBytes.copy(local, 30);
+    contents.copy(local, 30 + nameBytes.length);
+    localEntries.push(local);
+
+    const central = Buffer.alloc(46 + nameBytes.length);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(20, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt32LE(crc, 16);
+    central.writeUInt32LE(contents.length, 20);
+    central.writeUInt32LE(contents.length, 24);
+    central.writeUInt16LE(nameBytes.length, 28);
+    central.writeUInt32LE(localOffset, 42);
+    nameBytes.copy(central, 46);
+    centralEntries.push(central);
+    localOffset += local.length;
+  }
+  const central = Buffer.concat(centralEntries);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(central.length, 12);
+  eocd.writeUInt32LE(localOffset, 16);
+  return Buffer.concat([...localEntries, central, eocd]);
+}
+
+function crc32(buffer: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}

--- a/integrations/size-check/test/core.unit.test.ts
+++ b/integrations/size-check/test/core.unit.test.ts
@@ -90,10 +90,12 @@ test("createInputs requires target and keeps the baseline optional without a sep
   const comparison = createInputs({
     target: "current.mstat",
     baseline: "baseline.mstat",
+    baselineKey: "console/linux-x64",
   }, "/reports");
 
   assert.equal(current.baseline, undefined);
   assert.equal(comparison.baseline, path.resolve("baseline.mstat"));
+  assert.equal(comparison.baselineKey, "console/linux-x64");
   assert.equal("mode" in current, false);
   assert.equal("mode" in comparison, false);
 });

--- a/integrations/size-check/test/real.integration.test.ts
+++ b/integrations/size-check/test/real.integration.test.ts
@@ -40,7 +40,7 @@ test("real comparison accepts max and growth without modifying the baseline", as
   }));
   assert.equal(execution.exitCode, 0);
   assert.equal(execution.result, "passed");
-  assert.equal(execution.report?.schemaVersion, 1);
+  assert.equal(execution.report?.schemaVersion, 2);
   assert.equal(execution.report?.target, path.resolve(target));
   assert.equal(execution.report?.baseline, path.resolve(baseline));
   assert.ok((execution.report?.leftTotal ?? 0) > 0);
@@ -93,7 +93,7 @@ test("GitHub adapter keeps real reports and writes error outputs when summary pu
   assert.equal(jsonReportPath, path.resolve(reportDirectory, "dotsider-size-check.json"));
   assert.equal(markdownReportPath, path.resolve(reportDirectory, "dotsider-size-check.md"));
   const report = JSON.parse(await fs.readFile(jsonReportPath, "utf8")) as { schemaVersion?: number };
-  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.schemaVersion, 2);
   assert.equal((await fs.stat(markdownReportPath)).isFile(), true);
 });
 
@@ -135,7 +135,7 @@ test("real absolute budget without a baseline passes", async () => {
   const execution = await executeSizeCheck(executable, await inputs({ budgets: ["max=1gb"] }));
   assert.equal(execution.exitCode, 0);
   assert.equal(execution.result, "passed");
-  assert.equal(execution.report?.schemaVersion, 1);
+  assert.equal(execution.report?.schemaVersion, 2);
   assert.equal(execution.report?.baseline, undefined);
   assert.equal(execution.report?.leftTotal ?? null, null);
   assert.ok((execution.report?.rightTotal ?? 0) > 0);
@@ -153,6 +153,11 @@ test("real absolute budget without a baseline passes", async () => {
     "currentTotal",
     "delta",
     "violationCount",
+    "baselineStatus",
+    "baselineSourceId",
+    "baselineSourceCommit",
+    "baselineSourceUrl",
+    "baselineArtifactName",
   ]);
   assert.equal(outputs.baselineTotal, "");
   assert.deepEqual(
@@ -192,9 +197,32 @@ test("real growth budgets without a baseline return a direct error", async t => 
   }
 });
 
-test("GitHub adapter exposes stable error outputs for growth without a baseline", async () => {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-github-growth-error-"));
+test("real first-run policy defers growth and keeps absolute enforcement", async () => {
+  const execution = await executeSizeCheck(
+    executable,
+    await inputs({ budgets: ["max=1gb", "growth=1%", "ns=NativeAotConsole:growth=1kb"] }),
+    true,
+  );
+
+  assert.equal(execution.exitCode, 0, execution.stderr);
+  assert.equal(execution.result, "passed-with-warnings");
+  assert.equal(execution.report?.budgets?.hasDeferred, true);
+  assert.equal(execution.report?.budgets?.evaluations?.[0]?.deferredMetrics?.length ?? 0, 0);
+  assert.deepEqual(execution.report?.budgets?.evaluations?.[1]?.deferredMetrics, ["maxGrowthPercent"]);
+  assert.deepEqual(execution.report?.budgets?.evaluations?.[2]?.deferredMetrics, ["maxGrowthBytes"]);
+  assert.match(await fs.readFile(execution.markdownReportPath, "utf8"), /DEFERRED/u);
+});
+
+test("GitHub adapter exposes a deferred first-run result for growth without a stored baseline", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "dotsider-github-growth-first-run-"));
   const outputPath = path.join(directory, "github-output.txt");
+  const identity = {
+    provider: "github-actions",
+    scope: "owner/repo/ci.yml",
+    job: "size",
+    target: "app",
+    rid: `unused-${process.arch}`,
+  };
   const child = await runGitHub("run", {
     GITHUB_OUTPUT: outputPath,
     RUNNER_TEMP: directory,
@@ -214,27 +242,24 @@ test("GitHub adapter exposes stable error outputs for growth without a baseline"
     DOTSIDER_PREPARED_EXECUTABLE_PATH: executable,
     DOTSIDER_PREPARED_CACHE_KEY: "dotsider-custom",
     DOTSIDER_PREPARED_EXPLICIT: "true",
+    DOTSIDER_BASELINE_SOURCE: JSON.stringify({
+      status: "not-found",
+      provider: "github-actions",
+      branch: "main",
+      artifactName: "dotsider-baseline-test",
+    }),
+    DOTSIDER_BASELINE_IDENTITY: JSON.stringify(identity),
+    DOTSIDER_BASELINE_ARTIFACT_NAME: "dotsider-baseline-test",
+    DOTSIDER_BASELINE_PUBLISH: "false",
   });
 
   assert.equal(child.exitCode, 0);
-  assert.match(child.stderr, /limits growth, which needs --baseline/u);
+  assert.doesNotMatch(child.stderr, /needs --baseline/u);
   const outputs = parseGitHubOutputs(await fs.readFile(outputPath, "utf8"));
-  assert.equal(outputs.get("result"), "error");
-  assert.equal(outputs.get("exit-code"), "1");
+  assert.equal(outputs.get("result"), "passed-with-warnings");
+  assert.equal(outputs.get("exit-code"), "0");
+  assert.equal(outputs.get("baseline-status"), "not-found");
   assert.equal(outputs.has("mode"), false);
-
-  const enforcement = await runGitHub("enforce", {
-    DOTSIDER_EXIT_CODE: outputs.get("exit-code"),
-    DOTSIDER_RESULT: outputs.get("result"),
-    DOTSIDER_TOTAL_BASIS: outputs.get("total-basis"),
-    DOTSIDER_BASELINE_TOTAL: outputs.get("baseline-total"),
-    DOTSIDER_CURRENT_TOTAL: outputs.get("current-total"),
-    DOTSIDER_DELTA: outputs.get("delta"),
-    DOTSIDER_VIOLATION_COUNT: outputs.get("violation-count"),
-    DOTSIDER_ARTIFACT_NAME: outputs.get("artifact-name"),
-  });
-  assert.equal(enforcement.exitCode, 1);
-  assert.match(enforcement.stdout, /Dotsider size check failed with exit code 1 \(error\)/u);
 });
 
 test("real why report contains a dependency chain", async () => {

--- a/scripts/Validate-CiIntegrations.cs
+++ b/scripts/Validate-CiIntegrations.cs
@@ -26,6 +26,7 @@ internal static class CiIntegrationValidator
         (string? vsix, string? expectedVersion) = ParseArguments(args, root);
 
         ValidateGitHubAction(root);
+        ValidateOnDemandWorkflow(root);
         ValidateAzureTask(root);
         ValidatePackageManager(root);
         if (vsix is not null)
@@ -35,6 +36,33 @@ internal static class CiIntegrationValidator
             ? "CI integration manifests are valid."
             : $"CI integration manifests and {Path.GetFileName(vsix)} are valid.");
         return 0;
+    }
+
+    private static void ValidateOnDemandWorkflow(string root)
+    {
+        string workflowPath = Path.Combine(
+            root, "integrations", "size-check", "examples", "github-aot-size.yml");
+        string source = File.ReadAllText(workflowPath);
+        Require(source.Contains("workflow_dispatch:", StringComparison.Ordinal)
+            && source.Contains("issue_comment:", StringComparison.Ordinal)
+            && source.Contains("pull_request_review_comment:", StringComparison.Ordinal)
+            && source.Contains("/aot-size", StringComparison.Ordinal),
+            "The on-demand example must support manual and /aot-size pull-request requests.");
+        Require(source.Contains("getCollaboratorPermissionLevel", StringComparison.Ordinal)
+            && source.Contains("['admin', 'write']", StringComparison.Ordinal),
+            "The /aot-size example must require collaborator write access.");
+        Require(source.Contains("actions/download-artifact@v8", StringComparison.Ordinal)
+            && source.Contains("current-run", StringComparison.Ordinal)
+            && source.Contains("base-run", StringComparison.Ordinal),
+            "The on-demand example must consume successful PR and base-branch build artifacts.");
+        Require(source.Contains("run.event === 'pull_request'", StringComparison.Ordinal)
+            && source.Contains("run.event !== 'pull_request'", StringComparison.Ordinal)
+            && source.Contains("comment:", StringComparison.Ordinal),
+            "The on-demand example must separate PR and branch runs and comment from a dedicated job.");
+        Require(!source.Contains("actions/checkout", StringComparison.Ordinal),
+            "The write-capable on-demand workflow must not check out pull-request code.");
+        Require(source.Contains("<!-- dotsider-aot-size -->", StringComparison.Ordinal),
+            "The on-demand example must update one identifiable pull-request comment.");
     }
 
     private static void ValidateGitHubAction(string root)
@@ -47,10 +75,13 @@ internal static class CiIntegrationValidator
             && source.Contains("node-version: '24'", StringComparison.Ordinal),
             "action.yml must select Node 24 explicitly.");
         int runIndex = source.IndexOf("Run Dotsider size check", StringComparison.Ordinal);
+        int discoverIndex = source.IndexOf("Find Dotsider baseline", StringComparison.Ordinal);
         int uploadIndex = source.IndexOf("Upload Dotsider reports", StringComparison.Ordinal);
+        int baselineUploadIndex = source.IndexOf("Publish managed Dotsider baseline", StringComparison.Ordinal);
         int enforceIndex = source.IndexOf("Enforce Dotsider result", StringComparison.Ordinal);
-        Require(runIndex >= 0 && uploadIndex > runIndex && enforceIndex > uploadIndex,
-            "action.yml must publish reports before enforcing a failure.");
+        Require(discoverIndex >= 0 && runIndex > discoverIndex && uploadIndex > runIndex
+            && baselineUploadIndex > uploadIndex && enforceIndex > baselineUploadIndex,
+            "action.yml must discover baselines, publish reports and the next baseline, then enforce.");
         Require(source.Contains(
                 "if: always() && inputs.upload-reports == 'true' && steps.run.outputs.result != 'error'",
                 StringComparison.Ordinal),
@@ -70,9 +101,12 @@ internal static class CiIntegrationValidator
             "action.yml must not expose a separate mode; supplying baseline controls comparison.");
         Require(source.Contains("DOTSIDER_INPUT_BASELINE: ${{ inputs.baseline }}", StringComparison.Ordinal),
             "action.yml must pass the optional baseline to Dotsider.");
-        Require(!source.Contains("actions/download-artifact", StringComparison.Ordinal)
-            && !source.Contains("baseline artifact", StringComparison.OrdinalIgnoreCase),
-            "action.yml must not hide baseline discovery or retention.");
+        Require(source.Contains("actions/download-artifact@v8", StringComparison.Ordinal)
+            && source.Contains("steps.baseline.outputs.run-id", StringComparison.Ordinal),
+            "action.yml must restore the exact baseline artifact from the discovered successful run.");
+        Require(source.Contains("steps.run.outputs.publish-baseline", StringComparison.Ordinal)
+            && source.Contains("steps.run.outputs.baseline-upload-path", StringComparison.Ordinal),
+            "action.yml must retain the successful branch target as the next managed baseline.");
         Require(source.Contains("${{ steps.run.outputs.json-report-path }}", StringComparison.Ordinal)
             && source.Contains("${{ steps.run.outputs.markdown-report-path }}", StringComparison.Ordinal),
             "action.yml must upload only the reports produced by Dotsider.");
@@ -105,7 +139,7 @@ internal static class CiIntegrationValidator
         Require(target.GetProperty("type").GetString() == "filePath"
             && target.GetProperty("required").GetBoolean(),
             "The Azure task target must remain required.");
-        foreach (string name in new[] { "baseline", "budgetFile", "dotsiderPath" })
+        foreach (string name in new[] { "baseline", "baselineKey", "budgetFile", "dotsiderPath" })
         {
             JsonElement input = inputs[name];
             Require(input.GetProperty("type").GetString() == "string"
@@ -127,6 +161,11 @@ internal static class CiIntegrationValidator
             "currentTotal",
             "delta",
             "violationCount",
+            "baselineStatus",
+            "baselineSourceId",
+            "baselineSourceCommit",
+            "baselineSourceUrl",
+            "baselineArtifactName",
         ];
         string[] outputVariables =
         [
@@ -204,6 +243,8 @@ internal static class CiIntegrationValidator
             "extension.vsomanifest",
             "tasks/DotsiderSizeCheckV1/task.json",
             "tasks/DotsiderSizeCheckV1/runtime/azure.js",
+            "tasks/DotsiderSizeCheckV1/runtime/azure-baseline.js",
+            "tasks/DotsiderSizeCheckV1/runtime/baseline.js",
             "README.md",
             "LICENSE",
             "PRIVACY.md",

--- a/src/Dotsider.Core/Analysis/Models/SizeBudgetEvaluation.cs
+++ b/src/Dotsider.Core/Analysis/Models/SizeBudgetEvaluation.cs
@@ -26,4 +26,11 @@ public sealed record SizeBudgetEvaluation(
     long ActualBytes,
     long? BaselineBytes,
     IReadOnlyList<SizeBudgetViolation> Violations,
-    IReadOnlyList<SizeDiffContributor> TopContributors);
+    IReadOnlyList<SizeDiffContributor> TopContributors)
+{
+    /// <summary>
+    /// Growth limits that could not be evaluated because no baseline exists. Absolute limits
+    /// in the same budget are still evaluated normally.
+    /// </summary>
+    public IReadOnlyList<SizeBudgetMetric> DeferredMetrics { get; init; } = [];
+}

--- a/src/Dotsider.Core/Analysis/Models/SizeBudgetReport.cs
+++ b/src/Dotsider.Core/Analysis/Models/SizeBudgetReport.cs
@@ -21,4 +21,10 @@ public sealed record SizeBudgetReport(
     long RightTotal,
     long? LeftMstatTotal,
     long? RightMstatTotal,
-    IReadOnlyList<SizeBudgetEvaluation> Evaluations);
+    IReadOnlyList<SizeBudgetEvaluation> Evaluations)
+{
+    /// <summary>
+    /// True when one or more growth limits were deferred because no baseline exists.
+    /// </summary>
+    public bool HasDeferred { get; init; }
+}

--- a/src/Dotsider.Core/Analysis/SizeBudgetEvaluator.cs
+++ b/src/Dotsider.Core/Analysis/SizeBudgetEvaluator.cs
@@ -21,7 +21,7 @@ public static class SizeBudgetEvaluator
     /// <param name="baselineTotalBytes">The baseline's total on <paramref name="totalBasis"/>, or null when the check runs without one.</param>
     /// <param name="defaultTopN">How many contributors a breach lists when its budget does not pin its own count.</param>
     /// <returns>The report, failing only on error-severity breaches.</returns>
-    /// <exception cref="ArgumentException">A total-scope growth budget was supplied without a baseline; callers reject that combination before evaluating.</exception>
+    /// <exception cref="ArgumentException">A growth budget was supplied without a baseline.</exception>
     public static SizeBudgetReport Evaluate(
         IReadOnlyList<SizeBudget> budgets,
         MstatDiffResult diff,
@@ -29,6 +29,34 @@ public static class SizeBudgetEvaluator
         long currentTotalBytes,
         long? baselineTotalBytes,
         int defaultTopN = 10)
+        => EvaluateCore(
+            budgets, diff, totalBasis, currentTotalBytes, baselineTotalBytes, defaultTopN,
+            deferGrowthWithoutBaseline: false);
+
+    /// <summary>
+    /// Evaluates budgets while deferring growth limits when a provider has established that no
+    /// baseline artifact exists. Absolute limits continue to be enforced.
+    /// </summary>
+    public static SizeBudgetReport Evaluate(
+        IReadOnlyList<SizeBudget> budgets,
+        MstatDiffResult diff,
+        SizeBasis totalBasis,
+        long currentTotalBytes,
+        long? baselineTotalBytes,
+        int defaultTopN,
+        bool deferGrowthWithoutBaseline)
+        => EvaluateCore(
+            budgets, diff, totalBasis, currentTotalBytes, baselineTotalBytes, defaultTopN,
+            deferGrowthWithoutBaseline);
+
+    private static SizeBudgetReport EvaluateCore(
+        IReadOnlyList<SizeBudget> budgets,
+        MstatDiffResult diff,
+        SizeBasis totalBasis,
+        long currentTotalBytes,
+        long? baselineTotalBytes,
+        int defaultTopN,
+        bool deferGrowthWithoutBaseline)
     {
         ArgumentNullException.ThrowIfNull(budgets);
         ArgumentNullException.ThrowIfNull(diff);
@@ -36,7 +64,7 @@ public static class SizeBudgetEvaluator
         var evaluations = new List<SizeBudgetEvaluation>(budgets.Count);
         foreach (var budget in budgets)
         {
-            if (budget.Scope == SizeBudgetScope.Total
+            if (!deferGrowthWithoutBaseline
                 && baselineTotalBytes is null
                 && (budget.MaxGrowthBytes is not null || budget.MaxGrowthPercent is not null))
             {
@@ -44,7 +72,9 @@ public static class SizeBudgetEvaluator
                     $"Budget '{budget}' limits growth but no baseline was supplied.", nameof(budgets));
             }
 
-            evaluations.Add(EvaluateOne(budget, diff, totalBasis, currentTotalBytes, baselineTotalBytes, defaultTopN));
+            evaluations.Add(EvaluateOne(
+                budget, diff, totalBasis, currentTotalBytes, baselineTotalBytes, defaultTopN,
+                deferGrowthWithoutBaseline));
         }
 
         return new SizeBudgetReport(
@@ -55,12 +85,16 @@ public static class SizeBudgetEvaluator
             RightTotal: currentTotalBytes,
             LeftMstatTotal: totalBasis == SizeBasis.FileSize ? diff.Summary.LeftTotal : null,
             RightMstatTotal: totalBasis == SizeBasis.FileSize ? diff.Summary.RightTotal : null,
-            evaluations);
+            evaluations)
+        {
+            HasDeferred = evaluations.Any(e => e.DeferredMetrics.Count > 0)
+        };
     }
 
     private static SizeBudgetEvaluation EvaluateOne(
         SizeBudget budget, MstatDiffResult diff, SizeBasis totalBasis,
-        long currentTotalBytes, long? baselineTotalBytes, int defaultTopN)
+        long currentTotalBytes, long? baselineTotalBytes, int defaultTopN,
+        bool deferGrowthWithoutBaseline)
     {
         var (actual, baseline, basis) = budget.Scope switch
         {
@@ -69,7 +103,11 @@ public static class SizeBudgetEvaluator
             _ => ScopeTotals(diff.AssemblyDeltas, n => string.Equals(n, budget.Target, StringComparison.Ordinal)),
         };
 
+        if (baselineTotalBytes is null && budget.Scope != SizeBudgetScope.Total)
+            baseline = null;
+
         var violations = new List<SizeBudgetViolation>();
+        var deferredMetrics = new List<SizeBudgetMetric>(2);
 
         if (budget.MaxBytes is { } maxBytes && actual > maxBytes)
         {
@@ -79,13 +117,22 @@ public static class SizeBudgetEvaluator
 
         var growth = actual - (baseline ?? 0);
 
-        if (budget.MaxGrowthBytes is { } maxGrowth && growth > maxGrowth)
+        var deferGrowth = deferGrowthWithoutBaseline && baselineTotalBytes is null;
+        if (budget.MaxGrowthBytes is not null && deferGrowth)
+        {
+            deferredMetrics.Add(SizeBudgetMetric.MaxGrowthBytes);
+        }
+        else if (budget.MaxGrowthBytes is { } maxGrowth && growth > maxGrowth)
         {
             violations.Add(new SizeBudgetViolation(
                 SizeBudgetMetric.MaxGrowthBytes, growth, maxGrowth, growth - maxGrowth, null, null));
         }
 
-        if (budget.MaxGrowthPercent is { } maxPercent)
+        if (budget.MaxGrowthPercent is not null && deferGrowth)
+        {
+            deferredMetrics.Add(SizeBudgetMetric.MaxGrowthPercent);
+        }
+        else if (budget.MaxGrowthPercent is { } maxPercent)
         {
             var baselineBytes = baseline ?? 0;
             if (baselineBytes == 0)
@@ -121,7 +168,10 @@ public static class SizeBudgetEvaluator
         return new SizeBudgetEvaluation(
             budget, violations.Count == 0, basis, actual,
             budget.Scope == SizeBudgetScope.Total ? baselineTotalBytes : baseline,
-            violations, contributors);
+            violations, contributors)
+        {
+            DeferredMetrics = deferredMetrics
+        };
     }
 
     private static (long Actual, long? Baseline, SizeBasis Basis) ScopeTotals(

--- a/src/Dotsider/Commands/DiffCommand.cs
+++ b/src/Dotsider/Commands/DiffCommand.cs
@@ -115,7 +115,9 @@ internal static class DiffCommand
             totals.LeftTotal,
             JsonTop,
             WhyPaths: null,
-            Budgets: null);
+            Budgets: null,
+            TargetSource: rightSource,
+            BaselineSource: leftSource);
 
         using var fmt = new OutputFormatter { JsonMode = true };
         fmt.WriteJson(SizeDiffReportWriter.BuildDocument(context));

--- a/src/Dotsider/Commands/SizeCheckCommand.cs
+++ b/src/Dotsider/Commands/SizeCheckCommand.cs
@@ -13,6 +13,9 @@ namespace Dotsider.Commands;
 /// </summary>
 internal static class SizeCheckCommand
 {
+    private const string BaselineNotFoundEnvironmentVariable =
+        "DOTSIDER_SIZE_CHECK_BASELINE_NOT_FOUND";
+
     private static readonly Argument<FileInfo> s_targetArg = new("target")
     {
         Description = "Native AOT binary or .mstat size report to check"
@@ -147,11 +150,17 @@ internal static class SizeCheckCommand
             return 1;
         }
 
+        var baselineNotFound = baseline is null
+            && string.Equals(
+                Environment.GetEnvironmentVariable(BaselineNotFoundEnvironmentVariable),
+                "1",
+                StringComparison.Ordinal);
+
         if (baseline is null)
         {
             var growthBudget = budgets.FirstOrDefault(b =>
                 b.MaxGrowthBytes is not null || b.MaxGrowthPercent is not null);
-            if (growthBudget is not null)
+            if (growthBudget is not null && !baselineNotFound)
             {
                 OutputFormatter.WriteError(
                     $"Error: budget '{growthBudget.Name ?? growthBudget.ToString()}' limits growth, "
@@ -159,7 +168,7 @@ internal static class SizeCheckCommand
                 return 1;
             }
 
-            if (budgets.Count == 0)
+            if (budgets.Count == 0 && !baselineNotFound)
             {
                 OutputFormatter.WriteError(
                     "Error: nothing to do — give --baseline for a size-diff report, or --budget "
@@ -197,7 +206,8 @@ internal static class SizeCheckCommand
         if (budgets.Count > 0)
         {
             report = SizeBudgetEvaluator.Evaluate(
-                budgets, diff, totals.Basis, totals.RightTotal, totals.LeftTotal, defaultTopN: top);
+                budgets, diff, totals.Basis, totals.RightTotal, totals.LeftTotal, defaultTopN: top,
+                deferGrowthWithoutBaseline: baselineNotFound);
         }
 
         var whyPaths = why ? ResolveWhyPaths(targetSource, diff, top) : null;
@@ -211,7 +221,8 @@ internal static class SizeCheckCommand
         var context = new SizeDiffReportWriter.Context(
             targetSource.BinaryPath ?? targetSource.MstatPath,
             baselineSource is null ? null : baselineSource.BinaryPath ?? baselineSource.MstatPath,
-            diff, totals.Basis, totals.RightTotal, totals.LeftTotal, top, whyPaths, report);
+            diff, totals.Basis, totals.RightTotal, totals.LeftTotal, top, whyPaths, report,
+            targetSource, baselineSource);
 
         using (var fmt = new OutputFormatter(outputPath) { JsonMode = format == "json" })
         {

--- a/src/Dotsider/Infrastructure/CliSizeArtifactPayload.cs
+++ b/src/Dotsider/Infrastructure/CliSizeArtifactPayload.cs
@@ -1,0 +1,10 @@
+namespace Dotsider.Infrastructure;
+
+/// <summary>
+/// Resolved files used to produce one side of a size report.
+/// </summary>
+internal sealed record CliSizeArtifactPayload(
+    string InputPath,
+    string MstatPath,
+    string? BinaryPath,
+    string? DgmlPath);

--- a/src/Dotsider/Infrastructure/CliSizeReportPayload.cs
+++ b/src/Dotsider/Infrastructure/CliSizeReportPayload.cs
@@ -11,6 +11,8 @@ internal sealed record CliSizeReportPayload(
     int SchemaVersion,
     string Target,
     string? Baseline,
+    CliSizeArtifactPayload TargetArtifacts,
+    CliSizeArtifactPayload? BaselineArtifacts,
     SizeBasis TotalBasis,
     long? LeftTotal,
     long RightTotal,

--- a/src/Dotsider/Infrastructure/SizeDiffReportWriter.cs
+++ b/src/Dotsider/Infrastructure/SizeDiffReportWriter.cs
@@ -23,7 +23,9 @@ internal static class SizeDiffReportWriter
         long? LeftTotal,
         int Top,
         IReadOnlyDictionary<string, IReadOnlyList<DgmlPathStep>>? WhyPaths,
-        SizeBudgetReport? Budgets);
+        SizeBudgetReport? Budgets,
+        MstatSource? TargetSource = null,
+        MstatSource? BaselineSource = null);
 
     private const int AggregateRows = 15;
 
@@ -50,9 +52,11 @@ internal static class SizeDiffReportWriter
             .ToList();
 
         return new CliSizeReportPayload(
-            1,
+            2,
             ctx.TargetPath,
             ctx.BaselinePath,
+            ArtifactPayload(ctx.TargetPath, ctx.TargetSource),
+            ctx.BaselinePath is null ? null : ArtifactPayload(ctx.BaselinePath, ctx.BaselineSource),
             ctx.TotalBasis,
             ctx.LeftTotal,
             ctx.RightTotal,
@@ -66,6 +70,9 @@ internal static class SizeDiffReportWriter
             contributors,
             ctx.Budgets);
     }
+
+    private static CliSizeArtifactPayload ArtifactPayload(string inputPath, MstatSource? source) =>
+        new(inputPath, source?.MstatPath ?? inputPath, source?.BinaryPath, source?.DgmlPath);
 
     /// <summary>Writes the human-readable report through the formatter.</summary>
     internal static void WriteText(OutputFormatter fmt, Context ctx)
@@ -114,7 +121,8 @@ internal static class SizeDiffReportWriter
 
             fmt.WriteLine("");
             fmt.WriteLine(budgets.Passed
-                ? budgets.HasWarnings ? "Result: PASS (with warnings)" : "Result: PASS"
+                ? budgets.HasWarnings || budgets.HasDeferred
+                    ? "Result: PASS (with warnings)" : "Result: PASS"
                 : "Result: FAIL (a size budget was exceeded)");
         }
     }
@@ -196,6 +204,9 @@ internal static class SizeDiffReportWriter
                         : ""));
         }
 
+        foreach (var metric in evaluation.DeferredMetrics)
+            fmt.WriteLine($"        {MetricName(metric)}: deferred until a baseline exists");
+
         if (!evaluation.Passed && evaluation.TopContributors.Count > 0)
         {
             fmt.WriteLine("        Top contributors:");
@@ -219,8 +230,8 @@ internal static class SizeDiffReportWriter
             sb.AppendLine();
             var modeSuffix = currentMode ? " No baseline comparison was run." : "";
             sb.AppendLine((statusBudgets.Passed
-                ? statusBudgets.HasWarnings
-                    ? "⚠️ **PASS with warnings** — all error-severity size budgets passed."
+                ? statusBudgets.HasWarnings || statusBudgets.HasDeferred
+                    ? "⚠️ **PASS with warnings** — evaluated size budgets passed."
                     : "✅ **PASS** — all size budgets passed."
                 : "❌ **FAIL** — a size budget was exceeded.") + modeSuffix);
         }
@@ -284,8 +295,9 @@ internal static class SizeDiffReportWriter
         AppendSectionHeading(sb, "Budgets");
         foreach (var evaluation in budgets.Evaluations)
         {
-            var verdict = evaluation.Passed ? "✅ PASS"
-                : evaluation.Budget.Severity == SizeBudgetSeverity.Warning ? "⚠️ WARN" : "❌ FAIL";
+            var verdict = !evaluation.Passed
+                ? evaluation.Budget.Severity == SizeBudgetSeverity.Warning ? "⚠️ WARN" : "❌ FAIL"
+                : evaluation.DeferredMetrics.Count > 0 ? "⏸️ DEFERRED" : "✅ PASS";
             var value = evaluation.BaselineBytes is { } b
                 ? $"{MarkdownSize(DotsiderState.FormatSize(b))} → "
                     + MarkdownSize(DotsiderState.FormatSize(evaluation.ActualBytes))
@@ -293,6 +305,12 @@ internal static class SizeDiffReportWriter
             sb.AppendLine($"- **{verdict}** — {MarkdownCodeSpan(BudgetLabel(evaluation.Budget))}");
             sb.AppendLine($"  - **Value:** {value}");
             sb.AppendLine($"  - **Basis:** {BasisName(evaluation.Basis)}");
+            if (evaluation.DeferredMetrics.Count > 0)
+            {
+                sb.AppendLine("  - **Deferred:** "
+                    + string.Join(", ", evaluation.DeferredMetrics.Select(MetricName))
+                    + " until a baseline exists");
+            }
         }
 
         foreach (var evaluation in budgets.Evaluations.Where(e => !e.Passed))

--- a/tests/Dotsider.Tests/SizeBudgetEvaluatorTests.cs
+++ b/tests/Dotsider.Tests/SizeBudgetEvaluatorTests.cs
@@ -205,6 +205,62 @@ public class SizeBudgetEvaluatorTests
     }
 
     /// <summary>
+    /// Verifies a confirmed first run defers every growth metric while still enforcing an
+    /// absolute limit in the same evaluation pass.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Evaluate_FirstRun_DefersGrowthAndEnforcesAbsoluteLimits()
+    {
+        TestSkip.When(Samples.NativeAotConsoleV2Mstat is null, "V2 mstat sidecar was not produced");
+        var v2 = MstatReader.Read(Samples.NativeAotConsoleV2Mstat!);
+        Assert.IsNotNull(v2);
+        var diff = MstatDiffer.Compare(MstatData.Empty, v2);
+
+        var report = SizeBudgetEvaluator.Evaluate(
+            [
+                SizeBudgetParser.Parse("max=1b"),
+                SizeBudgetParser.Parse("ns=NativeAotConsole:growth=1b"),
+                SizeBudgetParser.Parse("asm=NativeAotConsole:growth=1%"),
+            ],
+            diff,
+            SizeBasis.MstatTotal,
+            diff.Summary.RightTotal,
+            baselineTotalBytes: null,
+            defaultTopN: 10,
+            deferGrowthWithoutBaseline: true);
+
+        Assert.IsFalse(report.Passed, "The absolute max budget must still fail.");
+        Assert.IsTrue(report.HasDeferred);
+        Assert.HasCount(1, report.Evaluations[0].Violations);
+        Assert.AreSequenceEqual<SizeBudgetMetric>(
+            [SizeBudgetMetric.MaxGrowthBytes],
+            report.Evaluations[1].DeferredMetrics);
+        Assert.AreSequenceEqual<SizeBudgetMetric>(
+            [SizeBudgetMetric.MaxGrowthPercent],
+            report.Evaluations[2].DeferredMetrics);
+        Assert.IsNull(report.Evaluations[1].BaselineBytes);
+        Assert.IsNull(report.Evaluations[2].BaselineBytes);
+    }
+
+    /// <summary>
+    /// Verifies strict evaluation rejects scoped growth without a baseline.
+    /// </summary>
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public void Evaluate_ScopedGrowthWithoutBaseline_Throws()
+    {
+        TestSkip.When(Samples.NativeAotConsoleV2Mstat is null, "V2 mstat sidecar was not produced");
+        var v2 = MstatReader.Read(Samples.NativeAotConsoleV2Mstat!);
+        Assert.IsNotNull(v2);
+        var diff = MstatDiffer.Compare(MstatData.Empty, v2);
+
+        Assert.ThrowsExactly<ArgumentException>(() => SizeBudgetEvaluator.Evaluate(
+            [SizeBudgetParser.Parse("asm=NativeAotConsole:growth=1b")], diff,
+            SizeBasis.MstatTotal, diff.Summary.RightTotal, baselineTotalBytes: null));
+    }
+
+    /// <summary>
     /// Verifies warning severity reports the breach without failing the check, and the
     /// warning surfaces through <see cref="SizeBudgetReport.HasWarnings"/>.
     /// </summary>

--- a/tests/Dotsider.Tests/SizeCheckCliTests.cs
+++ b/tests/Dotsider.Tests/SizeCheckCliTests.cs
@@ -232,7 +232,11 @@ public class SizeCheckCliTests
 
         Assert.AreEqual(2, exitCode);
         var json = JsonSerializer.Deserialize<JsonElement>(stdout);
-        Assert.AreEqual(1, json.GetProperty("schemaVersion").GetInt32());
+        Assert.AreEqual(2, json.GetProperty("schemaVersion").GetInt32());
+        var targetArtifacts = json.GetProperty("targetArtifacts");
+        Assert.AreEqual(v2, targetArtifacts.GetProperty("inputPath").GetString());
+        Assert.AreEqual(v2, targetArtifacts.GetProperty("mstatPath").GetString());
+        Assert.AreEqual(v1, json.GetProperty("baselineArtifacts").GetProperty("mstatPath").GetString());
         Assert.AreEqual("mstatTotal", json.GetProperty("totalBasis").GetString());
         Assert.IsGreaterThan(0, json.GetProperty("leftTotal").GetInt64());
         Assert.IsGreaterThan(0, json.GetProperty("rightTotal").GetInt64());

--- a/tests/Dotsider.Tests/SizeDiffReportWriterTests.cs
+++ b/tests/Dotsider.Tests/SizeDiffReportWriterTests.cs
@@ -108,6 +108,59 @@ public sealed class SizeDiffReportWriterTests
     }
 
     /// <summary>
+    /// Verifies first-run growth budgets are named as deferred rather than passed.
+    /// </summary>
+    [TestMethod]
+    public void BuildMarkdown_DeferredGrowth_ExplainsMissingBaseline()
+    {
+        var context = CreateContext("Compile()", withBudget: true, withDeferred: true);
+
+        var markdown = SizeDiffReportWriter.BuildMarkdown(context);
+
+        Assert.Contains("⚠️ **PASS with warnings** — evaluated size budgets passed.", markdown);
+        Assert.Contains("**⏸️ DEFERRED**", markdown);
+        Assert.Contains("**Deferred:** growth % until a baseline exists", markdown);
+        Assert.DoesNotContain("all size budgets passed", markdown);
+    }
+
+    /// <summary>
+    /// Verifies an absolute breach remains a failure when a growth limit in the same first-run
+    /// budget is deferred.
+    /// </summary>
+    [TestMethod]
+    public void BuildMarkdown_AbsoluteFailureWithDeferredGrowth_RemainsFailure()
+    {
+        var context = CreateContext("Compile()", withBudget: true, withDeferred: true);
+        var evaluation = context.Budgets!.Evaluations[0] with { Passed = false };
+        context = context with
+        {
+            Budgets = context.Budgets with { Passed = false, Evaluations = [evaluation] }
+        };
+
+        var markdown = SizeDiffReportWriter.BuildMarkdown(context);
+
+        Assert.Contains("❌ **FAIL** — a size budget was exceeded.", markdown);
+        Assert.Contains("**❌ FAIL**", markdown);
+        Assert.DoesNotContain("**⏸️ DEFERRED**", markdown);
+    }
+
+    /// <summary>
+    /// Verifies schema 2 names the resolved target-side artifacts.
+    /// </summary>
+    [TestMethod]
+    public void BuildDocument_IncludesResolvedArtifacts()
+    {
+        var context = CreateContext("Compile()");
+
+        var document = SizeDiffReportWriter.BuildDocument(context);
+
+        Assert.AreEqual(2, document.SchemaVersion);
+        Assert.AreEqual("/tmp/picket", document.TargetArtifacts.InputPath);
+        Assert.AreEqual("/tmp/picket", document.TargetArtifacts.MstatPath);
+        Assert.IsNull(document.BaselineArtifacts);
+    }
+
+    /// <summary>
     /// Verifies the Markdown report displays the complete Native AOT contributor name.
     /// </summary>
     [TestMethod]
@@ -133,7 +186,8 @@ public sealed class SizeDiffReportWriterTests
         string contributorName,
         long rightSize = 24_700,
         bool withBaseline = false,
-        bool withBudget = false)
+        bool withBudget = false,
+        bool withDeferred = false)
     {
         var leftSize = withBaseline ? 10_000 : 0;
         var delta = rightSize - leftSize;
@@ -191,7 +245,7 @@ public sealed class SizeDiffReportWriterTests
         SizeBudgetReport? budgets = null;
         if (withBudget)
         {
-            var budget = SizeBudgetParser.Parse("max=40mb");
+            var budget = SizeBudgetParser.Parse(withDeferred ? "growth=1%" : "max=40mb");
             var evaluation = new SizeBudgetEvaluation(
                 budget,
                 Passed: true,
@@ -199,7 +253,10 @@ public sealed class SizeDiffReportWriterTests
                 ActualBytes: rightTotal,
                 BaselineBytes: withBaseline ? leftTotal : null,
                 Violations: [],
-                TopContributors: [contributor]);
+                TopContributors: [contributor])
+            {
+                DeferredMetrics = withDeferred ? [SizeBudgetMetric.MaxGrowthPercent] : []
+            };
             budgets = new SizeBudgetReport(
                 Passed: true,
                 HasWarnings: false,
@@ -208,7 +265,10 @@ public sealed class SizeDiffReportWriterTests
                 RightTotal: rightTotal,
                 LeftMstatTotal: null,
                 RightMstatTotal: rightSize,
-                Evaluations: [evaluation]);
+                Evaluations: [evaluation])
+            {
+                HasDeferred = withDeferred
+            };
         }
 
         return new SizeDiffReportWriter.Context(


### PR DESCRIPTION
Automates size-check baselines for GitHub Actions and Azure Pipelines. Successful branch builds retain verified artifacts, while pull requests compare against the latest compatible base-branch baseline. First runs still enforce absolute budgets and defer only growth budgets. Adds the optional /aot-size analysis workflow and updates the public docs.

Fixes: #268